### PR TITLE
feat(ui): reorganize main menu — Utilities group, circle switcher in profile menu, circle management

### DIFF
--- a/apps/web/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -932,4 +932,78 @@ describe('Sidebar', () => {
       // keepMounted: false ensures drawer content unmounts when closed
     });
   });
+
+  describe('Utilities Section', () => {
+    it('renders a "Utilities" subheader', () => {
+      vi.mocked(usePermissions).mockReturnValue({
+        permissions: new Set(),
+        roles: new Set(),
+        hasPermission: vi.fn(),
+        hasAnyPermission: vi.fn(),
+        hasAllPermissions: vi.fn(),
+        hasRole: vi.fn(),
+        hasAnyRole: vi.fn(),
+        isAdmin: false,
+      });
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      expect(screen.getByText('Utilities')).toBeInTheDocument();
+    });
+
+    it('renders Review Bursts, Review Duplicates, and Location Suggestions as descendants of the Utilities list', () => {
+      vi.mocked(usePermissions).mockReturnValue({
+        permissions: new Set(),
+        roles: new Set(),
+        hasPermission: vi.fn(),
+        hasAnyPermission: vi.fn(),
+        hasAllPermissions: vi.fn(),
+        hasRole: vi.fn(),
+        hasAnyRole: vi.fn(),
+        isAdmin: false,
+      });
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      expect(screen.getByText('Review Bursts')).toBeInTheDocument();
+      expect(screen.getByText('Review Duplicates')).toBeInTheDocument();
+      expect(screen.getByText('Location Suggestions')).toBeInTheDocument();
+
+      const utilitiesSubheader = screen.getByText('Utilities');
+      const utilitiesList = utilitiesSubheader.closest('.MuiList-root');
+      expect(utilitiesList).not.toBeNull();
+      expect(utilitiesList!.textContent).toContain('Review Bursts');
+      expect(utilitiesList!.textContent).toContain('Review Duplicates');
+      expect(utilitiesList!.textContent).toContain('Location Suggestions');
+    });
+
+    it('no longer includes Review Bursts, Review Duplicates, or Location Suggestions under the Library list', () => {
+      vi.mocked(usePermissions).mockReturnValue({
+        permissions: new Set(),
+        roles: new Set(),
+        hasPermission: vi.fn(),
+        hasAnyPermission: vi.fn(),
+        hasAllPermissions: vi.fn(),
+        hasRole: vi.fn(),
+        hasAnyRole: vi.fn(),
+        isAdmin: false,
+      });
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const librarySubheader = screen.getByText('Library');
+      const libraryList = librarySubheader.closest('.MuiList-root');
+      expect(libraryList).not.toBeNull();
+
+      // Library retains People, Archive, Trash
+      expect(libraryList!.textContent).toContain('People');
+      expect(libraryList!.textContent).toContain('Archive');
+      expect(libraryList!.textContent).toContain('Trash');
+
+      // The three utility items moved out of Library
+      expect(libraryList!.textContent).not.toContain('Review Bursts');
+      expect(libraryList!.textContent).not.toContain('Review Duplicates');
+      expect(libraryList!.textContent).not.toContain('Location Suggestions');
+    });
+  });
 });

--- a/apps/web/src/__tests__/components/navigation/UserMenu.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/UserMenu.test.tsx
@@ -9,9 +9,60 @@ vi.mock('../../../hooks/usePermissions', () => ({
   usePermissions: vi.fn(),
 }));
 
+// Mock useCircle hook (test-utils' default MockCircleProvider only supplies a
+// single circle, which isn't enough to exercise multi-circle selection UI)
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+// Mock react-router-dom's useNavigate so we can assert on "Manage Circles" navigation
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 import { usePermissions } from '../../../hooks/usePermissions';
+import { useCircle } from '../../../hooks/useCircle';
 
 const mockUsePermissions = vi.mocked(usePermissions);
+const mockUseCircle = vi.mocked(useCircle);
+
+const mockCircle1 = {
+  id: 'circle-1',
+  name: 'Personal Library',
+  description: null,
+  ownerId: 'test-user-id',
+  isPersonal: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const mockCircle2 = {
+  id: 'circle-2',
+  name: 'Family Circle',
+  description: 'Our family',
+  ownerId: 'test-user-id',
+  isPersonal: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+function makeCircleDefaults(overrides: Record<string, unknown> = {}) {
+  return {
+    circles: [mockCircle1, mockCircle2],
+    activeCircle: mockCircle1,
+    activeCircleId: 'circle-1',
+    activeCircleRole: 'circle_admin' as const,
+    loading: false,
+    setActiveCircle: vi.fn().mockResolvedValue(undefined),
+    refreshCircles: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
 
 describe('UserMenu', () => {
   beforeEach(() => {
@@ -29,6 +80,8 @@ describe('UserMenu', () => {
       hasAnyRole: vi.fn(),
       isAdmin: false,
     });
+
+    mockUseCircle.mockReturnValue(makeCircleDefaults());
   });
 
   describe('Rendering', () => {
@@ -354,6 +407,85 @@ describe('UserMenu', () => {
       await waitFor(() => {
         const systemSettingsItem = screen.getByRole('menuitem', { name: /system settings/i });
         expect(systemSettingsItem).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Circle Section', () => {
+    it('shows a "Manage Circles" menu item', async () => {
+      const user = userEvent.setup();
+
+      render(<UserMenu />);
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: /manage circles/i })).toBeInTheDocument();
+      });
+    });
+
+    it('shows both circle names as menu items', async () => {
+      const user = userEvent.setup();
+
+      render(<UserMenu />);
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: /personal library/i })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('menuitem', { name: /family circle/i })).toBeInTheDocument();
+    });
+
+    it('calls setActiveCircle with the clicked circle id', async () => {
+      const setActiveCircle = vi.fn().mockResolvedValue(undefined);
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ setActiveCircle }));
+
+      const user = userEvent.setup();
+
+      render(<UserMenu />);
+
+      await user.click(screen.getByRole('button'));
+
+      const familyItem = await screen.findByRole('menuitem', { name: /family circle/i });
+      await user.click(familyItem);
+
+      await waitFor(() => {
+        expect(setActiveCircle).toHaveBeenCalledWith('circle-2');
+      });
+    });
+
+    it('shows a disabled "No circles yet" item when circles list is empty', async () => {
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ circles: [] }));
+
+      const user = userEvent.setup();
+
+      render(<UserMenu />);
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('No circles yet')).toBeInTheDocument();
+      });
+    });
+
+    it('navigates to /circles when "Manage Circles" is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(<UserMenu />);
+
+      await user.click(screen.getByRole('button'));
+
+      const manageItem = await screen.findByRole('menuitem', { name: /manage circles/i });
+      await user.click(manageItem);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/circles');
+      });
+
+      // Menu should also close after navigation
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
       });
     });
   });

--- a/apps/web/src/__tests__/pages/CircleListPage.test.tsx
+++ b/apps/web/src/__tests__/pages/CircleListPage.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../utils/test-utils';
+import CircleListPage from '../../pages/Circles/CircleListPage';
+import type { Circle } from '../../types/circles';
+
+// ------------------------------------------------------------------
+// Mock hooks
+// ------------------------------------------------------------------
+
+vi.mock('../../hooks/useCircles', () => ({
+  useCircles: vi.fn(),
+}));
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+// useCircleContext is exercised via the real CircleContext + test-utils'
+// MockCircleProvider (driven by wrapperOptions.activeCircle), so it is not
+// mocked here — this mirrors CircleDetailPage.test.tsx's approach when tighter
+// control isn't needed.
+
+import { useCircles } from '../../hooks/useCircles';
+import { usePermissions } from '../../hooks/usePermissions';
+
+const mockUseCircles = vi.mocked(useCircles);
+const mockUsePermissions = vi.mocked(usePermissions);
+
+// ------------------------------------------------------------------
+// Fixtures
+// ------------------------------------------------------------------
+
+// Owned by the default test-utils user ('test-user-id'), not personal —
+// eligible for both Edit and Delete when canManage is true.
+const circleOwned: Circle = {
+  id: 'circle-1',
+  name: 'Owned Circle',
+  description: 'Owned circle description',
+  ownerId: 'test-user-id',
+  isPersonal: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// Owned by someone else — with isAdmin: false, canManage is false.
+const circleNotOwned: Circle = {
+  id: 'circle-2',
+  name: 'Other Circle',
+  description: null,
+  ownerId: 'other-user-id',
+  isPersonal: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// Owned by the default test-utils user AND personal — canManage true but
+// Delete must be hidden (canManage && !circle.isPersonal).
+const circlePersonalOwned: Circle = {
+  id: 'circle-3',
+  name: 'My Personal Library',
+  description: null,
+  ownerId: 'test-user-id',
+  isPersonal: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+function makeCirclesDefaults(overrides: Record<string, unknown> = {}) {
+  return {
+    circles: [circleOwned, circleNotOwned, circlePersonalOwned],
+    loading: false,
+    error: null,
+    fetchCircles: vi.fn().mockResolvedValue(undefined),
+    addCircle: vi.fn().mockResolvedValue(circleOwned),
+    editCircle: vi.fn().mockResolvedValue(circleOwned),
+    removeCircle: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function getCardFor(circleName: string): HTMLElement {
+  const nameEl = screen.getByText(circleName);
+  const card = nameEl.closest('.MuiCard-root') as HTMLElement | null;
+  if (!card) throw new Error(`Could not find enclosing card for "${circleName}"`);
+  return card;
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+describe('CircleListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseCircles.mockReturnValue(makeCirclesDefaults());
+
+    mockUsePermissions.mockReturnValue({
+      permissions: new Set<string>(),
+      roles: new Set<string>(),
+      hasPermission: vi.fn(),
+      hasAnyPermission: vi.fn(),
+      hasAllPermissions: vi.fn(),
+      hasRole: vi.fn(),
+      hasAnyRole: vi.fn(),
+      isAdmin: false,
+    });
+  });
+
+  describe('Active chip', () => {
+    it('renders an "Active" chip only for the circle matching activeCircleId', async () => {
+      render(<CircleListPage />, { wrapperOptions: { activeCircle: circleOwned } });
+
+      await waitFor(() => {
+        expect(screen.getByText(circleOwned.name)).toBeInTheDocument();
+      });
+
+      const activeCard = getCardFor(circleOwned.name);
+      expect(within(activeCard).getByText('Active')).toBeInTheDocument();
+
+      const otherCard = getCardFor(circleNotOwned.name);
+      expect(within(otherCard).queryByText('Active')).not.toBeInTheDocument();
+
+      const personalCard = getCardFor(circlePersonalOwned.name);
+      expect(within(personalCard).queryByText('Active')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Edit / Delete visibility (canManage gating)', () => {
+    it('shows both Edit and Delete for a circle the user owns', async () => {
+      render(<CircleListPage />, { wrapperOptions: { activeCircle: circleOwned } });
+
+      await waitFor(() => {
+        expect(screen.getByText(circleOwned.name)).toBeInTheDocument();
+      });
+
+      const card = getCardFor(circleOwned.name);
+      expect(within(card).getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      expect(within(card).getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('hides both Edit and Delete for a circle the user does not own and is not admin', async () => {
+      render(<CircleListPage />, { wrapperOptions: { activeCircle: circleOwned } });
+
+      await waitFor(() => {
+        expect(screen.getByText(circleNotOwned.name)).toBeInTheDocument();
+      });
+
+      const card = getCardFor(circleNotOwned.name);
+      expect(within(card).queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(within(card).queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    });
+
+    it('shows Edit but not Delete for a personal circle even when manageable', async () => {
+      render(<CircleListPage />, { wrapperOptions: { activeCircle: circleOwned } });
+
+      await waitFor(() => {
+        expect(screen.getByText(circlePersonalOwned.name)).toBeInTheDocument();
+      });
+
+      const card = getCardFor(circlePersonalOwned.name);
+      expect(within(card).getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      expect(within(card).queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Edit dialog', () => {
+    it('opens an "Edit Circle" dialog pre-filled with the circle name and description', async () => {
+      const user = userEvent.setup();
+
+      render(<CircleListPage />, { wrapperOptions: { activeCircle: circleOwned } });
+
+      await waitFor(() => {
+        expect(screen.getByText(circleOwned.name)).toBeInTheDocument();
+      });
+
+      const card = getCardFor(circleOwned.name);
+      await user.click(within(card).getByRole('button', { name: /edit/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText('Edit Circle')).toBeInTheDocument();
+      expect(within(dialog).getByLabelText(/circle name/i)).toHaveValue(circleOwned.name);
+      expect(within(dialog).getByLabelText(/description/i)).toHaveValue(
+        circleOwned.description ?? '',
+      );
+    });
+  });
+
+  describe('Delete confirmation dialog', () => {
+    it('opens a "Delete Circle" confirmation dialog mentioning the circle name, and confirming calls removeCircle with the circle id', async () => {
+      const removeCircle = vi.fn().mockResolvedValue(undefined);
+      mockUseCircles.mockReturnValue(makeCirclesDefaults({ removeCircle }));
+
+      const user = userEvent.setup();
+
+      render(<CircleListPage />, { wrapperOptions: { activeCircle: circleOwned } });
+
+      await waitFor(() => {
+        expect(screen.getByText(circleOwned.name)).toBeInTheDocument();
+      });
+
+      const card = getCardFor(circleOwned.name);
+      await user.click(within(card).getByRole('button', { name: /delete/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText('Delete Circle')).toBeInTheDocument();
+      expect(within(dialog).getByText(circleOwned.name)).toBeInTheDocument();
+
+      // The dialog's own confirm button reads exactly "Delete" (distinct from
+      // the card-level Delete button, which lives outside `dialog`).
+      const confirmButton = within(dialog).getByRole('button', { name: /^delete$/i });
+      await user.click(confirmButton);
+
+      await waitFor(() => {
+        expect(removeCircle).toHaveBeenCalledWith(circleOwned.id);
+      });
+    });
+  });
+});

--- a/apps/web/src/components/navigation/AppBar.tsx
+++ b/apps/web/src/components/navigation/AppBar.tsx
@@ -22,7 +22,6 @@ import { useThemeContext } from '../../contexts/ThemeContext';
 import { useCircle } from '../../hooks/useCircle';
 import { useMediaRefresh } from '../../contexts/MediaRefreshContext';
 import { UserMenu } from './UserMenu';
-import { CircleSwitcher } from '../circles/CircleSwitcher';
 import { TopbarSearch } from '../search/TopbarSearch';
 import { MediaUploadDialog } from '../media/MediaUploadDialog';
 import { APP_NAME } from '../../constants/app';
@@ -127,9 +126,6 @@ export function AppBar({ onMenuClick }: AppBarProps) {
               </IconButton>
             )
           )}
-
-          {/* Circle Switcher */}
-          <CircleSwitcher />
 
           {/* Theme Toggle */}
           <IconButton

--- a/apps/web/src/components/navigation/Sidebar.tsx
+++ b/apps/web/src/components/navigation/Sidebar.tsx
@@ -87,11 +87,14 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
   const libraryItems: NavItemDef[] = [
     { label: 'People', icon: <GroupsIcon />, path: '/people' },
+    { label: 'Archive', icon: <ArchiveOutlinedIcon />, path: '/archive' },
+    { label: 'Trash', icon: <DeleteOutlineIcon />, path: '/trash' },
+  ];
+
+  const utilitiesItems: NavItemDef[] = [
     { label: 'Review Bursts', icon: <BurstModeIcon />, path: '/bursts' },
     { label: 'Review Duplicates', icon: <ContentCopyIcon />, path: '/duplicates' },
     { label: 'Location Suggestions', icon: <MyLocationIcon />, path: '/location-suggestions' },
-    { label: 'Archive', icon: <ArchiveOutlinedIcon />, path: '/archive' },
-    { label: 'Trash', icon: <DeleteOutlineIcon />, path: '/trash' },
   ];
 
   const adminItems: NavItemDef[] = [
@@ -185,6 +188,21 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           }
         >
           {libraryItems.map((item) => (
+            <NavItem key={item.path} item={item} />
+          ))}
+        </List>
+
+        {/* UTILITIES section */}
+        <List
+          dense
+          disablePadding
+          subheader={
+            <ListSubheader disableSticky sx={subheaderSx}>
+              Utilities
+            </ListSubheader>
+          }
+        >
+          {utilitiesItems.map((item) => (
             <NavItem key={item.path} item={item} />
           ))}
         </List>

--- a/apps/web/src/components/navigation/UserMenu.tsx
+++ b/apps/web/src/components/navigation/UserMenu.tsx
@@ -14,15 +14,18 @@ import {
   Settings as SettingsIcon,
   AdminPanelSettings as AdminIcon,
   Logout as LogoutIcon,
+  GroupWork as CircleIcon,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePermissions } from '../../hooks/usePermissions';
+import { useCircle } from '../../hooks/useCircle';
 
 export function UserMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const { user, logout } = useAuth();
   const { hasPermission } = usePermissions();
+  const { circles, activeCircle, setActiveCircle } = useCircle();
   const navigate = useNavigate();
 
   const open = Boolean(anchorEl);
@@ -93,6 +96,43 @@ export function UserMenu() {
             {user.email}
           </Typography>
         </Box>
+
+        <Divider />
+
+        {/* Circle Section */}
+        <Typography
+          variant="overline"
+          sx={{ px: 2, pt: 1, display: 'block' }}
+          color="text.secondary"
+        >
+          Circle
+        </Typography>
+
+        {circles.length === 0 ? (
+          <MenuItem disabled>
+            <ListItemText>No circles yet</ListItemText>
+          </MenuItem>
+        ) : (
+          circles.map((c) => (
+            <MenuItem
+              key={c.id}
+              selected={c.id === activeCircle?.id}
+              onClick={() => void setActiveCircle(c.id)}
+            >
+              <ListItemIcon>
+                <CircleIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>{c.name}</ListItemText>
+            </MenuItem>
+          ))
+        )}
+
+        <MenuItem onClick={() => handleNavigate('/circles')}>
+          <ListItemIcon>
+            <CircleIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Manage Circles</ListItemText>
+        </MenuItem>
 
         <Divider />
 

--- a/apps/web/src/pages/Circles/CircleListPage.tsx
+++ b/apps/web/src/pages/Circles/CircleListPage.tsx
@@ -17,21 +17,44 @@ import {
   Alert,
   Chip,
 } from '@mui/material';
-import { Add as AddIcon, GroupWork as CircleIcon } from '@mui/icons-material';
+import {
+  Add as AddIcon,
+  GroupWork as CircleIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+} from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useCircles } from '../../hooks/useCircles';
 import { useCircleContext } from '../../contexts/CircleContext';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useAuth } from '../../contexts/AuthContext';
+import type { Circle } from '../../types/circles';
 
 export default function CircleListPage() {
   const navigate = useNavigate();
-  const { circles, loading, error, fetchCircles, addCircle } = useCircles();
-  const { refreshCircles } = useCircleContext();
+  const { circles, loading, error, fetchCircles, addCircle, editCircle, removeCircle } =
+    useCircles();
+  const { refreshCircles, activeCircleId } = useCircleContext();
+  const { isAdmin } = usePermissions();
+  const { user } = useAuth();
 
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState('');
   const [createDescription, setCreateDescription] = useState('');
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  // Edit dialog state (single shared dialog, target held in `editing`)
+  const [editing, setEditing] = useState<Circle | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  // Delete confirmation dialog state
+  const [deleting, setDeleting] = useState<Circle | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     void fetchCircles();
@@ -64,6 +87,64 @@ export default function CircleListPage() {
     setCreateDescription('');
     setCreateError(null);
   }, [creating]);
+
+  const handleEditOpen = useCallback((circle: Circle) => {
+    setEditing(circle);
+    setEditName(circle.name);
+    setEditDescription(circle.description ?? '');
+    setEditError(null);
+  }, []);
+
+  const handleEditClose = useCallback(() => {
+    if (saving) return;
+    setEditing(null);
+    setEditName('');
+    setEditDescription('');
+    setEditError(null);
+  }, [saving]);
+
+  const handleEditSave = useCallback(async () => {
+    if (!editing || !editName.trim()) return;
+    setSaving(true);
+    setEditError(null);
+    try {
+      await editCircle(editing.id, {
+        name: editName.trim(),
+        description: editDescription.trim() || undefined,
+      });
+      await refreshCircles();
+      await fetchCircles();
+      setEditing(null);
+      setEditName('');
+      setEditDescription('');
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : 'Failed to update circle');
+    } finally {
+      setSaving(false);
+    }
+  }, [editing, editName, editDescription, editCircle, refreshCircles, fetchCircles]);
+
+  const handleDeleteClose = useCallback(() => {
+    if (deleteBusy) return;
+    setDeleting(null);
+    setDeleteError(null);
+  }, [deleteBusy]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleting) return;
+    setDeleteBusy(true);
+    setDeleteError(null);
+    try {
+      await removeCircle(deleting.id);
+      await refreshCircles();
+      await fetchCircles();
+      setDeleting(null);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete circle');
+    } finally {
+      setDeleteBusy(false);
+    }
+  }, [deleting, removeCircle, refreshCircles, fetchCircles]);
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
@@ -125,7 +206,9 @@ export default function CircleListPage() {
       {/* Circle grid */}
       {!loading && circles.length > 0 && (
         <Grid container spacing={2}>
-          {circles.map((circle) => (
+          {circles.map((circle) => {
+            const canManage = isAdmin || circle.ownerId === user?.id;
+            return (
             <Grid key={circle.id} size={{ xs: 12, sm: 6, md: 4 }}>
               <Card variant="outlined" sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
                 <CardContent sx={{ flex: 1 }}>
@@ -133,6 +216,9 @@ export default function CircleListPage() {
                     <Typography variant="h6" component="div" noWrap sx={{ flex: 1 }}>
                       {circle.name}
                     </Typography>
+                    {circle.id === activeCircleId && (
+                      <Chip label="Active" size="small" color="success" />
+                    )}
                     {circle.isPersonal && (
                       <Chip label="Personal" size="small" color="primary" variant="outlined" />
                     )}
@@ -150,10 +236,30 @@ export default function CircleListPage() {
                   <Button size="small" onClick={() => navigate(`/circles/${circle.id}`)}>
                     View
                   </Button>
+                  {canManage && (
+                    <Button
+                      size="small"
+                      startIcon={<EditIcon />}
+                      onClick={() => handleEditOpen(circle)}
+                    >
+                      Edit
+                    </Button>
+                  )}
+                  {canManage && !circle.isPersonal && (
+                    <Button
+                      size="small"
+                      color="error"
+                      startIcon={<DeleteIcon />}
+                      onClick={() => setDeleting(circle)}
+                    >
+                      Delete
+                    </Button>
+                  )}
                 </CardActions>
               </Card>
             </Grid>
-          ))}
+            );
+          })}
         </Grid>
       )}
 
@@ -198,6 +304,81 @@ export default function CircleListPage() {
             startIcon={creating ? <CircularProgress size={16} /> : undefined}
           >
             {creating ? 'Creating...' : 'Create'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={editing !== null} onClose={handleEditClose} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit Circle</DialogTitle>
+        <DialogContent>
+          {editError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {editError}
+            </Alert>
+          )}
+          <TextField
+            autoFocus
+            label="Circle name"
+            fullWidth
+            required
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            sx={{ mt: 1, mb: 2 }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !saving) void handleEditSave();
+            }}
+          />
+          <TextField
+            label="Description (optional)"
+            fullWidth
+            multiline
+            rows={3}
+            value={editDescription}
+            onChange={(e) => setEditDescription(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleEditClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => void handleEditSave()}
+            disabled={saving || !editName.trim()}
+            startIcon={saving ? <CircularProgress size={16} /> : undefined}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={deleting !== null} onClose={handleDeleteClose} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete Circle</DialogTitle>
+        <DialogContent>
+          {deleteError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {deleteError}
+            </Alert>
+          )}
+          <Typography variant="body2">
+            Are you sure you want to delete{' '}
+            <strong>{deleting?.name}</strong>? This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDeleteClose} disabled={deleteBusy}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => void handleDeleteConfirm()}
+            disabled={deleteBusy}
+            startIcon={deleteBusy ? <CircularProgress size={16} /> : undefined}
+          >
+            {deleteBusy ? 'Deleting...' : 'Delete'}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary

Reorganizes the web app's primary navigation for a cleaner information architecture:

- A dedicated **Utilities** sidebar group (placed directly under Library) for the review/utility features.
- Circle selection + **Manage Circles** moved off the top bar and into the profile-avatar dropdown, alongside Settings / System Settings.
- The **Circles** page upgraded so users can edit the active/main circle and manage circles (edit / delete) directly, without drilling into each circle's detail page.

Frontend-only (`apps/web`) — no API or DB changes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- none -->

## Changes Made

- **Utilities sidebar group** (`Sidebar.tsx`): added a new **Utilities** group under **Library** and moved **Review Bursts**, **Review Duplicates**, and **Location Suggestions** (geo inference) into it; Library now holds only People, Archive, Trash.
- **Circle selection in the profile menu** (`UserMenu.tsx`, `AppBar.tsx`): added a **Circle** section to the avatar dropdown with the selectable circle list (active circle marked) and a **Manage Circles** item, styled like the existing Settings / System Settings entries; removed the standalone circle-switcher button from the top bar.
- **Manage circles from the Circles page** (`CircleListPage.tsx`): each card shows an **Active** chip on the current/main circle and, for circles the user owns or administers, inline **Edit** (name/description dialog) and **Delete** (with confirmation; hidden for personal circles); changes refresh both the page and the global circle context so the sidebar/menu stay in sync.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

94 web tests pass across the 5 affected files (Sidebar, UserMenu, AppBar, CircleSwitcher, CircleListPage); `tsc --noEmit` is clean.

### Test Instructions

1. Open the app; confirm the sidebar shows a **Utilities** group under Library containing Bursts / Duplicates / Location Suggestions, and Library no longer lists them.
2. Open the profile avatar menu; confirm you can switch the active circle and reach **Manage Circles**, and the top bar no longer shows the standalone switcher.
3. On `/circles`, confirm the active circle is marked with an **Active** chip, can be edited, and non-personal circles you manage can be deleted — with changes reflected immediately in the sidebar/menu.

## Screenshots

<!-- none -->

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Design decisions: the three review items were **moved** into Utilities (not duplicated), and the standalone top-bar circle switcher was **removed** entirely (circle selection now lives only in the profile menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkWxzK5cu4AFpD1gp57HDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkWxzK5cu4AFpD1gp57HDS)_