### PR TITLE
feat(android): add backup on/off preference with legacy-install migration

### DIFF
--- a/apps/android/.gitignore
+++ b/apps/android/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle/
+.kotlin/
 /local.properties
 /.idea/
 .DS_Store

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,12 @@
             </intent-filter>
         </receiver>
 
+        <!-- Notification action buttons (e.g. "Turn on backup" on the reminder). -->
+        <receiver
+            android:name=".sync.NotificationActionReceiver"
+            android:exported="false" />
+
+
         <!-- Default WorkManager initializer is disabled; we provide a Hilt-aware
              WorkerFactory via Configuration.Provider on the Application. -->
         <provider

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/MainActivity.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cr.marin.memoriahub.sync.SyncNotifications
 import cr.marin.memoriahub.ui.RootDestination
 import cr.marin.memoriahub.ui.RootViewModel
 import cr.marin.memoriahub.ui.auth.DeviceAuthScreen
@@ -24,6 +25,7 @@ import cr.marin.memoriahub.ui.serverurl.ServerUrlScreen
 import cr.marin.memoriahub.data.repo.DeviceAuthRepository
 import cr.marin.memoriahub.ui.theme.MemoriaHubTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -32,13 +34,21 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var deviceAuthRepository: DeviceAuthRepository
 
+    /** In-app navigation requests from notification taps; consumed by [MainShell]. */
+    private val navTarget = MutableStateFlow<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         handleDeviceCompleteDeepLink(intent)
+        handleNavTarget(intent)
         setContent {
             MemoriaHubTheme {
-                AppRoot()
+                val target by navTarget.collectAsStateWithLifecycle()
+                AppRoot(
+                    navTarget = target,
+                    onNavTargetConsumed = { navTarget.value = null },
+                )
             }
         }
     }
@@ -47,6 +57,12 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         handleDeviceCompleteDeepLink(intent)
+        handleNavTarget(intent)
+    }
+
+    private fun handleNavTarget(intent: Intent?) {
+        val target = intent?.getStringExtra(SyncNotifications.EXTRA_NAV_TARGET) ?: return
+        navTarget.value = target
     }
 
     /**
@@ -63,7 +79,11 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun AppRoot(viewModel: RootViewModel = hiltViewModel()) {
+private fun AppRoot(
+    navTarget: String? = null,
+    onNavTargetConsumed: () -> Unit = {},
+    viewModel: RootViewModel = hiltViewModel(),
+) {
     val destination by viewModel.destination.collectAsStateWithLifecycle()
 
     Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
@@ -76,7 +96,11 @@ private fun AppRoot(viewModel: RootViewModel = hiltViewModel()) {
             RootDestination.Auth -> DeviceAuthScreen(modifier = contentModifier)
             RootDestination.Main -> {
                 LaunchedEffect(Unit) { viewModel.onMainVisible() }
-                MainShell(modifier = contentModifier)
+                MainShell(
+                    navTarget = navTarget,
+                    onNavTargetConsumed = onNavTargetConsumed,
+                    modifier = contentModifier,
+                )
             }
         }
     }

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/core/storage/AppConfigStore.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/core/storage/AppConfigStore.kt
@@ -35,6 +35,20 @@ class AppConfigStore @Inject constructor(
     /** The MediaStore bucket ids the user chose to back up; `null` until first configured. */
     val selectedBucketIdsFlow: StateFlow<Set<String>?> = _selectedBucketIds.asStateFlow()
 
+    private val _backupEnabled = MutableStateFlow(readInitialBackupEnabled())
+    /** Whether photo/video backup is on. Fresh installs default to off (opt-in). */
+    val backupEnabledFlow: StateFlow<Boolean> = _backupEnabled.asStateFlow()
+
+    private val _notifyBackupReminders =
+        MutableStateFlow(prefs.getBoolean(KEY_NOTIFY_REMINDERS, true))
+    /** Whether "backup is off and new items aren't backed up" reminders may be shown. */
+    val notifyBackupRemindersFlow: StateFlow<Boolean> = _notifyBackupReminders.asStateFlow()
+
+    private val _notifyBackupIssues =
+        MutableStateFlow(prefs.getBoolean(KEY_NOTIFY_ISSUES, true))
+    /** Whether "items failed to back up" alerts may be shown. */
+    val notifyBackupIssuesFlow: StateFlow<Boolean> = _notifyBackupIssues.asStateFlow()
+
     /** Synchronous accessor for interceptors. */
     val serverUrl: String? get() = _serverUrl.value
 
@@ -42,6 +56,13 @@ class AppConfigStore @Inject constructor(
 
     /** `null` = never configured (falls back to legacy camera-folder scanning). */
     val selectedBucketIds: Set<String>? get() = _selectedBucketIds.value
+
+    /** Synchronous accessor for workers/schedulers. */
+    val backupEnabled: Boolean get() = _backupEnabled.value
+
+    val notifyBackupReminders: Boolean get() = _notifyBackupReminders.value
+
+    val notifyBackupIssues: Boolean get() = _notifyBackupIssues.value
 
     fun setServerUrl(url: String?) {
         val normalized = url?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
@@ -60,6 +81,53 @@ class AppConfigStore @Inject constructor(
         val snapshot = ids.toSet()
         prefs.edit().putStringSet(KEY_SELECTED_BUCKETS, snapshot).apply()
         _selectedBucketIds.value = snapshot
+    }
+
+    fun setBackupEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_BACKUP_ENABLED, enabled).apply()
+        _backupEnabled.value = enabled
+    }
+
+    fun setNotifyBackupReminders(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_NOTIFY_REMINDERS, enabled).apply()
+        _notifyBackupReminders.value = enabled
+    }
+
+    fun setNotifyBackupIssues(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_NOTIFY_ISSUES, enabled).apply()
+        _notifyBackupIssues.value = enabled
+    }
+
+    /** When the last "backup is off" reminder notification was posted (anti-spam cooldown). */
+    var lastReminderNotifiedAtMs: Long
+        get() = prefs.getLong(KEY_LAST_REMINDER_AT, 0L)
+        set(value) {
+            prefs.edit().putLong(KEY_LAST_REMINDER_AT, value).apply()
+        }
+
+    /** When the last "backup issues" notification was posted (anti-spam cooldown). */
+    var lastIssueNotifiedAtMs: Long
+        get() = prefs.getLong(KEY_LAST_ISSUE_AT, 0L)
+        set(value) {
+            prefs.edit().putLong(KEY_LAST_ISSUE_AT, value).apply()
+        }
+
+    /**
+     * One-time default resolution for [backupEnabled]. Fresh installs start with backup
+     * OFF (opt-in), but installs that were already syncing before the toggle existed must
+     * stay ON — the update must never silently stop someone's backups. The computed
+     * default is persisted, so `prefs.contains(KEY_BACKUP_ENABLED)` doubles as the
+     * migration flag.
+     */
+    private fun readInitialBackupEnabled(): Boolean {
+        if (!prefs.contains(KEY_BACKUP_ENABLED)) {
+            val default = resolveInitialBackupEnabled(
+                hasTargetCircle = prefs.getString(KEY_TARGET_CIRCLE, null) != null,
+                lastScanDateAddedSec = prefs.getLong(KEY_LAST_SCAN_ADDED, 0L),
+            )
+            prefs.edit().putBoolean(KEY_BACKUP_ENABLED, default).apply()
+        }
+        return prefs.getBoolean(KEY_BACKUP_ENABLED, false)
     }
 
     private fun readSelectedBucketIds(): Set<String>? =
@@ -88,5 +156,20 @@ class AppConfigStore @Inject constructor(
         const val KEY_SELECTED_BUCKETS = "selected_bucket_ids"
         const val KEY_LAST_SCAN_ADDED = "last_scan_date_added_sec"
         const val KEY_DEVICE_ID = "device_id"
+        const val KEY_BACKUP_ENABLED = "backup_enabled"
+        const val KEY_NOTIFY_REMINDERS = "notify_backup_reminders"
+        const val KEY_NOTIFY_ISSUES = "notify_backup_issues"
+        const val KEY_LAST_REMINDER_AT = "last_reminder_notified_at_ms"
+        const val KEY_LAST_ISSUE_AT = "last_issue_notified_at_ms"
     }
 }
+
+/**
+ * Whether backup should default to ON for an install that predates the backup toggle:
+ * a configured target circle or a non-zero scan high-water mark proves the install was
+ * already backing up. Pure function, extracted for unit testing.
+ */
+internal fun resolveInitialBackupEnabled(
+    hasTargetCircle: Boolean,
+    lastScanDateAddedSec: Long,
+): Boolean = hasTargetCircle || lastScanDateAddedSec > 0

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/data/db/SyncFileDao.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/data/db/SyncFileDao.kt
@@ -45,6 +45,9 @@ interface SyncFileDao {
     @Query("SELECT COUNT(*) FROM sync_files WHERE status IN ('QUEUED', 'FAILED')")
     suspend fun pendingWorkCount(): Int
 
+    @Query("SELECT COUNT(*) FROM sync_files WHERE status IN ('FAILED', 'BLOCKED')")
+    suspend fun failureCount(): Int
+
     /** Crash recovery: rows left mid-flight by a killed process return to the queue. */
     @Query(
         "UPDATE sync_files SET status = 'QUEUED', updatedAt = :now " +

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/data/repo/SyncRepository.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/data/repo/SyncRepository.kt
@@ -102,6 +102,11 @@ class SyncRepository @Inject constructor(
         syncFileDao.pendingWorkCount()
     }
 
+    /** Items currently stuck in FAILED or BLOCKED, for the issue notification. */
+    suspend fun failureCount(): Int = withContext(Dispatchers.IO) {
+        syncFileDao.failureCount()
+    }
+
     /**
      * How many device items are not backed up: media added since the last scan that has
      * no state row yet, plus rows already queued/failed. Used by the backup-off reminder,

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/data/repo/SyncRepository.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/data/repo/SyncRepository.kt
@@ -103,6 +103,23 @@ class SyncRepository @Inject constructor(
     }
 
     /**
+     * How many device items are not backed up: media added since the last scan that has
+     * no state row yet, plus rows already queued/failed. Used by the backup-off reminder,
+     * where reconcile doesn't run — so this is a READ-ONLY scan that must not advance
+     * [AppConfigStore.lastScanDateAddedSec] (that high-water mark belongs to the engine).
+     */
+    suspend fun countNotBackedUp(): Int = withContext(Dispatchers.IO) {
+        val scanned = scanner.scan(
+            appConfigStore.selectedBucketIds,
+            sinceDateAddedSec = appConfigStore.lastScanDateAddedSec,
+        )
+        // Items with an existing row are either done (UPLOADED/SKIPPED) or already counted
+        // by pendingWorkCount below; only unseen items are new gap entries.
+        val newItems = scanned.count { syncFileDao.getById(it.mediaStoreId) == null }
+        newItems + syncFileDao.pendingWorkCount()
+    }
+
+    /**
      * Enumerate device folders that contain media, each marked selected per the user's
      * saved selection. When nothing has been configured yet (`selectedBucketIds == null`),
      * the legacy camera folders are shown pre-selected so the default matches current

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupController.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupController.kt
@@ -15,12 +15,14 @@ import javax.inject.Singleton
 class BackupController @Inject constructor(
     private val appConfigStore: AppConfigStore,
     private val syncScheduler: SyncScheduler,
+    private val notifications: SyncNotifications,
 ) {
     fun turnOn() {
         // Set the pref first: the scheduler gates every entry point on it.
         appConfigStore.setBackupEnabled(true)
         syncScheduler.ensureScheduled()
         syncScheduler.syncNow()
+        notifications.cancelReminder()
     }
 
     fun turnOff() {

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupController.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupController.kt
@@ -1,0 +1,30 @@
+package cr.marin.memoriahub.sync
+
+import cr.marin.memoriahub.core.storage.AppConfigStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The single place that flips backup on/off, so the settings toggle, the
+ * backup-off banner, and notification actions all behave identically.
+ *
+ * Turning off cancels sync work but leaves the reminder worker scheduled — the
+ * reminder is what nudges the user back when new photos pile up unbacked-up.
+ */
+@Singleton
+class BackupController @Inject constructor(
+    private val appConfigStore: AppConfigStore,
+    private val syncScheduler: SyncScheduler,
+) {
+    fun turnOn() {
+        // Set the pref first: the scheduler gates every entry point on it.
+        appConfigStore.setBackupEnabled(true)
+        syncScheduler.ensureScheduled()
+        syncScheduler.syncNow()
+    }
+
+    fun turnOff() {
+        appConfigStore.setBackupEnabled(false)
+        syncScheduler.cancelSyncWork()
+    }
+}

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupReminderPolicy.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupReminderPolicy.kt
@@ -1,0 +1,25 @@
+package cr.marin.memoriahub.sync
+
+/**
+ * Decides whether a "backup is off" reminder may be posted. Pure logic, extracted
+ * for unit testing.
+ *
+ * A reminder fires only when the user hasn't muted reminders, there is an actual
+ * gap (items on the device that aren't backed up), and the last reminder is at
+ * least [REMINDER_COOLDOWN_MS] old — nudge, don't nag.
+ */
+object BackupReminderPolicy {
+
+    /** Remind at most once every 3 days. */
+    const val REMINDER_COOLDOWN_MS: Long = 72L * 60 * 60 * 1000
+
+    fun shouldRemind(
+        remindersEnabled: Boolean,
+        lastRemindedAtMs: Long,
+        nowMs: Long,
+        gapCount: Int,
+    ): Boolean =
+        remindersEnabled &&
+            gapCount > 0 &&
+            nowMs - lastRemindedAtMs >= REMINDER_COOLDOWN_MS
+}

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupReminderWorker.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BackupReminderWorker.kt
@@ -1,0 +1,56 @@
+package cr.marin.memoriahub.sync
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import cr.marin.memoriahub.core.auth.TokenStore
+import cr.marin.memoriahub.core.storage.AppConfigStore
+import cr.marin.memoriahub.core.util.TimeProvider
+import cr.marin.memoriahub.data.repo.SyncRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+/**
+ * Daily check that nudges the user when backup is off and new photos/videos are
+ * piling up unprotected. Stays scheduled even while backup is off — it is the
+ * mechanism that brings users back. Plain background work (no foreground
+ * promotion): a read-only MediaStore scan plus a Room count is cheap.
+ *
+ * Never returns retry — a missed nudge just waits for tomorrow's run.
+ */
+@HiltWorker
+class BackupReminderWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val appConfigStore: AppConfigStore,
+    private val tokenStore: TokenStore,
+    private val syncRepository: SyncRepository,
+    private val notifications: SyncNotifications,
+    private val time: TimeProvider,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        if (!tokenStore.isLoggedIn) return Result.success()
+
+        if (appConfigStore.backupEnabled) {
+            // Backup came back on since the reminder was posted; clear any stale nudge.
+            notifications.cancelReminder()
+            return Result.success()
+        }
+
+        val gapCount = runCatching { syncRepository.countNotBackedUp() }.getOrElse { return Result.success() }
+        val now = time.nowMillis()
+        val shouldRemind = BackupReminderPolicy.shouldRemind(
+            remindersEnabled = appConfigStore.notifyBackupReminders,
+            lastRemindedAtMs = appConfigStore.lastReminderNotifiedAtMs,
+            nowMs = now,
+            gapCount = gapCount,
+        )
+        if (shouldRemind) {
+            notifications.showReminder(gapCount)
+            appConfigStore.lastReminderNotifiedAtMs = now
+        }
+        return Result.success()
+    }
+}

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BootReceiver.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/BootReceiver.kt
@@ -19,7 +19,10 @@ class BootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED && tokenStore.isLoggedIn) {
+            // ensureScheduled is a no-op while backup is off; the reminder check
+            // always survives reboots so gap nudges keep working.
             scheduler.ensureScheduled()
+            scheduler.ensureReminderScheduled()
         }
     }
 }

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/IssueNotificationPolicy.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/IssueNotificationPolicy.kt
@@ -1,0 +1,25 @@
+package cr.marin.memoriahub.sync
+
+/**
+ * Decides whether a "backup issues" alert may be posted after a sync run that
+ * failed items. Pure logic, extracted for unit testing.
+ *
+ * Alerts fire only when the user hasn't muted issue notifications, there are
+ * failed/blocked items right now, and the last alert is at least
+ * [ISSUE_COOLDOWN_MS] old — repeated failing runs (every ~15 min) must not nag.
+ */
+object IssueNotificationPolicy {
+
+    /** Alert at most once a day. */
+    const val ISSUE_COOLDOWN_MS: Long = 24L * 60 * 60 * 1000
+
+    fun shouldNotify(
+        issuesEnabled: Boolean,
+        failureCount: Int,
+        lastNotifiedAtMs: Long,
+        nowMs: Long,
+    ): Boolean =
+        issuesEnabled &&
+            failureCount > 0 &&
+            nowMs - lastNotifiedAtMs >= ISSUE_COOLDOWN_MS
+}

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/NotificationActionReceiver.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/NotificationActionReceiver.kt
@@ -1,0 +1,25 @@
+package cr.marin.memoriahub.sync
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/** Handles notification action buttons, e.g. "Turn on backup" on the reminder. */
+@AndroidEntryPoint
+class NotificationActionReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var backupController: BackupController
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ACTION_TURN_ON_BACKUP) {
+            backupController.turnOn()
+        }
+    }
+
+    companion object {
+        const val ACTION_TURN_ON_BACKUP = "cr.marin.memoriahub.action.TURN_ON_BACKUP"
+    }
+}

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncNotifications.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncNotifications.kt
@@ -3,36 +3,64 @@ package cr.marin.memoriahub.sync
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.work.ForegroundInfo
+import cr.marin.memoriahub.MainActivity
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/** Builds the ongoing notification shown while a foreground sync run is active. */
+/**
+ * Owns the app's notification channels and builds every backup notification.
+ *
+ * One channel per category (progress / reminders / issues) so users get free
+ * per-category control in system settings, layered under the in-app mute
+ * toggles in [cr.marin.memoriahub.core.storage.AppConfigStore].
+ */
 @Singleton
 class SyncNotifications @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
-    fun ensureChannel() {
+    fun ensureChannels() {
         val manager = context.getSystemService(NotificationManager::class.java) ?: return
-        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+        if (manager.getNotificationChannel(CHANNEL_PROGRESS) == null) {
             manager.createNotificationChannel(
                 NotificationChannel(
-                    CHANNEL_ID,
-                    "Photo backup",
+                    CHANNEL_PROGRESS,
+                    "Backup progress",
                     NotificationManager.IMPORTANCE_LOW,
                 ).apply { description = "Shown while photos are backing up" },
+            )
+        }
+        if (manager.getNotificationChannel(CHANNEL_REMINDERS) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_REMINDERS,
+                    "Backup reminders",
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply { description = "Reminds you when backup is off and new items aren't backed up" },
+            )
+        }
+        if (manager.getNotificationChannel(CHANNEL_ISSUES) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ISSUES,
+                    "Backup issues",
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply { description = "Alerts you when items fail to back up" },
             )
         }
     }
 
     fun buildNotification(text: String): Notification {
-        ensureChannel()
-        return NotificationCompat.Builder(context, CHANNEL_ID)
+        ensureChannels()
+        return NotificationCompat.Builder(context, CHANNEL_PROGRESS)
             .setContentTitle("MemoriaHub")
             .setContentText(text)
             .setSmallIcon(android.R.drawable.stat_sys_upload)
@@ -44,14 +72,94 @@ class SyncNotifications @Inject constructor(
     fun foregroundInfo(text: String = "Backing up photos…"): ForegroundInfo {
         val notification = buildNotification(text)
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            ForegroundInfo(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+            ForegroundInfo(NOTIFICATION_ID_PROGRESS, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
         } else {
-            ForegroundInfo(NOTIFICATION_ID, notification)
+            ForegroundInfo(NOTIFICATION_ID_PROGRESS, notification)
         }
     }
 
-    private companion object {
-        const val CHANNEL_ID = "sync_channel"
-        const val NOTIFICATION_ID = 1001
+    /** "Backup is off" nudge with a one-tap turn-on action. */
+    fun showReminder(gapCount: Int) {
+        if (!canNotify()) return
+        ensureChannels()
+        val items = if (gapCount == 1) "1 new item isn't" else "$gapCount new items aren't"
+        val notification = NotificationCompat.Builder(context, CHANNEL_REMINDERS)
+            .setContentTitle("Backup is off")
+            .setContentText("$items backed up. Turn on backup to protect your photos and videos.")
+            .setStyle(
+                NotificationCompat.BigTextStyle()
+                    .bigText("$items backed up. Turn on backup to protect your photos and videos."),
+            )
+            .setSmallIcon(android.R.drawable.stat_sys_warning)
+            .setContentIntent(openBackupTabIntent())
+            .addAction(0, "Turn on backup", turnOnBackupIntent())
+            .setAutoCancel(true)
+            .build()
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_REMINDER, notification)
+    }
+
+    fun cancelReminder() {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID_REMINDER)
+    }
+
+    /** "Items failed to back up" alert pointing at the Backup status screen. */
+    fun showIssues(failureCount: Int) {
+        if (!canNotify()) return
+        ensureChannels()
+        val items = if (failureCount == 1) "1 item" else "$failureCount items"
+        val notification = NotificationCompat.Builder(context, CHANNEL_ISSUES)
+            .setContentTitle("Backup issues")
+            .setContentText("$items couldn't be backed up. Tap to review and retry.")
+            .setSmallIcon(android.R.drawable.stat_notify_error)
+            .setContentIntent(openBackupTabIntent())
+            .setAutoCancel(true)
+            .build()
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_ISSUES, notification)
+    }
+
+    fun cancelIssues() {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID_ISSUES)
+    }
+
+    private fun canNotify(): Boolean = NotificationManagerCompat.from(context).areNotificationsEnabled()
+
+    private fun openBackupTabIntent(): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            putExtra(EXTRA_NAV_TARGET, NAV_TARGET_BACKUP)
+        }
+        return PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_BACKUP,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun turnOnBackupIntent(): PendingIntent {
+        val intent = Intent(context, NotificationActionReceiver::class.java).apply {
+            action = NotificationActionReceiver.ACTION_TURN_ON_BACKUP
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            REQUEST_TURN_ON,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    companion object {
+        // Keep the original foreground channel id so existing installs don't accumulate
+        // an orphaned channel; only its display name changes.
+        const val CHANNEL_PROGRESS = "sync_channel"
+        const val CHANNEL_REMINDERS = "backup_reminders"
+        const val CHANNEL_ISSUES = "backup_issues"
+        const val NOTIFICATION_ID_PROGRESS = 1001
+        const val NOTIFICATION_ID_REMINDER = 1002
+        const val NOTIFICATION_ID_ISSUES = 1003
+        const val EXTRA_NAV_TARGET = "nav_target"
+        const val NAV_TARGET_BACKUP = "backup"
+        private const val REQUEST_OPEN_BACKUP = 2001
+        private const val REQUEST_TURN_ON = 2002
     }
 }

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncScheduler.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncScheduler.kt
@@ -78,6 +78,18 @@ class SyncScheduler @Inject constructor(
     /** Cancels everything this app schedules — used on logout. */
     fun cancelAll() {
         cancelSyncWork()
+        workManager.cancelUniqueWork(WORK_REMINDER)
+    }
+
+    /**
+     * Keeps the daily backup-off reminder check scheduled. Deliberately NOT gated on the
+     * backup toggle — the reminder is what nudges users back after they turn backup off.
+     * Call whenever the user is logged in (app open, boot).
+     */
+    fun ensureReminderScheduled() {
+        val request = PeriodicWorkRequestBuilder<BackupReminderWorker>(Duration.ofHours(REMINDER_HOURS))
+            .build()
+        workManager.enqueueUniquePeriodicWork(WORK_REMINDER, ExistingPeriodicWorkPolicy.KEEP, request)
     }
 
     private fun schedulePeriodic() {
@@ -98,7 +110,9 @@ class SyncScheduler @Inject constructor(
         const val WORK_PERIODIC = "memoriahub-periodic-sync"
         const val WORK_CONTENT_OBSERVER = "memoriahub-content-observer"
         const val WORK_SYNC_NOW = "memoriahub-sync-now"
+        const val WORK_REMINDER = "memoriahub-backup-reminder"
         const val PERIODIC_MINUTES = 15L
+        const val REMINDER_HOURS = 24L
         const val MIN_BACKOFF = 30L
         const val CONTENT_DELAY_SECONDS = 5L
         const val CONTENT_MAX_DELAY_SECONDS = 30L

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncScheduler.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncScheduler.kt
@@ -11,6 +11,7 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import cr.marin.memoriahub.core.storage.AppConfigStore
 import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,18 +23,25 @@ import javax.inject.Singleton
  *  - on-demand "sync now".
  *
  * All paths run the same idempotent engine, so overlapping triggers are harmless.
+ *
+ * Every sync entry point is gated on the backup toggle here — the single choke point —
+ * so call sites (app open, boot, folder changes, manual sync) become no-ops when the
+ * user has backup turned off.
  */
 @Singleton
 class SyncScheduler @Inject constructor(
     private val workManager: WorkManager,
+    private val appConfigStore: AppConfigStore,
 ) {
     /** Call on login, app open, and boot. */
     fun ensureScheduled() {
+        if (!appConfigStore.backupEnabled) return
         schedulePeriodic()
         armContentObserver()
     }
 
     fun syncNow() {
+        if (!appConfigStore.backupEnabled) return
         val request = OneTimeWorkRequestBuilder<SyncWorker>()
             .setConstraints(networkConstraints())
             .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
@@ -45,6 +53,7 @@ class SyncScheduler @Inject constructor(
 
     /** (Re)arms the content-observer one-shot so future MediaStore changes wake a sync. */
     fun armContentObserver() {
+        if (!appConfigStore.backupEnabled) return
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .addContentUriTrigger(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, true)
@@ -59,10 +68,16 @@ class SyncScheduler @Inject constructor(
         workManager.enqueueUniqueWork(WORK_CONTENT_OBSERVER, ExistingWorkPolicy.REPLACE, request)
     }
 
-    fun cancelAll() {
+    /** Cancels sync work only — used when the user turns backup off. */
+    fun cancelSyncWork() {
         workManager.cancelUniqueWork(WORK_PERIODIC)
         workManager.cancelUniqueWork(WORK_CONTENT_OBSERVER)
         workManager.cancelUniqueWork(WORK_SYNC_NOW)
+    }
+
+    /** Cancels everything this app schedules — used on logout. */
+    fun cancelAll() {
+        cancelSyncWork()
     }
 
     private fun schedulePeriodic() {

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncWorker.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncWorker.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import cr.marin.memoriahub.core.storage.AppConfigStore
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -21,11 +22,17 @@ class SyncWorker @AssistedInject constructor(
     private val engine: SyncEngine,
     private val scheduler: SyncScheduler,
     private val notifications: SyncNotifications,
+    private val appConfigStore: AppConfigStore,
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun getForegroundInfo(): ForegroundInfo = notifications.foregroundInfo()
 
     override suspend fun doWork(): Result {
+        // Defensive gate: already-enqueued work (e.g. a content-observer trigger) may race
+        // the user turning backup off. Bail without foreground promotion and without
+        // re-arming the observer.
+        if (!appConfigStore.backupEnabled) return Result.success()
+
         val trigger = inputData.getString(KEY_TRIGGER) ?: TRIGGER_PERIODIC
         // Best-effort promotion to foreground; the run proceeds regardless.
         runCatching { setForeground(getForegroundInfo()) }

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncWorker.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/sync/SyncWorker.kt
@@ -6,6 +6,8 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import cr.marin.memoriahub.core.storage.AppConfigStore
+import cr.marin.memoriahub.core.util.TimeProvider
+import cr.marin.memoriahub.data.repo.SyncRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -23,6 +25,8 @@ class SyncWorker @AssistedInject constructor(
     private val scheduler: SyncScheduler,
     private val notifications: SyncNotifications,
     private val appConfigStore: AppConfigStore,
+    private val syncRepository: SyncRepository,
+    private val time: TimeProvider,
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun getForegroundInfo(): ForegroundInfo = notifications.foregroundInfo()
@@ -38,7 +42,10 @@ class SyncWorker @AssistedInject constructor(
         runCatching { setForeground(getForegroundInfo()) }
 
         return try {
-            engine.runSync(trigger = trigger, fullScan = trigger == TRIGGER_PERIODIC)
+            val summary = engine.runSync(trigger = trigger, fullScan = trigger == TRIGGER_PERIODIC)
+            // Notification concerns stay out of the engine: alert here when the run
+            // just failed items, clear the alert once everything recovered.
+            runCatching { notifyIssuesAfterRun(justFailed = summary.failed) }
             Result.success()
         } catch (e: Exception) {
             Result.retry()
@@ -47,6 +54,29 @@ class SyncWorker @AssistedInject constructor(
             if (trigger == TRIGGER_CONTENT) {
                 runCatching { scheduler.armContentObserver() }
             }
+        }
+    }
+
+    private suspend fun notifyIssuesAfterRun(justFailed: Int) {
+        val failureCount = syncRepository.failureCount()
+        if (failureCount == 0) {
+            // Everything recovered (e.g. a retry drained the failures): clear stale alerts.
+            notifications.cancelIssues()
+            return
+        }
+        // Only alert when this run failed items — old BLOCKED rows alone shouldn't
+        // re-nag every 15 minutes; the cooldown covers repeated failing runs.
+        if (justFailed == 0) return
+        val now = time.nowMillis()
+        val shouldNotify = IssueNotificationPolicy.shouldNotify(
+            issuesEnabled = appConfigStore.notifyBackupIssues,
+            failureCount = failureCount,
+            lastNotifiedAtMs = appConfigStore.lastIssueNotifiedAtMs,
+            nowMs = now,
+        )
+        if (shouldNotify) {
+            notifications.showIssues(failureCount)
+            appConfigStore.lastIssueNotifiedAtMs = now
         }
     }
 

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/RootViewModel.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/RootViewModel.kt
@@ -28,8 +28,10 @@ class RootViewModel @Inject constructor(
     fun onMainVisible() {
         if (scheduledThisProcess) return
         scheduledThisProcess = true
+        // No-ops while backup is off; the reminder check below always stays scheduled.
         syncScheduler.ensureScheduled()
         syncScheduler.syncNow()
+        syncScheduler.ensureReminderScheduled()
     }
 
     val destination: StateFlow<RootDestination> =

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/main/BackupOffBanner.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/main/BackupOffBanner.kt
@@ -1,0 +1,84 @@
+package cr.marin.memoriahub.ui.main
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cr.marin.memoriahub.core.storage.AppConfigStore
+import cr.marin.memoriahub.sync.BackupController
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class BackupBannerViewModel @Inject constructor(
+    appConfigStore: AppConfigStore,
+    private val backupController: BackupController,
+) : ViewModel() {
+    val backupEnabled: StateFlow<Boolean> = appConfigStore.backupEnabledFlow
+
+    fun turnOn() = backupController.turnOn()
+}
+
+/**
+ * Persistent "Backup is off" banner shown above every tab while backup is
+ * disabled, so the paused state is unmissable and one tap away from fixing.
+ */
+@Composable
+fun BackupOffBanner(
+    modifier: Modifier = Modifier,
+    viewModel: BackupBannerViewModel = hiltViewModel(),
+) {
+    val backupEnabled by viewModel.backupEnabled.collectAsStateWithLifecycle()
+    if (backupEnabled) return
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.CloudOff,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 12.dp),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Backup is off", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    "New photos and videos on this device aren't being backed up.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            FilledTonalButton(
+                onClick = viewModel::turnOn,
+                modifier = Modifier.padding(start = 12.dp),
+            ) {
+                Text("Turn on")
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/main/MainShell.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/main/MainShell.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +35,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import cr.marin.memoriahub.sync.SyncNotifications
 import cr.marin.memoriahub.ui.folders.FolderSelectionScreen
 import cr.marin.memoriahub.ui.photos.PhotosScreen
 import cr.marin.memoriahub.ui.settings.SettingsScreen
@@ -49,7 +51,11 @@ private enum class Tab(val route: String, val label: String, val icon: ImageVect
 private const val ROUTE_FOLDERS = "folders"
 
 @Composable
-fun MainShell(modifier: Modifier = Modifier) {
+fun MainShell(
+    modifier: Modifier = Modifier,
+    navTarget: String? = null,
+    onNavTargetConsumed: () -> Unit = {},
+) {
     val context = LocalContext.current
     var granted by remember { mutableStateOf(hasMediaReadPermission(context)) }
     val launcher = rememberLauncherForActivityResult(
@@ -62,6 +68,19 @@ fun MainShell(modifier: Modifier = Modifier) {
     }
 
     val navController = rememberNavController()
+
+    // Notification taps request a tab by name (e.g. "backup" → the Backup status screen).
+    LaunchedEffect(navTarget) {
+        if (navTarget == SyncNotifications.NAV_TARGET_BACKUP) {
+            navController.navigate(Tab.Sync.route) {
+                popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                launchSingleTop = true
+                restoreState = true
+            }
+        }
+        if (navTarget != null) onNavTargetConsumed()
+    }
+
     Scaffold(
         modifier = modifier,
         bottomBar = {
@@ -86,18 +105,21 @@ fun MainShell(modifier: Modifier = Modifier) {
             }
         },
     ) { padding ->
-        NavHost(
-            navController = navController,
-            startDestination = Tab.Photos.route,
-            modifier = Modifier.padding(padding),
-        ) {
-            composable(Tab.Photos.route) { PhotosScreen() }
-            composable(Tab.Sync.route) { SyncStatusScreen() }
-            composable(Tab.Settings.route) {
-                SettingsScreen(onOpenFolders = { navController.navigate(ROUTE_FOLDERS) })
-            }
-            composable(ROUTE_FOLDERS) {
-                FolderSelectionScreen(onBack = { navController.popBackStack() })
+        Column(modifier = Modifier.padding(padding)) {
+            // Persists across all tabs: the off state must be unmissable everywhere.
+            BackupOffBanner()
+            NavHost(
+                navController = navController,
+                startDestination = Tab.Photos.route,
+            ) {
+                composable(Tab.Photos.route) { PhotosScreen() }
+                composable(Tab.Sync.route) { SyncStatusScreen() }
+                composable(Tab.Settings.route) {
+                    SettingsScreen(onOpenFolders = { navController.navigate(ROUTE_FOLDERS) })
+                }
+                composable(ROUTE_FOLDERS) {
+                    FolderSelectionScreen(onBack = { navController.popBackStack() })
+                }
             }
         }
     }

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/settings/SettingsScreen.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/settings/SettingsScreen.kt
@@ -1,5 +1,12 @@
 package cr.marin.memoriahub.ui.settings
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,15 +20,22 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
@@ -32,6 +46,19 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    // POST_NOTIFICATIONS is runtime-requested on Android 13+. The in-app toggle is
+    // persisted regardless; on permanent denial we point at system settings below.
+    var notificationsPermitted by remember { mutableStateOf(hasNotificationPermission(context)) }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { notificationsPermitted = hasNotificationPermission(context) }
+    val requestNotificationPermissionIfNeeded = {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !notificationsPermitted) {
+            permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
 
     Column(
         modifier = modifier
@@ -40,6 +67,42 @@ fun SettingsScreen(
             .padding(16.dp),
     ) {
         Text("Settings", style = MaterialTheme.typography.headlineSmall)
+
+        Text(
+            "Backup",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 24.dp, bottom = 8.dp),
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = if (state.backupEnabled) {
+                CardDefaults.cardColors()
+            } else {
+                // Backup off must be unmissable, even inside Settings.
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            },
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ToggleRow(
+                    title = "Back up photos & videos",
+                    subtitle = if (state.backupEnabled) {
+                        "Backup is on — new photos and videos upload automatically"
+                    } else {
+                        "Backup is off — nothing on this device is being backed up"
+                    },
+                    checked = state.backupEnabled,
+                    onCheckedChange = viewModel::setBackupEnabled,
+                    subtitleColor = if (state.backupEnabled) {
+                        MaterialTheme.colorScheme.outline
+                    } else {
+                        MaterialTheme.colorScheme.onErrorContainer
+                    },
+                )
+            }
+        }
 
         Section("Account") {
             Text(state.displayName ?: state.email ?: "—", style = MaterialTheme.typography.bodyLarge)
@@ -93,6 +156,60 @@ fun SettingsScreen(
             }
         }
 
+        Section("Notifications") {
+            ToggleRow(
+                title = "Backup reminders",
+                subtitle = "Remind me when backup is off and new items aren't backed up",
+                checked = state.remindersEnabled,
+                onCheckedChange = { enabled ->
+                    viewModel.setRemindersEnabled(enabled)
+                    if (enabled) requestNotificationPermissionIfNeeded()
+                },
+            )
+            ToggleRow(
+                title = "Backup issues",
+                subtitle = "Alert me when items fail to back up",
+                checked = state.issuesEnabled,
+                onCheckedChange = { enabled ->
+                    viewModel.setIssuesEnabled(enabled)
+                    if (enabled) requestNotificationPermissionIfNeeded()
+                },
+            )
+            if (!notificationsPermitted) {
+                Text(
+                    "Notifications are blocked for MemoriaHub. Allow them in system settings for reminders and alerts to appear.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+            androidx.compose.foundation.layout.Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        context.startActivity(
+                            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                                .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName),
+                        )
+                    }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("System notification settings", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "Fine-tune sound, vibration, and per-category behavior",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                )
+            }
+        }
+
         Button(
             onClick = viewModel::logout,
             colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
@@ -102,6 +219,40 @@ fun SettingsScreen(
         ) {
             Text("Log out")
         }
+    }
+}
+
+private fun hasNotificationPermission(context: android.content.Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+
+@Composable
+private fun ToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    subtitleColor: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified,
+) {
+    androidx.compose.foundation.layout.Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = subtitleColor.takeIf { it != androidx.compose.ui.graphics.Color.Unspecified }
+                    ?: MaterialTheme.colorScheme.outline,
+            )
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
     }
 }
 

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/settings/SettingsViewModel.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import cr.marin.memoriahub.core.network.dto.Circle
 import cr.marin.memoriahub.core.storage.AppConfigStore
 import cr.marin.memoriahub.data.repo.AuthRepository
 import cr.marin.memoriahub.data.repo.CircleRepository
+import cr.marin.memoriahub.sync.BackupController
 import cr.marin.memoriahub.sync.SyncScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +22,9 @@ data class SettingsUiState(
     val serverUrl: String? = null,
     val circles: List<Circle> = emptyList(),
     val targetCircleId: String? = null,
+    val backupEnabled: Boolean = false,
+    val remindersEnabled: Boolean = true,
+    val issuesEnabled: Boolean = true,
     val loading: Boolean = true,
     val error: String? = null,
 )
@@ -31,18 +35,25 @@ class SettingsViewModel @Inject constructor(
     private val circleRepository: CircleRepository,
     private val appConfigStore: AppConfigStore,
     private val syncScheduler: SyncScheduler,
+    private val backupController: BackupController,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(
         SettingsUiState(
             serverUrl = appConfigStore.serverUrl,
             targetCircleId = appConfigStore.targetCircleId,
+            backupEnabled = appConfigStore.backupEnabled,
+            remindersEnabled = appConfigStore.notifyBackupReminders,
+            issuesEnabled = appConfigStore.notifyBackupIssues,
         ),
     )
     val state: StateFlow<SettingsUiState> = _state.asStateFlow()
 
     init {
         viewModelScope.launch { appConfigStore.targetCircleIdFlow.collect { id -> _state.update { it.copy(targetCircleId = id) } } }
+        viewModelScope.launch { appConfigStore.backupEnabledFlow.collect { on -> _state.update { it.copy(backupEnabled = on) } } }
+        viewModelScope.launch { appConfigStore.notifyBackupRemindersFlow.collect { on -> _state.update { it.copy(remindersEnabled = on) } } }
+        viewModelScope.launch { appConfigStore.notifyBackupIssuesFlow.collect { on -> _state.update { it.copy(issuesEnabled = on) } } }
         load()
     }
 
@@ -70,6 +81,18 @@ class SettingsViewModel @Inject constructor(
 
     fun selectCircle(circleId: String) {
         appConfigStore.setTargetCircleId(circleId)
+    }
+
+    fun setBackupEnabled(enabled: Boolean) {
+        if (enabled) backupController.turnOn() else backupController.turnOff()
+    }
+
+    fun setRemindersEnabled(enabled: Boolean) {
+        appConfigStore.setNotifyBackupReminders(enabled)
+    }
+
+    fun setIssuesEnabled(enabled: Boolean) {
+        appConfigStore.setNotifyBackupIssues(enabled)
     }
 
     fun logout() {

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/status/SyncStatusScreen.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/status/SyncStatusScreen.kt
@@ -47,12 +47,19 @@ fun SyncStatusScreen(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Button(onClick = viewModel::syncNow, modifier = Modifier.weight(1f)) {
-                Text("Sync now")
+            if (state.backupEnabled) {
+                Button(onClick = viewModel::syncNow, modifier = Modifier.weight(1f)) {
+                    Text("Sync now")
+                }
+            } else {
+                // Notification taps land here; give them a direct fix-it action.
+                Button(onClick = viewModel::turnOnBackup, modifier = Modifier.weight(1f)) {
+                    Text("Turn on backup")
+                }
             }
             OutlinedButton(
                 onClick = viewModel::retryFailed,
-                enabled = state.failed > 0,
+                enabled = state.backupEnabled && state.failed > 0,
                 modifier = Modifier.weight(1f),
             ) {
                 Text("Retry failed")

--- a/apps/android/app/src/main/java/cr/marin/memoriahub/ui/status/SyncStatusViewModel.kt
+++ b/apps/android/app/src/main/java/cr/marin/memoriahub/ui/status/SyncStatusViewModel.kt
@@ -2,10 +2,12 @@ package cr.marin.memoriahub.ui.status
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cr.marin.memoriahub.core.storage.AppConfigStore
 import cr.marin.memoriahub.data.db.SyncFileEntity
 import cr.marin.memoriahub.data.db.SyncRunEntity
 import cr.marin.memoriahub.data.db.SyncStatus
 import cr.marin.memoriahub.data.repo.SyncRepository
+import cr.marin.memoriahub.sync.BackupController
 import cr.marin.memoriahub.sync.SyncScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,6 +22,7 @@ data class SyncStatusUiState(
     val pending: Int = 0,
     val syncing: Int = 0,
     val failed: Int = 0,
+    val backupEnabled: Boolean = true,
     val lastRun: SyncRunEntity? = null,
     val failures: List<SyncFileEntity> = emptyList(),
 )
@@ -28,19 +31,23 @@ data class SyncStatusUiState(
 class SyncStatusViewModel @Inject constructor(
     private val syncRepository: SyncRepository,
     private val syncScheduler: SyncScheduler,
+    private val backupController: BackupController,
+    appConfigStore: AppConfigStore,
 ) : ViewModel() {
 
     val state: StateFlow<SyncStatusUiState> = combine(
         syncRepository.observeStatusCounts(),
         syncRepository.observeLatestRun(),
         syncRepository.observeFailures(),
-    ) { counts, lastRun, failures ->
+        appConfigStore.backupEnabledFlow,
+    ) { counts, lastRun, failures, backupEnabled ->
         val byStatus = counts.associate { it.status to it.count }
         SyncStatusUiState(
             synced = (byStatus[SyncStatus.UPLOADED] ?: 0) + (byStatus[SyncStatus.SKIPPED] ?: 0),
             pending = byStatus[SyncStatus.QUEUED] ?: 0,
             syncing = (byStatus[SyncStatus.HASHING] ?: 0) + (byStatus[SyncStatus.UPLOADING] ?: 0),
             failed = (byStatus[SyncStatus.FAILED] ?: 0) + (byStatus[SyncStatus.BLOCKED] ?: 0),
+            backupEnabled = backupEnabled,
             lastRun = lastRun,
             failures = failures,
         )
@@ -52,6 +59,10 @@ class SyncStatusViewModel @Inject constructor(
 
     fun syncNow() {
         syncScheduler.syncNow()
+    }
+
+    fun turnOnBackup() {
+        backupController.turnOn()
     }
 
     fun retryFailed() {

--- a/apps/android/app/src/test/java/cr/marin/memoriahub/core/storage/AppConfigStoreDefaultsTest.kt
+++ b/apps/android/app/src/test/java/cr/marin/memoriahub/core/storage/AppConfigStoreDefaultsTest.kt
@@ -1,0 +1,32 @@
+package cr.marin.memoriahub.core.storage
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppConfigStoreDefaultsTest {
+
+    @Test
+    fun `existing install with target circle stays enabled`() {
+        assertTrue(resolveInitialBackupEnabled(hasTargetCircle = true, lastScanDateAddedSec = 0L))
+    }
+
+    @Test
+    fun `existing install that has scanned stays enabled`() {
+        assertTrue(
+            resolveInitialBackupEnabled(hasTargetCircle = false, lastScanDateAddedSec = 1_700_000_000L),
+        )
+    }
+
+    @Test
+    fun `existing install with both signals stays enabled`() {
+        assertTrue(
+            resolveInitialBackupEnabled(hasTargetCircle = true, lastScanDateAddedSec = 1_700_000_000L),
+        )
+    }
+
+    @Test
+    fun `fresh install defaults to off`() {
+        assertFalse(resolveInitialBackupEnabled(hasTargetCircle = false, lastScanDateAddedSec = 0L))
+    }
+}

--- a/apps/android/app/src/test/java/cr/marin/memoriahub/sync/BackupReminderPolicyTest.kt
+++ b/apps/android/app/src/test/java/cr/marin/memoriahub/sync/BackupReminderPolicyTest.kt
@@ -1,0 +1,72 @@
+package cr.marin.memoriahub.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackupReminderPolicyTest {
+
+    private val now = 1_750_000_000_000L
+
+    @Test
+    fun `muted reminders never fire`() {
+        assertFalse(
+            BackupReminderPolicy.shouldRemind(
+                remindersEnabled = false,
+                lastRemindedAtMs = 0L,
+                nowMs = now,
+                gapCount = 42,
+            ),
+        )
+    }
+
+    @Test
+    fun `no gap means no reminder`() {
+        assertFalse(
+            BackupReminderPolicy.shouldRemind(
+                remindersEnabled = true,
+                lastRemindedAtMs = 0L,
+                nowMs = now,
+                gapCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `within cooldown does not re-remind`() {
+        val lastReminded = now - BackupReminderPolicy.REMINDER_COOLDOWN_MS + 1
+        assertFalse(
+            BackupReminderPolicy.shouldRemind(
+                remindersEnabled = true,
+                lastRemindedAtMs = lastReminded,
+                nowMs = now,
+                gapCount = 5,
+            ),
+        )
+    }
+
+    @Test
+    fun `exactly at cooldown boundary reminds`() {
+        val lastReminded = now - BackupReminderPolicy.REMINDER_COOLDOWN_MS
+        assertTrue(
+            BackupReminderPolicy.shouldRemind(
+                remindersEnabled = true,
+                lastRemindedAtMs = lastReminded,
+                nowMs = now,
+                gapCount = 5,
+            ),
+        )
+    }
+
+    @Test
+    fun `gap past cooldown reminds`() {
+        assertTrue(
+            BackupReminderPolicy.shouldRemind(
+                remindersEnabled = true,
+                lastRemindedAtMs = 0L,
+                nowMs = now,
+                gapCount = 1,
+            ),
+        )
+    }
+}

--- a/apps/android/app/src/test/java/cr/marin/memoriahub/sync/IssueNotificationPolicyTest.kt
+++ b/apps/android/app/src/test/java/cr/marin/memoriahub/sync/IssueNotificationPolicyTest.kt
@@ -1,0 +1,72 @@
+package cr.marin.memoriahub.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IssueNotificationPolicyTest {
+
+    private val now = 1_750_000_000_000L
+
+    @Test
+    fun `muted issue alerts never fire`() {
+        assertFalse(
+            IssueNotificationPolicy.shouldNotify(
+                issuesEnabled = false,
+                failureCount = 7,
+                lastNotifiedAtMs = 0L,
+                nowMs = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `zero failures never notifies`() {
+        assertFalse(
+            IssueNotificationPolicy.shouldNotify(
+                issuesEnabled = true,
+                failureCount = 0,
+                lastNotifiedAtMs = 0L,
+                nowMs = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `within cooldown does not re-notify`() {
+        val lastNotified = now - IssueNotificationPolicy.ISSUE_COOLDOWN_MS + 1
+        assertFalse(
+            IssueNotificationPolicy.shouldNotify(
+                issuesEnabled = true,
+                failureCount = 3,
+                lastNotifiedAtMs = lastNotified,
+                nowMs = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `exactly at cooldown boundary notifies`() {
+        val lastNotified = now - IssueNotificationPolicy.ISSUE_COOLDOWN_MS
+        assertTrue(
+            IssueNotificationPolicy.shouldNotify(
+                issuesEnabled = true,
+                failureCount = 3,
+                lastNotifiedAtMs = lastNotified,
+                nowMs = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `failures past cooldown notify`() {
+        assertTrue(
+            IssueNotificationPolicy.shouldNotify(
+                issuesEnabled = true,
+                failureCount = 1,
+                lastNotifiedAtMs = 0L,
+                nowMs = now,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Fresh installs default to backup OFF (opt-in); installs that were already
syncing (target circle set or scan high-water mark > 0) migrate to ON so
the update never silently stops existing backups. Adds notification
mute toggles and reminder/issue cooldown timestamps.

Notes: tests run deferred to end of branch (Android SDK being provisioned).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LUkbaRGkKEpm32mhZ4BpRK