### PR TITLE
feat(api): scaffold doctor module and export geo/enrichment services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,10 @@ Metrics are precomputed into a snapshot table on a configurable schedule (defaul
 - `GET /api/admin/insights` (system_settings:read) - Return the latest precomputed storage metrics snapshot plus a `refresh` object describing the in-flight job state; `{ status: 'ready'|'empty', metrics|null, computedAt|null, durationMs|null, refresh: { state: 'idle'|'pending'|'running'|'failed', jobId: uuid|null, lastError: string|null } }` — byte fields in `metrics` are STRINGS (BigInt-safe), counts are numbers
 - `POST /api/admin/insights/refresh` (system_settings:write) - Enqueue a `storage_insights` enrichment job at priority 0 (highest; pre-empts any scheduled job) and return IMMEDIATELY: `{ jobId: uuid, state: 'pending'|'running' }`; body-less; computation is async — poll `GET /api/admin/insights` until `refresh.state` becomes `idle` or `failed`
 
+### Admin: Doctor / Diagnostics (Admin role + system_settings:read)
+On-demand configuration health sweep across ~20 checks in 7 sections (core, auth, storage, AI, face, geo, jobs); reuses each domain's existing "test connection" service for live provider connectivity and surfaces feature-flag/provider inconsistencies (e.g. a feature enabled with no provider configured). No new permission, nothing persisted, no cron — a fresh report is computed on every call. See [Doctor Diagnostics spec](docs/specs/doctor.md).
+- `POST /api/admin/doctor/run` (system_settings:read) - Run all diagnostics and return a `DoctorReport` { computedAt, durationMs, summary:{ok,warning,error,skipped,total}, sections:[{ key, label, status, checks:[{ key, label, status, message, actionItem?, durationMs }] }] }; runs live provider connectivity tests (AI/face/geo/storage), a pgvector probe, feature-flag/provider consistency checks, and job-queue health; nothing persisted; each check has a 10s timeout
+
 ### Admin: Job Queue (Admin role + jobs:read / jobs:write)
 An admin dashboard at `/admin/settings/jobs` provides monitoring and control over the generic `enrichment_jobs` queue (used by face detection, storage insights computation, and all future enrichment handlers).
 - `GET /api/admin/jobs/stats` (jobs:read) - Queue stats: total, byStatus, byType breakdown, stuckRunning count, and `scheduled` (count of pending jobs currently in backoff, i.e. `scheduledFor > now`)
@@ -500,6 +504,7 @@ Sub-pages:
 - `/admin/settings/jobs/insights` — job queue insights & ETA dashboard (jobs:read); KPI cards + per-type duration/throughput table; reachable from the Settings hub Operations group and from a "View insights & ETA" link on the Job Queue page
 - `/admin/settings/backup` — backup configuration and run history
 - `/admin/settings/sharing` — public share management; per-row and bulk revoke/set-expiration/delete for all shares across the app (shares:manage_any)
+- `/admin/settings/doctor` — configuration health diagnostics (Doctor); runs live checks and shows action items
 
 ### Storage Provider Configuration (Admin only — storage_settings:read / storage_settings:write)
 Admins can configure multiple object-storage providers (AWS S3, Cloudflare R2, local disk), test connectivity, choose the ACTIVE provider for new uploads, and migrate existing objects between providers (COPY-ONLY: bytes are copied and the object is repointed; the source file is left in place as a fallback). Objects on different providers are served simultaneously via per-object routing.
@@ -856,6 +861,7 @@ Detailed specs live under `docs/specs/`:
 - [Bulk Import Resilience](docs/specs/bulk-import-resilience.md) — dual-path retry model, per-provider throttle gate, stuck-job auto-reset cron, provider rate-limit classification matrix, CLI durable multipart resume, PAT pre-flight, recovery runbook
 - [Job Queue Insights](docs/specs/job-insights.md) — on-demand live aggregate, lock-safety rationale, ETA formula and basis semantics, web dashboard, CLI TUI, nightly job_history_purge retention model
 - [Public Media Sharing](docs/specs/public-sharing.md) — token-based unauthenticated access, byte-proxy rationale, metadata-stripping contract, EXIF/GPS limitation, RBAC, enumeration-resistant 404 policy, archived/trashed item handling
+- [Doctor Diagnostics](docs/specs/doctor.md) — on-demand configuration health sweep, 20-check catalog across 7 sections, status semantics, `runCheck` concurrency/timeout/exception-normalization design, reuse of existing settings test-connection services
 
 ## Audits
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { MetadataModule } from './metadata/metadata.module';
 import { GeoModule } from './geo/geo.module';
 import { StorageSettingsModule } from './storage-settings/storage-settings.module';
 import { ShareModule } from './share/share.module';
+import { DoctorModule } from './doctor/doctor.module';
 import { LoggerModule } from './common/logger/logger.module';
 import { TestAuthModule } from './test-auth/test-auth.module';
 
@@ -78,6 +79,7 @@ import configuration from './config/configuration';
     SearchModule,
     TaggingModule,
     InsightsModule,
+    DoctorModule,
     BurstModule,
     MetadataModule,
     GeoModule,

--- a/apps/api/src/doctor/doctor.controller.spec.ts
+++ b/apps/api/src/doctor/doctor.controller.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for DoctorController.
+ *
+ * Verifies handler delegation to DoctorService.runDiagnostics() and the
+ * @Auth metadata wiring (Admin role + system_settings:read permission).
+ * RBAC enforcement itself is covered by integration tests — this is a
+ * delegation + decorator-wiring test only.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { DoctorController } from './doctor.controller';
+import { DoctorService } from './doctor.service';
+import { DoctorReport } from './doctor.types';
+import { PERMISSIONS, ROLES } from '../common/constants/roles.constants';
+import { ROLES_KEY } from '../auth/decorators/roles.decorator';
+import { PERMISSIONS_KEY } from '../auth/decorators/permissions.decorator';
+
+// ---------------------------------------------------------------------------
+// Mock DoctorService
+// ---------------------------------------------------------------------------
+
+const mockDoctorService = {
+  runDiagnostics: jest.fn(),
+};
+
+function makeReport(): DoctorReport {
+  return {
+    computedAt: '2026-07-03T00:00:00.000Z',
+    durationMs: 42,
+    summary: { ok: 20, warning: 0, error: 0, skipped: 0, total: 20 },
+    sections: [
+      { key: 'core', label: 'Core', status: 'ok', checks: [] },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DoctorController', () => {
+  let controller: DoctorController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DoctorController],
+      providers: [{ provide: DoctorService, useValue: mockDoctorService }],
+    })
+      .overrideGuard(require('../auth/guards/jwt-auth.guard').JwtAuthGuard ?? Object)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<DoctorController>(DoctorController);
+  });
+
+  // =========================================================================
+  // POST /admin/doctor/run — runDiagnostics
+  // =========================================================================
+
+  describe('runDiagnostics', () => {
+    it('delegates to doctorService.runDiagnostics()', async () => {
+      const report = makeReport();
+      mockDoctorService.runDiagnostics.mockResolvedValue(report);
+
+      await controller.runDiagnostics();
+
+      expect(mockDoctorService.runDiagnostics).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the report produced by the service unchanged', async () => {
+      const report = makeReport();
+      mockDoctorService.runDiagnostics.mockResolvedValue(report);
+
+      const result = await controller.runDiagnostics();
+
+      expect(result).toEqual(report);
+    });
+
+    it('propagates errors thrown by doctorService.runDiagnostics()', async () => {
+      mockDoctorService.runDiagnostics.mockRejectedValue(new Error('boom'));
+
+      await expect(controller.runDiagnostics()).rejects.toThrow('boom');
+    });
+  });
+
+  // =========================================================================
+  // @Auth metadata wiring
+  // =========================================================================
+
+  describe('@Auth metadata wiring', () => {
+    it('requires ADMIN role', () => {
+      const roles: string[] = Reflect.getMetadata(ROLES_KEY, controller.runDiagnostics);
+      expect(roles).toContain(ROLES.ADMIN);
+    });
+
+    it('requires SYSTEM_SETTINGS_READ permission', () => {
+      const permissions: string[] = Reflect.getMetadata(PERMISSIONS_KEY, controller.runDiagnostics);
+      expect(permissions).toContain(PERMISSIONS.SYSTEM_SETTINGS_READ);
+    });
+  });
+});

--- a/apps/api/src/doctor/doctor.controller.ts
+++ b/apps/api/src/doctor/doctor.controller.ts
@@ -1,0 +1,37 @@
+// =============================================================================
+// Doctor Controller
+// =============================================================================
+//
+// Admin-only endpoint that runs an on-demand configuration health sweep.
+// Mounted at /api/admin/doctor.
+// =============================================================================
+
+import { Controller, HttpCode, Post } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
+import { DoctorService } from './doctor.service';
+import { DoctorReport } from './doctor.types';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { PERMISSIONS, ROLES } from '../common/constants/roles.constants';
+
+@ApiTags('Admin - Doctor')
+@Controller('admin/doctor')
+export class DoctorController {
+  constructor(private readonly doctorService: DoctorService) {}
+
+  // -------------------------------------------------------------------------
+  // POST /admin/doctor/run
+  // -------------------------------------------------------------------------
+
+  @Post('run')
+  @HttpCode(200)
+  @Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.SYSTEM_SETTINGS_READ] })
+  @ApiOperation({ summary: 'Run an on-demand configuration health sweep (Admin)' })
+  @ApiOkResponse({
+    description:
+      'Diagnostics report grouped into sections (core, auth, storage, AI, face, geo, jobs). ' +
+      'Computed fresh on every call — nothing is persisted.',
+  })
+  async runDiagnostics(): Promise<DoctorReport> {
+    return this.doctorService.runDiagnostics();
+  }
+}

--- a/apps/api/src/doctor/doctor.module.ts
+++ b/apps/api/src/doctor/doctor.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { DoctorController } from './doctor.controller';
+import { DoctorService } from './doctor.service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SettingsModule } from '../settings/settings.module';
+import { AiModule } from '../ai/ai.module';
+import { FaceModule } from '../face/face.module';
+import { GeoModule } from '../geo/geo.module';
+import { StorageSettingsModule } from '../storage-settings/storage-settings.module';
+import { EnrichmentModule } from '../enrichment/enrichment.module';
+
+@Module({
+  imports: [
+    PrismaModule,
+    SettingsModule,
+    AiModule,
+    FaceModule,
+    GeoModule,
+    StorageSettingsModule,
+    EnrichmentModule,
+  ],
+  controllers: [DoctorController],
+  providers: [DoctorService],
+})
+export class DoctorModule {}

--- a/apps/api/src/doctor/doctor.service.spec.ts
+++ b/apps/api/src/doctor/doctor.service.spec.ts
@@ -1,0 +1,624 @@
+/**
+ * Unit tests for DoctorService.
+ *
+ * Verifies the on-demand configuration health sweep: report structure
+ * (sections/summary/timing), exception normalization for checks whose
+ * dependency throws, per-check timeout handling, feature-off → skipped
+ * semantics, feature-flag/provider consistency checks, and the pgvector
+ * missing-extension/table error path.
+ *
+ * No database required — PrismaService and all injected settings/admin
+ * services are fully mocked.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { DoctorService } from './doctor.service';
+import { DoctorCheck, DoctorReport } from './doctor.types';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService, ResolvedSettings } from '../settings/system-settings/system-settings.service';
+import { AiSettingsService } from '../ai/ai-settings.service';
+import { FaceSettingsService } from '../face/face-settings.service';
+import { GeoSettingsService } from '../geo/geo-settings.service';
+import { StorageSettingsService } from '../storage-settings/storage-settings.service';
+import { EnrichmentAdminService } from '../enrichment/enrichment-admin.service';
+import {
+  createMockPrismaService,
+  MockPrismaService,
+} from '../../test/mocks/prisma.mock';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flattens report.sections[].checks[] and returns the check by key. */
+function findCheck(report: DoctorReport, key: string): DoctorCheck {
+  for (const section of report.sections) {
+    const check = section.checks.find((c) => c.key === key);
+    if (check) return check;
+  }
+  throw new Error(`Check not found: ${key}`);
+}
+
+/** Routes prisma.$queryRaw calls to a canned result based on substring match
+ * against the joined template-literal SQL text, so tests don't depend on the
+ * concurrent call ordering of the 20 checks. */
+function mockQueryRawByText(prisma: MockPrismaService, handlers: Array<[string, unknown]>): void {
+  (prisma.$queryRaw as unknown as jest.Mock).mockImplementation((strings: TemplateStringsArray) => {
+    const text = Array.isArray(strings) ? strings.join('') : String(strings);
+    for (const [needle, value] of handlers) {
+      if (text.includes(needle)) {
+        return Promise.resolve(value);
+      }
+    }
+    return Promise.resolve([]);
+  });
+}
+
+function healthyQueryRawHandlers(): Array<[string, unknown]> {
+  return [
+    ['_prisma_migrations', [{ n: 0 }]],
+    ['pg_extension', [{ ok: 1 }]],
+    ['to_regclass', [{ t: 'media_item_embedding' }]],
+    ['SELECT 1', [{ '?column?': 1 }]],
+  ];
+}
+
+function makeSettings(overrides: Partial<ResolvedSettings> = {}): ResolvedSettings {
+  return {
+    ui: { allowUserThemeOverride: true },
+    features: { autoTagging: false, faceRecognition: false, burstDetection: false },
+    ai: {
+      features: {
+        search: { provider: null, model: null },
+        tagging: { provider: null, model: null },
+        embedding: { provider: null, model: null },
+      },
+    },
+    face: {
+      features: { detection: { provider: null, model: null } },
+      video: { enabled: true, sampleIntervalSeconds: 5, maxFramesPerVideo: 60 },
+    },
+    storage: {
+      activeProvider: 's3',
+      insights: { refreshIntervalHours: 4 },
+      trash: { retentionDays: 30 },
+    },
+    burst: { timeGapSeconds: 10, hashDistance: 10, minGroupSize: 3 },
+    geo: { reverseProvider: 'offline', forwardSearchEnabled: false },
+    jobs: { history: { retentionDays: 30, purgeEnabled: true } },
+    updatedAt: new Date(),
+    updatedBy: null,
+    version: 1,
+    ...overrides,
+  } as ResolvedSettings;
+}
+
+function makeHealthySettings(overrides: Partial<ResolvedSettings> = {}): ResolvedSettings {
+  return makeSettings({
+    features: { autoTagging: true, faceRecognition: true, burstDetection: true },
+    ai: {
+      features: {
+        search: { provider: 'openai', model: 'gpt-4o' },
+        tagging: { provider: 'openai', model: 'gpt-4o' },
+        embedding: { provider: 'openai', model: 'text-embedding-3-small' },
+      },
+    },
+    face: {
+      features: { detection: { provider: 'human', model: null } },
+      video: { enabled: true, sampleIntervalSeconds: 5, maxFramesPerVideo: 60 },
+    },
+    ...overrides,
+  });
+}
+
+const VALID_SECRETS_KEY = Buffer.alloc(32, 7).toString('base64');
+const VALID_JWT_SECRET = 'a'.repeat(32);
+
+/** Baseline env — every var Doctor reads set to a healthy value. Merge with
+ * overrides and swap in via ORIGINAL_ENV restore in afterEach. */
+function healthyEnv(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    SECRETS_ENCRYPTION_KEY: VALID_SECRETS_KEY,
+    JWT_SECRET: VALID_JWT_SECRET,
+    GOOGLE_CLIENT_ID: 'client-id',
+    GOOGLE_CLIENT_SECRET: 'client-secret',
+    APP_URL: 'https://app.example.com',
+    NODE_ENV: 'test',
+    STORAGE_PROVIDER: 's3',
+    GEO_PROVIDER: 'offline',
+    ENRICHMENT_WORKER_ENABLED: 'true',
+    FACE_WORKER_ENABLED: 'true',
+    INITIAL_ADMIN_EMAIL: 'admin@example.com',
+    ...overrides,
+  };
+}
+
+const HEALTHY_STATS = {
+  total: 0,
+  byStatus: { pending: 0, running: 0, succeeded: 0, failed: 0 },
+  byType: [],
+  stuckRunning: 0,
+  scheduled: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('DoctorService', () => {
+  let service: DoctorService;
+  let mockPrisma: MockPrismaService;
+  let mockSystemSettings: jest.Mocked<Pick<SystemSettingsService, 'getSettings'>>;
+  let mockAiSettings: jest.Mocked<Pick<AiSettingsService, 'testProvider' | 'testEmbedding'>>;
+  let mockFaceSettings: jest.Mocked<Pick<FaceSettingsService, 'testProvider'>>;
+  let mockGeoSettings: jest.Mocked<Pick<GeoSettingsService, 'testProvider'>>;
+  let mockStorageSettings: jest.Mocked<Pick<StorageSettingsService, 'testConnection'>>;
+  let mockEnrichmentAdmin: jest.Mocked<Pick<EnrichmentAdminService, 'getStats'>>;
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    mockSystemSettings = { getSettings: jest.fn() };
+    mockAiSettings = { testProvider: jest.fn(), testEmbedding: jest.fn() };
+    mockFaceSettings = { testProvider: jest.fn() };
+    mockGeoSettings = { testProvider: jest.fn() };
+    mockStorageSettings = { testConnection: jest.fn() };
+    mockEnrichmentAdmin = { getStats: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DoctorService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: SystemSettingsService, useValue: mockSystemSettings },
+        { provide: AiSettingsService, useValue: mockAiSettings },
+        { provide: FaceSettingsService, useValue: mockFaceSettings },
+        { provide: GeoSettingsService, useValue: mockGeoSettings },
+        { provide: StorageSettingsService, useValue: mockStorageSettings },
+        { provide: EnrichmentAdminService, useValue: mockEnrichmentAdmin },
+      ],
+    }).compile();
+
+    service = module.get<DoctorService>(DoctorService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  // =========================================================================
+  // 1. Happy-ish path / report structure
+  // =========================================================================
+
+  describe('report structure (all-healthy fixture)', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockSystemSettings.getSettings.mockResolvedValue(makeHealthySettings());
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+    });
+
+    it('returns sections in the documented order: core, auth, storage, ai, face, geo, jobs', async () => {
+      const report = await service.runDiagnostics();
+
+      expect(report.sections.map((s) => s.key)).toEqual([
+        'core',
+        'auth',
+        'storage',
+        'ai',
+        'face',
+        'geo',
+        'jobs',
+      ]);
+    });
+
+    it('produces a summary whose ok+warning+error+skipped sums to total', async () => {
+      const report = await service.runDiagnostics();
+
+      const { ok, warning, error, skipped, total } = report.summary;
+      expect(ok + warning + error + skipped).toBe(total);
+      expect(total).toBeGreaterThan(0);
+    });
+
+    it('has no error checks when everything is configured and healthy', async () => {
+      const report = await service.runDiagnostics();
+
+      expect(report.summary.error).toBe(0);
+    });
+
+    it('returns computedAt as a string and durationMs as a number', async () => {
+      const report = await service.runDiagnostics();
+
+      expect(typeof report.computedAt).toBe('string');
+      expect(typeof report.durationMs).toBe('number');
+    });
+
+    it('gives every individual check a numeric durationMs', async () => {
+      const report = await service.runDiagnostics();
+
+      for (const section of report.sections) {
+        for (const check of section.checks) {
+          expect(typeof check.durationMs).toBe('number');
+          expect(check.durationMs).toBeGreaterThanOrEqual(0);
+        }
+      }
+    });
+
+    it('includes all 20 documented checks across the 7 sections', async () => {
+      const report = await service.runDiagnostics();
+
+      const allKeys = report.sections.flatMap((s) => s.checks.map((c) => c.key));
+      expect(allKeys).toEqual([
+        'core.database',
+        'core.migrations',
+        'core.pgvector',
+        'core.secretsKey',
+        'core.appUrl',
+        'auth.jwt',
+        'auth.googleOauth',
+        'auth.adminBootstrap',
+        'storage.activeProvider',
+        'storage.liveTest',
+        'ai.search',
+        'ai.tagging',
+        'ai.embedding',
+        'ai.flagConsistency',
+        'face.detection',
+        'face.flagConsistency',
+        'geo.reverseProvider',
+        'jobs.workerEnabled',
+        'jobs.queueHealth',
+        'jobs.burstConfig',
+      ]);
+    });
+  });
+
+  // =========================================================================
+  // 2. Thrown exception is normalized to 'error'
+  // =========================================================================
+
+  describe('exception normalization', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockSystemSettings.getSettings.mockResolvedValue(makeHealthySettings());
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+    });
+
+    it('normalizes a thrown BadRequestException to a status:error check without rejecting the whole run', async () => {
+      mockStorageSettings.testConnection.mockRejectedValue(new BadRequestException('no creds'));
+
+      const report = await service.runDiagnostics();
+
+      const check = findCheck(report, 'storage.liveTest');
+      expect(check.status).toBe('error');
+      expect(check.message).toContain('no creds');
+    });
+
+    it('still completes the rest of the report when one dependency throws', async () => {
+      mockStorageSettings.testConnection.mockRejectedValue(new BadRequestException('no creds'));
+
+      const report = await service.runDiagnostics();
+
+      // Unrelated checks are unaffected.
+      expect(findCheck(report, 'core.database').status).toBe('ok');
+      expect(findCheck(report, 'ai.search').status).toBe('ok');
+      expect(report.summary.total).toBe(20);
+    });
+  });
+
+  // =========================================================================
+  // 3. Per-check timeout
+  // =========================================================================
+
+  describe('per-check timeout', () => {
+    it('resolves the hung check as status:error with a timeout message after 10s, while the rest of the report completes', async () => {
+      process.env = healthyEnv();
+      mockSystemSettings.getSettings.mockResolvedValue(makeHealthySettings());
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+
+      // Geo provider test hangs forever — never resolves or rejects.
+      mockGeoSettings.testProvider.mockReturnValue(new Promise(() => {}));
+
+      jest.useFakeTimers();
+      try {
+        const reportPromise = service.runDiagnostics();
+        await jest.advanceTimersByTimeAsync(10_000);
+        const report = await reportPromise;
+
+        const hungCheck = findCheck(report, 'geo.reverseProvider');
+        expect(hungCheck.status).toBe('error');
+        expect(hungCheck.message.toLowerCase()).toContain('timed out');
+
+        // The rest of the report still completed normally.
+        expect(findCheck(report, 'core.database').status).toBe('ok');
+        expect(findCheck(report, 'ai.search').status).toBe('ok');
+        expect(report.summary.total).toBe(20);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  // =========================================================================
+  // 4. Feature-off → skipped (fresh-install fixture)
+  // =========================================================================
+
+  describe('feature-off produces skipped checks (fresh install)', () => {
+    beforeEach(() => {
+      // Fresh install: env fully healthy, but no AI/face providers configured
+      // and all feature flags off — this must not raise any error checks.
+      process.env = healthyEnv();
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings()); // all features false, all providers null
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+      // AI/face provider test methods should not even be called in this fixture,
+      // but stub them defensively in case of an unexpected call.
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+    });
+
+    it('marks ai.search as skipped when no search provider/model is configured', async () => {
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.search').status).toBe('skipped');
+    });
+
+    it('marks ai.tagging as skipped when no tagging provider/model is configured', async () => {
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.tagging').status).toBe('skipped');
+    });
+
+    it('marks ai.embedding as skipped when no embedding provider/model is configured', async () => {
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.embedding').status).toBe('skipped');
+    });
+
+    it('marks face.detection as skipped when face recognition is disabled', async () => {
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'face.detection').status).toBe('skipped');
+    });
+
+    it('marks jobs.burstConfig as skipped when burst detection is disabled', async () => {
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'jobs.burstConfig').status).toBe('skipped');
+    });
+
+    it('produces zero error checks for a fresh-install configuration', async () => {
+      const report = await service.runDiagnostics();
+      expect(report.summary.error).toBe(0);
+    });
+
+    it('does not call out to AI/face provider test methods when unconfigured', async () => {
+      await service.runDiagnostics();
+      expect(mockAiSettings.testProvider).not.toHaveBeenCalled();
+      expect(mockFaceSettings.testProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // 5. Flag inconsistency matrix
+  // =========================================================================
+
+  describe('ai.flagConsistency', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+    });
+
+    it('is status:error when autoTagging is enabled but no tagging provider is configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: { autoTagging: true, faceRecognition: false, burstDetection: false },
+          ai: {
+            features: {
+              search: { provider: null, model: null },
+              tagging: { provider: null, model: null },
+              embedding: { provider: null, model: null },
+            },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.flagConsistency').status).toBe('error');
+    });
+
+    it('is status:warning when a tagging provider is configured but autoTagging is disabled', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: { autoTagging: false, faceRecognition: false, burstDetection: false },
+          ai: {
+            features: {
+              search: { provider: null, model: null },
+              tagging: { provider: 'openai', model: 'gpt-4o' },
+              embedding: { provider: null, model: null },
+            },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.flagConsistency').status).toBe('warning');
+    });
+
+    it('is status:ok when autoTagging is enabled and a tagging provider is configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: { autoTagging: true, faceRecognition: false, burstDetection: false },
+          ai: {
+            features: {
+              search: { provider: null, model: null },
+              tagging: { provider: 'openai', model: 'gpt-4o' },
+              embedding: { provider: null, model: null },
+            },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.flagConsistency').status).toBe('ok');
+    });
+  });
+
+  describe('face.flagConsistency', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+    });
+
+    it('is status:warning when a face provider is configured but faceRecognition is disabled', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: { autoTagging: false, faceRecognition: false, burstDetection: false },
+          face: {
+            features: { detection: { provider: 'human', model: null } },
+            video: { enabled: true, sampleIntervalSeconds: 5, maxFramesPerVideo: 60 },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'face.flagConsistency').status).toBe('warning');
+    });
+
+    it('is status:ok when faceRecognition is enabled (provider configured)', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: { autoTagging: false, faceRecognition: true, burstDetection: false },
+          face: {
+            features: { detection: { provider: 'human', model: null } },
+            video: { enabled: true, sampleIntervalSeconds: 5, maxFramesPerVideo: 60 },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'face.flagConsistency').status).toBe('ok');
+    });
+
+    it('is status:skipped when faceRecognition is disabled and no provider is configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings());
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'face.flagConsistency').status).toBe('skipped');
+    });
+  });
+
+  // =========================================================================
+  // 6. pgvector missing → error
+  // =========================================================================
+
+  describe('core.pgvector', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockSystemSettings.getSettings.mockResolvedValue(makeHealthySettings());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+    });
+
+    it('is status:error when the pgvector extension is not installed (empty extension row set)', async () => {
+      mockQueryRawByText(mockPrisma, [
+        ['_prisma_migrations', [{ n: 0 }]],
+        ['pg_extension', []], // extension missing
+        ['to_regclass', [{ t: 'media_item_embedding' }]],
+        ['SELECT 1', [{ '?column?': 1 }]],
+      ]);
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'core.pgvector');
+      expect(check.status).toBe('error');
+      expect(check.message).toContain('extension');
+    });
+
+    it('is status:error when the embedding table is missing (to_regclass returns null)', async () => {
+      mockQueryRawByText(mockPrisma, [
+        ['_prisma_migrations', [{ n: 0 }]],
+        ['pg_extension', [{ ok: 1 }]],
+        ['to_regclass', [{ t: null }]], // table missing
+        ['SELECT 1', [{ '?column?': 1 }]],
+      ]);
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'core.pgvector');
+      expect(check.status).toBe('error');
+      expect(check.message).toContain('table not found');
+    });
+
+    it('is status:ok when both the extension and table are present', async () => {
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'core.pgvector').status).toBe('ok');
+    });
+  });
+});

--- a/apps/api/src/doctor/doctor.service.ts
+++ b/apps/api/src/doctor/doctor.service.ts
@@ -10,13 +10,47 @@
 
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import {
+  SystemSettingsService,
+  ResolvedSettings,
+} from '../settings/system-settings/system-settings.service';
 import { AiSettingsService } from '../ai/ai-settings.service';
 import { FaceSettingsService } from '../face/face-settings.service';
 import { GeoSettingsService } from '../geo/geo-settings.service';
 import { StorageSettingsService } from '../storage-settings/storage-settings.service';
 import { EnrichmentAdminService } from '../enrichment/enrichment-admin.service';
-import { DoctorReport } from './doctor.types';
+import { isEnrichmentWorkerEnabled } from '../enrichment/enrichment-job.worker';
+import {
+  DoctorCheck,
+  DoctorCheckStatus,
+  DoctorReport,
+  DoctorSection,
+} from './doctor.types';
+
+/** Result shape returned by an individual check function, before the runCheck wrapper adds key/label/durationMs. */
+interface CheckOutcome {
+  status: DoctorCheckStatus;
+  message: string;
+  actionItem?: string;
+}
+
+interface CheckDef {
+  key: string;
+  label: string;
+  fn: () => Promise<CheckOutcome>;
+}
+
+interface SectionDef {
+  key: string;
+  label: string;
+  checkKeys: string[];
+}
+
+/** Per-check timeout — a hung provider call must not hang the whole sweep. */
+const CHECK_TIMEOUT_MS = 10_000;
+
+/** Sentinel thrown by the timeout race branch; never surfaced to callers. */
+const TIMEOUT_SENTINEL = Symbol('doctor-check-timeout');
 
 @Injectable()
 export class DoctorService {
@@ -32,21 +66,620 @@ export class DoctorService {
     private readonly enrichmentAdmin: EnrichmentAdminService,
   ) {}
 
-  /**
-   * Run the full diagnostics sweep.
-   *
-   * TODO: this is a scaffolding stub — the 20-check catalog is implemented in
-   * a follow-up commit. Returns a structurally valid, empty report for now.
-   */
+  // ---------------------------------------------------------------------------
+  // runDiagnostics
+  // ---------------------------------------------------------------------------
+
   async runDiagnostics(): Promise<DoctorReport> {
     const start = Date.now();
-    this.logger.debug('Doctor: runDiagnostics stub invoked');
+    this.logger.debug('Doctor: runDiagnostics started');
 
-    return {
+    const settings = await this.systemSettings.getSettings();
+
+    const defs: CheckDef[] = [
+      // Core
+      { key: 'core.database', label: 'Database connectivity', fn: () => this.checkDatabase() },
+      { key: 'core.migrations', label: 'Migrations applied', fn: () => this.checkMigrations() },
+      { key: 'core.pgvector', label: 'pgvector extension', fn: () => this.checkPgvector() },
+      { key: 'core.secretsKey', label: 'Secrets encryption key', fn: () => this.checkSecretsKey() },
+      { key: 'core.appUrl', label: 'App URL', fn: () => this.checkAppUrl() },
+      // Auth
+      { key: 'auth.jwt', label: 'JWT secret', fn: () => this.checkJwtSecret() },
+      { key: 'auth.googleOauth', label: 'Google OAuth', fn: () => this.checkGoogleOauth() },
+      { key: 'auth.adminBootstrap', label: 'Admin bootstrap', fn: () => this.checkAdminBootstrap() },
+      // Storage
+      {
+        key: 'storage.activeProvider',
+        label: 'Active storage provider',
+        fn: () => this.checkActiveStorageProvider(settings),
+      },
+      {
+        key: 'storage.liveTest',
+        label: 'Storage connectivity',
+        fn: () => this.checkStorageLiveTest(settings),
+      },
+      // AI
+      { key: 'ai.search', label: 'AI search provider', fn: () => this.checkAiSearch(settings) },
+      { key: 'ai.tagging', label: 'Auto-tagging provider', fn: () => this.checkAiTagging(settings) },
+      { key: 'ai.embedding', label: 'Text embedding provider', fn: () => this.checkAiEmbedding(settings) },
+      {
+        key: 'ai.flagConsistency',
+        label: 'Auto-tagging flag consistency',
+        fn: () => this.checkAiFlagConsistency(settings),
+      },
+      // Face
+      { key: 'face.detection', label: 'Face detection provider', fn: () => this.checkFaceDetection(settings) },
+      {
+        key: 'face.flagConsistency',
+        label: 'Face flag consistency',
+        fn: () => this.checkFaceFlagConsistency(settings),
+      },
+      // Geo
+      { key: 'geo.reverseProvider', label: 'Reverse geocoding', fn: () => this.checkGeoReverseProvider(settings) },
+      // Jobs
+      {
+        key: 'jobs.workerEnabled',
+        label: 'Enrichment worker enabled',
+        fn: () => this.checkWorkerEnabled(settings),
+      },
+      { key: 'jobs.queueHealth', label: 'Queue health', fn: () => this.checkQueueHealth() },
+      { key: 'jobs.burstConfig', label: 'Burst detection', fn: () => this.checkBurstConfig(settings) },
+    ];
+
+    const settled = await Promise.allSettled(defs.map((def) => this.runCheck(def)));
+
+    const checks: DoctorCheck[] = settled.map((result, i) => {
+      if (result.status === 'fulfilled') {
+        return result.value;
+      }
+      // Belt-and-suspenders: runCheck already catches everything internally,
+      // so this branch should be unreachable in practice.
+      const def = defs[i];
+      const reason = result.reason;
+      const message = reason instanceof Error ? reason.message : String(reason);
+      return { key: def.key, label: def.label, status: 'error', message, durationMs: 0 };
+    });
+
+    const checksByKey = new Map(checks.map((c) => [c.key, c]));
+
+    const sectionDefs: SectionDef[] = [
+      {
+        key: 'core',
+        label: 'Core',
+        checkKeys: ['core.database', 'core.migrations', 'core.pgvector', 'core.secretsKey', 'core.appUrl'],
+      },
+      {
+        key: 'auth',
+        label: 'Authentication',
+        checkKeys: ['auth.jwt', 'auth.googleOauth', 'auth.adminBootstrap'],
+      },
+      {
+        key: 'storage',
+        label: 'Storage',
+        checkKeys: ['storage.activeProvider', 'storage.liveTest'],
+      },
+      {
+        key: 'ai',
+        label: 'AI & Enrichment',
+        checkKeys: ['ai.search', 'ai.tagging', 'ai.embedding', 'ai.flagConsistency'],
+      },
+      {
+        key: 'face',
+        label: 'Face Recognition',
+        checkKeys: ['face.detection', 'face.flagConsistency'],
+      },
+      {
+        key: 'geo',
+        label: 'Geo',
+        checkKeys: ['geo.reverseProvider'],
+      },
+      {
+        key: 'jobs',
+        label: 'Job Queue & Worker',
+        checkKeys: ['jobs.workerEnabled', 'jobs.queueHealth', 'jobs.burstConfig'],
+      },
+    ];
+
+    const sections: DoctorSection[] = sectionDefs.map((sd) => {
+      const sectionChecks = sd.checkKeys.map((k) => checksByKey.get(k)!);
+      return {
+        key: sd.key,
+        label: sd.label,
+        status: this.worstStatus(sectionChecks.map((c) => c.status)),
+        checks: sectionChecks,
+      };
+    });
+
+    const summary = { ok: 0, warning: 0, error: 0, skipped: 0, total: 0 };
+    for (const c of checks) {
+      summary[c.status] += 1;
+      summary.total += 1;
+    }
+
+    const report: DoctorReport = {
       computedAt: new Date().toISOString(),
       durationMs: Date.now() - start,
-      summary: { ok: 0, warning: 0, error: 0, skipped: 0, total: 0 },
-      sections: [],
+      summary,
+      sections,
+    };
+
+    this.logger.debug(
+      `Doctor: runDiagnostics completed in ${report.durationMs}ms (ok=${summary.ok} warning=${summary.warning} error=${summary.error} skipped=${summary.skipped})`,
+    );
+
+    return report;
+  }
+
+  // ---------------------------------------------------------------------------
+  // worstStatus — precedence error > warning > ok; 'skipped' counts as 'ok'.
+  // ---------------------------------------------------------------------------
+
+  private worstStatus(statuses: DoctorCheckStatus[]): DoctorCheckStatus {
+    if (statuses.includes('error')) return 'error';
+    if (statuses.includes('warning')) return 'warning';
+    return 'ok';
+  }
+
+  // ---------------------------------------------------------------------------
+  // runCheck — timing, exception normalization, and per-check timeout.
+  // ---------------------------------------------------------------------------
+
+  private async runCheck(def: CheckDef): Promise<DoctorCheck> {
+    const start = Date.now();
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const outcome = await Promise.race([
+        def.fn(),
+        new Promise<CheckOutcome>((_, reject) => {
+          timeoutHandle = setTimeout(() => reject(TIMEOUT_SENTINEL), CHECK_TIMEOUT_MS);
+        }),
+      ]);
+
+      return {
+        key: def.key,
+        label: def.label,
+        status: outcome.status,
+        message: outcome.message,
+        ...(outcome.actionItem ? { actionItem: outcome.actionItem } : {}),
+        durationMs: Date.now() - start,
+      };
+    } catch (err) {
+      const durationMs = Date.now() - start;
+
+      if (err === TIMEOUT_SENTINEL) {
+        return {
+          key: def.key,
+          label: def.label,
+          status: 'error',
+          message: 'Check timed out after 10s',
+          durationMs,
+        };
+      }
+
+      // CRITICAL: several test-connectivity services throw (e.g.
+      // BadRequestException when credentials are missing) rather than
+      // returning { ok: false }. Never let that bubble past the sweep.
+      const message = err instanceof Error ? err.message : String(err);
+      return { key: def.key, label: def.label, status: 'error', message, durationMs };
+    } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+    }
+  }
+
+  // ===========================================================================
+  // Core checks
+  // ===========================================================================
+
+  private async checkDatabase(): Promise<CheckOutcome> {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return { status: 'ok', message: 'Database reachable.' };
+    } catch (err) {
+      return {
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+        actionItem: 'Verify POSTGRES_* env vars and that the database is reachable.',
+      };
+    }
+  }
+
+  private async checkMigrations(): Promise<CheckOutcome> {
+    try {
+      const rows = await this.prisma.$queryRaw<Array<{ n: number }>>`
+        SELECT count(*)::int AS n FROM _prisma_migrations WHERE finished_at IS NULL
+      `;
+      const n = rows[0]?.n ?? 0;
+      if (n > 0) {
+        return {
+          status: 'error',
+          message: `${n} migration(s) not fully applied.`,
+          actionItem: 'Run `npx prisma migrate deploy`.',
+        };
+      }
+      return { status: 'ok', message: 'All migrations applied.' };
+    } catch (err) {
+      return { status: 'error', message: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async checkPgvector(): Promise<CheckOutcome> {
+    try {
+      const [extRows, tableRows] = await Promise.all([
+        this.prisma.$queryRaw<Array<{ ok: number }>>`
+          SELECT 1 AS ok FROM pg_extension WHERE extname = 'vector'
+        `,
+        this.prisma.$queryRaw<Array<{ t: string | null }>>`
+          SELECT to_regclass('public.media_item_embedding') AS t
+        `,
+      ]);
+
+      const extensionPresent = extRows.length > 0;
+      const tablePresent = (tableRows[0]?.t ?? null) !== null;
+
+      if (!extensionPresent || !tablePresent) {
+        return {
+          status: 'error',
+          message: !extensionPresent
+            ? 'pgvector extension is not installed.'
+            : 'media_item_embedding table not found.',
+          actionItem:
+            'Use a pgvector-capable Postgres image (pgvector/pgvector:pg16) and re-run migrations; ' +
+            'semantic search is unavailable without it.',
+        };
+      }
+
+      return { status: 'ok', message: 'pgvector extension and embedding table present.' };
+    } catch (err) {
+      return { status: 'error', message: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async checkSecretsKey(): Promise<CheckOutcome> {
+    const value = process.env['SECRETS_ENCRYPTION_KEY'];
+    if (value) {
+      try {
+        if (Buffer.from(value, 'base64').length === 32) {
+          return { status: 'ok', message: 'Secrets encryption key configured.' };
+        }
+      } catch {
+        // fall through to error below
+      }
+    }
+    return {
+      status: 'error',
+      message: 'SECRETS_ENCRYPTION_KEY is missing or is not a valid base64-encoded 32-byte key.',
+      actionItem: 'Set SECRETS_ENCRYPTION_KEY to a base64-encoded 32-byte key (openssl rand -base64 32).',
+    };
+  }
+
+  private async checkAppUrl(): Promise<CheckOutcome> {
+    const appUrl = process.env['APP_URL'];
+    if (!appUrl) {
+      return { status: 'warning', message: 'APP_URL not set.' };
+    }
+    if (appUrl.includes('localhost') && process.env['NODE_ENV'] === 'production') {
+      return {
+        status: 'warning',
+        message: 'APP_URL is still localhost in production.',
+        actionItem: 'Set APP_URL to the public base URL.',
+      };
+    }
+    return { status: 'ok', message: `APP_URL: ${appUrl}` };
+  }
+
+  // ===========================================================================
+  // Auth checks
+  // ===========================================================================
+
+  private async checkJwtSecret(): Promise<CheckOutcome> {
+    const secret = process.env['JWT_SECRET'];
+    if (secret && secret.length >= 32) {
+      return { status: 'ok', message: 'JWT secret configured.' };
+    }
+    return {
+      status: 'error',
+      message: 'JWT_SECRET is missing or shorter than 32 characters.',
+      actionItem: 'Set JWT_SECRET to a random string of at least 32 characters.',
+    };
+  }
+
+  private async checkGoogleOauth(): Promise<CheckOutcome> {
+    const configured = !!process.env['GOOGLE_CLIENT_ID'] && !!process.env['GOOGLE_CLIENT_SECRET'];
+    if (configured) {
+      return { status: 'ok', message: 'Google OAuth configured.' };
+    }
+    if (process.env['NODE_ENV'] === 'production') {
+      return {
+        status: 'error',
+        message: 'Google OAuth is not configured.',
+        actionItem: 'Configure GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.',
+      };
+    }
+    return { status: 'warning', message: 'Google OAuth not configured (dev fallback only).' };
+  }
+
+  private async checkAdminBootstrap(): Promise<CheckOutcome> {
+    const adminCount = await this.prisma.user.count({
+      where: { userRoles: { some: { role: { name: 'admin' } } } },
+    });
+
+    if (adminCount === 0) {
+      const initialAdminSet = !!process.env['INITIAL_ADMIN_EMAIL'];
+      return {
+        status: 'warning',
+        message: initialAdminSet
+          ? 'No admin users found.'
+          : 'No admin users found. INITIAL_ADMIN_EMAIL is also not set.',
+        actionItem: 'Set INITIAL_ADMIN_EMAIL and have that user sign in.',
+      };
+    }
+
+    return { status: 'ok', message: `${adminCount} admin user(s).` };
+  }
+
+  // ===========================================================================
+  // Storage checks
+  // ===========================================================================
+
+  private resolveActiveStorageProvider(settings: ResolvedSettings): string {
+    return settings.storage?.activeProvider ?? process.env['STORAGE_PROVIDER'] ?? 's3';
+  }
+
+  private async checkActiveStorageProvider(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const provider = this.resolveActiveStorageProvider(settings);
+
+    if (provider === 'local') {
+      return { status: 'ok', message: `Active provider: ${provider}.` };
+    }
+
+    const cred = await this.prisma.storageProviderCredential.findFirst({
+      where: { provider, enabled: true },
+    });
+
+    if (!cred) {
+      return {
+        status: 'error',
+        message: `No enabled credential configured for active storage provider "${provider}".`,
+        actionItem: 'Configure a storage provider in Admin Settings → Storage Providers.',
+      };
+    }
+
+    return { status: 'ok', message: `Active provider: ${provider}.` };
+  }
+
+  private async checkStorageLiveTest(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const provider = this.resolveActiveStorageProvider(settings);
+    const result = await this.storageSettings.testConnection({ provider });
+
+    if (!result.ok) {
+      return {
+        status: 'error',
+        message: result.error ?? 'Storage connectivity test failed.',
+        actionItem: 'Fix storage credentials/bucket in Admin Settings → Storage Providers.',
+      };
+    }
+
+    return {
+      status: 'ok',
+      message: `Write→read→delete round-trip succeeded (bucket ${result.bucket ?? provider}).`,
+    };
+  }
+
+  // ===========================================================================
+  // AI checks
+  // ===========================================================================
+
+  private async checkAiSearch(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const cfg = settings.ai?.features?.search;
+    if (!cfg?.provider || !cfg?.model) {
+      return { status: 'skipped', message: 'AI search not configured.' };
+    }
+
+    const result = await this.aiSettings.testProvider({ provider: cfg.provider, model: cfg.model });
+    if (!result.ok) {
+      return {
+        status: 'error',
+        message: result.error ?? 'AI search provider test failed.',
+        actionItem: 'Check the provider API key and model in Admin Settings → AI.',
+      };
+    }
+    return { status: 'ok', message: `AI search provider "${cfg.provider}" (${cfg.model}) reachable.` };
+  }
+
+  private async checkAiTagging(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const cfg = settings.ai?.features?.tagging;
+    if (!cfg?.provider || !cfg?.model) {
+      return { status: 'skipped', message: 'Auto-tagging provider not configured.' };
+    }
+
+    const result = await this.aiSettings.testProvider({ provider: cfg.provider, model: cfg.model });
+    if (!result.ok) {
+      return {
+        status: 'error',
+        message: result.error ?? 'Auto-tagging provider test failed.',
+        actionItem: 'Check the provider API key and model in Admin Settings → AI.',
+      };
+    }
+    return { status: 'ok', message: `Auto-tagging provider "${cfg.provider}" (${cfg.model}) reachable.` };
+  }
+
+  private async checkAiEmbedding(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const cfg = settings.ai?.features?.embedding;
+    if (!cfg?.provider || !cfg?.model) {
+      return {
+        status: 'skipped',
+        message: 'Embeddings not configured; semantic search falls back to filter-only.',
+      };
+    }
+
+    const result = await this.aiSettings.testEmbedding({});
+    if (!result.ok) {
+      return {
+        status: 'error',
+        message: result.error ?? 'Embedding provider test failed.',
+        actionItem: 'Check the provider API key and model in Admin Settings → AI.',
+      };
+    }
+    if (result.warning) {
+      return { status: 'warning', message: result.warning };
+    }
+    return { status: 'ok', message: `Embeddings OK (${result.dimensions}-d).` };
+  }
+
+  private async checkAiFlagConsistency(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const autoTaggingEnabled = settings.features?.['autoTagging'] === true;
+    const taggingConfigured = !!settings.ai?.features?.tagging?.provider;
+
+    if (autoTaggingEnabled && !taggingConfigured) {
+      return {
+        status: 'error',
+        message: 'Auto-Tagging is enabled but no tagging provider is configured.',
+        actionItem: 'Configure a tagging provider or disable the Auto-Tagging feature flag.',
+      };
+    }
+
+    if (taggingConfigured && !autoTaggingEnabled) {
+      return {
+        status: 'warning',
+        message: 'Tagging provider configured but the Auto-Tagging feature flag is off.',
+        actionItem: 'Enable Auto-Tagging in Admin Settings → Tagging if desired.',
+      };
+    }
+
+    return { status: 'ok', message: 'Auto-Tagging flag and provider configuration are consistent.' };
+  }
+
+  // ===========================================================================
+  // Face checks
+  // ===========================================================================
+
+  private async checkFaceDetection(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const faceRecognitionEnabled = settings.features?.['faceRecognition'] === true;
+    const detection = settings.face?.features?.detection;
+    const provider = detection?.provider;
+
+    if (faceRecognitionEnabled && !provider) {
+      return {
+        status: 'error',
+        message: 'Face Recognition is enabled but no detection provider is configured.',
+        actionItem: 'Configure a face detection provider or disable Face Recognition.',
+      };
+    }
+
+    if (provider) {
+      const result = await this.faceSettings.testProvider({ provider });
+      if (!result.ok) {
+        return {
+          status: 'error',
+          message: result.error ?? 'Face detection provider test failed.',
+          actionItem: 'Check the provider configuration in Admin Settings → Face.',
+        };
+      }
+      return { status: 'ok', message: `Face detection provider "${provider}" reachable.` };
+    }
+
+    return { status: 'skipped', message: 'Face recognition disabled.' };
+  }
+
+  private async checkFaceFlagConsistency(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const faceRecognitionEnabled = settings.features?.['faceRecognition'] === true;
+    const provider = settings.face?.features?.detection?.provider;
+
+    if (provider && !faceRecognitionEnabled) {
+      return {
+        status: 'warning',
+        message: 'Face provider configured but Face Recognition feature flag is off.',
+        actionItem: 'Enable Face Recognition in Admin Settings → Face if desired.',
+      };
+    }
+
+    if (faceRecognitionEnabled) {
+      return { status: 'ok', message: 'Face Recognition flag and provider configuration are consistent.' };
+    }
+
+    return { status: 'skipped', message: 'Face recognition disabled.' };
+  }
+
+  // ===========================================================================
+  // Geo checks
+  // ===========================================================================
+
+  private async checkGeoReverseProvider(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const provider = settings.geo?.reverseProvider ?? process.env['GEO_PROVIDER'] ?? 'offline';
+    const result = await this.geoSettings.testProvider({
+      provider: provider as 'offline' | 'nominatim' | 'google',
+    });
+
+    if (!result.ok) {
+      return {
+        status: 'error',
+        message: result.error ?? 'Reverse geocoding provider test failed.',
+        actionItem: 'Configure the geo provider credentials in Admin Settings → Geo.',
+      };
+    }
+
+    return { status: 'ok', message: `Provider ${provider} responding.` };
+  }
+
+  // ===========================================================================
+  // Jobs checks
+  // ===========================================================================
+
+  private async checkWorkerEnabled(settings: ResolvedSettings): Promise<CheckOutcome> {
+    const enabled = isEnrichmentWorkerEnabled();
+    if (enabled) {
+      return { status: 'ok', message: 'Enrichment worker is enabled.' };
+    }
+
+    const anyEnrichmentFeatureOn =
+      settings.features?.['autoTagging'] === true ||
+      settings.features?.['faceRecognition'] === true ||
+      settings.features?.['burstDetection'] === true;
+
+    if (anyEnrichmentFeatureOn) {
+      return {
+        status: 'error',
+        message: 'Enrichment worker is disabled but at least one enrichment feature flag is on.',
+        actionItem: 'Set ENRICHMENT_WORKER_ENABLED=true so enrichment jobs get processed.',
+      };
+    }
+
+    return { status: 'warning', message: 'Enrichment worker is disabled.' };
+  }
+
+  private async checkQueueHealth(): Promise<CheckOutcome> {
+    const stats = await this.enrichmentAdmin.getStats();
+
+    if (stats.stuckRunning > 0) {
+      return {
+        status: 'warning',
+        message: `${stats.stuckRunning} job(s) stuck running.`,
+        actionItem: 'Reset stuck jobs from the Job Queue page.',
+      };
+    }
+
+    if (stats.byStatus.failed > 0) {
+      return {
+        status: 'warning',
+        message: `${stats.byStatus.failed} failed job(s) in the queue.`,
+        actionItem: 'Review and retry failed jobs from the Job Queue page.',
+      };
+    }
+
+    return {
+      status: 'ok',
+      message: `Queue healthy (pending ${stats.byStatus.pending}, running ${stats.byStatus.running}).`,
+    };
+  }
+
+  private async checkBurstConfig(settings: ResolvedSettings): Promise<CheckOutcome> {
+    if (settings.features?.['burstDetection'] !== true) {
+      return { status: 'skipped', message: 'Burst detection disabled.' };
+    }
+    return {
+      status: 'ok',
+      message: 'Burst detection enabled (no provider required; depends on the enrichment worker).',
     };
   }
 }

--- a/apps/api/src/doctor/doctor.service.ts
+++ b/apps/api/src/doctor/doctor.service.ts
@@ -1,0 +1,52 @@
+// =============================================================================
+// Doctor Service
+// =============================================================================
+//
+// On-demand configuration health sweep for admins. Runs a fixed catalog of
+// checks across core infra, auth, storage, AI, face, geo, and the job queue —
+// concurrently, with a per-check timeout and exception normalization. No
+// result is persisted; every call recomputes the report from scratch.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { AiSettingsService } from '../ai/ai-settings.service';
+import { FaceSettingsService } from '../face/face-settings.service';
+import { GeoSettingsService } from '../geo/geo-settings.service';
+import { StorageSettingsService } from '../storage-settings/storage-settings.service';
+import { EnrichmentAdminService } from '../enrichment/enrichment-admin.service';
+import { DoctorReport } from './doctor.types';
+
+@Injectable()
+export class DoctorService {
+  private readonly logger = new Logger(DoctorService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly systemSettings: SystemSettingsService,
+    private readonly aiSettings: AiSettingsService,
+    private readonly faceSettings: FaceSettingsService,
+    private readonly geoSettings: GeoSettingsService,
+    private readonly storageSettings: StorageSettingsService,
+    private readonly enrichmentAdmin: EnrichmentAdminService,
+  ) {}
+
+  /**
+   * Run the full diagnostics sweep.
+   *
+   * TODO: this is a scaffolding stub — the 20-check catalog is implemented in
+   * a follow-up commit. Returns a structurally valid, empty report for now.
+   */
+  async runDiagnostics(): Promise<DoctorReport> {
+    const start = Date.now();
+    this.logger.debug('Doctor: runDiagnostics stub invoked');
+
+    return {
+      computedAt: new Date().toISOString(),
+      durationMs: Date.now() - start,
+      summary: { ok: 0, warning: 0, error: 0, skipped: 0, total: 0 },
+      sections: [],
+    };
+  }
+}

--- a/apps/api/src/doctor/doctor.types.ts
+++ b/apps/api/src/doctor/doctor.types.ts
@@ -1,0 +1,33 @@
+// =============================================================================
+// Doctor Diagnostics — Types
+// =============================================================================
+//
+// Report contract for the admin "Doctor" configuration health sweep.
+// Pure on-demand computation — no DB persistence, no cron.
+// =============================================================================
+
+export type DoctorCheckStatus = 'ok' | 'warning' | 'error' | 'skipped';
+
+export interface DoctorCheck {
+  key: string;
+  label: string;
+  status: DoctorCheckStatus;
+  message: string;
+  actionItem?: string;
+  durationMs: number;
+}
+
+export interface DoctorSection {
+  key: string;
+  label: string;
+  /** Worst status among its checks; 'skipped' counts as 'ok' for aggregation. */
+  status: DoctorCheckStatus;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorReport {
+  computedAt: string;
+  durationMs: number;
+  summary: { ok: number; warning: number; error: number; skipped: number; total: number };
+  sections: DoctorSection[];
+}

--- a/apps/api/src/enrichment/enrichment-job.worker.ts
+++ b/apps/api/src/enrichment/enrichment-job.worker.ts
@@ -17,6 +17,22 @@ function getEnvInt(key: string, defaultValue: number): number {
   return isNaN(parsed) ? defaultValue : parsed;
 }
 
+/**
+ * Whether the shared enrichment worker is enabled, per env-var kill-switches.
+ * Checks both the current `ENRICHMENT_WORKER_ENABLED` var and the legacy
+ * `FACE_WORKER_ENABLED` alias for backwards compatibility — either one set to
+ * 'false' disables the worker.
+ *
+ * Extracted as a pure function (rather than inlined in onModuleInit) so other
+ * consumers — e.g. DoctorService's diagnostics sweep — can check the same
+ * enabled/disabled state without duplicating the boolean logic.
+ */
+export function isEnrichmentWorkerEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const enrichmentEnabled = env['ENRICHMENT_WORKER_ENABLED'];
+  const faceEnabled = env['FACE_WORKER_ENABLED'];
+  return !(enrichmentEnabled === 'false' || faceEnabled === 'false');
+}
+
 // Normal-failure retry config
 const MAX_ATTEMPTS = getEnvInt('ENRICHMENT_MAX_ATTEMPTS', 3);
 const RETRY_BASE_MS = getEnvInt('ENRICHMENT_RETRY_BASE_MS', 2_000);
@@ -41,9 +57,7 @@ export class EnrichmentJobWorker implements OnModuleInit, OnModuleDestroy {
 
   onModuleInit(): void {
     // Check both new and legacy env vars for backwards compatibility
-    const enrichmentEnabled = process.env['ENRICHMENT_WORKER_ENABLED'];
-    const faceEnabled = process.env['FACE_WORKER_ENABLED'];
-    if (enrichmentEnabled === 'false' || faceEnabled === 'false') {
+    if (!isEnrichmentWorkerEnabled()) {
       this.logger.log('EnrichmentJobWorker disabled via env var');
       return;
     }

--- a/apps/api/src/enrichment/enrichment.module.ts
+++ b/apps/api/src/enrichment/enrichment.module.ts
@@ -24,6 +24,6 @@ import { SettingsModule } from '../settings/settings.module';
     JobHistoryPurgeHandler,
     JobHistoryPurgeTask,
   ],
-  exports: [EnrichmentJobService, EnrichmentHandlerRegistry],
+  exports: [EnrichmentJobService, EnrichmentHandlerRegistry, EnrichmentAdminService],
 })
 export class EnrichmentModule {}

--- a/apps/api/src/geo/geo.module.ts
+++ b/apps/api/src/geo/geo.module.ts
@@ -14,6 +14,6 @@ import { CirclesModule } from '../circles/circles.module';
   imports: [GeoLocationModule, SettingsModule, EnrichmentModule, CirclesModule],
   controllers: [GeoSettingsController, GeocodeAdminController, GeocodeMediaController],
   providers: [GeoSettingsService, GeocodeBackfillService, GeocodeHandler],
-  exports: [GeocodeBackfillService],
+  exports: [GeocodeBackfillService, GeoSettingsService],
 })
 export class GeoModule {}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ const FaceSettingsPage = lazy(() => import('./pages/Admin/FaceSettingsPage'));
 const GeoSettingsPage = lazy(() => import('./pages/Admin/GeoSettingsPage'));
 const JobsPage = lazy(() => import('./pages/Admin/JobsPage'));
 const JobInsightsPage = lazy(() => import('./pages/Admin/JobInsightsPage'));
+const DoctorPage = lazy(() => import('./pages/Admin/DoctorPage'));
 const StorageInsightsPage = lazy(() => import('./pages/Admin/StorageInsightsPage'));
 const StorageProvidersPage = lazy(() => import('./pages/Admin/StorageProvidersPage'));
 const SettingsHubPage = lazy(() => import('./pages/Admin/SettingsHubPage'));
@@ -95,6 +96,7 @@ function AppRoutes() {
                 <Route path="/admin/settings/storage/insights" element={<StorageInsightsPage />} />
                 <Route path="/admin/settings/jobs" element={<JobsPage />} />
                 <Route path="/admin/settings/jobs/insights" element={<JobInsightsPage />} />
+                <Route path="/admin/settings/doctor" element={<DoctorPage />} />
                 <Route path="/admin/settings/backup" element={<BackupPage />} />
                 <Route path="/admin/settings/sharing" element={<PublicSharesPage />} />
                 {/* Legacy admin route redirects */}

--- a/apps/web/src/__tests__/pages/DoctorPage.test.tsx
+++ b/apps/web/src/__tests__/pages/DoctorPage.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for DoctorPage (Admin/DoctorPage.tsx).
+ *
+ * Mocking strategy:
+ *   - usePermissions is module-mocked to control admin state.
+ *   - useDoctor is module-mocked to control the diagnostics report, loading,
+ *     error, and run() directly — no network/service calls are made.
+ *
+ * The page redirects non-admins to /. Admins see:
+ *   - A "Doctor — Diagnostics" heading.
+ *   - A "Run diagnostics" button.
+ *   - A loading spinner on first load (loading && !report).
+ *   - An error alert when the initial load fails (error && !report).
+ *   - A summary Stack of Chips (overall status + OK/Warning/Error/Skipped counts).
+ *   - One Paper per section with per-check rows (label + message + optional
+ *     inline action-item Alert).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { render, mockAdminUser } from '../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before imports of the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../../hooks/useDoctor', () => ({
+  useDoctor: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import DoctorPage from '../../pages/Admin/DoctorPage';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useDoctor } from '../../hooks/useDoctor';
+import type { DoctorReport } from '../../services/doctor';
+
+const mockUsePermissions = vi.mocked(usePermissions);
+const mockUseDoctor = vi.mocked(useDoctor);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminPermissions() {
+  return {
+    isAdmin: true,
+    permissions: new Set(['system_settings:read', 'system_settings:write']),
+    roles: new Set(['admin']),
+    hasPermission: vi.fn().mockReturnValue(true),
+    hasAnyPermission: vi.fn().mockReturnValue(true),
+    hasAllPermissions: vi.fn().mockReturnValue(true),
+    hasRole: vi.fn().mockReturnValue(true),
+    hasAnyRole: vi.fn().mockReturnValue(true),
+  };
+}
+
+function nonAdminPermissions() {
+  return {
+    isAdmin: false,
+    permissions: new Set<string>(),
+    roles: new Set<string>(),
+    hasPermission: vi.fn().mockReturnValue(false),
+    hasAnyPermission: vi.fn().mockReturnValue(false),
+    hasAllPermissions: vi.fn().mockReturnValue(false),
+    hasRole: vi.fn().mockReturnValue(false),
+    hasAnyRole: vi.fn().mockReturnValue(false),
+  };
+}
+
+/**
+ * Builds a realistic DoctorReport fixture with mixed statuses across
+ * multiple sections, including one check with an actionItem.
+ */
+function makeReport(overrides: Partial<DoctorReport> = {}): DoctorReport {
+  return {
+    computedAt: new Date('2026-07-03T12:00:00Z').toISOString(),
+    durationMs: 842,
+    summary: {
+      ok: 3,
+      warning: 1,
+      error: 1,
+      skipped: 1,
+      total: 6,
+    },
+    sections: [
+      {
+        key: 'auth',
+        label: 'Authentication',
+        status: 'ok',
+        checks: [
+          {
+            key: 'jwt-secret',
+            label: 'JWT secret configured',
+            status: 'ok',
+            message: 'JWT_SECRET is set and meets minimum length.',
+            durationMs: 5,
+          },
+          {
+            key: 'google-oauth',
+            label: 'Google OAuth configured',
+            status: 'ok',
+            message: 'Google client ID and secret are present.',
+            durationMs: 4,
+          },
+        ],
+      },
+      {
+        key: 'storage',
+        label: 'Storage',
+        status: 'error',
+        checks: [
+          {
+            key: 'active-provider',
+            label: 'Active storage provider reachable',
+            status: 'error',
+            message: 'Could not connect to the configured S3 bucket.',
+            actionItem: 'Check storage credentials in Admin Settings → Storage Providers.',
+            durationMs: 120,
+          },
+          {
+            key: 'disk-space',
+            label: 'Local disk space',
+            status: 'ok',
+            message: 'Sufficient disk space available.',
+            durationMs: 10,
+          },
+        ],
+      },
+      {
+        key: 'jobs',
+        label: 'Background Jobs',
+        status: 'warning',
+        checks: [
+          {
+            key: 'stuck-jobs',
+            label: 'No stuck jobs',
+            status: 'warning',
+            message: '2 jobs have been running for over 15 minutes.',
+            durationMs: 30,
+          },
+          {
+            key: 'ai-provider',
+            label: 'AI provider configured',
+            status: 'skipped',
+            message: 'Auto-tagging is disabled; check skipped.',
+            durationMs: 1,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeDoctorHookResult(
+  opts: {
+    report?: DoctorReport | null;
+    loading?: boolean;
+    error?: string | null;
+    run?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  return {
+    report: opts.report !== undefined ? opts.report : null,
+    loading: opts.loading ?? false,
+    error: opts.error ?? null,
+    run: opts.run ?? vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DoctorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePermissions.mockReturnValue(adminPermissions() as ReturnType<typeof usePermissions>);
+    mockUseDoctor.mockReturnValue(makeDoctorHookResult() as ReturnType<typeof useDoctor>);
+  });
+
+  // -------------------------------------------------------------------------
+  describe('access control', () => {
+    it('redirects non-admin users to / and does not render the page heading', () => {
+      mockUsePermissions.mockReturnValue(nonAdminPermissions() as ReturnType<typeof usePermissions>);
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.queryByText(/doctor.*diagnostics/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('loading state', () => {
+    it('shows a loading spinner on first load (no report yet)', () => {
+      mockUseDoctor.mockReturnValue(
+        makeDoctorHookResult({ report: null, loading: true, error: null }) as ReturnType<typeof useDoctor>,
+      );
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('error state', () => {
+    it('shows an error alert when the initial load fails (no report)', () => {
+      mockUseDoctor.mockReturnValue(
+        makeDoctorHookResult({ report: null, loading: false, error: 'boom' }) as ReturnType<typeof useDoctor>,
+      );
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText('boom')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('rendering a report', () => {
+    it('renders the page title, sections, checks, action items, and summary chips', () => {
+      const report = makeReport();
+      mockUseDoctor.mockReturnValue(
+        makeDoctorHookResult({ report, loading: false, error: null }) as ReturnType<typeof useDoctor>,
+      );
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      // Page title
+      expect(screen.getByText(/doctor.*diagnostics/i)).toBeInTheDocument();
+
+      // Section labels
+      expect(screen.getByText('Authentication')).toBeInTheDocument();
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Background Jobs')).toBeInTheDocument();
+
+      // A check label + message
+      expect(screen.getByText('JWT secret configured')).toBeInTheDocument();
+      expect(screen.getByText('JWT_SECRET is set and meets minimum length.')).toBeInTheDocument();
+
+      // Action item text, rendered inside an Alert
+      const actionItemText = screen.getByText(
+        /check storage credentials in admin settings/i,
+      );
+      expect(actionItemText).toBeInTheDocument();
+      expect(actionItemText.closest('.MuiAlert-root')).not.toBeNull();
+
+      // Summary chips
+      expect(screen.getByText(/OK: 3/)).toBeInTheDocument();
+      expect(screen.getByText(/Warning: 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Error: 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Skipped: 1/)).toBeInTheDocument();
+
+      // Overall status chip — report has an error present, so "Unhealthy"
+      expect(screen.getByText('Unhealthy')).toBeInTheDocument();
+    });
+
+    it('shows "Healthy" overall status when there are no warnings or errors', () => {
+      const report = makeReport({
+        summary: { ok: 4, warning: 0, error: 0, skipped: 0, total: 4 },
+      });
+      mockUseDoctor.mockReturnValue(
+        makeDoctorHookResult({ report, loading: false, error: null }) as ReturnType<typeof useDoctor>,
+      );
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText('Healthy')).toBeInTheDocument();
+    });
+
+    it('shows "Needs attention" overall status when there are warnings but no errors', () => {
+      const report = makeReport({
+        summary: { ok: 4, warning: 2, error: 0, skipped: 0, total: 6 },
+      });
+      mockUseDoctor.mockReturnValue(
+        makeDoctorHookResult({ report, loading: false, error: null }) as ReturnType<typeof useDoctor>,
+      );
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('run button', () => {
+    it('calls run() when the "Run diagnostics" button is clicked', () => {
+      const run = vi.fn().mockResolvedValue(undefined);
+      const report = makeReport();
+      mockUseDoctor.mockReturnValue(
+        makeDoctorHookResult({ report, loading: false, error: null, run }) as ReturnType<typeof useDoctor>,
+      );
+
+      render(<DoctorPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      fireEvent.click(screen.getByRole('button', { name: /run diagnostics/i }));
+
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/hooks/useDoctor.ts
+++ b/apps/web/src/hooks/useDoctor.ts
@@ -1,0 +1,35 @@
+import { useState, useCallback, useEffect } from 'react';
+import { runDoctor } from '../services/doctor';
+import type { DoctorReport } from '../services/doctor';
+
+export interface UseDoctorResult {
+  report: DoctorReport | null;
+  loading: boolean;
+  error: string | null;
+  run: () => Promise<void>;
+}
+
+export function useDoctor(): UseDoctorResult {
+  const [report, setReport] = useState<DoctorReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await runDoctor();
+      setReport(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to run diagnostics');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void run();
+  }, [run]);
+
+  return { report, loading, error, run };
+}

--- a/apps/web/src/pages/Admin/DoctorPage.tsx
+++ b/apps/web/src/pages/Admin/DoctorPage.tsx
@@ -1,0 +1,213 @@
+import { Navigate, Link as RouterLink } from 'react-router-dom';
+import {
+  Container,
+  Box,
+  Typography,
+  Paper,
+  Chip,
+  Stack,
+  Button,
+  CircularProgress,
+  Alert,
+  Link,
+} from '@mui/material';
+import {
+  MonitorHeart as MonitorHeartIcon,
+  Refresh as RefreshIcon,
+  CheckCircle as CheckCircleIcon,
+  WarningAmber as WarningAmberIcon,
+  Error as ErrorIcon,
+  RemoveCircleOutlined as RemoveCircleOutlineIcon,
+} from '@mui/icons-material';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useDoctor } from '../../hooks/useDoctor';
+import type { DoctorCheck, DoctorCheckStatus, DoctorSection } from '../../services/doctor';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_META: Record<
+  DoctorCheckStatus,
+  {
+    icon: React.ReactElement;
+    chipColor: 'success' | 'warning' | 'error' | 'default';
+    alertSeverity: 'success' | 'warning' | 'error' | 'info';
+  }
+> = {
+  ok: { icon: <CheckCircleIcon color="success" />, chipColor: 'success', alertSeverity: 'success' },
+  warning: { icon: <WarningAmberIcon color="warning" />, chipColor: 'warning', alertSeverity: 'warning' },
+  error: { icon: <ErrorIcon color="error" />, chipColor: 'error', alertSeverity: 'error' },
+  skipped: { icon: <RemoveCircleOutlineIcon color="disabled" />, chipColor: 'default', alertSeverity: 'info' },
+};
+
+function StatusChip({ status }: { status: DoctorCheckStatus }) {
+  return (
+    <Chip
+      label={status}
+      color={STATUS_META[status]?.chipColor ?? 'default'}
+      size="small"
+      variant="outlined"
+    />
+  );
+}
+
+function CheckRow({ check }: { check: DoctorCheck }) {
+  const meta = STATUS_META[check.status];
+  return (
+    <Box sx={{ mb: 1.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {meta.icon}
+        <Typography component="span" sx={{ fontWeight: 600 }}>
+          {check.label}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {check.message}
+        </Typography>
+      </Box>
+      {check.actionItem && (
+        <Alert severity={meta.alertSeverity} sx={{ mt: 1 }}>
+          {check.actionItem}
+        </Alert>
+      )}
+    </Box>
+  );
+}
+
+function SectionCard({ section }: { section: DoctorSection }) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Typography variant="h6">{section.label}</Typography>
+        <StatusChip status={section.status} />
+      </Box>
+      {section.checks.map((check) => (
+        <CheckRow key={check.key} check={check} />
+      ))}
+    </Paper>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main content (admin-gated wrapper below)
+// ---------------------------------------------------------------------------
+
+function DoctorPageContent() {
+  const { report, loading, error, run } = useDoctor();
+
+  if (loading && !report) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error && !report) {
+    return (
+      <Alert severity="error" sx={{ m: 3 }}>
+        {error}
+      </Alert>
+    );
+  }
+
+  const summary = report?.summary;
+  const overallStatus =
+    summary && summary.error > 0
+      ? { label: 'Unhealthy', color: 'error' as const }
+      : summary && summary.warning > 0
+      ? { label: 'Needs attention', color: 'warning' as const }
+      : { label: 'Healthy', color: 'success' as const };
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ py: 4 }}>
+        {/* Back link */}
+        <Link
+          component={RouterLink}
+          to="/admin/settings"
+          underline="hover"
+          variant="body2"
+          sx={{ display: 'inline-block', mb: 2 }}
+        >
+          &larr; Back to Settings
+        </Link>
+
+        {/* Page header */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: { xs: 'flex-start', sm: 'center' },
+            justifyContent: 'space-between',
+            flexDirection: { xs: 'column', sm: 'row' },
+            gap: 1,
+            mb: 1,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <MonitorHeartIcon color="primary" />
+            <Typography variant="h4" component="h1">
+              Doctor &mdash; Diagnostics
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            onClick={() => void run()}
+            disabled={loading}
+            startIcon={loading ? <CircularProgress size={16} /> : <RefreshIcon />}
+          >
+            Run diagnostics
+          </Button>
+        </Box>
+        <Typography color="text.secondary" sx={{ mb: 3 }}>
+          Run configuration health checks across auth, storage, AI providers, and background jobs.
+        </Typography>
+
+        {/* Inline error (report already loaded, a re-run failed) */}
+        {error && report && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {report && (
+          <>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Computed {new Date(report.computedAt).toLocaleString()} &middot; {report.durationMs} ms
+            </Typography>
+
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={1}
+              sx={{ mb: 3, flexWrap: 'wrap' }}
+            >
+              <Chip label={overallStatus.label} color={overallStatus.color} />
+              <Chip label={`OK: ${summary!.ok}`} color="success" variant="outlined" />
+              <Chip label={`Warning: ${summary!.warning}`} color="warning" variant="outlined" />
+              <Chip label={`Error: ${summary!.error}`} color="error" variant="outlined" />
+              <Chip label={`Skipped: ${summary!.skipped}`} color="default" variant="outlined" />
+            </Stack>
+
+            {report.sections.map((section) => (
+              <SectionCard key={section.key} section={section} />
+            ))}
+          </>
+        )}
+      </Box>
+    </Container>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Admin-gated export (mirrors JobsPage / FaceSettingsPage pattern)
+// ---------------------------------------------------------------------------
+
+export default function DoctorPage() {
+  const { isAdmin } = usePermissions();
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <DoctorPageContent />;
+}

--- a/apps/web/src/pages/Admin/SettingsHubPage.tsx
+++ b/apps/web/src/pages/Admin/SettingsHubPage.tsx
@@ -23,6 +23,7 @@ import {
   Archive as ArchiveIcon,
   QueryStats as QueryStatsIcon,
   Public as PublicIcon,
+  MonitorHeart as MonitorHeartIcon,
 } from '@mui/icons-material';
 import { usePermissions } from '../../hooks/usePermissions';
 
@@ -171,6 +172,13 @@ export default function SettingsHubPage() {
           icon: <PublicIcon sx={{ fontSize: 40 }} color="primary" />,
           path: '/admin/settings/sharing',
           permission: 'shares:manage_any',
+        },
+        {
+          title: 'Doctor',
+          description: 'Run configuration health diagnostics and see required action items',
+          icon: <MonitorHeartIcon sx={{ fontSize: 40 }} color="primary" />,
+          path: '/admin/settings/doctor',
+          permission: 'system_settings:read',
         },
       ],
     },

--- a/apps/web/src/services/doctor.ts
+++ b/apps/web/src/services/doctor.ts
@@ -1,0 +1,44 @@
+import { api } from './api';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DoctorCheckStatus = 'ok' | 'warning' | 'error' | 'skipped';
+
+export interface DoctorCheck {
+  key: string;
+  label: string;
+  status: DoctorCheckStatus;
+  message: string;
+  actionItem?: string;
+  durationMs: number;
+}
+
+export interface DoctorSection {
+  key: string;
+  label: string;
+  status: DoctorCheckStatus;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorReport {
+  computedAt: string;
+  durationMs: number;
+  summary: {
+    ok: number;
+    warning: number;
+    error: number;
+    skipped: number;
+    total: number;
+  };
+  sections: DoctorSection[];
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+export async function runDoctor(): Promise<DoctorReport> {
+  return api.post<DoctorReport>('/admin/doctor/run', {});
+}

--- a/docs/specs/doctor.md
+++ b/docs/specs/doctor.md
@@ -1,0 +1,324 @@
+# Doctor Diagnostics — End-to-End Reference
+
+| Field | Value |
+|-------|-------|
+| **Version** | 1.0 |
+| **Last Updated** | July 2026 |
+| **Status** | Implemented |
+
+---
+
+## Table of Contents
+
+1. [Overview and Goals](#1-overview-and-goals)
+2. [Response Shape](#2-response-shape)
+3. [Status Semantics](#3-status-semantics)
+4. [Check Catalog](#4-check-catalog)
+5. [`runCheck` Design](#5-runcheck-design)
+6. [Reuse of Existing Services](#6-reuse-of-existing-services)
+7. [API Endpoint and RBAC](#7-api-endpoint-and-rbac)
+8. [Frontend Page](#8-frontend-page)
+9. [Gotchas and Implementation Notes](#9-gotchas-and-implementation-notes)
+
+---
+
+## 1. Overview and Goals
+
+Doctor is an admin-only, on-demand configuration health sweep. A single button click (or `POST` call) runs roughly twenty checks across core infrastructure, authentication, storage, AI, face recognition, geo, and the job queue, and returns a structured `DoctorReport`. It exists to give admins one place to verify that the application is correctly configured — instead of manually cross-checking environment variables, system settings, and provider credentials across half a dozen separate admin pages.
+
+A common failure mode Doctor is designed to catch: a feature flag is turned on (e.g. `features.autoTagging`) but the corresponding provider was never configured, so uploads silently enqueue jobs that will fail forever. Doctor's flag-consistency checks surface this class of misconfiguration directly, with an actionable next step.
+
+### Goals
+
+- Single place to verify configuration health across the database, pgvector, storage, AI, face, geo, and the enrichment job queue.
+- Actually exercise live provider connectivity (not just "is a credential present") by reusing each domain's existing "test connection" service.
+- Surface flag/provider inconsistencies (feature enabled with no provider, or provider configured with the feature off) that are otherwise invisible until something fails silently in the background.
+- Stay fast and safe: run all checks concurrently, bound every check to a hard timeout, and never let one hung or throwing check take down the whole sweep.
+- No new persistence, no new schedule — every call is a fresh, on-demand computation.
+
+### Non-Goals
+
+- No history or trend tracking — Doctor does not store past reports. Each call is independent.
+- No automatic remediation — Doctor only reports; the admin acts on the `actionItem` text manually (e.g. in the AI/Face/Geo/Storage settings pages).
+- Not a substitute for the Job Queue Insights or Storage Insights dashboards — Doctor's job-queue check is a coarse pending/running/failed/stuck health signal, not a durations/ETA breakdown.
+
+---
+
+## 2. Response Shape
+
+**File:** `apps/api/src/doctor/doctor.types.ts`
+
+```typescript
+export type DoctorCheckStatus = 'ok' | 'warning' | 'error' | 'skipped';
+
+export interface DoctorCheck {
+  key: string;
+  label: string;
+  status: DoctorCheckStatus;
+  message: string;
+  actionItem?: string;
+  durationMs: number;
+}
+
+export interface DoctorSection {
+  key: string;
+  label: string;
+  /** Worst status among its checks; 'skipped' counts as 'ok' for aggregation. */
+  status: DoctorCheckStatus;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorReport {
+  computedAt: string;
+  durationMs: number;
+  summary: { ok: number; warning: number; error: number; skipped: number; total: number };
+  sections: DoctorSection[];
+}
+```
+
+Example response (`POST /api/admin/doctor/run`):
+
+```json
+{
+  "computedAt": "2026-07-03T12:00:00.000Z",
+  "durationMs": 842,
+  "summary": { "ok": 16, "warning": 2, "error": 1, "skipped": 1, "total": 20 },
+  "sections": [
+    {
+      "key": "ai",
+      "label": "AI & Enrichment",
+      "status": "error",
+      "checks": [
+        {
+          "key": "ai.flagConsistency",
+          "label": "Auto-tagging flag consistency",
+          "status": "error",
+          "message": "Auto-Tagging is enabled but no tagging provider is configured.",
+          "actionItem": "Configure a tagging provider or disable the Auto-Tagging feature flag.",
+          "durationMs": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 3. Status Semantics
+
+| Status | Meaning |
+|--------|---------|
+| `ok` | The check passed; configuration is healthy. |
+| `warning` | Non-fatal issue — something is inconsistent or suboptimal but not blocking (e.g. a provider is configured but its feature flag is off; `APP_URL` still points at `localhost` in production). |
+| `error` | The check failed in a way that blocks correct operation; always carries an `actionItem` telling the admin what to do. |
+| `skipped` | The check intentionally did not run because the feature it covers is turned off (e.g. face recognition disabled). **Never treated as a failure.** |
+
+### Aggregation
+
+- **Section status** = the worst status among its checks, where `error` > `warning` > `ok`, and `skipped` counts as `ok` for this purpose (`DoctorService.worstStatus`). A section made entirely of `skipped` checks reports `ok`.
+- **Summary counts** (`summary.ok/warning/error/skipped/total`) are a flat tally across all checks regardless of section, computed by incrementing `summary[c.status]` for every check.
+- **Overall report status** is not a field on `DoctorReport` itself — the frontend derives it from `summary`: any `error` → "Unhealthy", else any `warning` → "Needs attention", else → "Healthy" (see `DoctorPage.tsx`).
+
+---
+
+## 4. Check Catalog
+
+Twenty checks across seven sections, defined in `DoctorService.runDiagnostics()` (`apps/api/src/doctor/doctor.service.ts`). Section status is the worst of its listed checks.
+
+### Core (`core`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `core.database` | Database connectivity | `SELECT 1` against Postgres via Prisma | `error` — "Verify POSTGRES_* env vars and that the database is reachable." |
+| `core.migrations` | Migrations applied | `_prisma_migrations` has no row with `finished_at IS NULL` | `error` — "Run `npx prisma migrate deploy`." |
+| `core.pgvector` | pgvector extension | `pg_extension` contains `vector` AND `to_regclass('public.media_item_embedding')` resolves | `error` — "Use a pgvector-capable Postgres image (pgvector/pgvector:pg16) and re-run migrations; semantic search is unavailable without it." |
+| `core.secretsKey` | Secrets encryption key | `SECRETS_ENCRYPTION_KEY` is set and base64-decodes to exactly 32 bytes | `error` — "Set SECRETS_ENCRYPTION_KEY to a base64-encoded 32-byte key (openssl rand -base64 32)." |
+| `core.appUrl` | App URL | `APP_URL` is set; warns if it still contains `localhost` while `NODE_ENV=production` | `warning` (both branches — unset, or localhost-in-prod) |
+
+### Authentication (`auth`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `auth.jwt` | JWT secret | `JWT_SECRET` is set and at least 32 characters | `error` — "Set JWT_SECRET to a random string of at least 32 characters." |
+| `auth.googleOauth` | Google OAuth | `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are both set | `error` in production ("Configure GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET."); `warning` ("dev fallback only") outside production |
+| `auth.adminBootstrap` | Admin bootstrap | At least one user holds the `admin` role | `warning` — "Set INITIAL_ADMIN_EMAIL and have that user sign in." (message notes whether `INITIAL_ADMIN_EMAIL` is even set) |
+
+### Storage (`storage`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `storage.activeProvider` | Active storage provider | The resolved active provider (`storage.activeProvider` setting, else `STORAGE_PROVIDER` env, else `s3`) is `local`, or has an `enabled` row in `storage_provider_credentials` | `error` — "Configure a storage provider in Admin Settings → Storage Providers." |
+| `storage.liveTest` | Storage connectivity | Live write→read→delete round-trip via `StorageSettingsService.testConnection()` against the active provider | `error` with the service's own error message — "Fix storage credentials/bucket in Admin Settings → Storage Providers." |
+
+### AI & Enrichment (`ai`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `ai.search` | AI search provider | If `ai.features.search` is configured, live connectivity via `AiSettingsService.testProvider()`; `skipped` if not configured | `error` — "Check the provider API key and model in Admin Settings → AI." |
+| `ai.tagging` | Auto-tagging provider | Same live test against `ai.features.tagging`; `skipped` if not configured | `error` — same action item as above |
+| `ai.embedding` | Text embedding provider | Live test via `AiSettingsService.testEmbedding()` against `ai.features.embedding`; `skipped` if not configured; downgrades to `warning` if the provider returns a dimension `warning` | `error` — same action item as above |
+| `ai.flagConsistency` | Auto-tagging flag consistency | Cross-checks `features.autoTagging` against whether a tagging provider is configured | `error` if flag on / no provider — "Configure a tagging provider or disable the Auto-Tagging feature flag."; `warning` if provider configured / flag off — "Enable Auto-Tagging in Admin Settings → Tagging if desired." |
+
+### Face Recognition (`face`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `face.detection` | Face detection provider | If `features.faceRecognition` is on with no provider configured → `error`; if a provider is configured, live test via `FaceSettingsService.testProvider()`; otherwise `skipped` | `error` — "Configure a face detection provider or disable Face Recognition." / "Check the provider configuration in Admin Settings → Face." |
+| `face.flagConsistency` | Face flag consistency | Cross-checks `features.faceRecognition` against whether a detection provider is configured | `warning` if provider configured / flag off — "Enable Face Recognition in Admin Settings → Face if desired."; `skipped` if flag off and no provider |
+
+### Geo (`geo`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `geo.reverseProvider` | Reverse geocoding | Live test via `GeoSettingsService.testProvider()` against the resolved active reverse provider (`geo.reverseProvider` setting, else `GEO_PROVIDER` env, else `offline`) | `error` — "Configure the geo provider credentials in Admin Settings → Geo." |
+
+### Job Queue & Worker (`jobs`)
+
+| Check key | Label | What it verifies | Failure → status + action item |
+|-----------|-------|-------------------|----------------------------------|
+| `jobs.workerEnabled` | Enrichment worker enabled | `isEnrichmentWorkerEnabled()`; if disabled but any of `features.autoTagging` / `features.faceRecognition` / `features.burstDetection` is on, escalates to `error` | `error` — "Set ENRICHMENT_WORKER_ENABLED=true so enrichment jobs get processed."; otherwise plain `warning` — "Enrichment worker is disabled." |
+| `jobs.queueHealth` | Queue health | `EnrichmentAdminService.getStats()`: warns on stuck-running jobs, then on any failed jobs | `warning` — "Reset stuck jobs from the Job Queue page." / "Review and retry failed jobs from the Job Queue page." |
+| `jobs.burstConfig` | Burst detection | Reports `ok` when `features.burstDetection` is on (no provider dependency — relies only on the enrichment worker); `skipped` when off | n/a (informational only, never `error`/`warning`) |
+
+---
+
+## 5. `runCheck` Design
+
+**File:** `apps/api/src/doctor/doctor.service.ts`
+
+Every check is defined as a `CheckDef { key, label, fn }` and wrapped by a shared `runCheck()` helper before being added to the report. Three properties make the sweep robust:
+
+### Concurrency via `Promise.allSettled`
+
+All twenty check functions are invoked together:
+
+```typescript
+const settled = await Promise.allSettled(defs.map((def) => this.runCheck(def)));
+```
+
+`Promise.allSettled` guarantees every check resolves (never rejects the whole batch), so a single check's exception can never prevent the other nineteen from completing. The `allSettled` rejection branch in `runDiagnostics()` is unreachable in practice — `runCheck()` already catches everything internally — and is kept only as defense in depth.
+
+### 10-second per-check timeout
+
+```typescript
+const CHECK_TIMEOUT_MS = 10_000;
+```
+
+Each check races its own promise against a `setTimeout`-based timeout using a private `Symbol` sentinel (`TIMEOUT_SENTINEL`) so a legitimate error value can never be confused with a timeout. If a live provider call (e.g. a slow or hung geo/AI/storage connectivity test) doesn't resolve within 10 seconds, the check is recorded as `error` with message `"Check timed out after 10s"` and the sweep continues — one unreachable third-party API can never hang the whole report.
+
+### Exception normalization
+
+Several of the reused "test connection" services throw (e.g. a `BadRequestException` when credentials are missing) rather than returning `{ ok: false }`. `runCheck()`'s `catch` block normalizes any thrown value — `Error` or otherwise — into a `DoctorCheck` with `status: 'error'` and the thrown message, so a throwing dependency never crashes `runDiagnostics()` or produces a malformed report.
+
+### Single settings snapshot
+
+```typescript
+const settings = await this.systemSettings.getSettings();
+```
+
+`getSettings()` is called exactly once at the top of `runDiagnostics()`, before any check runs, and the same `settings` object is threaded into every check that needs it (storage, AI, face, geo, jobs checks). This guarantees all twenty checks reason about one consistent point-in-time view of system settings, rather than each check independently re-reading settings mid-sweep (which could produce a report that mixes pre- and post-change state if an admin edits settings while Doctor is running).
+
+### Timing
+
+`runCheck()` records `Date.now()` before invoking the check function and computes `durationMs` in a `finally` block, so every `DoctorCheck` — success, `error`, or timeout — carries an accurate duration. The overall `DoctorReport.durationMs` is measured the same way around the whole `runDiagnostics()` call.
+
+---
+
+## 6. Reuse of Existing Services
+
+Doctor does not implement its own provider connectivity logic. It calls the same "test connection" services that power each settings page's own "Test connection" button, so a passing Doctor check has the same meaning as a passing manual test on that settings page:
+
+| Domain | Service | Method used |
+|--------|---------|-------------|
+| AI (search / tagging) | `AiSettingsService` | `testProvider({ provider, model })` |
+| AI (embedding) | `AiSettingsService` | `testEmbedding({})` |
+| Face detection | `FaceSettingsService` | `testProvider({ provider })` |
+| Geo (reverse) | `GeoSettingsService` | `testProvider({ provider })` |
+| Storage | `StorageSettingsService` | `testConnection({ provider })` |
+| Job queue stats | `EnrichmentAdminService` | `getStats()` (same source as `/admin/settings/jobs`) |
+| Worker enabled flag | `isEnrichmentWorkerEnabled()` | exported helper from `enrichment/enrichment-job.worker.ts` |
+
+The pgvector probe (`core.pgvector`) is Doctor-specific raw SQL — it is not backed by an existing settings service, since there is no "pgvector settings" page. It queries `pg_extension` for the `vector` extension and `to_regclass('public.media_item_embedding')` to confirm the embedding table exists, mirroring the requirements documented in the [Semantic Search spec](semantic-search.md).
+
+---
+
+## 7. API Endpoint and RBAC
+
+### `POST /api/admin/doctor/run`
+
+- **Auth:** Admin role + `system_settings:read` (`@Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.SYSTEM_SETTINGS_READ] })`)
+- **No new permission** — reuses the existing `system_settings:read` permission already granted to Admin users; there is no `doctor:*` permission scope.
+- **Request body:** none
+- **Behavior:** Synchronously runs all twenty checks concurrently (see §5) and returns the assembled `DoctorReport`. On-demand only — no cron, no queue, no persistence. Two consecutive calls can return different results if underlying configuration or provider reachability changed in between.
+- **Response 200:** `DoctorReport` (see §2).
+- **Side effects:** none — purely read-only against configuration and live provider endpoints; does not write to the database (aside from the read-only `SELECT 1` / `_prisma_migrations` / `pg_extension` probes) and does not enqueue any job.
+
+### RBAC Summary
+
+| Resource | Permission | Granted To |
+|----------|------------|------------|
+| Run diagnostics sweep | `system_settings:read` | Admin only |
+
+---
+
+## 8. Frontend Page
+
+**Route:** `/admin/settings/doctor`
+
+**File:** `apps/web/src/pages/Admin/DoctorPage.tsx`
+
+**Entry point:** A "Doctor" card in the Settings hub's Operations group (`apps/web/src/pages/Admin/SettingsHubPage.tsx`), gated on `system_settings:read`, described as "Run configuration health diagnostics and see required action items."
+
+The page is guarded by `usePermissions().isAdmin`; non-admin users are redirected to `/` via React Router's `<Navigate>` (mirrors the pattern used by `JobsPage` / `FaceSettingsPage`).
+
+### Layout
+
+- **Header:** "Doctor — Diagnostics" title with a "Run diagnostics" button (`POST /api/admin/doctor/run` via the `useDoctor` hook). The button shows a spinner while a run is in flight.
+- **Summary chips:** once a report is loaded, a chip row shows the overall status label plus per-status counts:
+  - Overall status label — `"Unhealthy"` (error, `summary.error > 0`), `"Needs attention"` (warning, no errors but `summary.warning > 0`), or `"Healthy"` (success, otherwise) — computed client-side from `summary`.
+  - `OK: N`, `Warning: N`, `Error: N`, `Skipped: N` outlined chips sourced directly from `summary`.
+- **Timestamp line:** "Computed {computedAt, localized} · {durationMs} ms".
+- **Per-section cards:** one `Paper` card per `DoctorSection`, each showing the section label and a status chip, followed by a row per `DoctorCheck` with a status icon (`CheckCircle` / `WarningAmber` / `Error` / `RemoveCircleOutline` for ok/warning/error/skipped respectively), the check label, and its message.
+- **Inline action-item alerts:** when a check carries `actionItem`, an MUI `Alert` (severity mirrors the check's status — `success`/`warning`/`error`/`info`) is rendered directly under that check row with the actionable next step.
+
+### States
+
+| State | Trigger | Display |
+|-------|---------|---------|
+| Loading (first load) | `loading && !report` | Centered `CircularProgress` |
+| Error (first load) | `error && !report` | Full-width `Alert severity="error"` |
+| Error (after a report exists) | `error && report` | `Alert severity="error"` above the existing report, which remains visible |
+| Loaded | `report` present | Summary chips, timestamp, and all section cards rendered |
+
+---
+
+## 9. Gotchas and Implementation Notes
+
+### `skipped` Is Not a Failure
+
+A check reporting `skipped` (e.g. `face.detection` when `features.faceRecognition` is off) is deliberately excluded from the "worst status" computation at the section level — `worstStatus()` only ever returns `ok`, `warning`, or `error`, treating `skipped` the same as `ok`. Do not add new logic that treats `summary.skipped > 0` as evidence of a problem; it reflects an intentionally-disabled feature, not a misconfiguration.
+
+### Timeout Sentinel Must Be a Private `Symbol`, Not a String or Error
+
+`TIMEOUT_SENTINEL = Symbol('doctor-check-timeout')` is used specifically so the `catch` block in `runCheck()` can distinguish "the check timed out" from "the check threw an error whose message happens to look like a timeout." Using a string or generic `Error` for the sentinel would risk a false-positive match against a real provider error message.
+
+### Reused Services Can Throw Instead of Returning `{ ok: false }`
+
+Some of the AI/face/geo/storage "test connection" methods throw exceptions (e.g. `BadRequestException`) for certain failure modes (missing credentials) rather than resolving with an `{ ok: false, error }` object. Any new check that reuses an existing settings service must not assume a resolved `{ ok }` shape — `runCheck()`'s catch-all exception normalization handles this at the wrapper level, but the individual check's own `try/catch` (where present, e.g. `checkSecretsKey`) should still be reviewed when adding checks against a new service to confirm which failure shape it uses.
+
+### Single Settings Snapshot Can Go Stale Mid-Sweep
+
+Because `settings` is fetched once and reused across all checks, if an admin changes a system setting via a separate request while a Doctor sweep is executing, some checks in that sweep will reflect the old value. This is intentional (see §5) and the sweep completes in well under a second in the common case, so the staleness window is negligible in practice. A fresh `POST /api/admin/doctor/run` call will pick up the change immediately.
+
+### Doctor Duplicates Some Signals Also Available Elsewhere
+
+`jobs.queueHealth` surfaces the same `stuckRunning` and `byStatus.failed` counts already visible on `/admin/settings/jobs`, and `ai`/`face`/`geo` live tests duplicate what each settings page's own "Test connection" button already does. This duplication is intentional — Doctor's value is aggregating all of these signals into one sweep rather than requiring an admin to visit six separate pages — but it means Doctor and the individual settings pages can occasionally show slightly different results if state changes between the two calls (e.g. a job fails moments after Doctor's `jobs.queueHealth` check ran).
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | July 2026 | AI Assistant | Initial specification |


### PR DESCRIPTION
Add DoctorModule/DoctorController/DoctorService skeleton with the
DoctorReport type contract, wire it into app.module, and export
GeoSettingsService and EnrichmentAdminService from their modules so
DoctorService can inject them.