### PR TITLE
feat(cli): probe video capture date + GPS via ffprobe in organize

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/metadata.ts
+++ b/apps/cli/src/metadata.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 
 import type { MediaKind, CaptureDateSource } from './db/types.js';
+import { readVideoPlacement } from './video-probe.js';
 
 // exifr ships ES-module and CJS builds; use dynamic import so both resolve.
 type ExifrModule = {
@@ -270,14 +271,16 @@ export async function readExifCaptureDate(
  * `organize` command's GPS-aware bucketing.
  *
  * Returns the raw `Date` (not an ISO string) so the caller can bucket by the
- * naive local wall-clock date, plus a boolean indicating whether EXIF supplied
- * usable numeric latitude AND longitude.
+ * naive local wall-clock date, plus a boolean indicating whether the file
+ * supplied a usable location.
  *
- * Videos always resolve to `{ capturedAt: null, hasGps: false }` (the CLI never
- * probes video metadata), matching readExifCaptureDate.
+ * Videos are probed via ffprobe (see video-probe.ts) for their container
+ * creation date and ISO 6709 location, since exifr cannot read QuickTime/MP4
+ * metadata. When ffprobe is unavailable, videos resolve to
+ * `{ capturedAt: null, hasGps: false }` (the legacy NODATE behavior).
  *
  * When `opts.full` is true, exifr reads the ENTIRE file (`chunked: false`) so a
- * date or GPS tag buried deep in the file is never missed.
+ * date or GPS tag buried deep in a PHOTO is never missed (no effect on videos).
  *
  * Never throws: any parse failure or genuine I/O error resolves to
  * `{ capturedAt: null, hasGps: false }`.
@@ -291,9 +294,9 @@ export async function readExifPlacement(
   mimeType: string,
   opts?: { full?: boolean },
 ): Promise<{ capturedAt: Date | null; hasGps: boolean }> {
-  // Videos: no EXIF probe — no date, no GPS.
+  // Videos: probe the container via ffprobe (exifr can't read MP4/QuickTime).
   if (mimeType.startsWith('video/')) {
-    return { capturedAt: null, hasGps: false };
+    return readVideoPlacement(filePath);
   }
 
   try {

--- a/apps/cli/src/organize/organize-engine.ts
+++ b/apps/cli/src/organize/organize-engine.ts
@@ -1,14 +1,16 @@
 /**
  * organize/organize-engine.ts — Event-driven OrganizeEngine.
  *
- * Walks one or more root folders, reads each photo's EXIF capture date (reading
- * the FULL file so a date buried deep inside is never missed), and MOVES each
- * file into a `YEAR/MM - Month/` sub-folder created inside that same root.
- * Files with no EXIF capture date — which includes every video, since the CLI
- * never probes video metadata — move into a top-level `NODATE/` folder. Within
- * each date bucket, files that have no EXIF GPS location are nested one level
- * deeper into a `NO-GPS/` sub-folder (applied uniformly, including under
- * `NODATE`), so the ones missing coordinates are grouped together.
+ * Walks one or more root folders, reads each file's capture date + GPS — photos
+ * via EXIF (reading the FULL file so a date buried deep inside is never missed),
+ * videos via an ffprobe probe of the container's creation date / ISO 6709
+ * location (see video-probe.ts) — and MOVES each file into a `YEAR/MM - Month/`
+ * sub-folder created inside that same root. Files with no resolvable capture
+ * date — photos without EXIF, and videos when ffprobe is unavailable or the
+ * container carries no date — move into a top-level `NODATE/` folder. Within
+ * each date bucket, files that have no GPS location are nested one level deeper
+ * into a `NO-GPS/` sub-folder (applied uniformly, including under `NODATE`), so
+ * the ones missing coordinates are grouped together.
  *
  * Fully offline and side-effect-free with respect to any server: it mirrors the
  * ScanEngine's structure (offline, UI-free, injected deps, typed events) rather

--- a/apps/cli/src/video-probe.ts
+++ b/apps/cli/src/video-probe.ts
@@ -1,0 +1,208 @@
+/**
+ * video-probe.ts — ffprobe-based capture-date + GPS reader for video files.
+ *
+ * exifr (used for photos in metadata.ts) cannot read QuickTime/MP4 container
+ * metadata, so the `organize` command historically bucketed every video into
+ * NODATE.  This module fills that gap by shelling out to `ffprobe` (which ships
+ * with ffmpeg) and parsing the container tags for a creation date and location.
+ *
+ * Uses Node built-ins only (child_process) — ffprobe is a runtime binary, NOT an
+ * npm dependency.  When ffprobe is absent the reader degrades gracefully to
+ * `{ capturedAt: null, hasGps: false }` (i.e. the pre-existing NODATE behavior),
+ * so `organize` still runs offline on hosts without ffmpeg installed.
+ *
+ * This module NEVER throws — every failure path resolves to nulls, mirroring the
+ * defensive posture of metadata.ts.
+ */
+
+import { execFile } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// ffprobe availability detection (memoized per process)
+// ---------------------------------------------------------------------------
+
+let cachedProbeAvailable: Promise<boolean> | null = null;
+
+/**
+ * Detect whether `ffprobe` is runnable on the PATH by invoking `ffprobe
+ * -version`.  Never throws — resolves `false` on ENOENT or a non-zero exit.
+ * Memoized for the lifetime of the process so a probe-less host never spawns a
+ * failing subprocess per video.
+ */
+export function detectFfprobe(bin = 'ffprobe'): Promise<boolean> {
+  if (cachedProbeAvailable) return cachedProbeAvailable;
+
+  cachedProbeAvailable = new Promise<boolean>((resolve) => {
+    execFile(bin, ['-version'], { timeout: 5000 }, (err) => {
+      resolve(!err);
+    });
+  });
+
+  return cachedProbeAvailable;
+}
+
+/** Reset the memoized detection result (test-only). */
+export function _resetProbeCache(): void {
+  cachedProbeAvailable = null;
+}
+
+// ---------------------------------------------------------------------------
+// ffprobe invocation
+// ---------------------------------------------------------------------------
+
+/** Shape of the slice of ffprobe's JSON output we care about. */
+interface FfprobeJson {
+  format?: { tags?: Record<string, unknown> };
+  streams?: Array<{ tags?: Record<string, unknown> }>;
+}
+
+/**
+ * Run `ffprobe` on a file and return the merged container/stream tag map, or
+ * `null` on any failure.  Format-level tags take precedence over stream-level
+ * tags (Apple writes the authoritative `creationdate`/`ISO6709` at the format
+ * level).  Never throws.
+ */
+async function runFfprobe(
+  filePath: string,
+  bin = 'ffprobe',
+): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    execFile(
+      bin,
+      [
+        '-v', 'quiet',
+        '-print_format', 'json',
+        '-show_format',
+        '-show_streams',
+        filePath,
+      ],
+      { timeout: 15000, maxBuffer: 8 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        try {
+          const parsed = JSON.parse(String(stdout)) as FfprobeJson;
+          const merged: Record<string, unknown> = {};
+          // Stream tags first so format tags override them on key collisions.
+          for (const stream of parsed.streams ?? []) {
+            Object.assign(merged, stream.tags ?? {});
+          }
+          Object.assign(merged, parsed.format?.tags ?? {});
+          resolve(merged);
+        } catch {
+          resolve(null);
+        }
+      },
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsing helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Case-insensitive lookup of the first present, non-empty string tag. */
+function firstStringTag(tags: Record<string, unknown>, keys: string[]): string | null {
+  const lowered = new Map<string, unknown>();
+  for (const [k, v] of Object.entries(tags)) lowered.set(k.toLowerCase(), v);
+  for (const key of keys) {
+    const v = lowered.get(key.toLowerCase());
+    if (typeof v === 'string' && v.trim().length > 0) return v.trim();
+  }
+  return null;
+}
+
+/**
+ * Parse a container creation timestamp into a LOCAL-time `Date` built from its
+ * wall-clock digits, so `organize`'s local-getter bucketing lands the video in
+ * the month it was actually recorded.
+ *
+ * Mirrors the photo path's philosophy (metadata.ts `exifDateToIso`): the digits
+ * are used verbatim rather than being reinterpreted through the host timezone.
+ * Apple's `com.apple.quicktime.creationdate` carries a real UTC offset, so its
+ * leading digits already express local capture time; the generic `creation_time`
+ * tag is UTC, so near a midnight boundary its bucket can be off by the offset —
+ * an accepted approximation, still far better than NODATE.
+ *
+ * Returns `null` for an unparseable or sentinel-zero timestamp.
+ */
+export function parseContainerDate(value: string | null): Date | null {
+  if (!value) return null;
+  const m = value
+    .trim()
+    .match(/^(\d{4})[:\-/](\d{2})[:\-/](\d{2})[ T](\d{2}):(\d{2}):(\d{2})/);
+  if (!m) return null;
+  const [, y, mo, d, h, mi, s] = m;
+  if (y === '0000' || mo === '00' || d === '00') return null;
+  const date = new Date(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    Number(h),
+    Number(mi),
+    Number(s),
+  );
+  return isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Does an ISO 6709 location string (e.g. `+37.7749-122.4194+000.000/`) contain a
+ * parseable latitude+longitude pair?  Returns true when both a signed lat and a
+ * signed lng are present (matching the photo path, which counts 0,0 as present).
+ */
+export function iso6709HasCoords(value: string | null): boolean {
+  if (!value) return false;
+  return /[+-]\d+(?:\.\d+)?[+-]\d+(?:\.\d+)?/.test(value.trim());
+}
+
+/**
+ * Extract `{ capturedAt, hasGps }` from a merged ffprobe tag map.  Pure and
+ * synchronous — the subprocess concern lives in `readVideoPlacement`.
+ */
+export function parseVideoPlacement(
+  tags: Record<string, unknown>,
+): { capturedAt: Date | null; hasGps: boolean } {
+  const dateStr =
+    firstStringTag(tags, ['com.apple.quicktime.creationdate']) ??
+    firstStringTag(tags, ['creation_time', 'date']);
+  const capturedAt = parseContainerDate(dateStr);
+
+  const loc = firstStringTag(tags, [
+    'com.apple.quicktime.location.iso6709',
+    'location',
+    'location-eng',
+  ]);
+  const hasGps = iso6709HasCoords(loc);
+
+  return { capturedAt, hasGps };
+}
+
+// ---------------------------------------------------------------------------
+// Public reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a video's capture date + GPS presence via ffprobe, for the `organize`
+ * command's date/GPS bucketing.  Returns a LOCAL-time `Date` (or null) and a GPS
+ * boolean, matching the shape of metadata.ts `readExifPlacement`.
+ *
+ * Degrades to `{ capturedAt: null, hasGps: false }` when ffprobe is unavailable
+ * or the file carries no usable metadata.  Never throws.
+ *
+ * @param filePath  Absolute path to the video file.
+ * @param opts      `bin` overrides the ffprobe binary (for tests).
+ */
+export async function readVideoPlacement(
+  filePath: string,
+  opts?: { bin?: string },
+): Promise<{ capturedAt: Date | null; hasGps: boolean }> {
+  const bin = opts?.bin ?? 'ffprobe';
+  if (!(await detectFfprobe(bin))) {
+    return { capturedAt: null, hasGps: false };
+  }
+  const tags = await runFfprobe(filePath, bin);
+  if (!tags) return { capturedAt: null, hasGps: false };
+  return parseVideoPlacement(tags);
+}

--- a/apps/cli/test/organize/organize-engine.spec.ts
+++ b/apps/cli/test/organize/organize-engine.spec.ts
@@ -44,6 +44,14 @@ function writeTmpJpeg(dir: string, name: string): string {
   return p;
 }
 
+/** Mirrors writeTmpJpeg but writes a .mov file — content is irrelevant since
+ * placementFn is a stub in these tests (no real ffprobe/EXIF parsing runs). */
+function writeTmpVideo(dir: string, name: string): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]));
+  return p;
+}
+
 /** A placementFn stub that returns a fixed {capturedAt, hasGps} for every call. */
 function makePlacementFn(date: Date | null, hasGps: boolean): AnyFn {
   return jest.fn<(...args: any[]) => any>().mockResolvedValue({ capturedAt: date, hasGps });
@@ -335,6 +343,42 @@ describe('OrganizeEngine', () => {
       expect((errorPayload as unknown as OrganizeErrorPayload).message).toMatch(
         /No target folders specified/,
       );
+    });
+  });
+
+  describe('video placement (ffprobe-backed)', () => {
+    it('moves a video with a placementFn-supplied date+GPS into YEAR/MM - Month/ (not NODATE)', async () => {
+      const filePath = writeTmpVideo(tmpDir, 'clip.mov');
+      const placementFn = makePlacementFn(new Date(2023, 5, 20, 20, 16, 7), true);
+      const { engine } = makeEngine(db, placementFn);
+
+      const result = await engine.run({ paths: [tmpDir] });
+
+      expect(fs.existsSync(filePath)).toBe(false);
+      const expectedTarget = path.join(tmpDir, '2023', '06 - June', 'clip.mov');
+      expect(fs.existsSync(expectedTarget)).toBe(true);
+
+      expect(result.totals.byBucket['2023/06 - June']).toBe(1);
+      expect(result.totals.nodate).toBe(0);
+
+      // mimeType is resolved by extension via enumerateFiles: mov -> video/quicktime.
+      expect(placementFn).toHaveBeenCalledWith(filePath, 'video/quicktime', { full: true });
+    });
+
+    it('routes a video with no ffprobe metadata (capturedAt: null, hasGps: false) into NODATE/NO-GPS/', async () => {
+      const filePath = writeTmpVideo(tmpDir, 'no-metadata.mov');
+      const placementFn = makePlacementFn(null, false);
+      const { engine } = makeEngine(db, placementFn);
+
+      const result = await engine.run({ paths: [tmpDir] });
+
+      expect(fs.existsSync(filePath)).toBe(false);
+      const expectedTarget = path.join(tmpDir, 'NODATE', 'NO-GPS', 'no-metadata.mov');
+      expect(fs.existsSync(expectedTarget)).toBe(true);
+
+      expect(result.totals.nodate).toBe(1);
+      expect(result.totals.noGps).toBe(1);
+      expect(result.totals.byBucket['NODATE/NO-GPS']).toBe(1);
     });
   });
 });

--- a/apps/cli/test/video-probe.spec.ts
+++ b/apps/cli/test/video-probe.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * test/video-probe.spec.ts
+ *
+ * Unit tests for the PURE, synchronous parsing helpers exported by
+ * src/video-probe.ts: parseContainerDate, iso6709HasCoords, and
+ * parseVideoPlacement. These never touch the filesystem or spawn ffprobe —
+ * that async/subprocess concern (readVideoPlacement, detectFfprobe) is
+ * explicitly out of scope here since no ffprobe binary is guaranteed in CI.
+ *
+ * Following the style of test/metadata.spec.ts: local-getter assertions
+ * (.getFullYear()/.getMonth()/.getDate()/...) are used instead of
+ * .toISOString(), since parseContainerDate builds a LOCAL-time Date from the
+ * wall-clock digits verbatim (not reinterpreted as UTC) — asserting via ISO
+ * string would make the test timezone-sensitive.
+ */
+
+import {
+  parseContainerDate,
+  iso6709HasCoords,
+  parseVideoPlacement,
+} from '../src/video-probe.js';
+
+describe('parseContainerDate', () => {
+  it('parses an Apple offset string using the wall-clock digits verbatim (local getters)', () => {
+    const result = parseContainerDate('2023-06-20T20:16:07-0500');
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result!.getFullYear()).toBe(2023);
+    expect(result!.getMonth()).toBe(5); // 0-indexed: June
+    expect(result!.getDate()).toBe(20);
+    expect(result!.getHours()).toBe(20);
+    expect(result!.getMinutes()).toBe(16);
+    expect(result!.getSeconds()).toBe(7);
+  });
+
+  it('parses a UTC creation_time value using only the captured date/time digits (trailing .000000Z ignored)', () => {
+    const result = parseContainerDate('2024-11-02T08:30:00.000000Z');
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result!.getFullYear()).toBe(2024);
+    expect(result!.getMonth()).toBe(10); // 0-indexed: November
+    expect(result!.getDate()).toBe(2);
+  });
+
+  it('returns null for null, empty, garbage, and the sentinel all-zero timestamp', () => {
+    expect(parseContainerDate(null)).toBeNull();
+    expect(parseContainerDate('')).toBeNull();
+    expect(parseContainerDate('garbage')).toBeNull();
+    expect(parseContainerDate('0000-00-00T00:00:00')).toBeNull();
+  });
+});
+
+describe('iso6709HasCoords', () => {
+  it('returns true for a well-formed ISO 6709 lat+lng+altitude string', () => {
+    expect(iso6709HasCoords('+37.7749-122.4194+000.000/')).toBe(true);
+  });
+
+  it('returns true for 0,0 coordinates (counts as present)', () => {
+    expect(iso6709HasCoords('+00.0000+000.0000/')).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(iso6709HasCoords(null)).toBe(false);
+  });
+
+  it('returns false for a non-coordinate string', () => {
+    expect(iso6709HasCoords('abc')).toBe(false);
+  });
+});
+
+describe('parseVideoPlacement', () => {
+  it('parses an Apple-style tag map (quicktime creationdate + ISO6709 location)', () => {
+    const result = parseVideoPlacement({
+      'com.apple.quicktime.creationdate': '2023-06-20T20:16:07-0500',
+      'com.apple.quicktime.location.ISO6709': '+37.7749-122.4194+000.000/',
+    });
+
+    expect(result.capturedAt).toBeInstanceOf(Date);
+    expect(result.capturedAt!.getFullYear()).toBe(2023);
+    expect(result.capturedAt!.getMonth()).toBe(5);
+    expect(result.capturedAt!.getDate()).toBe(20);
+    expect(result.hasGps).toBe(true);
+  });
+
+  it('parses an Android-style tag map (creation_time only, no location) with hasGps=false', () => {
+    const result = parseVideoPlacement({
+      creation_time: '2024-11-02T08:30:00.000000Z',
+    });
+
+    expect(result.capturedAt).toBeInstanceOf(Date);
+    expect(result.capturedAt!.getFullYear()).toBe(2024);
+    expect(result.capturedAt!.getMonth()).toBe(10);
+    expect(result.capturedAt!.getDate()).toBe(2);
+    expect(result.hasGps).toBe(false);
+  });
+
+  it('returns {capturedAt: null, hasGps: false} for an empty tag map', () => {
+    expect(parseVideoPlacement({})).toEqual({ capturedAt: null, hasGps: false });
+  });
+
+  it('looks up tag keys case-insensitively', () => {
+    const result = parseVideoPlacement({
+      Creation_Time: '2024-11-02T08:30:00.000000Z',
+    });
+
+    expect(result.capturedAt).toBeInstanceOf(Date);
+    expect(result.capturedAt!.getFullYear()).toBe(2024);
+    expect(result.capturedAt!.getMonth()).toBe(10);
+    expect(result.capturedAt!.getDate()).toBe(2);
+  });
+
+  it('prefers com.apple.quicktime.creationdate over creation_time when both are present', () => {
+    const result = parseVideoPlacement({
+      'com.apple.quicktime.creationdate': '2023-06-20T20:16:07-0500',
+      creation_time: '2020-01-01T00:00:00Z',
+    });
+
+    expect(result.capturedAt).toBeInstanceOf(Date);
+    expect(result.capturedAt!.getFullYear()).toBe(2023);
+    expect(result.capturedAt!.getMonth()).toBe(5);
+    expect(result.capturedAt!.getDate()).toBe(20);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.20",
+      "version": "1.1.21",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "boxen": "^5.1.2",


### PR DESCRIPTION
## Summary

The `organize` command used to dump every video into the `NODATE` bucket because `exifr` can't read MP4/QuickTime container metadata. This PR adds an `ffprobe`-based probe so videos are sorted into `YEAR/MM - Month/` folders by their real capture date, just like photos. Degrades gracefully to the previous `NODATE` behavior when `ffprobe` isn't installed.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

None

## Changes Made

- Added `src/video-probe.ts` — shells out to `ffprobe` (ships with ffmpeg) to read the container creation date and ISO 6709 location; memoized availability detection so probe-less hosts never spawn a failing subprocess per video.
- Prefers Apple's offset-bearing `com.apple.quicktime.creationdate` (correct local wall-clock month), falling back to the generic UTC `creation_time`; returns a local-time `Date` matching the photo path's wall-clock-preservation convention so bucketing is host-timezone independent.
- Wired the probe into `readExifPlacement`'s `video/*` branch in `src/metadata.ts`; photo behavior is unchanged.
- Updated the `OrganizeEngine` header docs to reflect video probing.
- Bumped CLI version `1.1.20 → 1.1.21` (feature addition per the CLI versioning rule).

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

New coverage:
- `test/video-probe.spec.ts` — `parseContainerDate` (Apple offset string, UTC `creation_time`, null/empty/garbage/sentinel-zero), `iso6709HasCoords` (incl. 0,0), `parseVideoPlacement` (Apple vs. Android tag shapes, empty map, case-insensitive key lookup, quicktime-over-`creation_time` precedence).
- `test/organize/organize-engine.spec.ts` — a probed video now buckets to `2023/06 - June/`; a video with no capture data still falls back to `NODATE/NO-GPS/`.

### Test Instructions

1. With ffmpeg/ffprobe installed, run `memoriahub organize <folder> --dry-run` on a folder of phone videos.
2. Confirm videos are planned into `YEAR/MM - Month/` buckets by capture date rather than `NODATE`.
3. Without ffprobe on PATH, confirm videos still fall back to `NODATE` and organize does not error.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Works for any format ffprobe understands (`.mov`, `.mp4`, `.mts`, …) — converting to mp4 first is not required for organizing. Verified graceful degradation end-to-end in an environment without ffprobe (videos → `NODATE/NO-GPS`, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeUPdH7i9YyFgTHnPwZjXn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeUPdH7i9YyFgTHnPwZjXn)_