### PR TITLE
fix(storage): resolve stored secret when testing S3/R2 connection

### DIFF
--- a/apps/api/src/storage-settings/storage-settings.service.spec.ts
+++ b/apps/api/src/storage-settings/storage-settings.service.spec.ts
@@ -9,7 +9,9 @@
  *  - upsertCredential(): encrypts secret, stores last4, preserves existing key on partial
  *    update, rejects r2 without endpoint, rejects requiresCredentials without secret
  *  - deleteCredential(): BadRequest when active; 404 when missing; success invalidates cache
- *  - testConnection(): success round-trip; failure returns ok:false; never throws
+ *  - testConnection(): success round-trip; failure returns ok:false; never throws;
+ *    partial override resolves stored secret; half-filled DTO with no row → clean error;
+ *    full DTO override works without stored row; no-overrides regressions
  *  - setActiveProvider(): patches system settings; unknown provider → BadRequest;
  *    missing credential (non-s3) → BadRequest
  */
@@ -519,6 +521,124 @@ describe('StorageSettingsService', () => {
 
       expect(result.ok).toBe(true);
       expect(mockResolver.getProviderFor).toHaveBeenCalledWith('local');
+    });
+
+    // -----------------------------------------------------------------------
+    // New cases: partial-override / credential-merge behaviour (R2 fix)
+    // -----------------------------------------------------------------------
+
+    it('partial override resolves stored secret: DTO has accessKeyId but no secret and a stored row exists', async () => {
+      // Arrange: stored credential with a known plaintext secret ("real-secret-key-1234")
+      // makeCredRow() encrypts that plaintext via encryptSecret() in its definition.
+      const cred = makeCredRow({
+        accessKeyId: 'STORED-AKI',
+        bucket: 'stored-bucket',
+        region: 'us-west-2',
+      });
+      mockPrisma.storageProviderCredential.findUnique.mockResolvedValue(cred as any);
+
+      const fakeProvider = makeStorageProvider();
+      mockResolver.buildEphemeral.mockReturnValue(fakeProvider);
+
+      // Act: supply accessKeyId override but omit secretAccessKey
+      const result = await service.testConnection({
+        provider: 's3',
+        accessKeyId: 'OVERRIDE-AKI',
+        bucket: 'override-bucket',
+        // secretAccessKey intentionally absent
+      });
+
+      // Assert: connection succeeds and the round-trip was exercised
+      expect(result.ok).toBe(true);
+
+      // buildEphemeral must have been called (not skipped), meaning the stored
+      // secret was decrypted and used to fill the gap.
+      expect(mockResolver.buildEphemeral).toHaveBeenCalledTimes(1);
+
+      // The config passed to buildEphemeral must use the OVERRIDE accessKeyId
+      // and the DECRYPTED stored secret, not an empty/undefined value.
+      const builtConfig = mockResolver.buildEphemeral.mock.calls[0][0];
+      expect(builtConfig.accessKeyId).toBe('OVERRIDE-AKI');
+      expect(builtConfig.secretAccessKey).toBeTruthy();
+      // 'real-secret-key-1234' is the plaintext encrypted by makeCredRow()
+      expect(builtConfig.secretAccessKey).toBe('real-secret-key-1234');
+
+      // S3 round-trip must have been performed
+      expect(fakeProvider.upload).toHaveBeenCalledTimes(1);
+      expect(fakeProvider.getMetadata).toHaveBeenCalledTimes(1);
+      expect(fakeProvider.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('half-filled override with NO stored row returns clean error and never constructs S3 client', async () => {
+      // Arrange: no credential row exists for the provider
+      mockPrisma.storageProviderCredential.findUnique.mockResolvedValue(null as any);
+
+      // Act: DTO has accessKeyId but no secret and no stored row to fall back to
+      const result = await service.testConnection({
+        provider: 's3',
+        accessKeyId: 'SOME-AKI',
+        bucket: 'some-bucket',
+        // secretAccessKey absent
+      });
+
+      // Assert: clean error mentioning the secret is required
+      expect(result.ok).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!.toLowerCase()).toMatch(/secret/);
+
+      // buildEphemeral must NOT have been called — no S3 client should be built
+      expect(mockResolver.buildEphemeral).not.toHaveBeenCalled();
+    });
+
+    it('full override (both key and secret in DTO) succeeds using DTO values only (regression)', async () => {
+      // Even if no stored row exists, a full DTO should work independently
+      mockPrisma.storageProviderCredential.findUnique.mockResolvedValue(null as any);
+
+      const fakeProvider = makeStorageProvider();
+      mockResolver.buildEphemeral.mockReturnValue(fakeProvider);
+
+      const result = await service.testConnection({
+        provider: 's3',
+        accessKeyId: 'DTO-AKI',
+        secretAccessKey: 'DTO-SECRET',
+        bucket: 'dto-bucket',
+        region: 'eu-central-1',
+      });
+
+      expect(result.ok).toBe(true);
+
+      const builtConfig = mockResolver.buildEphemeral.mock.calls[0][0];
+      expect(builtConfig.accessKeyId).toBe('DTO-AKI');
+      expect(builtConfig.secretAccessKey).toBe('DTO-SECRET');
+
+      expect(fakeProvider.upload).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-overrides path with stored enabled row loads from DB as before (regression)', async () => {
+      const cred = makeCredRow({ enabled: true });
+      mockPrisma.storageProviderCredential.findUnique.mockResolvedValue(cred as any);
+
+      const fakeProvider = makeStorageProvider();
+      mockResolver.buildEphemeral.mockReturnValue(fakeProvider);
+
+      // Empty DTO — only provider key supplied
+      const result = await service.testConnection({ provider: 's3' });
+
+      expect(result.ok).toBe(true);
+      expect(mockResolver.buildEphemeral).toHaveBeenCalledTimes(1);
+      expect(fakeProvider.upload).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-overrides path with stored DISABLED row still returns disabled error (regression)', async () => {
+      const cred = makeCredRow({ enabled: false });
+      mockPrisma.storageProviderCredential.findUnique.mockResolvedValue(cred as any);
+
+      const result = await service.testConnection({ provider: 's3' });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/disabled/i);
+      // Should not even attempt to build the provider
+      expect(mockResolver.buildEphemeral).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/storage-settings/storage-settings.service.ts
+++ b/apps/api/src/storage-settings/storage-settings.service.ts
@@ -338,51 +338,64 @@ export class StorageSettingsService {
       // S3 / R2 path
       let cfg: S3ProviderConfig;
 
+      // Always load the stored credential row so we can fill in any fields the
+      // DTO omits (e.g. the secret key that the UI never sends back).
+      const storedCred = await this.prisma.storageProviderCredential.findUnique({
+        where: { provider: providerKey },
+      });
+
+      // "No overrides" means the form was completely empty — all credential
+      // fields are absent.  Only in that case do we enforce the enabled flag.
       const hasOverrides = !!(
         dto.accessKeyId ||
         dto.secretAccessKey ||
         dto.bucket
       );
 
-      if (hasOverrides) {
-        // Build an ephemeral provider from supplied overrides (not yet persisted)
-        cfg = {
-          accessKeyId: dto.accessKeyId,
-          secretAccessKey: dto.secretAccessKey,
-          bucket: dto.bucket,
-          region: dto.region,
-          endpoint: dto.endpoint,
-          forcePathStyle: !!dto.endpoint,
-        };
-      } else {
-        // Load from DB
-        const cred = await this.prisma.storageProviderCredential.findUnique({
-          where: { provider: providerKey },
-        });
-        if (!cred) {
+      if (!hasOverrides) {
+        // Empty form — test the saved provider as-is.
+        if (!storedCred) {
           return {
             ok: false,
             provider: providerKey,
             error: `Provider "${providerKey}" is not configured`,
           };
         }
-        if (!cred.enabled) {
+        if (!storedCred.enabled) {
           return {
             ok: false,
             provider: providerKey,
             error: `Provider "${providerKey}" is disabled`,
           };
         }
+      }
 
-        const secretAccessKey = decryptSecret(cred.encryptedKey);
-        cfg = {
-          accessKeyId: cred.accessKeyId ?? undefined,
-          secretAccessKey,
-          bucket: cred.bucket ?? undefined,
-          region: cred.region ?? undefined,
-          endpoint: cred.endpoint ?? undefined,
-          forcePathStyle: !!cred.endpoint,
-        };
+      // Merge: DTO fields take precedence; fall back to stored values.
+      // For the secret, only use the DTO value when it is non-empty; otherwise
+      // decrypt whatever is stored in DB.
+      const effectiveSecret =
+        dto.secretAccessKey ||
+        (storedCred?.encryptedKey ? decryptSecret(storedCred.encryptedKey) : undefined);
+
+      cfg = {
+        accessKeyId: dto.accessKeyId ?? storedCred?.accessKeyId ?? undefined,
+        secretAccessKey: effectiveSecret,
+        bucket: dto.bucket ?? storedCred?.bucket ?? undefined,
+        region: dto.region ?? storedCred?.region ?? undefined,
+        endpoint: dto.endpoint ?? storedCred?.endpoint ?? undefined,
+        forcePathStyle: !!(dto.endpoint ?? storedCred?.endpoint),
+      };
+
+      // Validate that required credentials are present before attempting to
+      // build the provider — gives a clean error instead of an AWS SDK failure.
+      if (descriptor.requiresCredentials) {
+        if (!cfg.accessKeyId || !cfg.secretAccessKey) {
+          return {
+            ok: false,
+            provider: providerKey,
+            error: `Secret access key is required to test provider "${providerKey}". Save credentials first or enter the secret key.`,
+          };
+        }
       }
 
       const storageProvider = this.resolver.buildEphemeral(cfg);

--- a/apps/web/src/__tests__/pages/StorageProvidersPage.test.tsx
+++ b/apps/web/src/__tests__/pages/StorageProvidersPage.test.tsx
@@ -634,6 +634,112 @@ describe('StorageProvidersPage', () => {
   });
 
   // -------------------------------------------------------------------------
+  describe('Test button guard: unconfigured provider requiring credentials', () => {
+    function unconfiguredR2Settings() {
+      return {
+        providers: [],
+        knownProviders: [
+          makeProviderRow({
+            provider: 'r2',
+            label: 'Cloudflare R2',
+            configured: false,
+            enabled: false,
+            last4: null,
+            accessKeyId: null,
+            region: null,
+            bucket: null,
+          }),
+        ],
+        activeProvider: 's3',
+      };
+    }
+
+    it('disables Test button and shows caption when unconfigured requiresCredentials provider has empty secret field', () => {
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        settings: unconfiguredR2Settings(),
+      } as any);
+
+      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      // The Test connection button for R2 must be disabled
+      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
+      // Only one provider card (R2)
+      expect(testButtons[0]).toBeDisabled();
+
+      // The instructional caption must be visible
+      expect(
+        screen.getByText(/enter the secret access key to test before saving/i),
+      ).toBeInTheDocument();
+    });
+
+    it('enables Test button and hides caption once the user types a secret', async () => {
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        settings: unconfiguredR2Settings(),
+      } as any);
+
+      const user = userEvent.setup();
+      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      // Before typing: button is disabled
+      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
+      expect(testButtons[0]).toBeDisabled();
+
+      // Type a secret into the New Secret Access Key field
+      const secretField = screen.getByLabelText(/new secret access key/i);
+      await user.type(secretField, 'my-r2-secret');
+
+      // After typing: button should be enabled
+      await waitFor(() => {
+        const buttons = screen.getAllByRole('button', { name: /test connection/i });
+        expect(buttons[0]).not.toBeDisabled();
+      });
+
+      // Caption must no longer be shown
+      expect(
+        screen.queryByText(/enter the secret access key to test before saving/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows secret field helper text and keeps Test button enabled for a configured provider with empty secret', () => {
+      // Configured = true means a secret is already saved; empty field means "use saved"
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        settings: {
+          providers: [
+            makeProviderRow({
+              provider: 's3',
+              label: 'AWS S3',
+              configured: true,
+              enabled: true,
+              last4: 'wxyz',
+            }),
+          ],
+          knownProviders: [],
+          activeProvider: 's3',
+        },
+      } as any);
+
+      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      // Helper text for the secret field must be present (explains blank = use saved)
+      expect(
+        screen.getByText(/leave blank to use the saved secret when testing or saving/i),
+      ).toBeInTheDocument();
+
+      // Test button must be enabled (no guard fires for configured provider)
+      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
+      expect(testButtons[0]).not.toBeDisabled();
+
+      // The "enter secret to test" caption must NOT appear (guard only fires when !configured)
+      expect(
+        screen.queryByText(/enter the secret access key to test before saving/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   describe('Empty providers state', () => {
     it('renders without crashing when providers and knownProviders are both empty', () => {
       mockUseStorageProviders.mockReturnValue({

--- a/apps/web/src/pages/Admin/StorageProvidersPage.tsx
+++ b/apps/web/src/pages/Admin/StorageProvidersPage.tsx
@@ -197,6 +197,7 @@ function ProviderCard({
             value={formState.secretAccessKey ?? ''}
             onChange={(e) => onFormChange(key, 'secretAccessKey', e.target.value)}
             placeholder={providerConfig.configured ? 'Leave blank to keep current secret' : 'Enter Secret Access Key'}
+            helperText={providerConfig.configured ? 'Leave blank to use the saved secret when testing or saving.' : undefined}
             sx={{ mb: 2 }}
           />
 
@@ -255,6 +256,13 @@ function ProviderCard({
             sx={{ mb: 2, display: 'block' }}
           />
 
+          {/* Guard: provider requires credentials, not yet saved, and secret is blank */}
+          {providerConfig.requiresCredentials && !providerConfig.configured && !formState.secretAccessKey && (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              Enter the Secret Access Key to test before saving.
+            </Typography>
+          )}
+
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
             <Button
               variant="contained"
@@ -276,7 +284,15 @@ function ProviderCard({
             <Button
               variant="outlined"
               size="small"
-              disabled={testLoading}
+              disabled={
+                testLoading ||
+                (providerConfig.requiresCredentials && !providerConfig.configured && !formState.secretAccessKey)
+              }
+              title={
+                providerConfig.requiresCredentials && !providerConfig.configured && !formState.secretAccessKey
+                  ? 'Enter the Secret Access Key to test before saving'
+                  : undefined
+              }
               startIcon={testLoading ? <CircularProgress size={14} /> : undefined}
               onClick={() => void onTest(key)}
             >


### PR DESCRIPTION
> **Documentation-only PR.** These commits are **already merged into `main`** via merge commit `5fdd041` and deployed. The base here is a pre-merge snapshot (`base/pre-r2-fix-snapshot` @ `7f16b54`) purely so the diff is reviewable for the record — **do not merge this PR**.

## Problem
Testing an R2 (Cloudflare) storage provider failed with `Credential access key has length 20, should be 32`, even with a correct 32-char R2 Access Key ID.

**Root cause:** The Test form sends the (visible, pre-filled) Access Key ID but a blank Secret (secrets are never returned to the client). The backend took the "override" path with a missing secret, so the AWS SDK fell back to its default credential chain and picked up the host's 20-char `AWS_ACCESS_KEY_ID` env var. R2 rejected it. The user's real R2 key never reached R2.

## Fix
- **api** (`storage-settings.service.ts` `testConnection`): always load the stored credential row, then merge DTO over DB (secret falls back to the decrypted stored secret). If credentials are still incomplete for a provider that requires them, return a clear `{ ok:false, error }` **before** building any client — never fall through to env credentials.
- **web** (`StorageProvidersPage.tsx`): guard the Test button when an unsaved provider has an empty secret; configured providers can test with a blank secret and show a "Leave blank to use the saved secret" hint.

## Tests
- **api**: 5 new `testConnection` cases (partial-override → stored secret, half-filled → clean error, full override, no-overrides enabled/disabled). **35 passed, 0 failed.**
- **web**: 3 new Test-button-guard cases (not run locally — web deps are container-only per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HW5bovG4MqY4xnGQXYEXV1