### PR TITLE
fix(api): accept geo/storage/burst fields in system-settings PATCH

### DIFF
--- a/apps/api/src/settings/dto/update-system-settings.dto.spec.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.spec.ts
@@ -322,4 +322,50 @@ describe('PatchSystemSettingsDto (PATCH)', () => {
       expect(result.ai).toEqual({});
     });
   });
+
+  describe('previously-stripped fields (regression — Fix: geo/storage/burst/ai fields drifted out of schema)', () => {
+    it('should preserve geo.forwardSearchEnabled=true through a patch parse', () => {
+      const result = patchSystemSettingsSchema.parse({ geo: { forwardSearchEnabled: true } });
+      expect(result.geo?.forwardSearchEnabled).toBe(true);
+    });
+
+    it('should preserve geo.forwardSearchEnabled=false through a patch parse (must not be treated as absent)', () => {
+      const result = patchSystemSettingsSchema.parse({ geo: { forwardSearchEnabled: false } });
+      expect(result.geo?.forwardSearchEnabled).toBe(false);
+    });
+
+    it('should preserve geo.reverseProvider through a patch parse', () => {
+      const result = patchSystemSettingsSchema.parse({ geo: { reverseProvider: 'google' } });
+      expect(result.geo?.reverseProvider).toBe('google');
+    });
+
+    it('should preserve storage.trash.retentionDays through a patch parse', () => {
+      const result = patchSystemSettingsSchema.parse({ storage: { trash: { retentionDays: 45 } } });
+      expect(result.storage?.trash?.retentionDays).toBe(45);
+    });
+
+    it('should preserve burst.minGroupSize through a patch parse', () => {
+      const result = patchSystemSettingsSchema.parse({ burst: { minGroupSize: 5 } });
+      expect(result.burst?.minGroupSize).toBe(5);
+    });
+
+    it('should not inject any default values into an empty patch (geo/storage/burst/jobs all carry .default() on the PUT schema but must not on PATCH)', () => {
+      const result = patchSystemSettingsSchema.parse({});
+      expect(result).toEqual({});
+    });
+
+    it('should preserve ai.features.tagging and ai.features.embedding through a patch parse', () => {
+      const result = patchSystemSettingsSchema.parse({
+        ai: { features: { tagging: { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022' } } },
+      });
+      expect(result.ai?.features?.tagging?.provider).toBe('anthropic');
+      expect(result.ai?.features?.tagging?.model).toBe('claude-3-5-sonnet-20241022');
+
+      const result2 = patchSystemSettingsSchema.parse({
+        ai: { features: { embedding: { provider: 'openai', model: 'text-embedding-3-small' } } },
+      });
+      expect(result2.ai?.features?.embedding?.provider).toBe('openai');
+      expect(result2.ai?.features?.embedding?.model).toBe('text-embedding-3-small');
+    });
+  });
 });

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -1,7 +1,12 @@
 import { createZodDto } from 'nestjs-zod';
 import { z } from 'zod';
+import { systemSettingsPatchSchema } from '../../common/schemas/settings.schema';
 
 // Full replacement (PUT)
+// NOTE: PUT intentionally keeps its own local, narrower schema (not the canonical
+// systemSettingsSchema) because the canonical schema applies `.default(...)` to
+// face/storage/burst/geo/jobs, which would change the exact response shape callers
+// and existing tests rely on for a full replace. See update-system-settings.dto.spec.ts.
 export const updateSystemSettingsSchema = z.object({
   ui: z.object({
     allowUserThemeOverride: z.boolean(),
@@ -30,59 +35,13 @@ export class UpdateSystemSettingsDto extends createZodDto(
 ) {}
 
 // Partial update (PATCH)
-export const patchSystemSettingsSchema = z.object({
-  ui: z
-    .object({
-      allowUserThemeOverride: z.boolean().optional(),
-    })
-    .optional(),
-  features: z.record(z.string(), z.boolean()).optional(),
-  ai: z
-    .object({
-      features: z
-        .object({
-          search: z
-            .object({
-              provider: z.string().nullable().optional(),
-              model: z.string().nullable().optional(),
-            })
-            .optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-  face: z
-    .object({
-      features: z
-        .object({
-          detection: z
-            .object({
-              provider: z.string().nullable().optional(),
-              model: z.string().nullable().optional(),
-            })
-            .optional(),
-        })
-        .optional(),
-      video: z
-        .object({
-          enabled: z.boolean().optional(),
-          sampleIntervalSeconds: z.number().int().min(1).max(60).optional(),
-          maxFramesPerVideo: z.number().int().min(1).max(300).optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-  jobs: z
-    .object({
-      history: z
-        .object({
-          retentionDays: z.number().int().min(1).max(365).optional(),
-          purgeEnabled: z.boolean().optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-});
+// Re-export the canonical partial schema (apps/api/src/common/schemas/settings.schema.ts)
+// so this DTO always stays in sync with every field the service actually supports
+// (ui, features, ai search/tagging/embedding, face features+video, storage, burst,
+// geo, jobs). Do NOT redefine a local/narrower schema here — a prior local
+// definition drifted out of sync and silently stripped valid PATCH fields
+// (e.g. geo.forwardSearchEnabled) before they ever reached the service.
+export const patchSystemSettingsSchema = systemSettingsPatchSchema;
 
 export class PatchSystemSettingsDto extends createZodDto(
   patchSystemSettingsSchema,


### PR DESCRIPTION
The PATCH /api/system-settings DTO validated against a local
patchSystemSettingsSchema that had drifted out of sync with the service:
it omitted geo, storage, burst, and ai.features.tagging/embedding. The
global ZodValidationPipe strips unknown keys, so a body such as
{ geo: { forwardSearchEnabled: true } } was silently dropped before
reaching patchSettings(), which then fell back to the current value.

Result: the Admin Geo Settings forward-search toggle (and any storage/
burst PATCH) could never be enabled or disabled via the UI. Reverse
provider was unaffected because it uses a separate endpoint
(PUT /api/geo/features/reverse).

Fix: re-export the canonical, complete systemSettingsPatchSchema from
common/schemas/settings.schema.ts as the PATCH DTO source so it always
stays in sync with every field the service supports. PUT is left on its
narrower local schema intentionally (documented inline).

Notes: build/typecheck not run — node_modules not installed locally.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XuWrBFvMFA2DPVYQ1jHBBL