### PR TITLE
fix(api): route thumbnail upload and signing through active storage provider

### DIFF
--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'crypto';
 import { CircleMembershipService } from '../circles/circle-membership.service';
 import { GEO_LOCATION_PROVIDER } from './geo/geo-location-provider.interface';
 import { ForwardGeocodeService } from './geo/forward-geocode.service';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 
 // ---------------------------------------------------------------------------
 // Helper: build a Prisma P2002 error the way Prisma actually throws it
@@ -170,6 +171,7 @@ describe('MediaService', () => {
   let mockCircleMembershipService: { assertCircleAccess: jest.Mock };
   let mockGeoProvider: { reverseGeocode: jest.Mock };
   let mockForwardGeocodeService: { searchPlaces: jest.Mock };
+  let mockResolver: { getProviderFor: jest.Mock };
 
   beforeEach(async () => {
     mockPrisma = createMockPrismaService();
@@ -194,6 +196,7 @@ describe('MediaService', () => {
     };
     mockGeoProvider = { reverseGeocode: jest.fn().mockResolvedValue(null) };
     mockForwardGeocodeService = { searchPlaces: jest.fn().mockResolvedValue([]) };
+    mockResolver = { getProviderFor: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -204,6 +207,7 @@ describe('MediaService', () => {
         { provide: CircleMembershipService, useValue: mockCircleMembershipService },
         { provide: GEO_LOCATION_PROVIDER, useValue: mockGeoProvider },
         { provide: ForwardGeocodeService, useValue: mockForwardGeocodeService },
+        { provide: StorageProviderResolver, useValue: mockResolver },
       ],
     }).compile();
 
@@ -2493,6 +2497,79 @@ describe('MediaService', () => {
       const [call] = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls;
       expect(call[0].where.faces).toBeUndefined();
       expect(call[0].where.AND).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // signThumb — via getMedia so we can exercise the private method
+  // -------------------------------------------------------------------------
+
+  describe('signThumb (via getMedia thumbnailUrl)', () => {
+    it('routes signing through resolver.getProviderFor when the thumbnail StorageObject row exists', async () => {
+      const item = makeMediaItem({
+        metadata: { thumbnailStorageKey: 'thumbnails/obj-1.jpg' },
+      });
+      const r2MockProvider = { getSignedDownloadUrl: jest.fn().mockResolvedValue('https://r2.example.com/signed') };
+
+      mockPrisma.mediaItem.findUnique.mockResolvedValue({
+        ...item,
+        mediaTags: [],
+      } as any);
+      // getMedia calls storageObject.findUnique twice:
+      //   1. to get the original object's storageKey (for downloadUrl)
+      //   2. inside signThumb to look up the thumbnail object's provider+bucket
+      // We use mockResolvedValueOnce for the first call and mockResolvedValue for subsequent calls.
+      mockPrisma.storageObject.findUnique
+        .mockResolvedValueOnce({ storageKey: 'uploads/photo.jpg' } as any)   // original object
+        .mockResolvedValue({ storageProvider: 'r2', bucket: 'r2-bucket' } as any); // thumbnail lookup
+
+      mockResolver.getProviderFor.mockResolvedValue(r2MockProvider);
+
+      const result = await service.getMedia(item.id, 'user-1', anyPerms);
+
+      expect(mockResolver.getProviderFor).toHaveBeenCalledWith('r2', 'r2-bucket');
+      expect(r2MockProvider.getSignedDownloadUrl).toHaveBeenCalledWith('thumbnails/obj-1.jpg');
+      expect(result.thumbnailUrl).toBe('https://r2.example.com/signed');
+    });
+
+    it('falls back to the static storageProvider when the thumbnail StorageObject row does not exist', async () => {
+      const item = makeMediaItem({
+        metadata: { thumbnailStorageKey: 'thumbnails/obj-missing.jpg' },
+      });
+
+      mockPrisma.mediaItem.findUnique.mockResolvedValue({
+        ...item,
+        mediaTags: [],
+      } as any);
+      // First findUnique: original object (for downloadUrl); second: thumbnail lookup returns null
+      mockPrisma.storageObject.findUnique
+        .mockResolvedValueOnce({ storageKey: 'uploads/photo.jpg' } as any)
+        .mockResolvedValue(null); // thumbnail row not found
+
+      mockStorageProvider.getSignedDownloadUrl.mockResolvedValue('https://s3.example.com/fallback');
+
+      const result = await service.getMedia(item.id, 'user-1', anyPerms);
+
+      expect(mockResolver.getProviderFor).not.toHaveBeenCalled();
+      expect(mockStorageProvider.getSignedDownloadUrl).toHaveBeenCalledWith(
+        'thumbnails/obj-missing.jpg',
+      );
+      expect(result.thumbnailUrl).toBe('https://s3.example.com/fallback');
+    });
+
+    it('returns null thumbnailUrl when metadata has no thumbnailStorageKey', async () => {
+      const item = makeMediaItem({ metadata: null });
+
+      mockPrisma.mediaItem.findUnique.mockResolvedValue({
+        ...item,
+        mediaTags: [],
+      } as any);
+      mockPrisma.storageObject.findUnique.mockResolvedValue({ storageKey: 'uploads/photo.jpg' } as any);
+
+      const result = await service.getMedia(item.id, 'user-1', anyPerms);
+
+      expect(mockResolver.getProviderFor).not.toHaveBeenCalled();
+      expect(result.thumbnailUrl).toBeNull();
     });
   });
 });

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -16,6 +16,7 @@ import {
   STORAGE_PROVIDER,
   StorageProvider,
 } from '../storage/providers/storage-provider.interface';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { CreateMediaDto } from './dto/create-media.dto';
 import { UpdateMediaDto } from './dto/update-media.dto';
 import { MediaQueryDto } from './dto/media-query.dto';
@@ -66,6 +67,7 @@ export class MediaService {
     private readonly circleMembershipService: CircleMembershipService,
     @Inject(GEO_LOCATION_PROVIDER) private readonly geoProvider: GeoLocationProvider,
     private readonly forwardGeocodeService: ForwardGeocodeService,
+    private readonly resolver: StorageProviderResolver,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -1812,6 +1814,24 @@ export class MediaService {
       return null;
     }
     try {
+      // Look up the StorageObject row for the thumbnail to route signing
+      // through the correct provider (the active provider may have changed
+      // since the thumbnail was created).
+      const thumbObject = await this.prisma.storageObject.findUnique({
+        where: { storageKey: key },
+        select: { storageProvider: true, bucket: true },
+      });
+
+      if (thumbObject) {
+        const provider = await this.resolver.getProviderFor(
+          thumbObject.storageProvider,
+          thumbObject.bucket,
+        );
+        return await provider.getSignedDownloadUrl(key);
+      }
+
+      // Row not yet created (thumbnail still in-flight) — fall back to the
+      // legacy static provider to preserve existing behaviour.
       return await this.storageProvider.getSignedDownloadUrl(key);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/storage/processing/processors/thumbnail.processor.spec.ts
+++ b/apps/api/src/storage/processing/processors/thumbnail.processor.spec.ts
@@ -1,0 +1,228 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Readable } from 'stream';
+import { ThumbnailProcessor } from './thumbnail.processor';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { STORAGE_PROVIDER } from '../../providers/storage-provider.interface';
+import { StorageProviderResolver } from '../../providers/storage-provider.resolver';
+import { createMockPrismaService, MockPrismaService } from '../../../../test/mocks/prisma.mock';
+import { createMockStorageProvider } from '../../../../test/mocks/storage-provider.mock';
+
+// ---------------------------------------------------------------------------
+// Mock sharp so the image path can be exercised without real image data
+// ---------------------------------------------------------------------------
+jest.mock('sharp', () => {
+  const mockSharpInstance = {
+    rotate: jest.fn().mockReturnThis(),
+    resize: jest.fn().mockReturnThis(),
+    jpeg: jest.fn().mockReturnThis(),
+    toBuffer: jest.fn().mockResolvedValue(Buffer.from('fake-jpeg-data')),
+  };
+  return jest.fn(() => mockSharpInstance);
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeStorageObject(overrides: Partial<any> = {}) {
+  return {
+    id: 'obj-123',
+    name: 'photo.jpg',
+    size: BigInt(1024000),
+    mimeType: 'image/jpeg',
+    storageKey: 'uploads/photo.jpg',
+    storageProvider: 's3',
+    bucket: 'default-bucket',
+    status: 'processing',
+    s3UploadId: null,
+    uploadedById: 'user-1',
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ThumbnailProcessor', () => {
+  let processor: ThumbnailProcessor;
+  let mockPrisma: MockPrismaService;
+  let mockStaticProvider: ReturnType<typeof createMockStorageProvider>;
+  let mockResolver: { getActiveProvider: jest.Mock; getProviderFor: jest.Mock };
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    mockStaticProvider = createMockStorageProvider();
+    mockResolver = {
+      getActiveProvider: jest.fn(),
+      getProviderFor: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ThumbnailProcessor,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: STORAGE_PROVIDER, useValue: mockStaticProvider },
+        { provide: StorageProviderResolver, useValue: mockResolver },
+      ],
+    }).compile();
+
+    processor = module.get<ThumbnailProcessor>(ThumbnailProcessor);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // canProcess()
+  // -------------------------------------------------------------------------
+
+  describe('canProcess()', () => {
+    it('returns false for storageKeys starting with thumbnails/', () => {
+      const obj = makeStorageObject({ storageKey: 'thumbnails/obj-123.jpg', mimeType: 'image/jpeg' });
+      expect(processor.canProcess(obj as any)).toBe(false);
+    });
+
+    it('returns true for image/* mimeType with a non-thumbnail storageKey', () => {
+      const obj = makeStorageObject({ storageKey: 'uploads/photo.jpg', mimeType: 'image/jpeg' });
+      expect(processor.canProcess(obj as any)).toBe(true);
+    });
+
+    it('returns true for video/* mimeType with a non-thumbnail storageKey', () => {
+      const obj = makeStorageObject({ storageKey: 'uploads/clip.mp4', mimeType: 'video/mp4' });
+      expect(processor.canProcess(obj as any)).toBe(true);
+    });
+
+    it('returns false for unsupported mimeTypes', () => {
+      const obj = makeStorageObject({ storageKey: 'uploads/doc.pdf', mimeType: 'application/pdf' });
+      expect(processor.canProcess(obj as any)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // download() — must use static provider, NOT the resolver
+  // -------------------------------------------------------------------------
+
+  describe('download()', () => {
+    it('calls the static storage provider download, not the resolver', async () => {
+      const stream = Readable.from(['data']);
+      mockStaticProvider.download.mockResolvedValue(stream);
+
+      const result = await processor.download('some/key');
+
+      expect(mockStaticProvider.download).toHaveBeenCalledWith('some/key');
+      expect(mockResolver.getActiveProvider).not.toHaveBeenCalled();
+      expect(result).toBe(stream);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // uploadThumbnail (exercised via process())
+  // -------------------------------------------------------------------------
+
+  describe('uploadThumbnail()', () => {
+    let mockActiveProvider: ReturnType<typeof createMockStorageProvider>;
+
+    beforeEach(() => {
+      // Build a second mock provider that will be returned as the "active" provider
+      mockActiveProvider = createMockStorageProvider();
+      mockActiveProvider.getBucket.mockReturnValue('r2-bucket');
+
+      // Resolver returns the active provider with id 'r2'
+      mockResolver.getActiveProvider.mockResolvedValue({ id: 'r2', provider: mockActiveProvider });
+
+      // Prisma upsert returns a minimal thumb object
+      mockPrisma.storageObject.upsert.mockResolvedValue({
+        id: 'thumb-obj-1',
+        storageKey: 'thumbnails/obj-123.jpg',
+        storageProvider: 'r2',
+        bucket: 'r2-bucket',
+        name: 'thumb-photo.jpg',
+        size: BigInt(100),
+        mimeType: 'image/jpeg',
+        status: 'ready',
+        uploadedById: 'user-1',
+        metadata: { thumbnailOf: 'obj-123' },
+        s3UploadId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+    });
+
+    it('uploads via the active provider, not the static one', async () => {
+      const object = makeStorageObject({ mimeType: 'image/jpeg' });
+      const getStream = async () => Readable.from([Buffer.from('fake')]);
+
+      await processor.process(object as any, getStream);
+
+      expect(mockActiveProvider.upload).toHaveBeenCalledWith(
+        `thumbnails/${object.id}.jpg`,
+        expect.any(Readable),
+        expect.objectContaining({ mimeType: 'image/jpeg' }),
+      );
+      expect(mockStaticProvider.upload).not.toHaveBeenCalled();
+    });
+
+    it('persists the active provider id (r2) in the upsert create branch, not s3', async () => {
+      const object = makeStorageObject({ mimeType: 'image/jpeg' });
+      const getStream = async () => Readable.from([Buffer.from('fake')]);
+
+      await processor.process(object as any, getStream);
+
+      expect(mockPrisma.storageObject.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            storageProvider: 'r2',
+            bucket: 'r2-bucket',
+          }),
+        }),
+      );
+    });
+
+    it('does NOT hardcode s3 in the upsert create branch', async () => {
+      const object = makeStorageObject({ mimeType: 'image/jpeg' });
+      const getStream = async () => Readable.from([Buffer.from('fake')]);
+
+      await processor.process(object as any, getStream);
+
+      const upsertCall = (mockPrisma.storageObject.upsert as jest.Mock).mock.calls[0][0];
+      expect(upsertCall.create.storageProvider).not.toBe('s3');
+    });
+
+    it('refreshes provider/bucket in the upsert update branch (reprocess after provider switch)', async () => {
+      const object = makeStorageObject({ mimeType: 'image/jpeg' });
+      const getStream = async () => Readable.from([Buffer.from('fake')]);
+
+      await processor.process(object as any, getStream);
+
+      // The update branch must also carry the active provider id + bucket so a
+      // reprocess after the active provider changed doesn't leave the row
+      // pointing at the old (now-empty) provider.
+      expect(mockPrisma.storageObject.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            storageProvider: 'r2',
+            bucket: 'r2-bucket',
+          }),
+        }),
+      );
+    });
+
+    it('returns success with thumbnailObjectId and thumbnailStorageKey', async () => {
+      const object = makeStorageObject({ mimeType: 'image/jpeg' });
+      const getStream = async () => Readable.from([Buffer.from('fake')]);
+
+      const result = await processor.process(object as any, getStream);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toMatchObject({
+        thumbnailObjectId: 'thumb-obj-1',
+        thumbnailStorageKey: `thumbnails/${object.id}.jpg`,
+      });
+    });
+  });
+});

--- a/apps/api/src/storage/processing/processors/thumbnail.processor.ts
+++ b/apps/api/src/storage/processing/processors/thumbnail.processor.ts
@@ -246,6 +246,11 @@ export class ThumbnailProcessor implements ObjectProcessor {
         name: `thumb-${object.name}`,
         size: BigInt(thumbBuffer.length),
         mimeType: 'image/jpeg',
+        // Refresh provider/bucket too: a reprocess after the active provider
+        // changed uploads the new bytes to the new provider, so the row must
+        // point at it or signing would route to the old (now-empty) provider.
+        storageProvider: activeProviderId,
+        bucket: activeProvider.getBucket(),
         status: 'ready',
         metadata: { thumbnailOf: object.id },
         updatedAt: new Date(),

--- a/apps/api/src/storage/processing/processors/thumbnail.processor.ts
+++ b/apps/api/src/storage/processing/processors/thumbnail.processor.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'fs';
 import ffmpeg from 'fluent-ffmpeg';
 import { ObjectProcessor, ObjectProcessorResult } from '../object-processor.interface';
 import { STORAGE_PROVIDER, StorageProvider } from '../../providers/storage-provider.interface';
+import { StorageProviderResolver } from '../../providers/storage-provider.resolver';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { streamToBuffer } from './stream-utils';
 
@@ -62,6 +63,7 @@ export class ThumbnailProcessor implements ObjectProcessor {
     @Inject(STORAGE_PROVIDER)
     private readonly storageProvider: StorageProvider,
     private readonly prisma: PrismaService,
+    private readonly resolver: StorageProviderResolver,
   ) {
     this.maxDim = parseInt(process.env.THUMBNAIL_MAX_DIM ?? '800', 10);
     this.quality = parseInt(process.env.THUMBNAIL_QUALITY ?? '85', 10);
@@ -221,9 +223,14 @@ export class ThumbnailProcessor implements ObjectProcessor {
   ): Promise<ObjectProcessorResult> {
     const thumbKey = `thumbnails/${object.id}.jpg`;
 
+    // Resolve the currently active storage provider so the thumbnail lands in
+    // the same provider/bucket that new uploads are routed to.
+    const { id: activeProviderId, provider: activeProvider } =
+      await this.resolver.getActiveProvider();
+
     // Upload to storage
     const thumbStream = Readable.from(thumbBuffer);
-    await this.storageProvider.upload(thumbKey, thumbStream, {
+    await activeProvider.upload(thumbKey, thumbStream, {
       mimeType: 'image/jpeg',
       contentLength: thumbBuffer.length,
     });
@@ -248,8 +255,8 @@ export class ThumbnailProcessor implements ObjectProcessor {
         size: BigInt(thumbBuffer.length),
         mimeType: 'image/jpeg',
         storageKey: thumbKey,
-        storageProvider: 's3',
-        bucket: this.storageProvider.getBucket(),
+        storageProvider: activeProviderId,
+        bucket: activeProvider.getBucket(),
         status: 'ready',
         uploadedById: object.uploadedById ?? null,
         metadata: { thumbnailOf: object.id },


### PR DESCRIPTION
ThumbnailProcessor.uploadThumbnail() now resolves the active provider via
StorageProviderResolver instead of the legacy static STORAGE_PROVIDER token
— fixes thumbnails landing in the wrong bucket when R2 (or another
non-default provider) is active. download() retains the static provider for
backward compatibility with per-object-key reads where provider+bucket info
is not available.

MediaService.signThumb() now looks up the thumbnail StorageObject row to
route signing through the correct provider.