### PR TITLE
fix(web): clean up pre-existing broken frontend tests

### DIFF
--- a/apps/web/src/__tests__/components/common/Layout.test.tsx
+++ b/apps/web/src/__tests__/components/common/Layout.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../../components/navigation/Sidebar', () => ({
       </button>
     </div>
   )),
+  DRAWER_WIDTH: 240,
 }));
 
 // Mock react-router-dom Outlet

--- a/apps/web/src/__tests__/pages/AiSettingsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/AiSettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
 
@@ -71,6 +71,7 @@ function defaultSettingsMock() {
     removeCredentials: vi.fn().mockResolvedValue(undefined),
     testProvider: vi.fn().mockResolvedValue({ ok: true }),
     getModels: vi.fn().mockResolvedValue(['gpt-4o', 'gpt-4']),
+    getEmbeddingModels: vi.fn().mockResolvedValue([]),
     saveSearchFeature: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -208,8 +209,11 @@ describe('AiSettingsPage', () => {
       render(<AiSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
 
       // Wait for models to load (useEffect fires on mount)
+      // Scope to the Search Feature section — the Tagging Feature section
+      // below it also renders a "Test" button, so an unscoped query is ambiguous.
+      const searchSection = screen.getByText('Search Feature').closest('.MuiPaper-root') as HTMLElement;
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /test/i })).toBeInTheDocument();
+        expect(within(searchSection).getByRole('button', { name: /^test$/i })).toBeInTheDocument();
       });
     });
 
@@ -232,8 +236,11 @@ describe('AiSettingsPage', () => {
       });
 
       // The settings have features.search.model = 'gpt-4o' — pre-populated
-      // The Test button should be enabled after model is available
-      const testButton = await screen.findByRole('button', { name: /test/i });
+      // The Test button should be enabled after model is available.
+      // Scope to the Search Feature section — the Tagging Feature section
+      // below it also renders a "Test" button, so an unscoped query is ambiguous.
+      const searchSection = screen.getByText('Search Feature').closest('.MuiPaper-root') as HTMLElement;
+      const testButton = await within(searchSection).findByRole('button', { name: /^test$/i });
 
       await user.click(testButton);
 
@@ -261,7 +268,10 @@ describe('AiSettingsPage', () => {
 
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      const testButton = await screen.findByRole('button', { name: /test/i });
+      // Scope to the Search Feature section — the Tagging Feature section
+      // below it also renders a "Test" button, so an unscoped query is ambiguous.
+      const searchSection = screen.getByText('Search Feature').closest('.MuiPaper-root') as HTMLElement;
+      const testButton = await within(searchSection).findByRole('button', { name: /^test$/i });
       await user.click(testButton);
 
       await waitFor(() => {

--- a/apps/web/src/__tests__/pages/AiSettingsPageExtended.test.tsx
+++ b/apps/web/src/__tests__/pages/AiSettingsPageExtended.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
 
@@ -84,8 +84,18 @@ function defaultSettingsMock() {
     removeCredentials: vi.fn().mockResolvedValue(undefined),
     testProvider: vi.fn().mockResolvedValue({ ok: true }),
     getModels: vi.fn().mockResolvedValue(['gpt-4o', 'gpt-4']),
+    getEmbeddingModels: vi.fn().mockResolvedValue([]),
     saveSearchFeature: vi.fn().mockResolvedValue(undefined),
   };
+}
+
+// ---------------------------------------------------------------------------
+// The page renders a "Test" button and a "Save" button in each of the Search
+// Feature, Tagging Feature, and AI Description Search (embedding) sections,
+// so unscoped queries for those labels are ambiguous. Scope to the Search
+// Feature section specifically, matching the intent of these tests.
+function getSearchFeatureSection(): HTMLElement {
+  return screen.getByText('Search Feature').closest('.MuiPaper-root') as HTMLElement;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,8 +172,10 @@ describe('AiSettingsPage — extended coverage', () => {
       await user.click(saveButtons[0]);
 
       await waitFor(() => {
-        expect(screen.getByRole('alert')).toBeInTheDocument();
-        expect(screen.getByText(/network error/i)).toBeInTheDocument();
+        // The page also renders persistent informational <Alert role="alert">
+        // elements in the AI Description Search section, so scope the alert
+        // check to the one containing the actual error message.
+        expect(screen.getByText(/network error/i).closest('[role="alert"]')).toBeInTheDocument();
       });
     });
 
@@ -289,8 +301,10 @@ describe('AiSettingsPage — extended coverage', () => {
       await user.click(screen.getByRole('button', { name: /remove/i }));
 
       await waitFor(() => {
-        expect(screen.getByRole('alert')).toBeInTheDocument();
-        expect(screen.getByText(/delete failed/i)).toBeInTheDocument();
+        // The page also renders persistent informational <Alert role="alert">
+        // elements in the AI Description Search section, so scope the alert
+        // check to the one containing the actual error message.
+        expect(screen.getByText(/delete failed/i).closest('[role="alert"]')).toBeInTheDocument();
       });
     });
 
@@ -333,10 +347,11 @@ describe('AiSettingsPage — extended coverage', () => {
       // Wait for models to be loaded (useEffect fires on mount)
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      // The Search Feature Save button (second Save button after provider Save)
-      const saveButtons = await screen.findAllByRole('button', { name: /^save$/i });
-      // Last save button is the one in the Search Feature section
-      const searchFeatureSave = saveButtons[saveButtons.length - 1];
+      // The page also renders Save buttons in the Tagging Feature and AI
+      // Description Search sections, so scope to the Search Feature section.
+      const searchFeatureSave = await within(getSearchFeatureSection()).findByRole('button', {
+        name: /^save$/i,
+      });
       await user.click(searchFeatureSave);
 
       await waitFor(() => {
@@ -359,8 +374,12 @@ describe('AiSettingsPage — extended coverage', () => {
 
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      const saveButtons = await screen.findAllByRole('button', { name: /^save$/i });
-      await user.click(saveButtons[saveButtons.length - 1]);
+      // The page also renders Save buttons in the Tagging Feature and AI
+      // Description Search sections, so scope to the Search Feature section.
+      const searchFeatureSave = await within(getSearchFeatureSection()).findByRole('button', {
+        name: /^save$/i,
+      });
+      await user.click(searchFeatureSave);
 
       await waitFor(() => {
         expect(screen.getByText(/search feature settings saved/i)).toBeInTheDocument();
@@ -382,12 +401,18 @@ describe('AiSettingsPage — extended coverage', () => {
 
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      const saveButtons = await screen.findAllByRole('button', { name: /^save$/i });
-      await user.click(saveButtons[saveButtons.length - 1]);
+      // The page also renders Save buttons in the Tagging Feature and AI
+      // Description Search sections, so scope to the Search Feature section.
+      const searchFeatureSave = await within(getSearchFeatureSection()).findByRole('button', {
+        name: /^save$/i,
+      });
+      await user.click(searchFeatureSave);
 
       await waitFor(() => {
-        expect(screen.getByRole('alert')).toBeInTheDocument();
-        expect(screen.getByText(/feature save error/i)).toBeInTheDocument();
+        // The page also renders persistent informational <Alert role="alert">
+        // elements in the AI Description Search section, so scope the alert
+        // check to the one containing the actual error message.
+        expect(screen.getByText(/feature save error/i).closest('[role="alert"]')).toBeInTheDocument();
       });
     });
 
@@ -406,8 +431,12 @@ describe('AiSettingsPage — extended coverage', () => {
 
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      const saveButtons = await screen.findAllByRole('button', { name: /^save$/i });
-      await user.click(saveButtons[saveButtons.length - 1]);
+      // The page also renders Save buttons in the Tagging Feature and AI
+      // Description Search sections, so scope to the Search Feature section.
+      const searchFeatureSave = await within(getSearchFeatureSection()).findByRole('button', {
+        name: /^save$/i,
+      });
+      await user.click(searchFeatureSave);
 
       await waitFor(() => {
         expect(screen.getByText(/failed to save search feature/i)).toBeInTheDocument();
@@ -432,7 +461,11 @@ describe('AiSettingsPage — extended coverage', () => {
 
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      const testButton = await screen.findByRole('button', { name: /test/i });
+      // The page also renders "Test" buttons in the Tagging Feature and AI
+      // Description Search sections, so scope to the Search Feature section.
+      const testButton = await within(getSearchFeatureSection()).findByRole('button', {
+        name: /^test$/i,
+      });
       await user.click(testButton);
 
       await waitFor(() => {
@@ -455,7 +488,11 @@ describe('AiSettingsPage — extended coverage', () => {
 
       await waitFor(() => expect(mockGetModels).toHaveBeenCalled());
 
-      const testButton = await screen.findByRole('button', { name: /test/i });
+      // The page also renders "Test" buttons in the Tagging Feature and AI
+      // Description Search sections, so scope to the Search Feature section.
+      const testButton = await within(getSearchFeatureSection()).findByRole('button', {
+        name: /^test$/i,
+      });
       await user.click(testButton);
 
       await waitFor(() => {

--- a/apps/web/src/__tests__/pages/JobsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/JobsPage.test.tsx
@@ -862,8 +862,12 @@ describe('JobsPage', () => {
 
       render(<JobsPage />, { wrapperOptions: { user: mockAdminUser } });
 
+      // The per-row status Chip label is exactly "backing off" (lowercase),
+      // while the "Backing off" filter toggle label always renders in the
+      // filters bar above the table — match the exact lowercase chip text so
+      // the two elements don't collide.
       await waitFor(() => {
-        expect(screen.getByText(/backing off/i)).toBeInTheDocument();
+        expect(screen.getByText('backing off')).toBeInTheDocument();
       });
     });
 
@@ -877,7 +881,9 @@ describe('JobsPage', () => {
         expect(screen.getByText('face_detection')).toBeInTheDocument();
       });
 
-      expect(screen.queryByText(/backing off/i)).not.toBeInTheDocument();
+      // Exact lowercase match targets only the per-row Chip — the "Backing
+      // off" filter toggle label (capitalized) always renders regardless.
+      expect(screen.queryByText('backing off')).not.toBeInTheDocument();
     });
 
     it('does not show the backoff chip for a failed job even if scheduledFor is set', async () => {
@@ -891,7 +897,9 @@ describe('JobsPage', () => {
         expect(screen.getByText('face_detection')).toBeInTheDocument();
       });
 
-      expect(screen.queryByText(/backing off/i)).not.toBeInTheDocument();
+      // Exact lowercase match targets only the per-row Chip — the "Backing
+      // off" filter toggle label (capitalized) always renders regardless.
+      expect(screen.queryByText('backing off')).not.toBeInTheDocument();
     });
   });
 
@@ -915,7 +923,12 @@ describe('JobsPage', () => {
 
       render(<JobsPage />, { wrapperOptions: { user: mockAdminUser } });
 
-      const toggle = await screen.findByRole('checkbox', { name: /backing off/i });
+      // MUI's Switch input renders with role="switch" (not the native
+      // "checkbox" role) since the current MUI version. Its accessible name
+      // comes from the wrapping Tooltip's `title` text ("Show only pending
+      // jobs currently waiting on backoff…"), not the visible "Backing off"
+      // label, so match on a substring of the tooltip text instead.
+      const toggle = await screen.findByRole('switch', { name: /waiting on backoff/i });
       await user.click(toggle);
 
       expect(setFilters).toHaveBeenCalledWith(
@@ -931,7 +944,12 @@ describe('JobsPage', () => {
       render(<JobsPage />, { wrapperOptions: { user: mockAdminUser } });
 
       // Enable then disable
-      const toggle = await screen.findByRole('checkbox', { name: /backing off/i });
+      // MUI's Switch input renders with role="switch" (not the native
+      // "checkbox" role) since the current MUI version. Its accessible name
+      // comes from the wrapping Tooltip's `title` text ("Show only pending
+      // jobs currently waiting on backoff…"), not the visible "Backing off"
+      // label, so match on a substring of the tooltip text instead.
+      const toggle = await screen.findByRole('switch', { name: /waiting on backoff/i });
       await user.click(toggle); // on
       await user.click(toggle); // off
 

--- a/apps/web/src/__tests__/pages/MediaLibraryPage.test.tsx
+++ b/apps/web/src/__tests__/pages/MediaLibraryPage.test.tsx
@@ -284,14 +284,34 @@ describe('MediaLibraryPage', () => {
     });
 
     it('should render separate group headers for items in different months', () => {
+      // Use mid-month, midday UTC timestamps (not midnight) so the local
+      // calendar date/month stays put across every real-world timezone —
+      // a UTC-midnight timestamp would roll back into the previous day (and
+      // potentially the previous month) in timezones west of UTC.
+      const capturedAt1 = '2024-06-15T12:00:00.000Z';
+      const capturedAt2 = '2024-05-15T12:00:00.000Z';
       const items = [
-        makeMediaItem('m1', { capturedAt: '2024-06-01T00:00:00.000Z' }),
-        makeMediaItem('m2', { capturedAt: '2024-05-15T00:00:00.000Z' }),
+        makeMediaItem('m1', { capturedAt: capturedAt1 }),
+        makeMediaItem('m2', { capturedAt: capturedAt2 }),
       ];
       mockUseMedia.mockReturnValue(makeUseMediaDefaults(items));
       render(<MediaLibraryPage />);
-      expect(screen.getByText(/june 2024/i)).toBeInTheDocument();
-      expect(screen.getByText(/may 2024/i)).toBeInTheDocument();
+      // Compute the expected label the same way groupByYearMonth() does
+      // (toLocaleDateString(undefined, ...) — system locale) rather than
+      // hardcoding "June 2024" / "May 2024", so the assertion holds under
+      // any system locale while still meaningfully verifying that the two
+      // items land in two distinct month groups.
+      const label1 = new Date(capturedAt1).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+      });
+      const label2 = new Date(capturedAt2).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+      });
+      expect(label1).not.toBe(label2);
+      expect(screen.getByText(label1)).toBeInTheDocument();
+      expect(screen.getByText(label2)).toBeInTheDocument();
     });
 
     it('should render an "Unknown Date" group for items with null capturedAt', () => {

--- a/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
@@ -437,7 +437,10 @@ describe('MediaGallery', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByAltText('Photo s1')).toBeInTheDocument();
+        // MediaGallery renders alt={item.originalFilename}; makeItem() defaults
+        // originalFilename to `file-${id}.jpg`, i.e. "file-s1.jpg" here — not
+        // the literal "Photo s1" the component has never produced.
+        expect(screen.getByAltText('file-s1.jpg')).toBeInTheDocument();
       });
 
       // The sentinel is an empty <Box sx={{ height: 1 }}> rendered after the last group.


### PR DESCRIPTION
## Summary
Fixes 5 pre-existing test files on `main` that were broken independent of any feature work (test-only staleness, no production code changes):
- `AiSettingsPage.test.tsx` / `AiSettingsPageExtended.test.tsx` — mock of `useAiSettings` was missing the real `getEmbeddingModels` function, crashing every test
- `JobsPage.test.tsx` — ambiguous `getByText(/backing off/i)` query matched both a status label and a chip that legitimately both render "backing off"; queries scoped/disambiguated
- `MediaLibraryPage.test.tsx` — month-grouping assertion hardcoded "June 2024" but the component formats via locale-dependent `toLocaleDateString`; made the assertion locale-independent
- `MediaGallery.test.tsx` — assertion expected alt text `'Photo s1'` but the component (correctly) renders the item's actual filename as alt text
- `Layout.test.tsx` — `Sidebar` mock was missing a `DRAWER_WIDTH` export that `Layout.tsx` imports and uses directly

## Test plan
- [x] Full `apps/web` test suite passes (2627/2627, up from 91 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)