### PR TITLE
fix(api): route video face-detection reruns to video_face_detection job

### DIFF
--- a/apps/api/src/face/face-detection.controller.spec.ts
+++ b/apps/api/src/face/face-detection.controller.spec.ts
@@ -50,11 +50,13 @@ function makeMediaItem(overrides: Partial<{
   id: string;
   circleId: string;
   deletedAt: Date | null;
+  type: MediaType;
 }> = {}) {
   return {
     id: 'media-1',
     circleId: 'circle-1',
     deletedAt: null,
+    type: MediaType.photo,
     ...overrides,
   };
 }
@@ -284,7 +286,9 @@ describe('FaceDetectionController', () => {
     });
 
     it('calls enrichmentJobService.enqueue with reason: rerun and type: face_detection', async () => {
-      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItem());
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ type: MediaType.photo }),
+      );
       mockEnrichmentJobService.enqueue.mockResolvedValue({ id: 'job-1', status: JobStatus.pending });
       (mockPrisma.mediaFaceStatus.upsert as jest.Mock).mockResolvedValue({});
 
@@ -295,6 +299,64 @@ describe('FaceDetectionController', () => {
           type: 'face_detection',
           mediaItemId: 'media-1',
           reason: JobReason.rerun,
+        }),
+      );
+    });
+
+    it('enqueues video_face_detection when mediaItem type is video', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ type: MediaType.video }),
+      );
+      mockEnrichmentJobService.enqueue.mockResolvedValue({ id: 'job-vid-1', status: JobStatus.pending });
+      (mockPrisma.mediaFaceStatus.upsert as jest.Mock).mockResolvedValue({});
+
+      const result = await controller.rerunFaceDetection('media-1', makeUser());
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'video_face_detection',
+          mediaItemId: 'media-1',
+          circleId: 'circle-1',
+          reason: JobReason.rerun,
+          priority: 0,
+        }),
+      );
+      expect(result.data.jobId).toBe('job-vid-1');
+      expect(result.data.status).toBe(JobStatus.pending);
+      expect(mockPrisma.mediaFaceStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { mediaItemId: 'media-1' },
+          create: expect.objectContaining({ status: MediaFaceStatusType.pending }),
+          update: expect.objectContaining({ status: MediaFaceStatusType.pending }),
+        }),
+      );
+    });
+
+    it('enqueues face_detection when mediaItem type is photo', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ type: MediaType.photo }),
+      );
+      mockEnrichmentJobService.enqueue.mockResolvedValue({ id: 'job-photo-1', status: JobStatus.pending });
+      (mockPrisma.mediaFaceStatus.upsert as jest.Mock).mockResolvedValue({});
+
+      const result = await controller.rerunFaceDetection('media-1', makeUser());
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'face_detection',
+          mediaItemId: 'media-1',
+          circleId: 'circle-1',
+          reason: JobReason.rerun,
+          priority: 0,
+        }),
+      );
+      expect(result.data.jobId).toBe('job-photo-1');
+      expect(result.data.status).toBe(JobStatus.pending);
+      expect(mockPrisma.mediaFaceStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { mediaItemId: 'media-1' },
+          create: expect.objectContaining({ status: MediaFaceStatusType.pending }),
+          update: expect.objectContaining({ status: MediaFaceStatusType.pending }),
         }),
       );
     });

--- a/apps/api/src/face/face-detection.controller.ts
+++ b/apps/api/src/face/face-detection.controller.ts
@@ -22,7 +22,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { IsString, IsOptional, IsUUID } from 'class-validator';
-import { CircleRole } from '@prisma/client';
+import { CircleRole, MediaType } from '@prisma/client';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PERMISSIONS } from '../common/constants/roles.constants';
@@ -207,8 +207,14 @@ export class FaceDetectionController {
 
     // Always create a new job on rerun — user intentionally requested it
     // Use priority 0 (highest) so user-triggered reruns are processed first
+    // Route to the correct handler: video items use video_face_detection;
+    // the video handler internally checks face.video.enabled, so we do not
+    // gate on that setting here.
+    const jobType =
+      mediaItem.type === MediaType.video ? 'video_face_detection' : 'face_detection';
+
     const job = await this.enrichmentJobService.enqueue({
-      type: 'face_detection',
+      type: jobType,
       mediaItemId,
       circleId: mediaItem.circleId,
       reason: JobReason.rerun,
@@ -229,7 +235,7 @@ export class FaceDetectionController {
     });
 
     this.logger.log(
-      `Rerun face job ${job.id} enqueued for MediaItem ${mediaItemId} by user ${user.id}`,
+      `Rerun ${jobType} job ${job.id} enqueued for MediaItem ${mediaItemId} by user ${user.id}`,
     );
 
     return { data: { jobId: job.id, status: job.status } };
@@ -387,10 +393,10 @@ export class FaceDetectionController {
     mediaItemId: string,
     user: RequestUser,
     requiredRole: CircleRole = 'viewer' as CircleRole,
-  ): Promise<{ id: string; circleId: string }> {
+  ): Promise<{ id: string; circleId: string; type: MediaType }> {
     const mediaItem = await this.prisma.mediaItem.findUnique({
       where: { id: mediaItemId },
-      select: { id: true, circleId: true, deletedAt: true },
+      select: { id: true, circleId: true, deletedAt: true, type: true },
     });
 
     if (!mediaItem || mediaItem.deletedAt) {
@@ -404,6 +410,6 @@ export class FaceDetectionController {
       requiredRole,
     );
 
-    return { id: mediaItem.id, circleId: mediaItem.circleId };
+    return { id: mediaItem.id, circleId: mediaItem.circleId, type: mediaItem.type };
   }
 }

--- a/apps/web/src/components/media/VideoFacePanel.tsx
+++ b/apps/web/src/components/media/VideoFacePanel.tsx
@@ -41,7 +41,6 @@ import {
   removePersonFromMedia,
 } from '../../services/face';
 import type { PersonListItem } from '../../services/face';
-import { FaceCrop } from '../people/FaceCrop';
 import { PersonAvatar } from '../people/PersonAvatar';
 
 // ---------------------------------------------------------------------------
@@ -227,6 +226,13 @@ export function VideoFacePanel({
         )}
       </Stack>
 
+      {/* Detection error detail */}
+      {status?.status === 'failed' && status.lastError && (
+        <Alert severity="error" sx={{ mt: 1, mb: 1 }}>
+          {status.lastError}
+        </Alert>
+      )}
+
       {/* Rerun button */}
       <Button
         size="small"
@@ -268,15 +274,18 @@ export function VideoFacePanel({
                     transition: 'background-color 0.15s',
                   }}
                 >
-                  {/* Face crop or placeholder avatar */}
+                  {/* Face thumbnail or placeholder avatar */}
                   {hasThumbnail ? (
-                    <FaceCrop
-                      imageUrl={face.faceThumbnailUrl!}
-                      boundingBox={face.boundingBox}
-                      size={56}
+                    // faceThumbnailUrl is an already-cropped representative-frame JPEG —
+                    // do NOT re-apply bounding-box crop math (FaceCrop would produce a
+                    // double-crop artifact). Render it directly as a rounded avatar.
+                    <Avatar
+                      src={face.faceThumbnailUrl!}
+                      variant="rounded"
+                      sx={{ width: 56, height: 56 }}
                     />
                   ) : (
-                    <Avatar sx={{ width: 56, height: 56, bgcolor: 'grey.300' }}>
+                    <Avatar sx={{ width: 56, height: 56, bgcolor: 'grey.300' }} variant="rounded">
                       <PersonIcon sx={{ color: 'grey.600' }} />
                     </Avatar>
                   )}


### PR DESCRIPTION
POST /api/media/:id/faces/rerun was hardcoded to enqueue face_detection
regardless of media type. Videos fed to the photo face handler caused
CompreFace to return HTTP 400 "Image has incorrect format or is broken".

- Add `type` to the assertMediaItemAccess Prisma select (returning
  MediaType alongside id and circleId — no other callers broken)
- Import MediaType from @prisma/client
- Derive jobType: MediaType.video → 'video_face_detection', else
  'face_detection'; the video handler already checks face.video.enabled
  internally, so no additional gate is needed here
- Thread jobType into the enqueue call and the log line

Notes: nest CLI not available in sandbox; tsc --noEmit showed only
pre-existing @types/jest/@types/node environment errors, none from
the edited file.