### PR TITLE
feat(cli): add shared capture-date range parser

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -245,7 +245,7 @@ The CLI validates any token (device-issued or manually supplied) by calling `GET
 | `folders remove <id\|path>` | (none) | Remove a folder and cascade-delete its file records | Settings ▸ Manage folders → [d] remove |
 | `folders enable <id\|path>` | (none) | Re-enable a disabled folder | Settings ▸ Manage folders → [e] toggle |
 | `folders disable <id\|path>` | (none) | Disable a folder (skipped during sync) | Settings ▸ Manage folders → [e] toggle |
-| `sync [folder...] --all` | `--all` / `--dry-run` / `-r, --recursive` / `--concurrency <n>` | Incremental sync of registered or specified folders | Sync ▸ Sync all folders / Sync selected folders |
+| `sync [folder...] --all` | `--all` / `--dry-run` / `-r, --recursive` / `--concurrency <n>` / `--from <date>` / `--to <date>` | Incremental sync of registered or specified folders | Sync ▸ Sync all folders / Sync selected folders |
 | `status` | `--runs` / `--json` | Quick per-folder sync status or recent run history; covers the same underlying data as `reports show overview` / `reports show runs`, just with a fixed, non-extensible output shape | Reports ▸ Folder overview / Recent runs |
 | `retry` | `--all` / `--folder <id\|path>` / `--force` | Retry failed uploads; `--force` resets files blocked at the attempts cap | Sync ▸ Retry failed files |
 | `settings list` | (none) | Print all settings and their current values | Settings ▸ App settings |
@@ -320,9 +320,24 @@ memoriahub sync --all --dry-run
 
 # Override the concurrent upload worker count for this run
 memoriahub sync --all --concurrency 5
+
+# Restrict the run to files captured in a date range
+memoriahub sync ~/Photos --from 2023-01-01 --to 2023-12-31
+
+# Later, sync everything else — files outside the earlier range are not re-processed
+memoriahub sync ~/Photos
 ```
 
 Passing folder paths directly to `sync` auto-registers any path not already in the registry. The `-r` flag sets the recursive flag on newly registered folders.
+
+| Flag | Description |
+|------|-------------|
+| `--from <date>` | Only include files captured on or after this date (`YYYY-MM-DD` or full ISO 8601) |
+| `--to <date>` | Only include files captured on or before this date (`YYYY-MM-DD` or full ISO 8601) |
+
+`--from` and `--to` are independent — pass either one alone or both together. Both bounds are **inclusive** and apply to the **start/end of that calendar day in the machine's local timezone** (`--from` = 00:00:00 local, `--to` = 23:59:59.999 local). A file's capture date is resolved using the same source ladder described in [Capture-date inference](#capture-date-inference) (EXIF `DateTimeOriginal` → `CreateDate` → `ModifyDate`, falling back to the oldest filesystem timestamp); a file whose date cannot be determined at all is excluded from a filtered run.
+
+Because out-of-range files are recorded as `skipped` rather than `uploaded` (see [Date range filtering](#date-range-filtering) below), a later unfiltered `memoriahub sync ~/Photos` picks them up and uploads them normally — filtering never permanently excludes a file, and it never causes already-uploaded files to be re-processed.
 
 ### `memoriahub status`
 
@@ -441,6 +456,12 @@ Three checks prevent redundant uploads:
 
 **Server-side dedup backstop:** After a successful upload the CLI sends `contentHash` as part of the `POST /api/media` registration request. The server enforces a partial unique index on `(circle_id, content_hash)` for active items, so if two CLI sessions upload the same file concurrently into the same circle only one `MediaItem` is created. Dedup is scoped to the circle, not the uploading user: two different users uploading the same file into the same circle will be flagged as duplicates, but uploading the same file into two different circles will not be. The server returns `deduplicated: true` on the response when this happens; the CLI records the file as `skipped` (dedup) rather than `uploaded` so the local database accurately reflects that the file is already represented in the library.
 
+### Date range filtering
+
+`sync --from <date>` and `sync --to <date>` (see [`memoriahub sync`](#memoriahub-sync)) restrict a run's work-set to files whose inferred capture date falls in the requested range. Filtering happens before the dedup checks above and only ever narrows which files are *considered* — it never changes how an included file is deduplicated.
+
+Files outside the requested range are recorded as `skipped` with skip reason `out_of_range` ("out of date range" in status output and reports), a new reason alongside the unchanged-skip and server dedup paths above. Critically, out-of-range files are **not** marked `uploaded`, so they are not "used up" by a filtered run: a later `memoriahub sync` with no `--from`/`--to` re-evaluates them from scratch and uploads them normally. Files already uploaded during an earlier filtered run stay protected on subsequent runs the same way any already-uploaded file does — via the unchanged-skip fast path and server-side content-hash dedup. Applying or removing the date filter across runs is therefore always safe: it can only affect which files are considered in a given run, never cause duplicate uploads or permanently exclude a file.
+
 ### Upload and registration
 
 Files that pass both checks are uploaded via the server's resumable multipart upload API (init → upload parts → complete). After a successful upload the file is registered as a `MediaItem` on the server and its status is set to `uploaded` in the local DB.
@@ -462,7 +483,7 @@ Each file row in the `files` table moves through these statuses:
 | `queued` | Discovered and waiting to be processed |
 | `uploading` | Currently being uploaded (in-progress) |
 | `uploaded` | Successfully uploaded and registered |
-| `skipped` | Duplicate on server or unchanged since last sync |
+| `skipped` | Duplicate on server, unchanged since last sync, or outside a `--from`/`--to` date range |
 | `failed` | Upload failed; `attempt_count` and `last_error` are recorded |
 
 ### Retry and attempts cap
@@ -660,6 +681,10 @@ The progress meter is a 56-character block-grid bar (similar to the `/context` m
 ### Folder picker
 
 "Sync selected folders" opens a checkbox picker. Use `Space` to toggle folders, `a`/`n` to select/deselect all, and `Enter` to start the sync with the checked folders.
+
+### Date range filter
+
+Both **Sync all folders** and **Sync selected folders** proceed to a "Date range filter" step before the sync starts. Enter optional From/To dates (`YYYY-MM-DD`); a live preview line updates as you type — `Syncing: all dates` when both fields are blank, or `Syncing: 2023-01-01 -> 2023-12-31` once a bound is set. Leaving both blank syncs all dates, matching the headless default. The [sync dashboard](#sync-dashboard-layout) shows the active range in its header while the run is in progress.
 
 ### Folder manager
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -21,6 +21,7 @@ import { SettingsRepo } from '../repo/settings.js';
 import { ScanRepo } from '../repo/scans.js';
 import { SyncEngine } from '../sync/sync-engine.js';
 import { SyncReportCollector, writeSyncReport } from '../sync/sync-report.js';
+import { parseDateRange, describeRange } from '../sync/date-range.js';
 import { EV } from '../sync/events.js';
 import { renderSyncHeadless } from '../render/headless-sync.js';
 import { runPatPreflight } from '../preflight.js';
@@ -38,11 +39,13 @@ export function syncCommand(): Command {
     .option('-r, --recursive', 'Descend into sub-directories (when auto-registering a folder)', false)
     .option('--concurrency <n>', 'Number of concurrent upload workers', parseInt)
     .option('--circle <id>', 'Target circle ID (overrides active circle in config)')
-    .option('--scan <id>', 'Reconcile against a prior scan (id or "latest") and report changes since then');
+    .option('--scan <id>', 'Reconcile against a prior scan (id or "latest") and report changes since then')
+    .option('--from <date>', 'Only sync media captured on/after this date (YYYY-MM-DD, local, inclusive)')
+    .option('--to <date>', 'Only sync media captured on/before this date (YYYY-MM-DD, local, inclusive)');
 
   cmd.action(async (
     folderArgs: string[],
-    options: { all: boolean; dryRun: boolean; recursive: boolean; concurrency?: number; circle?: string; scan?: string },
+    options: { all: boolean; dryRun: boolean; recursive: boolean; concurrency?: number; circle?: string; scan?: string; from?: string; to?: string },
   ) => {
     // Validate invocation
     if (folderArgs.length === 0 && !options.all) {
@@ -85,6 +88,16 @@ export function syncCommand(): Command {
         scanId = parsed;
       }
     }
+
+    // Parse the optional capture-date range filter (--from / --to).
+    let range: { fromMs?: number; toMs?: number };
+    try {
+      range = parseDateRange(options.from, options.to);
+    } catch (err) {
+      ui.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    const hasDateFilter = range.fromMs !== undefined || range.toMs !== undefined;
 
     // A single cooldown gate shared by all upload workers: a 429/503 seen by
     // one worker pauses the others. The onTrip callback forwards a UI event
@@ -141,6 +154,10 @@ export function syncCommand(): Command {
 
     renderSyncHeadless(engine);
 
+    if (hasDateFilter) {
+      ui.info(`Date filter: ${describeRange(range)}`);
+    }
+
     try {
       await engine.run({
         folderIds,
@@ -149,6 +166,8 @@ export function syncCommand(): Command {
         concurrency: options.concurrency,
         circleId:    options.circle ?? cfg.activeCircleId,
         scanId,
+        fromMs:      range.fromMs,
+        toMs:        range.toMs,
         trigger:     'cli',
       });
     } catch (err) {

--- a/apps/cli/src/render/headless-sync.ts
+++ b/apps/cli/src/render/headless-sync.ts
@@ -49,6 +49,16 @@ interface RendererState {
   rows: FileSummaryRow[];
 }
 
+/** Human-readable label for a FILE_SKIPPED reason (shown in the summary table). */
+function skipReasonLabel(reason: FileSkippedPayload['reason']): string {
+  switch (reason) {
+    case 'dedup':        return 'dedup';
+    case 'unchanged':    return 'unchanged';
+    case 'out_of_range': return 'out of date range';
+    default:             return reason;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // renderSyncHeadless
 // ---------------------------------------------------------------------------
@@ -223,7 +233,7 @@ export function renderSyncHeadless(engine: SyncEngine): void {
     state.rows.push({
       file: payload.path,
       status: 'skipped',
-      detail: payload.reason,
+      detail: skipReasonLabel(payload.reason),
     });
 
     advanceBar();

--- a/apps/cli/src/sync/date-range.ts
+++ b/apps/cli/src/sync/date-range.ts
@@ -1,0 +1,91 @@
+/**
+ * sync/date-range.ts — Capture-date range parsing for the `sync` command.
+ *
+ * A small, dependency-free helper that turns the optional `--from` / `--to`
+ * CLI options into an inclusive epoch-ms window the SyncEngine filters capture
+ * dates against.  Bare `YYYY-MM-DD` inputs are interpreted in LOCAL time —
+ * `from` snaps to the start of the day (00:00:00.000), `to` to the end of the
+ * day (23:59:59.999) — so a same-day `--from`/`--to` covers the whole day the
+ * user meant.  Full ISO 8601 datetimes are parsed as-is.
+ *
+ * Like the other files in this directory the engine stays UI-free: parsing
+ * failures are surfaced as thrown Errors for the command layer to present.
+ */
+
+/** Inclusive epoch-ms bounds on capture date; undefined = unbounded that side. */
+export interface DateRange {
+  fromMs?: number;
+  toMs?: number;
+}
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse a single bound. `which` selects the day-edge for bare dates. */
+function parseBound(
+  raw: string | undefined,
+  which: 'from' | 'to',
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+
+  if (DATE_ONLY_RE.test(trimmed)) {
+    const [y, m, d] = trimmed.split('-').map((s) => parseInt(s, 10));
+    // Construct in LOCAL time at the appropriate day edge.
+    const dt =
+      which === 'from'
+        ? new Date(y, m - 1, d, 0, 0, 0, 0)
+        : new Date(y, m - 1, d, 23, 59, 59, 999);
+    const ms = dt.getTime();
+    if (Number.isNaN(ms)) {
+      throw new Error(`Invalid --${which} date: "${raw}" (expected YYYY-MM-DD)`);
+    }
+    return ms;
+  }
+
+  // Full ISO 8601 datetime — parse as-is.
+  const ms = Date.parse(trimmed);
+  if (Number.isNaN(ms)) {
+    throw new Error(`Invalid --${which} date: "${raw}" (expected YYYY-MM-DD)`);
+  }
+  return ms;
+}
+
+/**
+ * Parse `--from` / `--to` into an inclusive epoch-ms range.
+ *
+ * @throws Error on unparseable input, or when `fromMs > toMs`.
+ */
+export function parseDateRange(from?: string, to?: string): DateRange {
+  const fromMs = parseBound(from, 'from');
+  const toMs = parseBound(to, 'to');
+
+  if (fromMs !== undefined && toMs !== undefined && fromMs > toMs) {
+    throw new Error('--from must be on or before --to');
+  }
+
+  return { fromMs, toMs };
+}
+
+/** Format epoch-ms as `YYYY-MM-DD` in LOCAL time. */
+function ymdLocal(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Human-readable one-line description of a range for informational output.
+ * `"all dates"` when unbounded; `"A → B"`, `"on/after A"`, or `"on/before B"`.
+ */
+export function describeRange(r: DateRange): string {
+  const hasFrom = r.fromMs !== undefined;
+  const hasTo = r.toMs !== undefined;
+
+  if (!hasFrom && !hasTo) return 'all dates';
+  if (hasFrom && hasTo) return `${ymdLocal(r.fromMs!)} → ${ymdLocal(r.toMs!)}`;
+  if (hasFrom) return `on/after ${ymdLocal(r.fromMs!)}`;
+  return `on/before ${ymdLocal(r.toMs!)}`;
+}

--- a/apps/cli/src/sync/events.ts
+++ b/apps/cli/src/sync/events.ts
@@ -74,7 +74,7 @@ export interface FileProgressPayload {
 export interface FileSkippedPayload {
   fileId: number;
   path: string;
-  reason: 'dedup' | 'unchanged';
+  reason: 'dedup' | 'unchanged' | 'out_of_range';
 }
 
 export interface FileDonePayload {

--- a/apps/cli/src/sync/sync-engine.ts
+++ b/apps/cli/src/sync/sync-engine.ts
@@ -14,7 +14,7 @@ import * as path from 'node:path';
 import { TypedEmitter, EV } from './events.js';
 import { runPool } from './worker-pool.js';
 import { enumerateFiles } from '../files.js';
-import { resolveCapturedAt } from '../metadata.js';
+import { resolveCapturedAt, type ResolvedCaptureDate } from '../metadata.js';
 import { sha256File } from '../hash.js';
 import { uploadFile, type UploadPersistence } from '../upload.js';
 import { ApiError, type ApiClient } from '../api.js';
@@ -58,6 +58,18 @@ export interface SyncOptions {
    * still built from the live filesystem.  Requires the `scans` dep.
    */
   scanId?: number;
+  /**
+   * Inclusive lower bound (epoch ms) on a file's resolved capture date. Files
+   * captured before this are skipped (FILE_SKIPPED reason 'out_of_range').
+   * undefined = unbounded on this side.
+   */
+  fromMs?: number;
+  /**
+   * Inclusive upper bound (epoch ms) on a file's resolved capture date. Files
+   * captured after this are skipped (FILE_SKIPPED reason 'out_of_range').
+   * undefined = unbounded on this side.
+   */
+  toMs?: number;
 }
 
 export interface SyncRunResult {
@@ -219,7 +231,12 @@ export class SyncEngine extends TypedEmitter {
     const workList: Array<{ fileId: number; filePath: string; mimeType: string; folderId: number }> = [];
     // Track per-file stat info so the worker can reuse cached hashes.
     const fileStatCache = new Map<number, { sizeBytes: number; mtimeMs: number }>();
+    // Cache the resolved capture date computed during date-range filtering so the
+    // worker's register step can reuse it instead of re-parsing EXIF.
+    const captureDateCache = new Map<number, ResolvedCaptureDate>();
     let unchangedSkippedCount = 0;
+    let outOfRangeSkippedCount = 0;
+    const dateFilterActive = opts.fromMs != null || opts.toMs != null;
 
     if (opts.retryFailedOnly) {
       // Retry path: collect failed (and optionally blocked) file records
@@ -295,6 +312,28 @@ export class SyncEngine extends TypedEmitter {
             continue;
           }
 
+          // Capture-date range filter: only resolve the date when a range is
+          // active so the no-filter path stays byte-for-byte unchanged in cost.
+          if (dateFilterActive) {
+            const cap = await resolveCapturedAt(filePath, mimeType);
+            const capMs = cap.capturedAt ? Date.parse(cap.capturedAt) : NaN;
+            if (
+              Number.isNaN(capMs) ||
+              (opts.fromMs != null && capMs < opts.fromMs) ||
+              (opts.toMs != null && capMs > opts.toMs)
+            ) {
+              outOfRangeSkippedCount++;
+              this.emit(EV.FILE_SKIPPED, {
+                fileId: rec.id,
+                path: filePath,
+                reason: 'out_of_range',
+              });
+              continue;
+            }
+            // In range — keep the resolved date for reuse in the register step.
+            captureDateCache.set(rec.id, cap);
+          }
+
           // Stash the stat for the worker so it can check the mtime cache
           if (sizeBytes !== null && mtimeMs !== null) {
             fileStatCache.set(rec.id, { sizeBytes, mtimeMs });
@@ -311,7 +350,7 @@ export class SyncEngine extends TypedEmitter {
     // ------------------------------------------------------------------
     // 4. Start the run record
     // ------------------------------------------------------------------
-    const total = workList.length + unchangedSkippedCount;
+    const total = workList.length + unchangedSkippedCount + outOfRangeSkippedCount;
     const runId = runs.startRun({
       trigger: opts.trigger,
       folderIds: targetFolderIds,
@@ -537,7 +576,10 @@ export class SyncEngine extends TypedEmitter {
         // originalCreatedAt records the file's creation time as provenance.
         const basename = path.basename(filePath);
         const type = mimeToMediaType(mimeType);
-        const cap = await resolveCapturedAt(filePath, mimeType);
+        // Reuse the date resolved during range filtering when available; otherwise
+        // resolve it now (the no-filter path, unchanged from before).
+        const cap =
+          captureDateCache.get(fileId) ?? (await resolveCapturedAt(filePath, mimeType));
         const mediaItem = await api.post<MediaItem>('/api/media', {
           storageObjectId: objectId,
           type,
@@ -630,7 +672,7 @@ export class SyncEngine extends TypedEmitter {
     const totalCounts = files.counts(targetFolderIds);
     const stats = {
       uploaded: totalCounts.uploaded,
-      skipped:  totalCounts.skipped + unchangedSkippedCount,
+      skipped:  totalCounts.skipped + unchangedSkippedCount + outOfRangeSkippedCount,
       failed:   totalCounts.failed,
     };
 

--- a/apps/cli/src/sync/sync-report.ts
+++ b/apps/cli/src/sync/sync-report.ts
@@ -22,10 +22,20 @@ import { exportSyncReport } from '../export/sync-export.js';
 
 export type SyncFileStatus = 'uploaded' | 'skipped' | 'failed' | 'would-upload';
 
+/** Map a FILE_SKIPPED reason to the label recorded in the Excel report. */
+function skipReasonLabel(reason: 'dedup' | 'unchanged' | 'out_of_range'): string {
+  switch (reason) {
+    case 'dedup':        return 'dedup';
+    case 'unchanged':    return 'unchanged';
+    case 'out_of_range': return 'out of date range';
+    default:             return reason;
+  }
+}
+
 export interface SyncFileRow {
   filePath: string;
   status: SyncFileStatus;
-  /** Skip reason ('dedup' | 'unchanged') or failure message; null otherwise. */
+  /** Skip reason ('dedup' | 'unchanged' | 'out of date range') or failure message; null otherwise. */
   detail: string | null;
   sizeBytes: number | null;
   mimeType: string | null;
@@ -88,7 +98,7 @@ export class SyncReportCollector {
       });
     });
     engine.on(EV.FILE_SKIPPED, (p) => {
-      this.outcomes.set(p.fileId, { status: 'skipped', detail: p.reason });
+      this.outcomes.set(p.fileId, { status: 'skipped', detail: skipReasonLabel(p.reason) });
     });
     engine.on(EV.FILE_FAILED, (p) => {
       this.outcomes.set(p.fileId, { status: 'failed', detail: p.error });

--- a/apps/cli/src/tui/DateRangeFilter.tsx
+++ b/apps/cli/src/tui/DateRangeFilter.tsx
@@ -1,0 +1,189 @@
+/**
+ * tui/DateRangeFilter.tsx — Optional capture-date range filter step.
+ *
+ * Sits between the sync-flow entry (Sync all / Sync selected) and the live
+ * SyncDashboard. Lets the user optionally bound the sync to a capture-date
+ * window before the engine runs. Both fields are optional — an empty field
+ * means "unbounded that side", and both empty means "all dates".
+ *
+ * Props: { onApply, onBack }
+ *
+ * Interaction:
+ *   up/down — move focus between the From and To fields
+ *   type    — edit the focused field (sanitized to date characters only)
+ *   Enter   — apply the parsed range (blocked while invalid)
+ *   c       — clear both fields
+ *   Esc/q   — back
+ *
+ * The screen live-validates on every keystroke via parseDateRange() and shows
+ * either an inline error (blocking Enter) or a prominent preview line built
+ * from describeRange() so the user always sees exactly what will sync.
+ *
+ * Only date characters (digits, '-', and the ISO extras 'T:.Zz+ ') are allowed
+ * into the fields; command keys ('c'/'q') are stripped by the sanitizer, so a
+ * command keystroke never lands as text — it only triggers its command.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+
+import {
+  parseDateRange,
+  describeRange,
+  type DateRange,
+} from '../sync/date-range.js';
+import { BOX_BORDER, GLYPHS } from './theme.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DateRangeFilterProps {
+  onApply: (r: DateRange) => void;
+  onBack: () => void;
+}
+
+type FocusField = 'from' | 'to';
+
+// Characters legal in a bare `YYYY-MM-DD` date or a full ISO 8601 datetime.
+// Everything else (including the command keys 'c'/'q') is stripped so it can
+// never appear as typed text in a field.
+const DATE_CHARS_RE = /[^\dTZz:.\-+ ]/g;
+
+function sanitize(raw: string): string {
+  return raw.replace(DATE_CHARS_RE, '');
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DateRangeFilter({
+  onApply,
+  onBack,
+}: DateRangeFilterProps): React.ReactElement {
+  const [fromStr, setFromStr] = useState('');
+  const [toStr, setToStr]     = useState('');
+  const [focus, setFocus]     = useState<FocusField>('from');
+
+  // Live validation + preview — recomputed every render.
+  let previewText: string | null = null;
+  let errorText: string | null = null;
+  let parsedRange: DateRange | null = null;
+  try {
+    parsedRange = parseDateRange(fromStr || undefined, toStr || undefined);
+    previewText = describeRange(parsedRange);
+  } catch (err) {
+    errorText = err instanceof Error ? err.message : String(err);
+  }
+
+  // ---- Field edits: sanitize, and skip no-op writes so a stripped command
+  //      key ('c'/'q') never clobbers the command's own state change. ----
+  const handleChange = useCallback(
+    (which: FocusField, raw: string) => {
+      const clean = sanitize(raw);
+      if (which === 'from') {
+        setFromStr((prev) => (clean === prev ? prev : clean));
+      } else {
+        setToStr((prev) => (clean === prev ? prev : clean));
+      }
+    },
+    [],
+  );
+
+  const handleApply = useCallback(() => {
+    // Re-parse defensively; block when the current input is invalid.
+    try {
+      const r = parseDateRange(fromStr || undefined, toStr || undefined);
+      onApply(r);
+    } catch {
+      // Invalid — do nothing; the inline error already tells the user why.
+    }
+  }, [fromStr, toStr, onApply]);
+
+  // ---- Global keybindings (arrows/commands; typing goes to TextInput). ----
+  useInput((input, key) => {
+    if (key.escape || input === 'q') {
+      onBack();
+      return;
+    }
+    if (input === 'c') {
+      setFromStr('');
+      setToStr('');
+      return;
+    }
+    if (key.upArrow) {
+      setFocus('from');
+      return;
+    }
+    if (key.downArrow) {
+      setFocus('to');
+      return;
+    }
+    if (key.tab) {
+      setFocus((f) => (f === 'from' ? 'to' : 'from'));
+      return;
+    }
+  });
+
+  const fieldMarker = (field: FocusField): string =>
+    focus === field ? GLYPHS.arrow : ' ';
+
+  return (
+    <Box
+      borderStyle={BOX_BORDER}
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={2}
+      paddingY={1}
+    >
+      <Text bold color="cyan">Date range filter</Text>
+      <Text dimColor>
+        Filter by photo capture date (EXIF, else file date). Leave blank to sync all dates.
+      </Text>
+
+      {/* From field */}
+      <Box flexDirection="row" gap={1} marginTop={1}>
+        <Text color={focus === 'from' ? 'cyan' : undefined}>{fieldMarker('from')}</Text>
+        <Text color={focus === 'from' ? 'cyan' : undefined}>From</Text>
+        <TextInput
+          value={fromStr}
+          onChange={(v) => handleChange('from', v)}
+          onSubmit={handleApply}
+          placeholder="YYYY-MM-DD"
+          focus={focus === 'from'}
+        />
+      </Box>
+
+      {/* To field */}
+      <Box flexDirection="row" gap={1}>
+        <Text color={focus === 'to' ? 'cyan' : undefined}>{fieldMarker('to')}</Text>
+        <Text color={focus === 'to' ? 'cyan' : undefined}>To  </Text>
+        <TextInput
+          value={toStr}
+          onChange={(v) => handleChange('to', v)}
+          onSubmit={handleApply}
+          placeholder="YYYY-MM-DD"
+          focus={focus === 'to'}
+        />
+      </Box>
+
+      {/* Live preview / validation */}
+      <Box marginTop={1}>
+        {errorText ? (
+          <Text color="red">{GLYPHS.cross} {errorText}</Text>
+        ) : (
+          <Text color="green">
+            {GLYPHS.check} Syncing: <Text bold>{previewText}</Text>
+          </Text>
+        )}
+      </Box>
+
+      {/* Keybindings footer */}
+      <Box marginTop={1}>
+        <Text dimColor>[up/down] field  [Enter] apply  [c] clear both  [Esc/q] back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/SyncDashboard.tsx
+++ b/apps/cli/src/tui/SyncDashboard.tsx
@@ -30,6 +30,7 @@ import { FileRepo } from '../repo/files.js';
 import { RunRepo } from '../repo/runs.js';
 import { SettingsRepo } from '../repo/settings.js';
 import type { CliConfig } from '../config.js';
+import { describeRange } from '../sync/date-range.js';
 
 import { StatusLine } from './components/StatusLine.js';
 import { ContextMeter } from './components/ContextMeter.js';
@@ -50,6 +51,10 @@ export interface SyncDashboardProps {
   folderIds?: number[];
   /** When true, engine is invoked with retryFailedOnly=true and trigger='retry'. */
   retryFailedOnly?: boolean;
+  /** Inclusive capture-date lower bound (epoch ms); undefined = unbounded. */
+  fromMs?: number;
+  /** Inclusive capture-date upper bound (epoch ms); undefined = unbounded. */
+  toMs?: number;
   onHome: () => void;
   /**
    * Optional pre-built engine instance for tests.
@@ -95,6 +100,8 @@ export function SyncDashboard({
   all,
   folderIds,
   retryFailedOnly,
+  fromMs,
+  toMs,
   onHome,
   _engineForTesting,
 }: SyncDashboardProps): React.ReactElement {
@@ -322,6 +329,8 @@ export function SyncDashboard({
         folderIds: folderIds ?? [],
         retryFailedOnly: retryFailedOnly ?? false,
         circleId: config.activeCircleId,
+        fromMs,
+        toMs,
       }).catch(() => {
         // Fatal errors emitted via EV.ERROR already
       });
@@ -377,10 +386,12 @@ export function SyncDashboard({
 
   const dashboardTitle = retryFailedOnly ? 'Retry' : 'Sync';
 
+  const hasDateFilter = fromMs != null || toMs != null;
+
   return (
     <Box flexDirection="column" gap={1}>
       {/* Header */}
-      <Box borderStyle={BOX_BORDER} borderColor="cyan" paddingX={1}>
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={1}>
         <StatusLine
           serverUrl={serverHost}
           folderCount={folderCount}
@@ -388,6 +399,9 @@ export function SyncDashboard({
           durationMs={durationMs}
           title={dashboardTitle}
         />
+        {hasDateFilter && (
+          <Text dimColor>Filter: {describeRange({ fromMs, toMs })}</Text>
+        )}
       </Box>
 
       {/* Context meter */}

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -28,6 +28,7 @@ import { LoginScreen } from './LoginScreen.js';
 import { FolderManager } from './FolderManager.js';
 import { CircleManager } from './CircleManager.js';
 import { PickFolders } from './PickFolders.js';
+import { DateRangeFilter } from './DateRangeFilter.js';
 import { SyncDashboard } from './SyncDashboard.js';
 import { ScanScreen } from './ScanScreen.js';
 import { ReportView } from './ReportView.js';
@@ -54,7 +55,8 @@ type Screen =
   | { kind: 'folders' }
   | { kind: 'circles' }
   | { kind: 'pickFolders'; purpose?: 'sync' | 'scan' }
-  | { kind: 'dashboard'; all?: boolean; folderIds?: number[]; retryFailedOnly?: boolean }
+  | { kind: 'dateRange'; all?: boolean; folderIds?: number[] }
+  | { kind: 'dashboard'; all?: boolean; folderIds?: number[]; retryFailedOnly?: boolean; fromMs?: number; toMs?: number }
   | { kind: 'scan'; all?: boolean; folderIds?: number[] }
   | { kind: 'scanReport' }
   | { kind: 'help' }
@@ -196,7 +198,7 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
         push({ kind: 'screen', screen: { kind: 'factoryReset' } });
         break;
       case 'sync-all':
-        push({ kind: 'screen', screen: { kind: 'dashboard', all: true } });
+        push({ kind: 'screen', screen: { kind: 'dateRange', all: true } });
         break;
       case 'sync-select':
         push({ kind: 'screen', screen: { kind: 'pickFolders' } });
@@ -381,7 +383,7 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
                 screen:
                   purpose === 'scan'
                     ? { kind: 'scan', folderIds }
-                    : { kind: 'dashboard', folderIds },
+                    : { kind: 'dateRange', folderIds },
               },
             ])
           }
@@ -389,6 +391,25 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
         />
       );
     }
+
+    case 'dateRange':
+      return (
+        <DateRangeFilter
+          onApply={(r) =>
+            push({
+              kind: 'screen',
+              screen: {
+                kind: 'dashboard',
+                all: screen.all,
+                folderIds: screen.folderIds,
+                fromMs: r.fromMs,
+                toMs: r.toMs,
+              },
+            })
+          }
+          onBack={pop}
+        />
+      );
 
     case 'scan':
       return (
@@ -421,6 +442,8 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
           all={screen.all}
           folderIds={screen.folderIds}
           retryFailedOnly={screen.retryFailedOnly}
+          fromMs={screen.fromMs}
+          toMs={screen.toMs}
           onHome={resetToRoot}
         />
       );

--- a/apps/cli/src/tui/components/EventLog.tsx
+++ b/apps/cli/src/tui/components/EventLog.tsx
@@ -42,6 +42,16 @@ function truncate(s: string, max: number): string {
   return s.slice(0, max - 1) + '…';
 }
 
+/** Human-friendly labels for known skip reasons; falls back to the raw value. */
+const REASON_LABELS: Record<string, string> = {
+  out_of_range: 'out of date range',
+};
+
+function reasonLabel(reason?: string): string {
+  if (!reason) return 'skipped';
+  return REASON_LABELS[reason] ?? reason;
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -72,7 +82,7 @@ export function EventLog({
               <Box key={ev.id} flexDirection="row" gap={1}>
                 <Text color="blue">{GLYPHS.retry}</Text>
                 <Text dimColor>{name}</Text>
-                <Text dimColor>({ev.reason ?? 'skipped'})</Text>
+                <Text dimColor>({reasonLabel(ev.reason)})</Text>
               </Box>
             );
           case 'failed':

--- a/apps/cli/test/sync/date-range.spec.ts
+++ b/apps/cli/test/sync/date-range.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * test/sync/date-range.spec.ts
+ *
+ * Unit tests for sync/date-range.ts — the pure --from/--to parsing and
+ * human-readable description helpers used by the sync command and the
+ * DateRangeFilter TUI screen.
+ *
+ * No DB, no fs, no mocking — plain function-in/value-out assertions. Local
+ * day-edge expectations are built with `new Date(y, m-1, d, ...)` so the test
+ * is timezone-independent (matches whatever TZ the test runner happens to be
+ * in, the same way the implementation does).
+ */
+
+import { parseDateRange, describeRange } from '../../src/sync/date-range.js';
+
+describe('parseDateRange', () => {
+  describe('bare YYYY-MM-DD inputs', () => {
+    it('parses a bare --from date to local start-of-day (00:00:00.000)', () => {
+      const { fromMs } = parseDateRange('2023-06-15', undefined);
+      const expected = new Date(2023, 5, 15, 0, 0, 0, 0).getTime();
+      expect(fromMs).toBe(expected);
+    });
+
+    it('parses a bare --to date to local end-of-day (23:59:59.999)', () => {
+      const { toMs } = parseDateRange(undefined, '2023-06-15');
+      const expected = new Date(2023, 5, 15, 23, 59, 59, 999).getTime();
+      expect(toMs).toBe(expected);
+    });
+
+    it('parses matching --from/--to on the same day to the full day window', () => {
+      const { fromMs, toMs } = parseDateRange('2023-06-15', '2023-06-15');
+      expect(fromMs).toBe(new Date(2023, 5, 15, 0, 0, 0, 0).getTime());
+      expect(toMs).toBe(new Date(2023, 5, 15, 23, 59, 59, 999).getTime());
+    });
+  });
+
+  describe('one-sided bounds', () => {
+    it('leaves toMs undefined when only --from is supplied', () => {
+      const r = parseDateRange('2023-01-01', undefined);
+      expect(r.fromMs).toBeDefined();
+      expect(r.toMs).toBeUndefined();
+    });
+
+    it('leaves fromMs undefined when only --to is supplied', () => {
+      const r = parseDateRange(undefined, '2023-01-31');
+      expect(r.toMs).toBeDefined();
+      expect(r.fromMs).toBeUndefined();
+    });
+  });
+
+  describe('unbounded / empty input', () => {
+    it('returns an empty range when both are undefined', () => {
+      expect(parseDateRange(undefined, undefined)).toEqual({});
+    });
+
+    it('treats empty strings as omitted', () => {
+      expect(parseDateRange('', '')).toEqual({});
+    });
+
+    it('treats whitespace-only strings as omitted', () => {
+      expect(parseDateRange('   ', '\t\n ')).toEqual({});
+    });
+
+    it('trims surrounding whitespace around a valid date', () => {
+      const { fromMs } = parseDateRange('  2023-06-15  ', undefined);
+      expect(fromMs).toBe(new Date(2023, 5, 15, 0, 0, 0, 0).getTime());
+    });
+  });
+
+  describe('full ISO 8601 datetimes', () => {
+    it('parses a full ISO datetime for --from as-is (not snapped to a day edge)', () => {
+      const iso = '2023-06-15T10:30:00.000Z';
+      const { fromMs } = parseDateRange(iso, undefined);
+      expect(fromMs).toBe(Date.parse(iso));
+    });
+
+    it('parses a full ISO datetime for --to as-is', () => {
+      const iso = '2023-06-15T10:30:00.000Z';
+      const { toMs } = parseDateRange(undefined, iso);
+      expect(toMs).toBe(Date.parse(iso));
+    });
+  });
+
+  describe('validation', () => {
+    it('throws when --from is after --to', () => {
+      expect(() => parseDateRange('2023-06-16', '2023-06-15')).toThrow(
+        '--from must be on or before --to',
+      );
+    });
+
+    it('does not throw when --from equals --to', () => {
+      expect(() => parseDateRange('2023-06-15', '2023-06-15')).not.toThrow();
+    });
+
+    it('throws a helpful error for an unparseable --from string', () => {
+      expect(() => parseDateRange('not-a-date', undefined)).toThrow(
+        /Invalid --from date: "not-a-date"/,
+      );
+    });
+
+    it('throws a helpful error for an unparseable --to string', () => {
+      expect(() => parseDateRange(undefined, 'garbage')).toThrow(
+        /Invalid --to date: "garbage"/,
+      );
+    });
+  });
+});
+
+describe('describeRange', () => {
+  it('returns "all dates" when both bounds are unbounded', () => {
+    const r = parseDateRange(undefined, undefined);
+    expect(describeRange(r)).toBe('all dates');
+  });
+
+  it('returns "A → B" when both bounds are set', () => {
+    const r = parseDateRange('2023-01-01', '2023-01-31');
+    expect(describeRange(r)).toBe('2023-01-01 → 2023-01-31');
+  });
+
+  it('returns "on/after A" when only fromMs is set', () => {
+    const r = parseDateRange('2023-01-01', undefined);
+    expect(describeRange(r)).toBe('on/after 2023-01-01');
+  });
+
+  it('returns "on/before B" when only toMs is set', () => {
+    const r = parseDateRange(undefined, '2023-01-31');
+    expect(describeRange(r)).toBe('on/before 2023-01-31');
+  });
+
+  it('formats a full ISO datetime bound down to its local calendar day', () => {
+    // describeRange formats via ymdLocal(), which only shows the day —
+    // a datetime bound should round-trip to the same YYYY-MM-DD.
+    const r = parseDateRange('2023-06-15T23:00:00.000', undefined);
+    expect(describeRange(r)).toBe('on/after 2023-06-15');
+  });
+});

--- a/apps/cli/test/sync/sync-engine-date-range.spec.ts
+++ b/apps/cli/test/sync/sync-engine-date-range.spec.ts
@@ -1,0 +1,456 @@
+/**
+ * test/sync/sync-engine-date-range.spec.ts
+ *
+ * Tests for the capture-date range filter (`fromMs`/`toMs` on SyncOptions) in
+ * the SyncEngine work-set build loop (src/sync/sync-engine.ts).
+ *
+ * Harness: mirrors test/sync/sync-engine.spec.ts — in-memory SQLite
+ * (openDb(':memory:')), a mock ApiClient, and injectable uploadFn/hashFn —
+ * plus REAL temp files on disk so enumerateFiles() / fs.statSync() work
+ * unmodified (files.js is NOT mocked).
+ *
+ * SyncEngine has no DI hook for `resolveCapturedAt` (unlike uploadFn/hashFn),
+ * so controlling capture dates per file requires mocking src/metadata.js.
+ * Under ESM with --experimental-vm-modules, static jest.mock() does not
+ * intercept relative imports, so we use jest.unstable_mockModule + dynamic
+ * import (after the mock is registered) — the same pattern already used in
+ * test/manifest.spec.ts and test/tui/login-screen.spec.tsx.
+ *
+ * IMPORTANT — resolveCapturedAt has TWO call sites in sync-engine.ts:
+ *   1. The work-set build loop, gated by `dateFilterActive` (the guard this
+ *      file is chiefly about).
+ *   2. The worker's register step, which resolves capturedAt/originalCreatedAt
+ *      to attach to POST /api/media — unrelated to date filtering, and it
+ *      always runs for a normal upload regardless of whether a range filter
+ *      is active (it reuses the build-phase result via captureDateCache when
+ *      available, otherwise resolves fresh).
+ * Because of call site #2, asserting "resolveCapturedAt was never called"
+ * against an ordinary successful upload can NOT prove the build-phase guard
+ * — call site #2 will always fire once. To isolate the guard, the
+ * no-filter-call-count tests below use a DEDUP HIT, which short-circuits the
+ * worker before it ever reaches the register step (see the dedup tests at
+ * the bottom of this file for the reasoning spelled out again inline).
+ */
+
+import { jest } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ResolvedCaptureDate } from '../../src/metadata.js';
+import type {
+  FileSkippedPayload,
+  FileQueuedPayload,
+  FileDonePayload,
+} from '../../src/sync/events.js';
+import type { SyncEngineDeps } from '../../src/sync/sync-engine.js';
+import type { ApiClient } from '../../src/api.js';
+import type BetterSqlite3 from 'better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// Mock metadata.js's resolveCapturedAt — controllable per absolute file path.
+// Everything else (enumerateFiles, repos, DB) is real.
+// ---------------------------------------------------------------------------
+
+const capturedAtByPath = new Map<string, ResolvedCaptureDate>();
+
+const resolveCapturedAtMock = jest.fn(
+  async (filePath: string, _mimeType: string): Promise<ResolvedCaptureDate> =>
+    capturedAtByPath.get(filePath) ?? {
+      capturedAt: null,
+      source: 'none',
+      originalCreatedAt: null,
+    },
+);
+
+jest.unstable_mockModule('../../src/metadata.js', () => ({
+  resolveCapturedAt: resolveCapturedAtMock,
+  readMediaMetadata: jest.fn(),
+  oldestFileTimestamp: jest.fn(),
+}));
+
+// Dynamic imports AFTER jest.unstable_mockModule so the mock is applied.
+const { openDb } = await import('../../src/db/database.js');
+const { FolderRepo } = await import('../../src/repo/folders.js');
+const { FileRepo } = await import('../../src/repo/files.js');
+const { RunRepo } = await import('../../src/repo/runs.js');
+const { SettingsRepo } = await import('../../src/repo/settings.js');
+const { SyncEngine } = await import('../../src/sync/sync-engine.js');
+const { EV } = await import('../../src/sync/events.js');
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors test/sync/sync-engine.spec.ts)
+// ---------------------------------------------------------------------------
+
+function makeDb(): BetterSqlite3.Database {
+  return openDb(':memory:');
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = jest.Mock<(...args: any[]) => any>;
+
+/** Return a jest mock that resolves with `value`. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockResolving(value: any): AnyFn {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fn = jest.fn<(...args: any[]) => any>();
+  fn.mockResolvedValue(value);
+  return fn;
+}
+
+/** Create a minimal mock ApiClient with overrideable get/post stubs. */
+function makeApi(overrides: { get?: AnyFn; post?: AnyFn } = {}): ApiClient {
+  return {
+    get:    overrides.get  ?? mockResolving({ items: [] }),
+    post:   overrides.post ?? mockResolving({ id: 'media-default' }),
+    putRaw: mockResolving('etag'),
+  } as unknown as ApiClient;
+}
+
+function makeUploadFn(objectId = 'obj-default'): AnyFn {
+  return mockResolving({ objectId });
+}
+
+function makeHashFn(fixedHash = 'deadbeefdeadbeef'): AnyFn {
+  return mockResolving(fixedHash);
+}
+
+/** Write a real temp file (JPEG header) so statSync and enumerateFiles work. */
+function writeTmpJpeg(dir: string, name: string): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+  return p;
+}
+
+/** Build a SyncEngine with in-memory repos. Returns engine + repos for inspection. */
+function makeEngine(
+  db: BetterSqlite3.Database,
+  apiOverrides: { get?: AnyFn; post?: AnyFn } = {},
+  uploadFn?: AnyFn,
+  hashFn?: AnyFn,
+): {
+  engine: InstanceType<typeof SyncEngine>;
+  folders: InstanceType<typeof FolderRepo>;
+  files: InstanceType<typeof FileRepo>;
+  runs: InstanceType<typeof RunRepo>;
+  settings: InstanceType<typeof SettingsRepo>;
+  api: ApiClient;
+  uploadFn: AnyFn;
+  hashFn: AnyFn;
+} {
+  const folders = new FolderRepo(db);
+  const files = new FileRepo(db);
+  const runs = new RunRepo(db);
+  const settings = new SettingsRepo(db);
+  const api = makeApi(apiOverrides);
+  const upload = uploadFn ?? makeUploadFn();
+  const hash = hashFn ?? makeHashFn();
+
+  const engine = new SyncEngine({
+    api,
+    folders,
+    files,
+    runs,
+    settings,
+    uploadFn: upload as unknown as SyncEngineDeps['uploadFn'],
+    hashFn: hash as unknown as SyncEngineDeps['hashFn'],
+  });
+
+  return { engine, folders, files, runs, settings, api, uploadFn: upload, hashFn: hash };
+}
+
+const IN_RANGE_FROM_MS = Date.parse('2024-01-01T00:00:00.000Z');
+const IN_RANGE_TO_MS = Date.parse('2024-12-31T23:59:59.999Z');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SyncEngine — capture-date range filter', () => {
+  let db: BetterSqlite3.Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    db = makeDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-engine-daterange-'));
+    capturedAtByPath.clear();
+    resolveCapturedAtMock.mockClear();
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // In-range file: queued and uploaded, not skipped
+  // -------------------------------------------------------------------------
+
+  it('queues and uploads a file whose resolved capture date falls within [fromMs, toMs]', async () => {
+    const filePath = writeTmpJpeg(tmpDir, 'in-range.jpg');
+    capturedAtByPath.set(filePath, {
+      capturedAt: '2024-06-15T12:00:00.000Z',
+      source: 'exif',
+      originalCreatedAt: null,
+    });
+
+    const ctx = makeEngine(
+      db,
+      { get: mockResolving({ items: [] }), post: mockResolving({ id: 'media-in-range' }) },
+      makeUploadFn('obj-in-range'),
+    );
+    const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+    const skipped: FileSkippedPayload[] = [];
+    const done: FileDonePayload[] = [];
+    ctx.engine.on(EV.FILE_SKIPPED, (p) => skipped.push(p));
+    ctx.engine.on(EV.FILE_DONE, (p) => done.push(p));
+
+    await ctx.engine.run({
+      trigger: 'cli',
+      folderIds: [folder.id],
+      fromMs: IN_RANGE_FROM_MS,
+      toMs: IN_RANGE_TO_MS,
+    });
+
+    expect(skipped.some((s) => s.reason === 'out_of_range')).toBe(false);
+    expect(done).toHaveLength(1);
+    expect(ctx.uploadFn).toHaveBeenCalledTimes(1);
+
+    const rec = ctx.files.listByFolder(folder.id)[0];
+    expect(rec.status).toBe('uploaded');
+  });
+
+  // -------------------------------------------------------------------------
+  // Out-of-range file: FILE_SKIPPED reason=out_of_range, never queued/uploaded
+  // -------------------------------------------------------------------------
+
+  it('skips an out-of-range file with reason=out_of_range and never queues or uploads it', async () => {
+    const filePath = writeTmpJpeg(tmpDir, 'out-of-range.jpg');
+    capturedAtByPath.set(filePath, {
+      capturedAt: '2020-01-01T00:00:00.000Z',
+      source: 'exif',
+      originalCreatedAt: null,
+    });
+
+    const ctx = makeEngine(db, { get: mockResolving({ items: [] }) }, makeUploadFn());
+    const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+    const skipped: FileSkippedPayload[] = [];
+    const queued: FileQueuedPayload[] = [];
+    ctx.engine.on(EV.FILE_SKIPPED, (p) => skipped.push(p));
+    ctx.engine.on(EV.FILE_QUEUED, (p) => queued.push(p));
+
+    await ctx.engine.run({
+      trigger: 'cli',
+      folderIds: [folder.id],
+      fromMs: IN_RANGE_FROM_MS,
+      toMs: IN_RANGE_TO_MS,
+    });
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('out_of_range');
+    expect(queued).toHaveLength(0);
+    expect(ctx.uploadFn).not.toHaveBeenCalled();
+
+    const rec = ctx.files.listByFolder(folder.id)[0];
+    expect(rec.status).not.toBe('uploaded');
+  });
+
+  // -------------------------------------------------------------------------
+  // Undated file (capturedAt: null) while a range is active
+  // -------------------------------------------------------------------------
+
+  it('treats a file with capturedAt=null as out_of_range while a range filter is active', async () => {
+    const filePath = writeTmpJpeg(tmpDir, 'undated.jpg');
+    capturedAtByPath.set(filePath, { capturedAt: null, source: 'none', originalCreatedAt: null });
+
+    const ctx = makeEngine(db, { get: mockResolving({ items: [] }) }, makeUploadFn());
+    const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+    const skipped: FileSkippedPayload[] = [];
+    ctx.engine.on(EV.FILE_SKIPPED, (p) => skipped.push(p));
+
+    await ctx.engine.run({
+      trigger: 'cli',
+      folderIds: [folder.id],
+      fromMs: IN_RANGE_FROM_MS,
+      toMs: IN_RANGE_TO_MS,
+    });
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('out_of_range');
+    expect(ctx.uploadFn).not.toHaveBeenCalled();
+
+    const rec = ctx.files.listByFolder(folder.id)[0];
+    expect(rec.status).not.toBe('uploaded');
+  });
+
+  // -------------------------------------------------------------------------
+  // Unchanged fast-skip wins over the date filter
+  // -------------------------------------------------------------------------
+
+  it('lets the unchanged fast-skip win over an active date filter, without consulting resolveCapturedAt', async () => {
+    const filePath = writeTmpJpeg(tmpDir, 'stable.jpg');
+    const size = fs.statSync(filePath).size;
+
+    const seedCtx = makeEngine(db);
+    const folder = seedCtx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+    // Pre-seed as already uploaded with matching size — simulates a prior successful sync.
+    seedCtx.files.upsert(folder.id, filePath, {
+      status: 'uploaded',
+      size_bytes: size,
+      mime_type: 'image/jpeg',
+    });
+
+    // Deliberately leave this path unregistered in capturedAtByPath. If the
+    // unchanged check did NOT run first, the engine would fall through to the
+    // date-range check, call the mock (default fallback capturedAt: null),
+    // and mis-skip this file as out_of_range instead of unchanged.
+    resolveCapturedAtMock.mockClear();
+
+    const ctx = makeEngine(db, { get: mockResolving({ items: [] }) }, makeUploadFn());
+
+    const skipped: FileSkippedPayload[] = [];
+    ctx.engine.on(EV.FILE_SKIPPED, (p) => skipped.push(p));
+
+    await ctx.engine.run({
+      trigger: 'cli',
+      folderIds: [folder.id],
+      fromMs: IN_RANGE_FROM_MS,
+      toMs: IN_RANGE_TO_MS,
+    });
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('unchanged');
+    expect(resolveCapturedAtMock).not.toHaveBeenCalled();
+    expect(ctx.uploadFn).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Re-process guarantee: a later unfiltered run picks up the skipped file
+  // -------------------------------------------------------------------------
+
+  it('re-processes a previously out-of-range file on a later unfiltered run (skipped -> uploaded)', async () => {
+    const filePath = writeTmpJpeg(tmpDir, 'reprocess.jpg');
+    capturedAtByPath.set(filePath, {
+      capturedAt: '2020-05-05T00:00:00.000Z',
+      source: 'exif',
+      originalCreatedAt: null,
+    });
+
+    // First run — filtered — the file is out of range and left un-uploaded.
+    const ctx1 = makeEngine(db, { get: mockResolving({ items: [] }) }, makeUploadFn('obj-1'));
+    const folder = ctx1.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+    const skipped1: FileSkippedPayload[] = [];
+    ctx1.engine.on(EV.FILE_SKIPPED, (p) => skipped1.push(p));
+
+    await ctx1.engine.run({
+      trigger: 'cli',
+      folderIds: [folder.id],
+      fromMs: IN_RANGE_FROM_MS,
+      toMs: IN_RANGE_TO_MS,
+    });
+
+    expect(skipped1).toHaveLength(1);
+    expect(skipped1[0].reason).toBe('out_of_range');
+    expect(ctx1.uploadFn).not.toHaveBeenCalled();
+
+    const afterFirstRun = ctx1.files.listByFolder(folder.id)[0];
+    expect(afterFirstRun.status).not.toBe('uploaded');
+
+    // Second run — same DB/file, same (still stale) capturedAt, but NO range —
+    // the file must be picked back up and uploaded.
+    const ctx2 = makeEngine(
+      db,
+      { get: mockResolving({ items: [] }), post: mockResolving({ id: 'media-reprocess' }) },
+      makeUploadFn('obj-2'),
+    );
+
+    const done2: FileDonePayload[] = [];
+    ctx2.engine.on(EV.FILE_DONE, (p) => done2.push(p));
+
+    await ctx2.engine.run({ trigger: 'cli', folderIds: [folder.id] });
+
+    expect(done2).toHaveLength(1);
+    expect(ctx2.uploadFn).toHaveBeenCalledTimes(1);
+
+    const afterSecondRun = ctx2.files.listByFolder(folder.id)[0];
+    expect(afterSecondRun.status).toBe('uploaded');
+  });
+
+  // -------------------------------------------------------------------------
+  // dateFilterActive gate — build-phase call-site isolation via dedup hits
+  // -------------------------------------------------------------------------
+  //
+  // See the file header comment: resolveCapturedAt has a second call site (the
+  // register step) that always fires for a normal successful upload regardless
+  // of filter state, so it cannot be used to prove the build-phase guard on
+  // its own. A dedup hit short-circuits the worker BEFORE the register step,
+  // so any call recorded against the mock in these two tests can only have
+  // come from the build-phase `if (dateFilterActive)` gate.
+
+  describe('dateFilterActive gate (isolated via dedup short-circuit)', () => {
+    it('does NOT call resolveCapturedAt at all when no range is active (dedup hit)', async () => {
+      const filePath = writeTmpJpeg(tmpDir, 'dedup-no-filter.jpg');
+      // No entry registered in capturedAtByPath for this path — if the gate
+      // were broken and the mock got called, its fallback would still not
+      // throw, but the assertion below on call count would fail either way.
+      resolveCapturedAtMock.mockClear();
+
+      const ctx = makeEngine(
+        db,
+        { get: mockResolving({ items: [{ id: 'existing-media', contentHash: 'deadbeefdeadbeef' }] }) },
+        makeUploadFn(),
+        makeHashFn('deadbeefdeadbeef'),
+      );
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      const skipped: FileSkippedPayload[] = [];
+      ctx.engine.on(EV.FILE_SKIPPED, (p) => skipped.push(p));
+
+      // No fromMs/toMs at all — dateFilterActive must be false.
+      await ctx.engine.run({ trigger: 'cli', folderIds: [folder.id] });
+
+      expect(skipped).toHaveLength(1);
+      expect(skipped[0].reason).toBe('dedup');
+      expect(resolveCapturedAtMock).not.toHaveBeenCalled();
+    });
+
+    it('DOES call resolveCapturedAt exactly once when a range is active (positive control, dedup hit)', async () => {
+      const filePath = writeTmpJpeg(tmpDir, 'dedup-with-filter.jpg');
+      capturedAtByPath.set(filePath, {
+        capturedAt: '2024-06-15T12:00:00.000Z',
+        source: 'exif',
+        originalCreatedAt: null,
+      });
+      resolveCapturedAtMock.mockClear();
+
+      const ctx = makeEngine(
+        db,
+        { get: mockResolving({ items: [{ id: 'existing-media', contentHash: 'deadbeefdeadbeef' }] }) },
+        makeUploadFn(),
+        makeHashFn('deadbeefdeadbeef'),
+      );
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      const skipped: FileSkippedPayload[] = [];
+      ctx.engine.on(EV.FILE_SKIPPED, (p) => skipped.push(p));
+
+      await ctx.engine.run({
+        trigger: 'cli',
+        folderIds: [folder.id],
+        fromMs: IN_RANGE_FROM_MS,
+        toMs: IN_RANGE_TO_MS,
+      });
+
+      // The file is in-range, so the worker proceeds to the dedup check — which
+      // hits and short-circuits before the register step. The single call must
+      // therefore have come from the build-phase gate.
+      expect(skipped).toHaveLength(1);
+      expect(skipped[0].reason).toBe('dedup');
+      expect(resolveCapturedAtMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/cli/test/tui/date-range-filter.spec.tsx
+++ b/apps/cli/test/tui/date-range-filter.spec.tsx
@@ -1,0 +1,199 @@
+/**
+ * test/tui/date-range-filter.spec.tsx
+ *
+ * Tests for the DateRangeFilter Ink screen (src/tui/DateRangeFilter.tsx).
+ *
+ * The component only depends on the pure sync/date-range.js helpers and the
+ * theme module — no fs/network — so no jest.unstable_mockModule is needed
+ * here (unlike the sync-engine date-range tests). Harness mirrors
+ * test/tui/folder-manager.spec.tsx / test/tui/login-screen.spec.tsx:
+ * ink-testing-library's render()/stdin, ANSI-stripped frame assertions, and
+ * a real-timer flushAsync() between keystrokes and assertions.
+ */
+
+import { jest } from '@jest/globals';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+import { DateRangeFilter } from '../../src/tui/DateRangeFilter.js';
+import type { DateRange } from '../../src/sync/date-range.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Strip ANSI escape sequences so text assertions are colour-independent. */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+/** Wait for React/Ink to flush state updates. */
+function flushAsync(ms = 50): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DateRangeFilter', () => {
+  // -------------------------------------------------------------------------
+  // Initial render
+  // -------------------------------------------------------------------------
+
+  it('renders the title and the initial "all dates" preview', () => {
+    const { lastFrame } = render(
+      <DateRangeFilter onApply={() => {}} onBack={() => {}} />,
+    );
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('Date range filter');
+    expect(plain).toContain('Syncing: all dates');
+  });
+
+  // -------------------------------------------------------------------------
+  // Typing a valid date into the (initially focused) From field
+  // -------------------------------------------------------------------------
+
+  it('updates the preview to "on/after <date>" when a valid date is typed into From', async () => {
+    const { lastFrame, stdin } = render(
+      <DateRangeFilter onApply={() => {}} onBack={() => {}} />,
+    );
+
+    stdin.write('2023-01-01');
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('on/after 2023-01-01');
+  });
+
+  it('updates the preview to a "From → To" range when both fields are filled', async () => {
+    const { lastFrame, stdin } = render(
+      <DateRangeFilter onApply={() => {}} onBack={() => {}} />,
+    );
+
+    stdin.write('2023-01-01'); // From
+    await flushAsync();
+
+    stdin.write('\x1B[B'); // down arrow -> focus To
+    await flushAsync();
+
+    stdin.write('2023-01-31'); // To
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('2023-01-01 → 2023-01-31');
+  });
+
+  // -------------------------------------------------------------------------
+  // Invalid input (From after To): error shown, Enter blocked
+  // -------------------------------------------------------------------------
+
+  it('shows an inline error and blocks Enter when From is after To', async () => {
+    const onApply = jest.fn();
+    const { lastFrame, stdin } = render(
+      <DateRangeFilter onApply={onApply} onBack={() => {}} />,
+    );
+
+    stdin.write('2023-06-01'); // From — later date
+    await flushAsync();
+
+    stdin.write('\x1B[B'); // focus -> To
+    await flushAsync();
+
+    stdin.write('2023-01-01'); // To — earlier than From: invalid range
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('--from must be on or before --to');
+
+    stdin.write('\r');
+    await flushAsync();
+
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Enter with valid/empty input calls onApply
+  // -------------------------------------------------------------------------
+
+  it('calls onApply with {} when Enter is pressed with both fields empty', async () => {
+    const onApply = jest.fn();
+    const { stdin } = render(
+      <DateRangeFilter onApply={onApply} onBack={() => {}} />,
+    );
+
+    stdin.write('\r');
+    await flushAsync();
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply).toHaveBeenCalledWith({});
+  });
+
+  it('calls onApply with the parsed range when Enter is pressed with a valid From date', async () => {
+    const onApply = jest.fn();
+    const { stdin } = render(
+      <DateRangeFilter onApply={onApply} onBack={() => {}} />,
+    );
+
+    stdin.write('2023-01-01');
+    await flushAsync();
+
+    stdin.write('\r');
+    await flushAsync();
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const arg = onApply.mock.calls[0][0] as DateRange;
+    expect(arg.fromMs).toBe(new Date(2023, 0, 1, 0, 0, 0, 0).getTime());
+    expect(arg.toMs).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Esc / q -> onBack
+  // -------------------------------------------------------------------------
+
+  it('calls onBack when Esc is pressed', async () => {
+    const onBack = jest.fn();
+    const { stdin } = render(
+      <DateRangeFilter onApply={() => {}} onBack={onBack} />,
+    );
+
+    stdin.write('\x1B');
+    await flushAsync();
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onBack when q is pressed', async () => {
+    const onBack = jest.fn();
+    const { stdin } = render(
+      <DateRangeFilter onApply={() => {}} onBack={onBack} />,
+    );
+
+    stdin.write('q');
+    await flushAsync();
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak the "q" back-command keystroke into the focused field', async () => {
+    // 'q' is stripped by the field sanitizer, so pressing it should trigger
+    // onBack without also appending a stray 'q' character to fromStr.
+    const onBack = jest.fn();
+    const { lastFrame, stdin } = render(
+      <DateRangeFilter onApply={() => {}} onBack={onBack} />,
+    );
+
+    stdin.write('q');
+    await flushAsync();
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('Syncing: all dates');
+  });
+});

--- a/docs/specs/bulk-import-resilience.md
+++ b/docs/specs/bulk-import-resilience.md
@@ -178,6 +178,12 @@ Primary key is `(file_id, part_number)` — re-saving the same part is safe via 
 
 The SHA-256 of each file is computed locally and sent to the server. The server deduplicates on `(circle_id, content_hash)`. Uploading the same file twice is safe and returns the existing `media_item_id`. The CLI marks the file `uploaded` on any 2xx including the deduplicated case.
 
+### Capture-date range filter (new — `--from`/`--to`)
+
+`memoriahub sync` accepts optional `--from <date>` and `--to <date>` flags that restrict the run's work-set to files whose capture date falls within an **inclusive, local-timezone** range (`--from` = start of that day, `--to` = end of that day, machine local time). Either bound may be supplied alone. Capture date is resolved via the same source ladder as `resolveCapturedAt` in `apps/cli/src/metadata.ts` (EXIF `DateTimeOriginal` → `CreateDate` → `ModifyDate`, falling back to filesystem timestamps) — see the CLI README's [Capture-date inference](../../apps/cli/README.md#capture-date-inference) section for the full algorithm. A file whose date cannot be determined at all is excluded from a filtered run.
+
+**Why this is safe:** the filter only gates work-set *inclusion* — it does not introduce a new terminal ledger status. A file outside the requested range is written as `status = 'skipped'` with `skip_reason = 'out_of_range'`, alongside the existing dedup skip path. Because out-of-range files are never marked `uploaded`, they are not consumed by a filtered run: a later unfiltered `memoriahub sync` re-evaluates them from scratch and uploads them normally. Files already uploaded during an earlier filtered run remain protected on the next run by the two mechanisms already documented above — the unchanged-skip fast path (size match short-circuits before any network call) and server-side `(circle_id, content_hash)` dedup (see [Content-hash dedup (pre-existing)](#content-hash-dedup-pre-existing)). Net effect: applying or removing the date filter across runs can only change which files are *considered* for upload in a given run — it never causes a duplicate upload and never permanently excludes a file.
+
 ### PAT pre-flight (new — `runPatPreflight`)
 
 Runs before every `sync` or `retry` command:

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "boxen": "^5.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "boxen": "^5.1.2",


### PR DESCRIPTION
Add sync/date-range.ts with parseDateRange (YYYY-MM-DD or ISO, local
inclusive day edges) and describeRange for human-readable output. Shared
by the sync command flags and the TUI date-range form.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XrpC49bLJ1kYFLf68Km2jT