### PR TITLE
fix: build and vendor enrichment-compute package in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,6 +401,22 @@ info "Installing CLI workspace dependencies …"
 }
 ok "Dependencies installed"
 
+# apps/cli imports the shared @memoriahub/enrichment-compute package by
+# subpath (e.g. .../clip, .../dto) resolved against its built dist/ — that
+# output is git-ignored, so it must be built here on every fresh checkout
+# before the CLI's TypeScript can compile (mirrors the identical fix already
+# applied to .github/workflows/ci.yml).
+info "Building shared enrichment-compute package …"
+(
+  cd "$TMP_DIR"
+  npm run build --workspace=@memoriahub/enrichment-compute 2>&1 \
+    | grep -v "^$" | while IFS= read -r line; do dim "$line"; done
+) || {
+  err "Failed to build @memoriahub/enrichment-compute"
+  exit 1
+}
+ok "Shared package built"
+
 info "Compiling TypeScript …"
 (
   cd "$TMP_DIR"

--- a/install.sh
+++ b/install.sh
@@ -448,6 +448,35 @@ fi
 
 ok "Copied dist + package.json to $APP_DIR"
 
+# ---------------------------------------------------------------------------
+# Step 4a: Vendor the shared enrichment-compute package
+# ---------------------------------------------------------------------------
+# $APP_DIR runs OUTSIDE the monorepo, but apps/cli/package.json lists
+# @memoriahub/enrichment-compute as a real runtime dependency (its compiled
+# dist/*.js does `require()`/`import` the package by subpath, e.g. .../clip,
+# .../dto — the same reason it had to be built in Step 3). It is a private,
+# unpublished workspace package, so the runtime `npm install --omit=dev`
+# below can never resolve it from the npm registry by name/version. Vendor
+# the already-built package into the deployed app directory and repoint the
+# dependency at it via a local `file:` reference so npm links it from disk
+# instead of trying (and failing) to fetch it from the registry.
+info "Vendoring shared enrichment-compute package …"
+mkdir -p "$APP_DIR/vendor/enrichment-compute"
+cp -r "$TMP_DIR/packages/enrichment-compute/dist"         "$APP_DIR/vendor/enrichment-compute/dist"
+cp    "$TMP_DIR/packages/enrichment-compute/package.json" "$APP_DIR/vendor/enrichment-compute/package.json"
+node -e '
+  const fs = require("fs");
+  const p = process.argv[1];
+  const pkg = JSON.parse(fs.readFileSync(p, "utf8"));
+  pkg.dependencies = pkg.dependencies || {};
+  pkg.dependencies["@memoriahub/enrichment-compute"] = "file:./vendor/enrichment-compute";
+  fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + "\n");
+' "$APP_DIR/package.json" || {
+  err "Failed to vendor @memoriahub/enrichment-compute into $APP_DIR"
+  exit 1
+}
+ok "Vendored enrichment-compute package"
+
 info "Installing runtime dependencies (omitting devDeps) …"
 # This runs OUTSIDE the monorepo, so npm installs only the CLI's own
 # runtime deps (better-sqlite3, ink, react, commander, chalk, cli-table3, etc.).


### PR DESCRIPTION
## Summary

The production installer (`curl ... | bash`) was broken for any install/update after the distributed-nodes work (#69) merged — same root cause as a CI bug already fixed in `.github/workflows/ci.yml`, in a completely separate pipeline that was missed.

- **Build-time**: `install.sh` never built the shared `packages/enrichment-compute` workspace package before compiling `apps/cli`. Its `dist/` output is git-ignored, so on a fresh clone (exactly what the installer does) every `@memoriahub/enrichment-compute/*` subpath import failed with `TS2307`, plus several cascading secondary errors — all confirmed to disappear once the package is built first.
- **Runtime**: even after fixing the build, the standalone deploy step (`$APP_DIR`, built outside the monorepo) would still break — `@memoriahub/enrichment-compute` is a private, unpublished workspace package, so the runtime `npm install --omit=dev` step would 404 trying to resolve it from the registry. Fixed by vendoring the built package into the deployed app directory and repointing the dependency at it via a local `file:` reference.

## Test plan

- [x] Ran the real, unmodified `install.sh` end-to-end against a throwaway `MEMORIAHUB_HOME`/`MEMORIAHUB_BIN_DIR` (never touched the real `~/.memoriahub`)
- [x] `memoriahub --version` → `1.1.30`, no errors
- [x] `memoriahub node doctor` — exercises the vendored package's compute modules at runtime outside the monorepo: real CLIP embedding (512-d), real Human face detection, real sharp encode/decode, zero `MODULE_NOT_FOUND`
- [x] Confirmed `node_modules/@memoriahub/enrichment-compute` in the deployed app resolves as a relative symlink to the vendored copy, survives being moved independently of the monorepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198UdgN5sQVABzcDJ9vvrqy