### PR TITLE
feat(cli): per-folder memoriahub.json metadata override for uploads

### DIFF
--- a/apps/api/src/media/dto/create-media.dto.ts
+++ b/apps/api/src/media/dto/create-media.dto.ts
@@ -19,6 +19,16 @@ export const createMediaSchema = z.object({
   sourceDeviceName: z.string().max(256).optional(),
   circleId: z.string().uuid(),
   /**
+   * Client-supplied FALLBACK location (e.g. from a per-folder memoriahub.json
+   * override). Applied only when the item has no EXIF GPS: the server-extracted
+   * EXIF location always wins. `coordSource` is restricted to `'manual'` so a
+   * client cannot spoof `'exif'`/`'inferred'` provenance.
+   */
+  takenLat: z.number().min(-90).max(90).optional(),
+  takenLng: z.number().min(-180).max(180).optional(),
+  takenAltitude: z.number().optional(),
+  coordSource: z.literal('manual').optional(),
+  /**
    * Client-provided SHA-256 content hash (64 lowercase hex characters).
    * When supplied, the server uses it to deduplicate: if an active MediaItem
    * with the same (circle_id, content_hash) already exists the existing item is

--- a/apps/api/src/media/media.service.fallback-location.spec.ts
+++ b/apps/api/src/media/media.service.fallback-location.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * Unit tests for the fallback-location block inside MediaService.createMedia
+ * (apps/api/src/media/media.service.ts, ~lines 229-261).
+ *
+ * The CLI's per-folder memoriahub.json can supply a FALLBACK takenLat/takenLng
+ * (EXIF always wins per field). createMedia must only apply the client-supplied
+ * fallback when a FRESH re-read of the just-created row shows EXIF sync did not
+ * already write coordinates. Any failure while applying the fallback (including
+ * a geoProvider.reverseGeocode throw) must be swallowed and logged, never
+ * propagated out of createMedia.
+ *
+ * Mirrors the beforeEach/module wiring and test factory style used in
+ * media.service.spec.ts (see its createMedia describe block) and the smaller,
+ * single-purpose file structure used in media.service.locations.spec.ts.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { MediaService } from './media.service';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  createMockPrismaService,
+  MockPrismaService,
+} from '../../test/mocks/prisma.mock';
+import { STORAGE_PROVIDER } from '../storage/providers/storage-provider.interface';
+import { MediaMetadataSyncService } from './sync/media-metadata-sync.service';
+import { PERMISSIONS } from '../common/constants/roles.constants';
+import { randomUUID } from 'crypto';
+import { CircleMembershipService } from '../circles/circle-membership.service';
+import { GEO_LOCATION_PROVIDER } from './geo/geo-location-provider.interface';
+import { ForwardGeocodeService } from './geo/forward-geocode.service';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
+
+const CIRCLE_ID = 'circle-uuid-0001-0002-0003';
+
+// ---------------------------------------------------------------------------
+// Test factories (copied from media.service.spec.ts — not exported there)
+// ---------------------------------------------------------------------------
+
+function makeStorageObject(overrides: Partial<any> = {}) {
+  return {
+    id: randomUUID(),
+    name: 'photo.jpg',
+    size: BigInt(1024000),
+    mimeType: 'image/jpeg',
+    storageKey: 'uploads/photo.jpg',
+    storageProvider: 's3',
+    bucket: 'test-bucket',
+    status: 'ready',
+    s3UploadId: null,
+    uploadedById: 'user-1',
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeMediaItem(overrides: Partial<any> = {}) {
+  return {
+    id: randomUUID(),
+    storageObjectId: randomUUID(),
+    addedById: 'user-1',
+    circleId: CIRCLE_ID,
+    type: 'photo' as const,
+    source: 'web' as const,
+    originalFilename: 'photo.jpg',
+    capturedAt: null,
+    capturedAtOffset: null,
+    importedAt: new Date(),
+    width: null,
+    height: null,
+    durationMs: null,
+    orientation: null,
+    cameraMake: null,
+    cameraModel: null,
+    contentHash: null,
+    description: null,
+    favorite: false,
+    deletedAt: null,
+    originalCreatedAt: null,
+    sourcePath: null,
+    sourceDeviceId: null,
+    sourceDeviceName: null,
+    takenLat: null,
+    takenLng: null,
+    takenAltitude: null,
+    geoCountry: null,
+    geoCountryCode: null,
+    geoAdmin1: null,
+    geoAdmin2: null,
+    geoLocality: null,
+    geoPlaceName: null,
+    geoSource: null,
+    geocodedAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// Permissions helper
+const ownPerms = [
+  PERMISSIONS.MEDIA_READ,
+  PERMISSIONS.MEDIA_WRITE,
+  PERMISSIONS.MEDIA_DELETE,
+];
+
+describe('MediaService.createMedia — fallback location', () => {
+  let service: MediaService;
+  let mockPrisma: MockPrismaService;
+  let mockStorageProvider: { getSignedDownloadUrl: jest.Mock; delete: jest.Mock };
+  let mockSyncService: jest.Mocked<Pick<MediaMetadataSyncService, 'syncFromStorageObject'>>;
+  let mockCircleMembershipService: { assertCircleAccess: jest.Mock };
+  let mockGeoProvider: { reverseGeocode: jest.Mock };
+  let mockForwardGeocodeService: { searchPlaces: jest.Mock };
+  let mockResolver: { getProviderFor: jest.Mock };
+  let mockMediaEnrichmentService: { enqueueUploadEnrichment: jest.Mock; enqueueForStorageObject: jest.Mock };
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    (mockPrisma.$transaction as jest.Mock).mockImplementation(async (arg: any) => {
+      if (typeof arg === 'function') {
+        return arg(mockPrisma);
+      } else if (Array.isArray(arg)) {
+        return Promise.all(arg);
+      }
+      return arg;
+    });
+    mockStorageProvider = {
+      getSignedDownloadUrl: jest.fn().mockResolvedValue('https://cdn.example.com/signed'),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    mockSyncService = {
+      syncFromStorageObject: jest.fn().mockResolvedValue(undefined),
+    };
+    mockCircleMembershipService = {
+      assertCircleAccess: jest.fn().mockResolvedValue({ role: 'collaborator', isSuperAdmin: false }),
+    };
+    mockGeoProvider = { reverseGeocode: jest.fn().mockResolvedValue(null) };
+    mockForwardGeocodeService = { searchPlaces: jest.fn().mockResolvedValue([]) };
+    mockResolver = {
+      getProviderFor: jest.fn().mockResolvedValue({
+        getSignedDownloadUrl: jest.fn().mockResolvedValue('https://cdn.example.com/signed'),
+      }),
+    };
+    mockMediaEnrichmentService = {
+      enqueueUploadEnrichment: jest.fn().mockResolvedValue(undefined),
+      enqueueForStorageObject: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: STORAGE_PROVIDER, useValue: mockStorageProvider },
+        { provide: MediaMetadataSyncService, useValue: mockSyncService },
+        { provide: CircleMembershipService, useValue: mockCircleMembershipService },
+        { provide: GEO_LOCATION_PROVIDER, useValue: mockGeoProvider },
+        { provide: ForwardGeocodeService, useValue: mockForwardGeocodeService },
+        { provide: StorageProviderResolver, useValue: mockResolver },
+        { provide: MediaEnrichmentService, useValue: mockMediaEnrichmentService },
+      ],
+    }).compile();
+
+    service = module.get<MediaService>(MediaService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const FALLBACK_LAT = 37.7749;
+  const FALLBACK_LNG = -122.4194;
+
+  function baseDto(overrides: Partial<any> = {}, storageObjectId: string) {
+    return {
+      storageObjectId,
+      type: 'photo' as const,
+      source: 'cli' as const,
+      originalFilename: 'photo.jpg',
+      circleId: CIRCLE_ID,
+      ...overrides,
+    };
+  }
+
+  it('1. applies the fallback location when the fresh re-read shows EXIF did not set coordinates', async () => {
+    const storageObject = makeStorageObject({ uploadedById: 'user-1' });
+    const createdItem = makeMediaItem({ storageObjectId: storageObject.id });
+
+    mockPrisma.storageObject.findUnique.mockResolvedValue(storageObject as any);
+    // "already linked" check → null, then fresh post-sync re-read → takenLat null
+    mockPrisma.mediaItem.findUnique
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ takenLat: null } as any);
+    mockPrisma.mediaItem.create.mockResolvedValue(createdItem as any);
+    mockPrisma.mediaItem.update.mockResolvedValue({} as any);
+
+    const dto = baseDto(
+      { takenLat: FALLBACK_LAT, takenLng: FALLBACK_LNG, takenAltitude: 12.5 },
+      storageObject.id,
+    );
+
+    const result = await service.createMedia(dto, 'user-1', ownPerms);
+
+    expect(result.deduplicated).toBe(false);
+    expect(mockGeoProvider.reverseGeocode).toHaveBeenCalledWith(FALLBACK_LAT, FALLBACK_LNG);
+    expect(mockPrisma.mediaItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: createdItem.id },
+        data: expect.objectContaining({
+          takenLat: FALLBACK_LAT,
+          takenLng: FALLBACK_LNG,
+          coordSource: 'manual',
+        }),
+      }),
+    );
+    // Fresh re-read must use the created item's id and select only takenLat
+    expect(mockPrisma.mediaItem.findUnique).toHaveBeenNthCalledWith(2, {
+      where: { id: createdItem.id },
+      select: { takenLat: true },
+    });
+  });
+
+  it('2. skips the fallback when the fresh re-read shows EXIF already set coordinates', async () => {
+    const storageObject = makeStorageObject({ uploadedById: 'user-1' });
+    const createdItem = makeMediaItem({ storageObjectId: storageObject.id });
+
+    mockPrisma.storageObject.findUnique.mockResolvedValue(storageObject as any);
+    mockPrisma.mediaItem.findUnique
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ takenLat: 40.7128 } as any);
+    mockPrisma.mediaItem.create.mockResolvedValue(createdItem as any);
+
+    const dto = baseDto(
+      { takenLat: FALLBACK_LAT, takenLng: FALLBACK_LNG },
+      storageObject.id,
+    );
+
+    const result = await service.createMedia(dto, 'user-1', ownPerms);
+
+    expect(result.deduplicated).toBe(false);
+    expect(mockGeoProvider.reverseGeocode).not.toHaveBeenCalled();
+    expect(mockPrisma.mediaItem.update).not.toHaveBeenCalled();
+  });
+
+  it('3. never attempts the fresh re-read when the DTO has no fallback coordinates', async () => {
+    const storageObject = makeStorageObject({ uploadedById: 'user-1' });
+    const createdItem = makeMediaItem({ storageObjectId: storageObject.id });
+
+    mockPrisma.storageObject.findUnique.mockResolvedValue(storageObject as any);
+    // Only the "already linked" check should occur.
+    mockPrisma.mediaItem.findUnique.mockResolvedValueOnce(null as any);
+    mockPrisma.mediaItem.create.mockResolvedValue(createdItem as any);
+
+    const dto = baseDto({}, storageObject.id);
+
+    await service.createMedia(dto, 'user-1', ownPerms);
+
+    expect(mockPrisma.mediaItem.findUnique).toHaveBeenCalledTimes(1);
+    expect(mockGeoProvider.reverseGeocode).not.toHaveBeenCalled();
+    expect(mockPrisma.mediaItem.update).not.toHaveBeenCalled();
+  });
+
+  it('4. swallows an error thrown while applying the fallback location and still resolves', async () => {
+    const storageObject = makeStorageObject({ uploadedById: 'user-1' });
+    const createdItem = makeMediaItem({ storageObjectId: storageObject.id });
+
+    mockPrisma.storageObject.findUnique.mockResolvedValue(storageObject as any);
+    mockPrisma.mediaItem.findUnique
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ takenLat: null } as any);
+    mockPrisma.mediaItem.create.mockResolvedValue(createdItem as any);
+    mockGeoProvider.reverseGeocode.mockRejectedValue(new Error('geo provider down'));
+
+    const dto = baseDto(
+      { takenLat: FALLBACK_LAT, takenLng: FALLBACK_LNG },
+      storageObject.id,
+    );
+
+    const result = await service.createMedia(dto, 'user-1', ownPerms);
+
+    // createMedia must still resolve successfully with the created item
+    expect(result).toMatchObject(createdItem);
+    expect(result.deduplicated).toBe(false);
+    expect(mockPrisma.mediaItem.update).not.toHaveBeenCalled();
+  });
+
+  it('5. dedup pre-check short-circuits before the fallback-location block runs', async () => {
+    const TEST_HASH = 'b'.repeat(64);
+    const storageObject = makeStorageObject({ uploadedById: 'user-1', storageKey: 'uploads/new.jpg' });
+    const existingItem = makeMediaItem({ addedById: 'user-1', contentHash: TEST_HASH });
+
+    mockPrisma.storageObject.findUnique.mockResolvedValue(storageObject as any);
+    // "already linked" check on storageObjectId → no match
+    mockPrisma.mediaItem.findUnique.mockResolvedValue(null as any);
+    // Dedup pre-check by (circleId, contentHash) → existing item found
+    mockPrisma.mediaItem.findFirst.mockResolvedValue(existingItem as any);
+
+    const dto = baseDto(
+      { contentHash: TEST_HASH, takenLat: FALLBACK_LAT, takenLng: FALLBACK_LNG },
+      storageObject.id,
+    );
+
+    const result = await service.createMedia(dto, 'user-1', ownPerms);
+
+    expect(result.deduplicated).toBe(true);
+    expect(result.id).toBe(existingItem.id);
+    // Dedup return happens well before mediaItem.create / the fallback block
+    expect(mockPrisma.mediaItem.create).not.toHaveBeenCalled();
+    expect(mockGeoProvider.reverseGeocode).not.toHaveBeenCalled();
+    expect(mockPrisma.mediaItem.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -226,6 +226,40 @@ export class MediaService {
       // Never fail createMedia because of a sync issue
     }
 
+    // Fallback location: apply the client-supplied coordinates ONLY when the
+    // server-extracted EXIF did not set a location. The metadata sync above may
+    // have just written EXIF coords directly to the DB, so re-read the row fresh
+    // rather than trusting the stale in-memory `mediaItem`. A geo/reverse-geocode
+    // failure must never fail createMedia — mirror the sync try/catch posture.
+    if (dto.takenLat != null && dto.takenLng != null) {
+      try {
+        const current = await this.prisma.mediaItem.findUnique({
+          where: { id: mediaItem.id },
+          select: { takenLat: true },
+        });
+
+        if (current?.takenLat == null) {
+          const patch = await applyLocation(
+            this.geoProvider,
+            dto.takenLat,
+            dto.takenLng,
+            dto.takenAltitude ?? null,
+            'manual',
+          );
+          await this.prisma.mediaItem.update({
+            where: { id: mediaItem.id },
+            data: patch,
+          });
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          `Fallback location apply failed for MediaItem ${mediaItem.id}: ${msg}`,
+        );
+        // Never fail createMedia because of a fallback-location issue
+      }
+    }
+
     // Synchronously enqueue all upload-time enrichment jobs (auto_tagging,
     // face_detection, burst_detection) before returning. This is the single
     // authoritative trigger — job rows exist before createMedia returns,

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/scan.ts
+++ b/apps/cli/src/commands/scan.ts
@@ -128,6 +128,18 @@ async function runScan(folderArgs: string[], options: ScanActionOptions): Promis
       `Scanned ${result.totals.totalFiles} file(s), ${formatBytes(result.totals.totalBytes)} ` +
         `(scan #${result.scanId})`,
     );
+    // Surface any present-but-invalid memoriahub.json overrides prominently. The
+    // scan does not abort on these (unlike sync) — it reports exactly which file
+    // is broken and why so the user can fix it before running a real sync. Kept
+    // off stdout in --json mode so scripted output stays clean.
+    if (result.overrideErrors.length > 0 && !options.json) {
+      ui.warn(
+        `${result.overrideErrors.length} folder override(s) were invalid and skipped:`,
+      );
+      for (const oe of result.overrideErrors) {
+        ui.warn(`  ${oe.reason}`);
+      }
+    }
   } catch (err) {
     spinner?.fail('Scan failed');
     const msg = err instanceof Error ? err.message : String(err);

--- a/apps/cli/src/db/migrations.ts
+++ b/apps/cli/src/db/migrations.ts
@@ -32,6 +32,8 @@ import {
   CREATE_SCAN_FILES_IDX_SCAN,
   CREATE_SCAN_FILES_IDX_SCAN_KIND,
   ALTER_SCAN_FILES_ADD_CAPTURED_AT_SOURCE,
+  ALTER_SCAN_FILES_ADD_FALLBACK_DATE,
+  ALTER_SCAN_FILES_ADD_FALLBACK_LOCATION,
 } from './schema.js';
 
 interface Migration {
@@ -142,6 +144,17 @@ const MIGRATIONS: Migration[] = [
       // so the scan preview never presents a guessed date as a real EXIF date.
       // Nullable — existing scan rows get NULL (unknown provenance).
       db.exec(ALTER_SCAN_FILES_ADD_CAPTURED_AT_SOURCE);
+    },
+  },
+  {
+    version: 9,
+    up(db: BetterSqlite3.Database): void {
+      // Add the memoriahub.json fallback-preview flags to scan_files so the scan
+      // dashboard / Excel detail sheet can show which files a sync would date-
+      // stamp or geo-tag from a folder override. NOT NULL DEFAULT 0 — existing
+      // snapshot rows read as "no fallback applied".
+      db.exec(ALTER_SCAN_FILES_ADD_FALLBACK_DATE);
+      db.exec(ALTER_SCAN_FILES_ADD_FALLBACK_LOCATION);
     },
   },
 ];

--- a/apps/cli/src/db/schema.ts
+++ b/apps/cli/src/db/schema.ts
@@ -211,3 +211,19 @@ CREATE INDEX IF NOT EXISTS idx_scan_files_scan_kind ON scan_files(scan_id, media
  */
 export const ALTER_SCAN_FILES_ADD_CAPTURED_AT_SOURCE = `
 ALTER TABLE scan_files ADD COLUMN captured_at_source TEXT`;
+
+/**
+ * Migration v9: record whether a per-folder `memoriahub.json` override WOULD
+ * fill a gap the file's own EXIF left open, so the scan preview shows the user
+ * exactly which files a sync would date-stamp / geo-tag from the override before
+ * they upload.  Both flags are booleans stored as 0/1, NOT NULL DEFAULT 0 so
+ * existing snapshot rows read as "no fallback applied".
+ *
+ * fallback_date_applied     — override supplies capturedAt (file has no EXIF date).
+ * fallback_location_applied — override supplies GPS (file has no EXIF location).
+ */
+export const ALTER_SCAN_FILES_ADD_FALLBACK_DATE = `
+ALTER TABLE scan_files ADD COLUMN fallback_date_applied INTEGER NOT NULL DEFAULT 0`;
+
+export const ALTER_SCAN_FILES_ADD_FALLBACK_LOCATION = `
+ALTER TABLE scan_files ADD COLUMN fallback_location_applied INTEGER NOT NULL DEFAULT 0`;

--- a/apps/cli/src/db/types.ts
+++ b/apps/cli/src/db/types.ts
@@ -138,5 +138,9 @@ export interface ScanFile {
   taken_lat: number | null;
   taken_lng: number | null;
   captured_at_source: CaptureDateSource | null;
+  /** True when a folder override would supply capturedAt (file has no EXIF date). */
+  fallback_date_applied: boolean;
+  /** True when a folder override would supply GPS (file has no EXIF location). */
+  fallback_location_applied: boolean;
   meta_error: string | null;
 }

--- a/apps/cli/src/export/scan-export.ts
+++ b/apps/cli/src/export/scan-export.ts
@@ -45,6 +45,8 @@ const DETAIL_COLUMNS: Array<{ header: string; key: keyof ScanFileRowView; width:
   { header: 'Has location', key: 'hasGps', width: 12 },
   { header: 'Captured at', key: 'capturedAt', width: 22 },
   { header: 'Date source', key: 'capturedAtSource', width: 14 },
+  { header: 'Fallback date', key: 'fallbackDate', width: 14 },
+  { header: 'Fallback location', key: 'fallbackLocation', width: 16 },
   { header: 'Width', key: 'width', width: 8 },
   { header: 'Height', key: 'height', width: 8 },
   { header: 'Camera make', key: 'cameraMake', width: 16 },
@@ -64,6 +66,8 @@ interface ScanFileRowView {
   hasGps: string;
   capturedAt: string | null;
   capturedAtSource: string;
+  fallbackDate: string;
+  fallbackLocation: string;
   width: number | null;
   height: number | null;
   cameraMake: string | null;
@@ -84,6 +88,8 @@ function toRowView(f: ScanFile): ScanFileRowView {
     hasGps: f.has_gps ? 'yes' : 'no',
     capturedAt: f.captured_at,
     capturedAtSource: captureSourceLabel(f.captured_at_source),
+    fallbackDate: f.fallback_date_applied ? 'yes' : 'no',
+    fallbackLocation: f.fallback_location_applied ? 'yes' : 'no',
     width: f.width,
     height: f.height,
     cameraMake: f.camera_make,

--- a/apps/cli/src/files.ts
+++ b/apps/cli/src/files.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { OVERRIDE_FILENAME } from './override.js';
 
 /**
  * Supported media file extensions → MIME type.
@@ -145,6 +146,13 @@ export function enumerateFiles(
         continue;
       }
       if (!entry.isFile()) {
+        continue;
+      }
+
+      // The per-folder metadata override sidecar is never media — skip it
+      // explicitly so it can never be enumerated for upload regardless of
+      // extension mapping.
+      if (entry.name === OVERRIDE_FILENAME) {
         continue;
       }
 

--- a/apps/cli/src/override.ts
+++ b/apps/cli/src/override.ts
@@ -1,0 +1,356 @@
+/**
+ * override.ts — Per-folder metadata override reader for the sync/upload flow.
+ *
+ * A user may drop a `memoriahub.json` file into a media folder to supply
+ * FALLBACK "date taken" and "GPS location" for the files in THAT folder that
+ * lack the datum in their own EXIF. The contract is deliberately narrow:
+ *
+ *   - EXIF ALWAYS WINS per-field. An override value is only ever used to fill a
+ *     gap the file's own metadata left open (no capture date / no GPS).
+ *   - The file is OPTIONAL. If it is absent, `loadOverrideFile` returns null.
+ *   - If it is PRESENT but INVALID, the CLI must FAIL LOUDLY — an invalid
+ *     override is thrown as an `OverrideValidationError`, never silently
+ *     ignored. Silently dropping a malformed override would attach the wrong
+ *     date/location to a user's photos, which is worse than refusing to run.
+ *
+ * This module only parses/validates/normalizes the file and computes the
+ * effective per-file fallback. It performs NO uploads and knows nothing about
+ * the sync engine — a later task wires it into the pipeline. `loadOverrideFile`
+ * does its own fs read on every call (a caller-level cache wraps it); the
+ * decision logic in `pickFallback` is a pure, never-throwing function.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { MediaMetadata } from './metadata.js';
+
+// Re-export the relevant metadata surface for reference; `MediaMetadata`
+// exposes `hasGps` and `capturedAt`, the two inputs `pickFallback` gates on.
+export type { MediaMetadata };
+
+/** The magic filename a user drops into a folder to override metadata. */
+export const OVERRIDE_FILENAME = 'memoriahub.json';
+
+/** A GPS location parsed from an override file. */
+export interface OverrideLocation {
+  latitude: number;
+  longitude: number;
+  /** Altitude in meters, or null when not supplied. */
+  altitude: number | null;
+}
+
+/**
+ * A normalized override entry. `capturedAt` has already been expanded to a full
+ * ISO 8601 datetime string (see `normalizeCapturedAt`), or is null.
+ */
+export interface OverrideEntry {
+  capturedAt: string | null;
+  /** Signed minutes of the original UTC offset, or null when none was present
+   * (date-only or offset-less inputs). */
+  capturedAtOffset: number | null;
+  location: OverrideLocation | null;
+}
+
+/** The parsed, validated, normalized contents of a `memoriahub.json` file. */
+export interface FolderOverride {
+  version: number;
+  fallback: OverrideEntry | null;
+  files: Array<{ name: string } & OverrideEntry>;
+}
+
+/**
+ * Thrown when a present `memoriahub.json` is malformed. Carries the file path so
+ * callers can surface exactly which folder's override is broken.
+ */
+export class OverrideValidationError extends Error {
+  constructor(
+    public filePath: string,
+    reason: string,
+  ) {
+    super(`memoriahub.json invalid (${filePath}): ${reason}`);
+    this.name = 'OverrideValidationError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const OFFSET_RE = /([+-]\d{2}:?\d{2}|Z)$/;
+
+/**
+ * Normalize a raw capturedAt string into a full ISO 8601 datetime plus the
+ * signed UTC-offset minutes carried by the original (or null when none).
+ *
+ * - Date-only `YYYY-MM-DD` → LOCAL noon of that day (avoids date drift across
+ *   time zones), offsetMinutes = null.
+ * - Otherwise `Date.parse` must yield a finite timestamp; if the original
+ *   string carried a `Z` or `±HH:MM` offset, that offset is reported in
+ *   minutes (Z → 0). Throws a plain Error on unparseable input — the caller
+ *   wraps it into an OverrideValidationError with context.
+ */
+export function normalizeCapturedAt(raw: string): { iso: string; offsetMinutes: number | null } {
+  if (DATE_ONLY_RE.test(raw)) {
+    const [y, m, d] = raw.split('-').map((p) => Number(p));
+    const local = new Date(y, m - 1, d, 12, 0, 0, 0);
+    if (isNaN(local.getTime())) {
+      throw new Error(`unparseable capturedAt "${raw}"`);
+    }
+    return { iso: local.toISOString(), offsetMinutes: null };
+  }
+
+  const parsed = Date.parse(raw);
+  if (!isFinite(parsed)) {
+    throw new Error(`unparseable capturedAt "${raw}"`);
+  }
+
+  let offsetMinutes: number | null = null;
+  const match = OFFSET_RE.exec(raw);
+  if (match) {
+    const token = match[1];
+    if (token === 'Z') {
+      offsetMinutes = 0;
+    } else {
+      const sign = token[0] === '-' ? -1 : 1;
+      const digits = token.slice(1).replace(':', '');
+      const hh = Number(digits.slice(0, 2));
+      const mm = Number(digits.slice(2, 4));
+      offsetMinutes = sign * (hh * 60 + mm);
+    }
+  }
+
+  return { iso: new Date(parsed).toISOString(), offsetMinutes };
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate + normalize an object's `capturedAt` / `location` fields into an
+ * OverrideEntry. `where` labels the source ("fallback" or `files[i] "name"`)
+ * for clear error messages. Throws a plain Error on violation.
+ */
+function parseEntry(source: Record<string, unknown>, where: string): OverrideEntry {
+  let capturedAt: string | null = null;
+  let capturedAtOffset: number | null = null;
+
+  if (source.capturedAt !== undefined && source.capturedAt !== null) {
+    if (typeof source.capturedAt !== 'string') {
+      throw new Error(`${where}.capturedAt must be a string`);
+    }
+    try {
+      const norm = normalizeCapturedAt(source.capturedAt);
+      capturedAt = norm.iso;
+      capturedAtOffset = norm.offsetMinutes;
+    } catch (err) {
+      throw new Error(`${where}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  let location: OverrideLocation | null = null;
+  if (source.location !== undefined && source.location !== null) {
+    if (!isPlainObject(source.location)) {
+      throw new Error(`${where}.location must be an object`);
+    }
+    const loc = source.location;
+    const lat = loc.latitude;
+    const lng = loc.longitude;
+    if (typeof lat !== 'number' || !isFinite(lat)) {
+      throw new Error(`${where}.location.latitude is required and must be a number`);
+    }
+    if (typeof lng !== 'number' || !isFinite(lng)) {
+      throw new Error(`${where}.location.longitude is required and must be a number`);
+    }
+    if (lat < -90 || lat > 90) {
+      throw new Error(`${where}.location.latitude must be within [-90, 90]`);
+    }
+    if (lng < -180 || lng > 180) {
+      throw new Error(`${where}.location.longitude must be within [-180, 180]`);
+    }
+    let altitude: number | null = null;
+    if (loc.altitude !== undefined && loc.altitude !== null) {
+      if (typeof loc.altitude !== 'number' || !isFinite(loc.altitude)) {
+        throw new Error(`${where}.location.altitude must be a finite number`);
+      }
+      altitude = loc.altitude;
+    }
+    location = { latitude: lat, longitude: lng, altitude };
+  }
+
+  return { capturedAt, capturedAtOffset, location };
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and validate the `memoriahub.json` override in a folder.
+ *
+ * @param dir  Directory to look in.
+ * @returns    The parsed FolderOverride, or null when no override file exists.
+ * @throws     OverrideValidationError when the file exists but is unreadable,
+ *             not valid JSON, or violates any rule in the format spec.
+ */
+export function loadOverrideFile(dir: string): FolderOverride | null {
+  const filePath = path.join(dir, OVERRIDE_FILENAME);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new OverrideValidationError(
+      filePath,
+      `could not be read: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new OverrideValidationError(filePath, 'not valid JSON');
+  }
+
+  if (!isPlainObject(data)) {
+    throw new OverrideValidationError(filePath, 'top-level value must be an object');
+  }
+
+  // version — required int, only 1 supported.
+  const version = data.version;
+  if (typeof version !== 'number' || !Number.isInteger(version)) {
+    throw new OverrideValidationError(filePath, 'version is required and must be an integer');
+  }
+  if (version !== 1) {
+    throw new OverrideValidationError(filePath, `unsupported version ${version} (only 1 is supported)`);
+  }
+
+  // fallback — optional object.
+  let fallback: OverrideEntry | null = null;
+  if (data.fallback !== undefined && data.fallback !== null) {
+    if (!isPlainObject(data.fallback)) {
+      throw new OverrideValidationError(filePath, 'fallback must be an object');
+    }
+    try {
+      fallback = parseEntry(data.fallback, 'fallback');
+    } catch (err) {
+      throw new OverrideValidationError(filePath, err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // files — optional array.
+  const files: Array<{ name: string } & OverrideEntry> = [];
+  if (data.files !== undefined && data.files !== null) {
+    if (!Array.isArray(data.files)) {
+      throw new OverrideValidationError(filePath, 'files must be an array');
+    }
+    const seen = new Set<string>();
+    data.files.forEach((raw, i) => {
+      if (!isPlainObject(raw)) {
+        throw new OverrideValidationError(filePath, `files[${i}] must be an object`);
+      }
+      const name = raw.name;
+      if (typeof name !== 'string' || name.trim() === '') {
+        throw new OverrideValidationError(filePath, `files[${i}].name is required and must be a non-empty string`);
+      }
+      if (seen.has(name)) {
+        throw new OverrideValidationError(filePath, `duplicate files entry for name "${name}"`);
+      }
+      seen.add(name);
+      let entry: OverrideEntry;
+      try {
+        entry = parseEntry(raw, `files[${i}] "${name}"`);
+      } catch (err) {
+        throw new OverrideValidationError(filePath, err instanceof Error ? err.message : String(err));
+      }
+      files.push({ name, ...entry });
+    });
+  }
+
+  return { version, fallback, files };
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+/** The subset of MediaMetadata `pickFallback` gates on. */
+type MetaGate = Pick<MediaMetadata, 'hasGps' | 'capturedAt'>;
+
+/** Fields `pickFallback` may contribute to fill EXIF gaps. */
+export interface PickedFallback {
+  capturedAt?: string;
+  capturedAtOffset?: number;
+  takenLat?: number;
+  takenLng?: number;
+  takenAltitude?: number;
+}
+
+/**
+ * Compute the override values that apply to a single file, filling only the
+ * gaps its own EXIF left open. Pure — never reads the filesystem, never throws.
+ *
+ * The effective entry is the folder `fallback` merged per-field with the
+ * matching `files` entry (a `files` entry's present fields override the
+ * fallback; absent fields inherit it). A value is contributed ONLY WHEN the
+ * file lacks that datum:
+ *   - capturedAt (and capturedAtOffset when non-null) only when the file has no
+ *     EXIF capture date.
+ *   - takenLat/takenLng (and takenAltitude when non-null) only when the file
+ *     has no EXIF GPS.
+ *
+ * @param override  The folder override, or null (→ returns `{}`).
+ * @param basename  The file's basename, matched against `files[].name`.
+ * @param meta      The file's own metadata gate (hasGps + capturedAt).
+ */
+export function pickFallback(
+  override: FolderOverride | null,
+  basename: string,
+  meta: MetaGate,
+): PickedFallback {
+  if (!override) {
+    return {};
+  }
+
+  // Per-field merge: start from fallback, let a matching files entry override.
+  const fileEntry = override.files.find((f) => f.name === basename);
+  const capturedAt = fileEntry?.capturedAt ?? override.fallback?.capturedAt ?? null;
+  const capturedAtOffset =
+    fileEntry?.capturedAt != null
+      ? fileEntry.capturedAtOffset
+      : override.fallback?.capturedAt != null
+        ? override.fallback.capturedAtOffset
+        : null;
+  const location = fileEntry?.location ?? override.fallback?.location ?? null;
+
+  const result: PickedFallback = {};
+
+  const fileHasDate = typeof meta.capturedAt === 'string' && meta.capturedAt.trim() !== '';
+  if (!fileHasDate && capturedAt) {
+    result.capturedAt = capturedAt;
+    if (capturedAtOffset !== null) {
+      result.capturedAtOffset = capturedAtOffset;
+    }
+  }
+
+  if (meta.hasGps === false && location) {
+    result.takenLat = location.latitude;
+    result.takenLng = location.longitude;
+    if (location.altitude !== null) {
+      result.takenAltitude = location.altitude;
+    }
+  }
+
+  return result;
+}

--- a/apps/cli/src/repo/scans.ts
+++ b/apps/cli/src/repo/scans.ts
@@ -51,6 +51,8 @@ interface ScanFileRow {
   taken_lat: number | null;
   taken_lng: number | null;
   captured_at_source: string | null;
+  fallback_date_applied: number;
+  fallback_location_applied: number;
   meta_error: string | null;
 }
 
@@ -91,6 +93,8 @@ function rowToScanFile(row: ScanFileRow): ScanFile {
     taken_lat: row.taken_lat,
     taken_lng: row.taken_lng,
     captured_at_source: (row.captured_at_source as CaptureDateSource | null) ?? null,
+    fallback_date_applied: row.fallback_date_applied !== 0,
+    fallback_location_applied: row.fallback_location_applied !== 0,
     meta_error: row.meta_error,
   };
 }
@@ -116,6 +120,8 @@ export interface ScanFileInput {
   takenLat?: number | null;
   takenLng?: number | null;
   capturedAtSource?: CaptureDateSource | null;
+  fallbackDateApplied?: boolean;
+  fallbackLocationApplied?: boolean;
   metaError?: string | null;
 }
 
@@ -179,8 +185,9 @@ export class ScanRepo {
            (scan_id, folder_id, file_path, size_bytes, mtime_ms, mime_type,
             media_kind, has_exif, has_gps, captured_at, width, height,
             camera_make, camera_model, taken_lat, taken_lng,
-            captured_at_source, meta_error)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            captured_at_source, fallback_date_applied, fallback_location_applied,
+            meta_error)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         scanId,
@@ -200,6 +207,8 @@ export class ScanRepo {
         input.takenLat ?? null,
         input.takenLng ?? null,
         input.capturedAtSource ?? null,
+        input.fallbackDateApplied ? 1 : 0,
+        input.fallbackLocationApplied ? 1 : 0,
         input.metaError ?? null,
       );
   }

--- a/apps/cli/src/scan/scan-engine.ts
+++ b/apps/cli/src/scan/scan-engine.ts
@@ -13,10 +13,17 @@
  */
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { ScanTypedEmitter, SCAN_EV } from './events.js';
 import { runPool } from '../sync/worker-pool.js';
 import { enumerateFiles } from '../files.js';
 import { readMediaMetadata, resolveCapturedAt } from '../metadata.js';
+import {
+  loadOverrideFile,
+  pickFallback,
+  OverrideValidationError,
+  type FolderOverride,
+} from '../override.js';
 import type { ScanRepo } from '../repo/scans.js';
 import type { FolderRepo } from '../repo/folders.js';
 import type { SettingsRepo } from '../repo/settings.js';
@@ -36,6 +43,21 @@ export interface ScanOptions {
   trigger: 'cli' | 'menu';
 }
 
+/**
+ * A folder whose `memoriahub.json` was present but INVALID during a scan. Unlike
+ * sync (which aborts), a scan is diagnostic — it records the broken override so
+ * the user sees exactly which file is broken and why, then skips fallback
+ * computation for that folder rather than failing the whole scan.
+ */
+export interface ScanOverrideError {
+  /** Directory the invalid memoriahub.json lives in. */
+  dir: string;
+  /** Full path to the invalid override file. */
+  filePath: string;
+  /** Human-readable validation reason. */
+  reason: string;
+}
+
 export interface ScanRunResult {
   scanId: number;
   totals: {
@@ -47,6 +69,8 @@ export interface ScanRunResult {
     gpsCount: number;
   };
   durationMs: number;
+  /** Present-but-invalid folder overrides encountered during the scan (fallback skipped). */
+  overrideErrors: ScanOverrideError[];
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +178,37 @@ export class ScanEngine extends ScanTypedEmitter {
     const total = workList.length;
 
     // ------------------------------------------------------------------
+    // 3b. Per-scan folder-override cache (diagnostic — never aborts)
+    // ------------------------------------------------------------------
+    // Parsed memoriahub.json overrides keyed by directory, memoized so each
+    // folder's override is read at most once. A present-but-invalid override is
+    // recorded (deduped by directory) and its folder is treated as having no
+    // override — the scan surfaces the problem rather than aborting like sync.
+    const overrideCache = new Map<string, FolderOverride | null>();
+    const overrideErrors: ScanOverrideError[] = [];
+    const overrideErrorDirs = new Set<string>();
+    const getOverrideForDir = (dir: string): FolderOverride | null => {
+      if (overrideCache.has(dir)) return overrideCache.get(dir) ?? null;
+      let override: FolderOverride | null = null;
+      try {
+        override = loadOverrideFile(dir);
+      } catch (err) {
+        override = null; // skip fallback for this folder
+        if (err instanceof OverrideValidationError) {
+          if (!overrideErrorDirs.has(dir)) {
+            overrideErrorDirs.add(dir);
+            overrideErrors.push({ dir, filePath: err.filePath, reason: err.message });
+            this.emit(SCAN_EV.ERROR, { message: err.message });
+          }
+        } else {
+          throw err;
+        }
+      }
+      overrideCache.set(dir, override);
+      return override;
+    };
+
+    // ------------------------------------------------------------------
     // 4. Worker pool — extract metadata + persist snapshot rows
     // ------------------------------------------------------------------
     const concurrency = opts.concurrency ?? settings.concurrency();
@@ -170,6 +225,19 @@ export class ScanEngine extends ScanTypedEmitter {
       // source keeps the preview honest — guessed dates are labelled, not
       // presented as real EXIF.
       const cap = await resolveCapturedAt(filePath, mimeType, meta.capturedAt);
+
+      // Preview the per-folder memoriahub.json fallback the same way sync will:
+      // an override only ever fills a gap the file's own EXIF left open. Compute
+      // the two flags so the report shows which files a sync would date-stamp /
+      // geo-tag from the override. A broken override is recorded (above) and
+      // yields no fallback for its folder rather than aborting the scan.
+      const override = getOverrideForDir(path.dirname(filePath));
+      const picked = pickFallback(override, path.basename(filePath), {
+        hasGps: meta.hasGps,
+        capturedAt: meta.capturedAt,
+      });
+      const fallbackDateApplied = picked.capturedAt != null;
+      const fallbackLocationApplied = picked.takenLat != null && picked.takenLng != null;
 
       scans.insertScanFile(scanId, {
         folderId,
@@ -188,6 +256,8 @@ export class ScanEngine extends ScanTypedEmitter {
         takenLat: meta.takenLat,
         takenLng: meta.takenLng,
         capturedAtSource: cap.source,
+        fallbackDateApplied,
+        fallbackLocationApplied,
         metaError: meta.error,
       });
 
@@ -213,6 +283,6 @@ export class ScanEngine extends ScanTypedEmitter {
     const durationMs = Date.now() - startMs;
     this.emit(SCAN_EV.SCAN_DONE, { scanId, totals, durationMs });
 
-    return { scanId, totals, durationMs };
+    return { scanId, totals, durationMs, overrideErrors };
   }
 }

--- a/apps/cli/src/sync/sync-engine.ts
+++ b/apps/cli/src/sync/sync-engine.ts
@@ -14,7 +14,13 @@ import * as path from 'node:path';
 import { TypedEmitter, EV } from './events.js';
 import { runPool } from './worker-pool.js';
 import { enumerateFiles } from '../files.js';
-import { resolveCapturedAt, type ResolvedCaptureDate } from '../metadata.js';
+import { readMediaMetadata, resolveCapturedAt, type ResolvedCaptureDate } from '../metadata.js';
+import {
+  loadOverrideFile,
+  pickFallback,
+  OverrideValidationError,
+  type FolderOverride,
+} from '../override.js';
 import { sha256File } from '../hash.js';
 import { uploadFile, type UploadPersistence } from '../upload.js';
 import { ApiError, type ApiClient } from '../api.js';
@@ -226,6 +232,22 @@ export class SyncEngine extends TypedEmitter {
     }
 
     // ------------------------------------------------------------------
+    // 2c. Per-run folder-override cache
+    // ------------------------------------------------------------------
+    // Parsed `memoriahub.json` overrides, keyed by the directory a file lives in.
+    // loadOverrideFile does its own fs read + validation on every call, so
+    // memoizing here means each folder's override is read at most once per run
+    // and reused by both the pre-flight validation pass and the worker's register
+    // step. A cached value may be a FolderOverride or null (no override present).
+    const overrideCache = new Map<string, FolderOverride | null>();
+    const getOverrideForDir = (dir: string): FolderOverride | null => {
+      if (overrideCache.has(dir)) return overrideCache.get(dir) ?? null;
+      const override = loadOverrideFile(dir); // may throw OverrideValidationError
+      overrideCache.set(dir, override);
+      return override;
+    };
+
+    // ------------------------------------------------------------------
     // 3. Build the work set
     // ------------------------------------------------------------------
     const workList: Array<{ fileId: number; filePath: string; mimeType: string; folderId: number }> = [];
@@ -343,6 +365,34 @@ export class SyncEngine extends TypedEmitter {
           files.setStatus(rec.id, 'queued');
           workList.push({ fileId: rec.id, filePath, mimeType, folderId });
           this.emit(EV.FILE_QUEUED, { fileId: rec.id, path: filePath });
+        }
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // 3b. Pre-flight: validate every folder override before uploading bytes
+    // ------------------------------------------------------------------
+    // A present-but-invalid memoriahub.json must abort the run BEFORE any media is
+    // uploaded — silently ignoring it would attach the wrong date/location to the
+    // user's photos, which is worse than refusing to run. We validate the distinct
+    // parent directories of the work set exactly once (scope: whole run — any bad
+    // override aborts everything). Successful parses stay cached for the worker to
+    // reuse, so no folder's override is read twice. This runs before the run record
+    // is started (step 4), so an abort leaves no run row and uploads nothing.
+    {
+      const overrideDirs = new Set(workList.map((w) => path.dirname(w.filePath)));
+      for (const dir of overrideDirs) {
+        try {
+          getOverrideForDir(dir);
+        } catch (err) {
+          if (err instanceof OverrideValidationError) {
+            const msg =
+              `Sync aborted — ${err.message}. ` +
+              'Fix or remove that file, then re-run. No media was uploaded.';
+            this.emit(EV.ERROR, { message: msg });
+            return Promise.reject(new Error(msg));
+          }
+          throw err;
         }
       }
     }
@@ -576,10 +626,39 @@ export class SyncEngine extends TypedEmitter {
         // originalCreatedAt records the file's creation time as provenance.
         const basename = path.basename(filePath);
         const type = mimeToMediaType(mimeType);
+        // Read the file's own metadata ONCE. Its capturedAt feeds the capture-date
+        // resolution (so exifr is not parsed twice), and its hasGps/capturedAt gate
+        // the per-folder memoriahub.json fallback below.
+        const meta = await readMediaMetadata(filePath, mimeType);
         // Reuse the date resolved during range filtering when available; otherwise
-        // resolve it now (the no-filter path, unchanged from before).
+        // resolve it now, passing meta.capturedAt so exifr is not parsed again.
         const cap =
-          captureDateCache.get(fileId) ?? (await resolveCapturedAt(filePath, mimeType));
+          captureDateCache.get(fileId) ??
+          (await resolveCapturedAt(filePath, mimeType, meta.capturedAt));
+
+        // Per-folder metadata override (memoriahub.json): fills ONLY the gaps the
+        // file's own EXIF left open. Already validated in the pre-flight pass, so
+        // this is a pure cache hit that never throws.
+        const override = getOverrideForDir(path.dirname(filePath));
+        const picked = pickFallback(override, basename, {
+          hasGps: meta.hasGps,
+          capturedAt: meta.capturedAt,
+        });
+
+        // Date precedence: real EXIF always wins; otherwise an override date beats
+        // the file-timestamp guess; otherwise fall back to the file-timestamp guess
+        // (which may be null). originalCreatedAt is sent unchanged as provenance.
+        let capturedAt: string | null;
+        let capturedAtOffset: number | undefined;
+        if (cap.source === 'exif') {
+          capturedAt = cap.capturedAt;
+        } else if (picked.capturedAt) {
+          capturedAt = picked.capturedAt;
+          capturedAtOffset = picked.capturedAtOffset;
+        } else {
+          capturedAt = cap.capturedAt;
+        }
+
         const mediaItem = await api.post<MediaItem>('/api/media', {
           storageObjectId: objectId,
           type,
@@ -587,8 +666,21 @@ export class SyncEngine extends TypedEmitter {
           originalFilename: basename,
           contentHash: sha256,
           circleId: resolvedCircleId,
-          ...(cap.capturedAt ? { capturedAt: cap.capturedAt } : {}),
+          ...(capturedAt ? { capturedAt } : {}),
+          ...(capturedAtOffset != null ? { capturedAtOffset } : {}),
           ...(cap.originalCreatedAt ? { originalCreatedAt: cap.originalCreatedAt } : {}),
+          // Location fallback only ever fires when the file had no EXIF GPS. The
+          // server still applies it present-only (real EXIF GPS wins server-side).
+          ...(picked.takenLat != null && picked.takenLng != null
+            ? {
+                takenLat: picked.takenLat,
+                takenLng: picked.takenLng,
+                coordSource: 'manual',
+                ...(picked.takenAltitude != null
+                  ? { takenAltitude: picked.takenAltitude }
+                  : {}),
+              }
+            : {}),
         });
 
         // If the server deduplicated (race: another device registered same content first),

--- a/apps/cli/test/override.spec.ts
+++ b/apps/cli/test/override.spec.ts
@@ -1,0 +1,352 @@
+/**
+ * test/override.spec.ts
+ *
+ * Unit tests for the per-folder metadata-override reader (`memoriahub.json`):
+ *   - loadOverrideFile(dir): fs read + validation + normalization
+ *   - normalizeCapturedAt(raw): low-level date normalization helper
+ *   - pickFallback(override, basename, meta): pure per-file decision logic
+ *
+ * Mirrors the temp-file setup pattern used in test/metadata.spec.ts and
+ * test/hash.spec.ts.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  loadOverrideFile,
+  pickFallback,
+  normalizeCapturedAt,
+  OVERRIDE_FILENAME,
+  OverrideValidationError,
+} from '../src/override.js';
+import type { FolderOverride } from '../src/override.js';
+
+function writeOverride(dir: string, data: unknown): void {
+  fs.writeFileSync(path.join(dir, OVERRIDE_FILENAME), JSON.stringify(data));
+}
+
+function writeRawOverride(dir: string, text: string): void {
+  fs.writeFileSync(path.join(dir, OVERRIDE_FILENAME), text);
+}
+
+describe('OVERRIDE_FILENAME', () => {
+  it('is memoriahub.json', () => {
+    expect(OVERRIDE_FILENAME).toBe('memoriahub.json');
+  });
+});
+
+describe('loadOverrideFile', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-override-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no memoriahub.json is present', () => {
+    expect(loadOverrideFile(tmpDir)).toBeNull();
+  });
+
+  it('returns a normalized FolderOverride for a valid full file', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      fallback: {
+        capturedAt: '2019-06-15T14:30:00-06:00',
+        location: { latitude: 37.7749, longitude: -122.4194, altitude: 12.5 },
+      },
+      files: [
+        {
+          name: 'IMG_0001.jpg',
+          location: { latitude: 40.7128, longitude: -74.006 },
+        },
+      ],
+    });
+
+    const result = loadOverrideFile(tmpDir);
+
+    const expected: FolderOverride = {
+      version: 1,
+      fallback: {
+        capturedAt: new Date(Date.parse('2019-06-15T14:30:00-06:00')).toISOString(),
+        capturedAtOffset: -360,
+        location: { latitude: 37.7749, longitude: -122.4194, altitude: 12.5 },
+      },
+      files: [
+        {
+          name: 'IMG_0001.jpg',
+          capturedAt: null,
+          capturedAtOffset: null,
+          location: { latitude: 40.7128, longitude: -74.006, altitude: null },
+        },
+      ],
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it('throws OverrideValidationError with the file path in the message for invalid JSON', () => {
+    writeRawOverride(tmpDir, '{ this is not json');
+
+    let caught: unknown;
+    try {
+      loadOverrideFile(tmpDir);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OverrideValidationError);
+    const err = caught as OverrideValidationError;
+    expect(err.name).toBe('OverrideValidationError');
+    expect(err.filePath).toBe(path.join(tmpDir, OVERRIDE_FILENAME));
+    expect(err.message).toContain(path.join(tmpDir, OVERRIDE_FILENAME));
+  });
+
+  it('throws OverrideValidationError when version is missing', () => {
+    writeOverride(tmpDir, { fallback: { capturedAt: '2020-01-01' } });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when version is non-integer', () => {
+    writeOverride(tmpDir, { version: 1.5 });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when version is not 1', () => {
+    writeOverride(tmpDir, { version: 2 });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when fallback.location.latitude is out of range', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      fallback: { location: { latitude: 91, longitude: 0 } },
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when fallback.location.longitude is out of range', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      fallback: { location: { latitude: 0, longitude: -181 } },
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when location is missing latitude', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      fallback: { location: { longitude: 10 } },
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when location is missing longitude', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      fallback: { location: { latitude: 10 } },
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when files is not an array', () => {
+    writeOverride(tmpDir, { version: 1, files: { name: 'a.jpg' } });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when a files[] entry is missing name', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      files: [{ capturedAt: '2020-01-01' }],
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError when a files[] entry has an empty-string name', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      files: [{ name: '', capturedAt: '2020-01-01' }],
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('throws OverrideValidationError on duplicate names across files[] entries', () => {
+    writeOverride(tmpDir, {
+      version: 1,
+      files: [
+        { name: 'IMG_0001.jpg', capturedAt: '2020-01-01' },
+        { name: 'IMG_0001.jpg', capturedAt: '2020-01-02' },
+      ],
+    });
+    expect(() => loadOverrideFile(tmpDir)).toThrow(OverrideValidationError);
+  });
+
+  it('ignores unknown top-level keys without throwing', () => {
+    writeOverride(tmpDir, { version: 1, somethingUnknown: 'ignored', extra: { nested: true } });
+    expect(() => loadOverrideFile(tmpDir)).not.toThrow();
+    const result = loadOverrideFile(tmpDir);
+    expect(result).toEqual({ version: 1, fallback: null, files: [] });
+  });
+});
+
+describe('normalizeCapturedAt', () => {
+  it('expands a date-only string to local noon with offsetMinutes null', () => {
+    const result = normalizeCapturedAt('2019-06-16');
+    const expectedIso = new Date(2019, 5, 16, 12, 0, 0).toISOString();
+    expect(result.iso).toBe(expectedIso);
+    expect(result.offsetMinutes).toBeNull();
+  });
+
+  it('parses a negative-offset datetime and reports offsetMinutes', () => {
+    const result = normalizeCapturedAt('2019-06-15T14:30:00-06:00');
+    expect(result.offsetMinutes).toBe(-360);
+    expect(result.iso).toBe(new Date(Date.parse('2019-06-15T14:30:00-06:00')).toISOString());
+  });
+
+  it('parses a Z-suffixed datetime and reports offsetMinutes 0', () => {
+    const result = normalizeCapturedAt('2019-06-15T14:30:00Z');
+    expect(result.offsetMinutes).toBe(0);
+    expect(result.iso).toBe('2019-06-15T14:30:00.000Z');
+  });
+
+  it('throws a plain Error (not OverrideValidationError) for an unparseable string', () => {
+    expect(() => normalizeCapturedAt('not-a-date')).toThrow(Error);
+    let caught: unknown;
+    try {
+      normalizeCapturedAt('not-a-date');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(OverrideValidationError);
+  });
+});
+
+describe('pickFallback', () => {
+  const folderOverride: FolderOverride = {
+    version: 1,
+    fallback: {
+      capturedAt: '2020-05-01T00:00:00.000Z',
+      capturedAtOffset: 0,
+      location: { latitude: 10, longitude: 20, altitude: 100 },
+    },
+    files: [],
+  };
+
+  it('returns {} when override is null', () => {
+    expect(pickFallback(null, 'anything.jpg', { hasGps: false, capturedAt: null })).toEqual({});
+  });
+
+  it('fills GPS only when the file has an EXIF date but no GPS', () => {
+    const result = pickFallback(folderOverride, 'a.jpg', {
+      capturedAt: '2020-01-01T00:00:00.000Z',
+      hasGps: false,
+    });
+
+    expect(result.takenLat).toBe(10);
+    expect(result.takenLng).toBe(20);
+    expect(result).not.toHaveProperty('capturedAt');
+  });
+
+  it('fills capturedAt only when the file has GPS but no EXIF date', () => {
+    const result = pickFallback(folderOverride, 'a.jpg', {
+      capturedAt: null,
+      hasGps: true,
+    });
+
+    expect(result.capturedAt).toBe('2020-05-01T00:00:00.000Z');
+    expect(result).not.toHaveProperty('takenLat');
+    expect(result).not.toHaveProperty('takenLng');
+    expect(result).not.toHaveProperty('takenAltitude');
+  });
+
+  it('fills both capturedAt and location when the file has neither', () => {
+    const result = pickFallback(folderOverride, 'a.jpg', {
+      capturedAt: null,
+      hasGps: false,
+    });
+
+    expect(result.capturedAt).toBe('2020-05-01T00:00:00.000Z');
+    expect(result.takenLat).toBe(10);
+    expect(result.takenLng).toBe(20);
+    expect(result.takenAltitude).toBe(100);
+  });
+
+  it('returns {} when the file has both EXIF date and GPS', () => {
+    const result = pickFallback(folderOverride, 'a.jpg', {
+      capturedAt: '2020-01-01T00:00:00.000Z',
+      hasGps: true,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('lets a matching files[] entry override the fallback per-field, inheriting missing fields', () => {
+    const overrideWithFileEntry: FolderOverride = {
+      version: 1,
+      fallback: {
+        capturedAt: '2020-05-01T00:00:00.000Z',
+        capturedAtOffset: 0,
+        location: { latitude: 10, longitude: 20, altitude: 100 },
+      },
+      files: [
+        {
+          name: 'special.jpg',
+          capturedAt: null,
+          capturedAtOffset: null,
+          location: { latitude: 55, longitude: 66, altitude: null },
+        },
+      ],
+    };
+
+    // File has neither EXIF date nor GPS: location comes from the files[] entry
+    // (55/66), capturedAt inherits from the folder fallback since the files[]
+    // entry did not supply its own.
+    const result = pickFallback(overrideWithFileEntry, 'special.jpg', {
+      capturedAt: null,
+      hasGps: false,
+    });
+
+    expect(result.takenLat).toBe(55);
+    expect(result.takenLng).toBe(66);
+    expect(result.capturedAt).toBe('2020-05-01T00:00:00.000Z');
+  });
+
+  it('includes capturedAtOffset only when the chosen capturedAt source has a non-null offset', () => {
+    const overrideNoOffset: FolderOverride = {
+      version: 1,
+      fallback: {
+        capturedAt: '2020-05-01T12:00:00.000Z',
+        capturedAtOffset: null,
+        location: null,
+      },
+      files: [],
+    };
+
+    const result = pickFallback(overrideNoOffset, 'a.jpg', { capturedAt: null, hasGps: true });
+
+    expect(result.capturedAt).toBe('2020-05-01T12:00:00.000Z');
+    expect(result).not.toHaveProperty('capturedAtOffset');
+  });
+
+  it('includes takenAltitude only when the chosen location has a non-null altitude', () => {
+    const overrideNoAltitude: FolderOverride = {
+      version: 1,
+      fallback: {
+        capturedAt: null,
+        capturedAtOffset: null,
+        location: { latitude: 1, longitude: 2, altitude: null },
+      },
+      files: [],
+    };
+
+    const result = pickFallback(overrideNoAltitude, 'a.jpg', { capturedAt: '2020-01-01', hasGps: false });
+
+    expect(result.takenLat).toBe(1);
+    expect(result.takenLng).toBe(2);
+    expect(result).not.toHaveProperty('takenAltitude');
+  });
+});

--- a/apps/cli/test/sync/sync-engine.spec.ts
+++ b/apps/cli/test/sync/sync-engine.spec.ts
@@ -22,6 +22,7 @@ import { FileRepo } from '../../src/repo/files.js';
 import { RunRepo } from '../../src/repo/runs.js';
 import { SettingsRepo } from '../../src/repo/settings.js';
 import { SyncEngine } from '../../src/sync/sync-engine.js';
+import { OVERRIDE_FILENAME } from '../../src/override.js';
 import { EV } from '../../src/sync/events.js';
 import type {
   RunStartPayload,
@@ -970,6 +971,74 @@ describe('SyncEngine', () => {
       expect(doneEvents).toHaveLength(1);
       const rec = ctx.files.listByFolder(folder.id)[0];
       expect(rec.status).toBe('uploaded');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // per-folder metadata override (memoriahub.json)
+  // -------------------------------------------------------------------------
+
+  describe('per-folder metadata override (memoriahub.json)', () => {
+    it('includes takenLat/takenLng/coordSource from memoriahub.json fallback when the file has no EXIF GPS', async () => {
+      // writeTmpJpeg() writes a fake JPEG header with no real EXIF, so
+      // meta.hasGps will be false for this file — the folder fallback location
+      // should fill the gap.
+      fs.writeFileSync(
+        path.join(tmpDir, OVERRIDE_FILENAME),
+        JSON.stringify({
+          version: 1,
+          fallback: {
+            location: { latitude: 37.7749, longitude: -122.4194 },
+          },
+        }),
+      );
+      writeTmpJpeg(tmpDir, 'override-gps.jpg');
+
+      const postFn = mockResolving({ id: 'media-override-gps' });
+      const ctx = makeEngine(
+        db,
+        {
+          get: mockResolving({ items: [] }),
+          post: postFn,
+        },
+        makeUploadFn('obj-override-gps'),
+      );
+
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+      await ctx.engine.run({ trigger: 'cli', folderIds: [folder.id] });
+
+      expect(postFn).toHaveBeenCalledTimes(1);
+      const callArgs = postFn.mock.calls[0] as [string, Record<string, unknown>];
+      expect(callArgs[0]).toBe('/api/media');
+      expect(callArgs[1]).toMatchObject({
+        takenLat: 37.7749,
+        takenLng: -122.4194,
+        coordSource: 'manual',
+      });
+    });
+
+    it('does NOT include takenLat/takenLng/coordSource when no memoriahub.json is present in the folder', async () => {
+      writeTmpJpeg(tmpDir, 'no-override.jpg');
+
+      const postFn = mockResolving({ id: 'media-no-override' });
+      const ctx = makeEngine(
+        db,
+        {
+          get: mockResolving({ items: [] }),
+          post: postFn,
+        },
+        makeUploadFn('obj-no-override'),
+      );
+
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+      await ctx.engine.run({ trigger: 'cli', folderIds: [folder.id] });
+
+      expect(postFn).toHaveBeenCalledTimes(1);
+      const callArgs = postFn.mock.calls[0] as [string, Record<string, unknown>];
+      expect(callArgs[0]).toBe('/api/media');
+      expect(callArgs[1]).not.toHaveProperty('takenLat');
+      expect(callArgs[1]).not.toHaveProperty('takenLng');
+      expect(callArgs[1]).not.toHaveProperty('coordSource');
     });
   });
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1354,6 +1354,10 @@ Register an uploaded `StorageObject` as a `MediaItem`.
 | `contentHash` | string (64 lowercase hex chars) | No | SHA-256 hex digest of the file bytes. When supplied the server deduplicates by `(circleId, contentHash)`. |
 | `capturedAt` | ISO 8601 datetime | No | When the photo/video was taken |
 | `capturedAtOffset` | integer (minutes) | No | UTC offset of `capturedAt` |
+| `takenLat` | number | No | Client-supplied GPS latitude fallback (-90 to 90). Applied only when the item has no EXIF-derived GPS. See [CLI Metadata Override](specs/cli-metadata-override.md). |
+| `takenLng` | number | No | Client-supplied GPS longitude fallback (-180 to 180). Applied only when the item has no EXIF-derived GPS. |
+| `takenAltitude` | number | No | Client-supplied altitude fallback, in meters. |
+| `coordSource` | `"manual"` | No | Must be the literal string `"manual"` when supplied — no other value is accepted on this endpoint. Marks `takenLat`/`takenLng`/`takenAltitude` as client-supplied (as opposed to EXIF-derived) coordinate provenance. |
 | `title` | string (max 512) | No | |
 | `description` | string (max 8192) | No | |
 | `favorite` | boolean | No | Defaults to `false` |
@@ -1362,6 +1366,10 @@ Register an uploaded `StorageObject` as a `MediaItem`.
 | `sourcePath` | string (max 2048) | No | Original path on source device |
 | `sourceDeviceId` | string (max 256) | No | |
 | `sourceDeviceName` | string (max 256) | No | |
+
+**Client-supplied location fallback (`takenLat`/`takenLng`/`takenAltitude`/`coordSource`):** These four fields let a client supply a fallback GPS location for an item that has no EXIF-derived coordinates — the primary consumer is the CLI's `memoriahub.json` per-folder override feature (see [CLI Metadata Override](specs/cli-metadata-override.md)). Server-extracted EXIF location always wins: if the uploaded file's own EXIF already supplies GPS, these fields are ignored and never overwrite the EXIF-derived coordinates. When the fallback **is** applied (i.e. the item has no EXIF GPS), the server reverse-geocodes the supplied coordinates — writing `geoCountry`, `geoAdmin1`, `geoAdmin2`, `geoLocality`, `geoPlaceName`, and `geoSource`, the same pipeline described in [Geocoding](specs/geocoding.md) — and stores `coordSource` as `'manual'`.
+
+`capturedAt` follows the same precedence rule as a date fallback, even though the row above doesn't spell it out: a server-extracted EXIF capture date always wins over a client-supplied `capturedAt` when both are present for the same item. A client-supplied `capturedAt` is only used when the item has no EXIF-derived capture date.
 
 **Example request (with dedup hash):**
 

--- a/docs/specs/cli-metadata-override.md
+++ b/docs/specs/cli-metadata-override.md
@@ -1,0 +1,225 @@
+# CLI Metadata Override File (memoriahub.json)
+
+| Field | Value |
+|-------|-------|
+| **Version** | 1.0 |
+| **Last Updated** | July 2026 |
+| **Status** | Specification |
+
+Cross-references: [CLI Scan](cli-scan.md) | [Geocoding](geocoding.md) | [Location Inference](location-inference.md)
+
+---
+
+## Table of Contents
+
+1. [Overview and Motivation](#1-overview-and-motivation)
+2. [Filename and Placement](#2-filename-and-placement)
+3. [Schema Reference](#3-schema-reference)
+4. [Merge Semantics](#4-merge-semantics)
+5. [Reverse Geocoding and coordSource](#5-reverse-geocoding-and-coordsource)
+6. [Validation and Error Handling](#6-validation-and-error-handling)
+7. [Verifying Before You Upload](#7-verifying-before-you-upload)
+8. [Worked Scenarios — Costa Rica 2019](#8-worked-scenarios--costa-rica-2019)
+9. [Implementation Notes](#9-implementation-notes)
+
+---
+
+## 1. Overview and Motivation
+
+When a user bulk-imports a folder of media with `memoriahub sync <folder>` (the same underlying upload path is also reachable via `import`), many files arrive with incomplete metadata. Photos scanned from an old print, exported from a messaging app, or pulled off a device with location services disabled often have **no EXIF date and no EXIF GPS at all**. Videos are worse: this pipeline never reads EXIF from video containers, so a video's date and location are always missing unless something else supplies them.
+
+Without any override, a file with no capture date falls back to a best-effort file-timestamp guess (see [Bulk Import Resilience](bulk-import-resilience.md) for how capture dates are resolved), and a file with no GPS simply has no coordinates — it never appears on the map or in place-based browsing.
+
+`memoriahub.json` is a small, hand-editable JSON file a user drops into a media folder before running `sync`. It supplies a **fallback** capture date and/or GPS location for files in that folder that are missing that data in their own EXIF. It never overrides metadata a file already has — it only fills gaps. This is the primary tool for correctly dating and geotagging old scanned photo folders and video-heavy folders in bulk, without hand-editing every file.
+
+---
+
+## 2. Filename and Placement
+
+- The file must be named exactly `memoriahub.json` — case-sensitive, a normal visible filename (not dot-prefixed like `.memoriahub.json`).
+- It is placed directly inside the media folder it applies to. It applies **only** to media files directly inside that same folder — it does **not** recurse into subfolders. A subfolder that needs its own overrides needs its own `memoriahub.json`.
+- The practical workflow this is designed around: segregate a trip, a day, or a batch of old scans into its own folder (e.g. `~/Pictures/CostaRica2019/`), and drop one `memoriahub.json` into that folder describing the fallback date/location for everything in it, then run `memoriahub sync ~/Pictures/CostaRica2019`.
+- The file itself is never uploaded as a media item. The CLI treats it as a control file and skips it during folder enumeration — the same way it silently skips any file whose extension is not in the supported-extensions list (see [CLI Scan §4](cli-scan.md#4-metadata-extraction-scope) for the full `MIME_BY_EXT` discussion). A `.json` file was never going to match an image or video extension in the first place, so this exclusion falls out naturally from the existing discovery logic.
+
+---
+
+## 3. Schema Reference
+
+Example `memoriahub.json`:
+
+```json
+{
+  "version": 1,
+  "fallback": {
+    "capturedAt": "2019-06-15T14:30:00-06:00",
+    "location": { "latitude": 9.9281, "longitude": -84.0907, "altitude": 1170 }
+  },
+  "files": [
+    { "name": "IMG_0042.jpg", "capturedAt": "2019-06-16", "location": { "latitude": 9.63, "longitude": -84.66 } }
+  ]
+}
+```
+
+### `version` (required integer)
+
+Must be exactly `1`. Any other value — missing, a different number, a string, etc. — is a validation error (see [§6](#6-validation-and-error-handling)). This field exists so a future breaking schema change can be introduced without silently misreading old override files.
+
+### `fallback` (optional object)
+
+Folder-wide defaults applied to every file in the folder that doesn't already have the corresponding data (in its own EXIF, or in a more specific `files[]` entry — see [§4](#4-merge-semantics)).
+
+| Field | Type | Required within `fallback` | Description |
+|-------|------|------|-------------|
+| `capturedAt` | ISO 8601 datetime or `YYYY-MM-DD` date | No | The date (and ideally time) the folder's contents were captured. |
+| `location` | object | No | `{ latitude, longitude, altitude? }` — the folder's GPS fallback. |
+| `location.latitude` | number | Yes, if `location` is present | Range `[-90, 90]`. |
+| `location.longitude` | number | Yes, if `location` is present | Range `[-180, 180]`. |
+| `location.altitude` | number | No | Meters. Optional even when `location` is present. |
+
+**`capturedAt` date-only expansion:** `fallback.capturedAt` accepts either a full datetime with a UTC offset (preferred, e.g. `"2019-06-15T14:30:00-06:00"`) or a bare date string `"YYYY-MM-DD"`. When a date-only string is supplied, the CLI expands it to **local noon** (`12:00:00` in the offset implied by the date, i.e. treated as a wall-clock local time) rather than midnight. This is deliberate: midnight sits at the edge of the calendar day, so any subsequent UTC-offset shift (server timezone handling, a viewer in a different timezone, DST edge cases) risks pushing the timestamp to the *previous* calendar day. Noon sits in the middle of the day, so no plausible offset shift can move it across a date boundary. The result is that a date-only override reliably displays as the intended calendar date everywhere it's shown, at the cost of an arbitrary (but harmless) time-of-day component.
+
+**`location` requires both coordinates together.** Supplying `latitude` without `longitude` (or vice versa) is a validation error — see [§6](#6-validation-and-error-handling). `altitude` alone, without both coordinates, is also invalid since `location` would then be meaningless as a position.
+
+### `files` (optional array)
+
+Per-file overrides, for the cases where one or a few files in the folder need something different from the folder-wide `fallback` (a file taken at a different moment, or a specific correction).
+
+Each entry:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | **Yes** | The file's exact basename (e.g. `"IMG_0042.jpg"`) — **not** a full path, and **not** a case-insensitive glob or pattern. Matching is an exact, case-sensitive string comparison against the basename of each file discovered in the folder. |
+| `capturedAt` | ISO 8601 datetime or `YYYY-MM-DD` | No | Same format and same local-noon expansion rule as `fallback.capturedAt`. |
+| `location` | object | No | Same shape and validation rules as `fallback.location` (`latitude`/`longitude` both required together, `altitude` optional). |
+
+A `files[]` entry only needs to specify the field(s) it wants to override — see [§4](#4-merge-semantics) for exactly how a partial entry composes with the folder `fallback`.
+
+**Duplicate `name` values in `files[]` are a validation error.** If the same basename appears twice, the CLI cannot determine which entry should win, so the whole file is rejected rather than silently picking one (see [§6](#6-validation-and-error-handling)).
+
+---
+
+## 4. Merge Semantics
+
+### EXIF always wins, per field, independently
+
+The override file only ever fills a **gap**. If a file already has EXIF data for a given field, the override is ignored for that field — even if the file also has a `files[]` entry or the folder has a `fallback`. Critically, this evaluation happens **per field, independently**, not per file as an all-or-nothing choice:
+
+- A photo with an EXIF capture date but **no** EXIF GPS keeps its EXIF date and receives the override's location.
+- A photo with EXIF GPS but **no** EXIF capture date keeps its EXIF GPS and receives the override's date.
+- A photo with both already keeps both — the override contributes nothing for that file.
+- A photo with neither receives both fields from the override.
+
+### Videos always take the override
+
+This pipeline does not read EXIF from video containers, so a video file has no EXIF date and no EXIF GPS by definition. Every video in a folder governed by a `memoriahub.json` receives whatever the override supplies (folder `fallback`, or a more specific `files[]` entry) for both `capturedAt` and `location`. This is, in practice, the primary way to bulk date- and geotag videos — there is no other mechanism that assigns location to a video today.
+
+### `files[]` entries override `fallback`, per field, independently — never as a package
+
+A `files[]` entry's *present* fields take precedence over the folder `fallback` for that file, but only for the fields the entry actually specifies. An entry with only `location` still inherits the folder's `fallback.capturedAt` for that file (if the file lacks EXIF date); an entry with only `capturedAt` still inherits `fallback.location` (if the file lacks EXIF GPS). A `files[]` entry is a scoped override, not a full replacement of the folder default for that file.
+
+### Precedence tables
+
+**Capture date** (highest to lowest):
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | The file's own EXIF `capturedAt` |
+| 2 | A matching `files[]` entry's `capturedAt` |
+| 3 | The folder's `fallback.capturedAt` |
+| 4 (lowest) | If none of the above applied: the existing CLI/server best-effort file-timestamp guess (see [Bulk Import Resilience](bulk-import-resilience.md)) |
+
+**Location** (highest to lowest):
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | The file's own EXIF GPS |
+| 2 | A matching `files[]` entry's `location` |
+| 3 | The folder's `fallback.location` |
+| — (no lower fallback) | If none of the above applied, the item simply has no coordinates |
+
+Note the asymmetry with capture date: there is no last-resort location guess analogous to the file-timestamp fallback. A photo with no EXIF GPS and no applicable override has no location, full stop.
+
+---
+
+## 5. Reverse Geocoding and coordSource
+
+When a `memoriahub.json` fallback (folder-level or per-file) supplies coordinates for an item that lacks its own EXIF GPS, the server reverse-geocodes those coordinates into `geoCountry`, `geoAdmin1`, `geoAdmin2`, `geoLocality`, `geoPlaceName`, and `geoSource` — the same reverse-geocoding pipeline described in [Geocoding](geocoding.md), using whichever provider is currently active (`system_settings.geo.reverseProvider`). This is what makes the item appear correctly on the map and in place-based browsing (Explore > Places), exactly as if the coordinates had come from the camera's own GPS.
+
+The server records `coordSource = 'manual'` for items whose coordinates came from a `memoriahub.json` fallback. This CLI-supplied-coordinates path is a **fourth call site** of the same `'manual'` convention already used by the pre-existing manual location edit path — as documented in [Location Inference §2](location-inference.md#2-coordinate-provenance-model), there are three writers of `coordSource`: EXIF metadata sync writes `'exif'`, `bulkUpdateMedia`'s manual location edit writes `'manual'`, and location inference writes `'inferred'` (auto-apply/unmodified-accept) or `'manual'` (adjusted accept). The CLI override path is client-supplied coordinates arriving at item-creation time rather than a later edit, but it is not machine-inferred, so it follows the existing `'manual'` convention rather than introducing a fourth `coordSource` value.
+
+---
+
+## 6. Validation and Error Handling
+
+### A malformed override file is a hard stop for that folder
+
+If `memoriahub.json` is present in a folder but is malformed in any of the following ways, the `sync` run **aborts for that invocation** with a clear error naming the offending file and the specific problem, and **uploads nothing for that folder**:
+
+- The file is not valid, parseable JSON.
+- `version` is missing, or is present but not exactly `1`.
+- `location.latitude` or `location.longitude` is outside its valid range (`[-90, 90]` / `[-180, 180]`).
+- `location` is present with only one of `latitude` / `longitude` (they are required together).
+- Two or more entries in `files[]` share the same `name`.
+- A field has the wrong type (e.g. `capturedAt` is a number, `files` is an object instead of an array).
+
+The rationale is deliberate: a typo in a hand-edited JSON file must never silently mis-tag an entire folder's worth of photos with the wrong date or the wrong country. Failing loudly and refusing to upload anything for that folder is safer than guessing or partially applying a broken override.
+
+### A missing override file is not an error
+
+If a folder simply has no `memoriahub.json`, that is **not** an error condition — the folder is processed exactly as it is today, with no fallback date or location applied to any file in it. The feature is entirely additive and opt-in per folder.
+
+---
+
+## 7. Verifying Before You Upload
+
+The existing pre-sync dry-run preview (`memoriahub scan` and `memoriahub sync --dry-run` — see [CLI Scan](cli-scan.md)) is extended to account for `memoriahub.json`:
+
+- If a folder being scanned contains a `memoriahub.json`, the scan report indicates, per file, whether a date fallback and/or a location fallback from that override would be applied to it once `sync` actually runs.
+- If the `memoriahub.json` in a scanned folder is malformed, the scan surfaces that problem up front — before a real `sync` run — with the same kind of specific, file-and-reason error described in [§6](#6-validation-and-error-handling), so a user can fix a typo during a fast, local, no-upload preview rather than discovering it mid-import.
+
+> **Note:** the exact field/column names the scan report and its export (dashboard, piped table, JSON, and Excel Detail sheet — see [CLI Scan §5](cli-scan.md#5-report-and-dashboard) and [§6](cli-scan.md#6-excel-and-csv-export)) will use to represent "date fallback would apply" / "location fallback would apply" per file are **not specified here**, because this reporting integration is not yet implemented as of this writing. Whatever naming is chosen should follow the scan report's existing conventions (e.g. alongside the existing `has_exif` / `has_gps` columns) at implementation time — this document intentionally describes the behavior functionally rather than asserting a specific field name.
+
+---
+
+## 8. Worked Scenarios — Costa Rica 2019
+
+A user has a folder `~/Pictures/CostaRica2019/` mixing a modern phone photo, an old scanned print, a video, and one photo that needs a specific correction. The folder's `memoriahub.json` is the example from [§3](#3-schema-reference):
+
+```json
+{
+  "version": 1,
+  "fallback": {
+    "capturedAt": "2019-06-15T14:30:00-06:00",
+    "location": { "latitude": 9.9281, "longitude": -84.0907, "altitude": 1170 }
+  },
+  "files": [
+    { "name": "IMG_0042.jpg", "capturedAt": "2019-06-16", "location": { "latitude": 9.63, "longitude": -84.66 } }
+  ]
+}
+```
+
+**(a) `IMG_0501.jpg` — a modern phone photo with EXIF date and GPS already present.**
+EXIF wins for both fields per [§4](#4-merge-semantics). The folder `fallback` is evaluated and simply ignored for this file — it keeps its own EXIF capture date and its own EXIF GPS untouched.
+
+**(b) `scan-0007.jpg` — an old scanned print with no EXIF date and no EXIF GPS.**
+Neither field is present in EXIF, and this file has no entry in `files[]`, so it inherits both fields from the folder `fallback`: `capturedAt = 2019-06-15T14:30:00-06:00` and the San José, Costa Rica coordinates (with `altitude = 1170`). The server reverse-geocodes those coordinates and records `coordSource = 'manual'` (per [§5](#5-reverse-geocoding-and-coordsource)).
+
+**(c) `IMG_0512.mov` — a video.**
+Videos have no EXIF at all in this pipeline, so `IMG_0512.mov` unconditionally receives both fields from the folder `fallback`, exactly like case (b) — the video is not eligible for a `files[]` override in this example only because it happens not to be listed there, not because videos are treated specially. If it had a `files[]` entry it would follow the same per-field override rule as any photo.
+
+**(d) `IMG_0042.jpg` — a specific correction via `files[]`.**
+This one photo was actually taken a day later than the rest of the trip and at a different specific location (perhaps a side excursion). Its `files[]` entry supplies both `capturedAt: "2019-06-16"` (expanded to local noon per [§3](#3-schema-reference)) and its own `location`, both of which take precedence over the folder `fallback` per [§4](#4-merge-semantics). If this entry had specified only `location` and omitted `capturedAt`, the file would have inherited the folder's `fallback.capturedAt` for its date while still getting its own corrected location.
+
+---
+
+## 9. Implementation Notes
+
+This is a CLI-side feature introduced in CLI **v1.1.15**. It depends on the API accepting client-supplied fallback location fields on media creation — see [`POST /api/media`](../API.md#post-apimedia) in [API.md](../API.md), specifically the `takenLat` / `takenLng` / `takenAltitude` / `coordSource` request-body fields.
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | July 2026 | AI Assistant | Initial specification |

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "boxen": "^5.1.2",


### PR DESCRIPTION
## Summary

Adds a per-folder metadata override for CLI uploads. A user drops a `memoriahub.json` file into a media folder to supply **date taken** and **GPS location** as a fallback for files in that folder that lack it in their own EXIF. EXIF always wins per-field; the override only fills gaps. Videos (no readable EXIF) always receive the fallback. Malformed override files abort the sync with a clear error before any upload.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

<!-- none -->

## Changes Made

- **API:** `POST /api/media` now accepts optional `takenLat`/`takenLng`/`takenAltitude`/`coordSource` (restricted to `'manual'`), applied via the existing `applyLocation` helper only when the server's own EXIF found no location (re-reads the row post-sync so EXIF always wins). No DB migration.
- **CLI:** new `apps/cli/src/override.ts` parses/validates/normalizes `memoriahub.json` (fail-loud on invalid, null when absent; date-only → local noon; per-file `files[]` array overrides). Wired into `sync-engine.ts` with pre-flight validation and fallback in the `POST /api/media` payload, and into the scan/dry-run report (`fallbackDateApplied`/`fallbackLocationApplied` columns, migration v9). The sidecar is skipped during enumeration so it's never uploaded. CLI bumped **1.1.14 → 1.1.15**.
- **Docs:** new `docs/specs/cli-metadata-override.md` (full file spec, EXIF-wins semantics, validation, worked examples) and `docs/API.md` update for the new fallback fields.
- **Tests:** CLI `override.spec.ts` (28) + `sync-engine.spec.ts` (+2, 33 total) and API `media.service.fallback-location.spec.ts` (5).

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

### Test Instructions

1. Create a folder with (a) a photo that has EXIF date+GPS, (b) a photo with neither, (c) a video, plus a `memoriahub.json` giving a date and coordinates.
2. Run `memoriahub sync --dry-run <folder>` and confirm the scan report shows the fallback applied to (b) and (c) but not (a).
3. Run `memoriahub sync <folder>` and confirm in the web app: (a) keeps its EXIF date/place; (b) and (c) show the override date and appear on the map with reverse-geocoded place names.
4. Add an invalid `memoriahub.json` (out-of-range coords) and confirm the sync aborts with a clear error and uploads nothing.

## Screenshots

<!-- n/a -->

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

`coordSource` for override-supplied locations is recorded as `'manual'` (reuses the existing enum, no migration); a dedicated `'fallback'` provenance value is a possible future refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKdrGAkgBCUJeH8YZ8D9yL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKdrGAkgBCUJeH8YZ8D9yL)_