### PR TITLE
feat(cli): surface node doctor, register, list, logs, and service in the TUI

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/tui/NodeDashboard.tsx
+++ b/apps/cli/src/tui/NodeDashboard.tsx
@@ -33,18 +33,14 @@ import Spinner from 'ink-spinner';
 
 import { ApiClient } from '../api.js';
 import type { CliConfig } from '../config.js';
-import {
-  ComputeDispatcher,
-  detectCapabilities,
-  NODE_JOB_TYPES,
-  type CapabilityStatus,
-} from '../node/capabilities.js';
+import { ComputeDispatcher, NODE_JOB_TYPES } from '../node/capabilities.js';
 import { NodeEngine, type NodeEngineOptions } from '../node/node-engine.js';
 import { NODE_EV } from '../node/node-events.js';
 import { ensureModels } from '../node/models.js';
 import { isDaemonRunning } from '../node/ipc-client.js';
 import { readPidFile } from '../node/daemon.js';
 import { BOX_BORDER } from './theme.js';
+import { runNodeDoctorSweep, type DoctorSweepState } from './useNodeDoctorSweep.js';
 import {
   appendLogLines,
   createAttachedSource,
@@ -178,10 +174,11 @@ export function NodeDashboard({ config, onBack, onOpenConfig }: NodeDashboardPro
   // 1s ticker so elapsed times + throughput refresh
   const [, setTick] = useState<number>(0);
 
-  // Doctor overlay
+  // Doctor overlay — runs the full sweep via useNodeDoctorSweep.js (see the
+  // module header comment above for why this reuses the shared sweep
+  // function rather than mounting <NodeDoctor> directly).
   const [showDoctor, setShowDoctor] = useState<boolean>(false);
-  const [doctorLoading, setDoctorLoading] = useState<boolean>(false);
-  const [doctorReport, setDoctorReport] = useState<Record<string, CapabilityStatus> | null>(null);
+  const [doctorSweep, setDoctorSweep] = useState<DoctorSweepState | null>(null);
 
   const mountedRef = useRef<boolean>(true);
 
@@ -359,20 +356,23 @@ export function NodeDashboard({ config, onBack, onOpenConfig }: NodeDashboardPro
   }, [pushLog]);
 
   // -------------------------------------------------------------------------
-  // Run doctor overlay (on `r`)
+  // Run doctor overlay (on `r`) — the FULL sweep (API access, installed
+  // capabilities, real operational self-tests, job-type readiness, models,
+  // daemon liveness), not just the old presence-only detectCapabilities()
+  // probe. See useNodeDoctorSweep.js for the step list and rationale.
   // -------------------------------------------------------------------------
   const runDoctor = useCallback(async (): Promise<void> => {
     setShowDoctor(true);
-    setDoctorLoading(true);
+    setDoctorSweep(null);
     try {
-      const caps = await detectCapabilities();
-      setDoctorReport(caps);
+      const api = new ApiClient(config);
+      await runNodeDoctorSweep(api, config, (state) => {
+        if (mountedRef.current) setDoctorSweep(state);
+      });
     } catch (err) {
       pushLog('error', `doctor failed: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      setDoctorLoading(false);
     }
-  }, [pushLog]);
+  }, [config, pushLog]);
 
   // -------------------------------------------------------------------------
   // Key handling
@@ -480,30 +480,71 @@ export function NodeDashboard({ config, onBack, onOpenConfig }: NodeDashboardPro
   // Doctor overlay render
   // -------------------------------------------------------------------------
   if (showDoctor) {
+    const sweeping = !doctorSweep || !doctorSweep.done;
     return (
       <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
-        <Text bold color="cyan">Worker Node — Capability Doctor</Text>
-        {doctorLoading && (
+        <Text bold color="cyan">Worker Node — Doctor</Text>
+        {sweeping && (
           <Box marginTop={1}>
-            <Text color="cyan"><Spinner type="dots" /> probing capabilities…</Text>
+            <Text color="cyan">
+              <Spinner type="dots" /> {doctorSweep?.currentStep ? `running: ${doctorSweep.currentStep}…` : 'starting…'}
+            </Text>
           </Box>
         )}
-        {!doctorLoading && doctorReport && (
+        {doctorSweep?.caps && doctorSweep.operationalCaps && (
           <Box flexDirection="column" marginTop={1}>
             <Box flexDirection="row">
               <Text bold dimColor>{'Capability'.padEnd(14)}</Text>
-              <Text bold dimColor>{'Status'.padEnd(8)}</Text>
+              <Text bold dimColor>{'Installed'.padEnd(11)}</Text>
+              <Text bold dimColor>{'Operational'.padEnd(13)}</Text>
               <Text bold dimColor>Detail</Text>
             </Box>
-            {Object.entries(doctorReport).map(([key, status]) => (
-              <Box key={key} flexDirection="row">
-                <Text>{key.padEnd(14)}</Text>
-                <Text color={status.available ? 'green' : 'red'}>
-                  {(status.available ? 'yes' : 'no').padEnd(8)}
-                </Text>
-                <Text dimColor>{truncate(status.detail ?? '', 44)}</Text>
-              </Box>
+            {Object.entries(doctorSweep.caps).map(([key, status]) => {
+              const op = doctorSweep.operationalCaps![key] ?? status;
+              let opLabel: string;
+              let opColor: string | undefined;
+              if (!status.available) {
+                opLabel = 'n/a';
+                opColor = undefined;
+              } else if (op.available) {
+                opLabel = 'yes';
+                opColor = 'green';
+              } else {
+                opLabel = 'not yet';
+                opColor = 'yellow';
+              }
+              return (
+                <Box key={key} flexDirection="row">
+                  <Text>{key.padEnd(14)}</Text>
+                  <Text color={status.available ? 'green' : 'red'}>
+                    {(status.available ? 'yes' : 'no').padEnd(11)}
+                  </Text>
+                  <Text color={opColor} dimColor={opColor === undefined}>
+                    {opLabel.padEnd(13)}
+                  </Text>
+                  <Text dimColor>{truncate(op.detail ?? status.detail ?? '', 40)}</Text>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+        {doctorSweep?.jobReadiness && (
+          <Box flexDirection="column" marginTop={1}>
+            {doctorSweep.jobReadiness.map((row) => (
+              <Text key={row.type} color={row.ready ? 'green' : 'red'}>
+                {row.ready ? '✔' : '✖'} {row.type}
+                {!row.ready && <Text dimColor> — missing {row.missing.join(', ')}</Text>}
+              </Text>
             ))}
+          </Box>
+        )}
+        {doctorSweep?.done && (
+          <Box marginTop={1}>
+            {doctorSweep.hasError ? (
+              <Text color="red" bold>✖ Doctor found problems.</Text>
+            ) : (
+              <Text color="green" bold>✔ Doctor: all checks passed.</Text>
+            )}
           </Box>
         )}
         <Box marginTop={1}>

--- a/apps/cli/src/tui/NodeDoctor.tsx
+++ b/apps/cli/src/tui/NodeDoctor.tsx
@@ -1,0 +1,266 @@
+/**
+ * tui/NodeDoctor.tsx — Ink screen for the full worker-node doctor sweep.
+ *
+ * Runs the exact same six-step sweep as `memoriahub node doctor`
+ * (commands/node.ts's `doctorCmd()`) via the shared, React-agnostic
+ * `runNodeDoctorSweep()` in ./useNodeDoctorSweep.js — see that module's header
+ * comment for the full step list and rationale. This screen renders it as a
+ * step-by-step running log (like the CLI's sequential `ui.step`/`ui.success`/
+ * `ui.warn`/`ui.error` output, but appended as scrolling Ink text) followed by
+ * the full report: the installed-vs-operational capability table (mirrors
+ * `printOperationalCapabilityTable` in commands/node.ts), job-type readiness,
+ * model status, and daemon liveness. Unlike the CLI command, this screen never
+ * calls `process.exit()` — the pass/fail verdict is rendered as a colored
+ * summary line only.
+ *
+ * `variant` prop:
+ *   - 'screen'  (default) — full, menu-reachable screen. Owns its own
+ *     Esc/q → onBack key handling (matches every other full-screen TUI
+ *     component in this repo, e.g. BackupScreen/NodeConfig).
+ *   - 'overlay' — compact rendering (capability table + summary only, no
+ *     step log) intended for embedding inside another screen's own
+ *     conditional render. Does NOT bind its own useInput — the host screen
+ *     owns all key handling, so it composes cleanly with a parent that's
+ *     already intercepting keys for its own popup state (e.g. how
+ *     NodeDashboard's `[r]` overlay owns Esc/q/r itself). NodeDashboard
+ *     currently calls the underlying `runNodeDoctorSweep()` sweep function
+ *     directly rather than mounting this component (see its own doc comment)
+ *     to keep a single input-handling owner, but the variant is kept here so
+ *     a future compact reuse of the full rendered report doesn't need a
+ *     second implementation.
+ *
+ * The sweep starts automatically on mount (`autoRun: true`) — matches running
+ * `memoriahub node doctor` from the command line, which doesn't prompt first.
+ */
+
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+
+import { ApiClient } from '../api.js';
+import type { CliConfig } from '../config.js';
+import type { CapabilityStatus } from '../node/capabilities.js';
+import { BOX_BORDER } from './theme.js';
+import {
+  DOCTOR_STEP_ORDER,
+  DOCTOR_STEP_LABELS,
+  useNodeDoctorSweep,
+  type DoctorStepKey,
+} from './useNodeDoctorSweep.js';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface NodeDoctorProps {
+  config: CliConfig;
+  /** Pop back to the previous screen/menu. Required for variant 'screen'. */
+  onBack: () => void;
+  /** See the module header comment. Defaults to 'screen'. */
+  variant?: 'screen' | 'overlay';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+/** Combined installed/operational capability row, mirroring
+ *  printOperationalCapabilityTable in commands/node.ts. */
+function CapabilityTable({
+  caps,
+  operational,
+  detailWidth,
+}: {
+  caps: Record<string, CapabilityStatus>;
+  operational: Record<string, CapabilityStatus>;
+  detailWidth: number;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Text bold dimColor>{'Capability'.padEnd(14)}</Text>
+        <Text bold dimColor>{'Installed'.padEnd(11)}</Text>
+        <Text bold dimColor>{'Operational'.padEnd(13)}</Text>
+        <Text bold dimColor>Detail</Text>
+      </Box>
+      {Object.entries(caps).map(([key, status]) => {
+        const op = operational[key] ?? status;
+        let opLabel: string;
+        let opColor: string | undefined;
+        if (!status.available) {
+          opLabel = 'n/a';
+          opColor = undefined;
+        } else if (op.available) {
+          opLabel = 'yes';
+          opColor = 'green';
+        } else {
+          opLabel = 'not yet';
+          opColor = 'yellow';
+        }
+        return (
+          <Box key={key} flexDirection="row">
+            <Text>{key.padEnd(14)}</Text>
+            <Text color={status.available ? 'green' : 'red'}>
+              {(status.available ? 'yes' : 'no').padEnd(11)}
+            </Text>
+            <Text color={opColor} dimColor={opColor === undefined}>
+              {opLabel.padEnd(13)}
+            </Text>
+            <Text dimColor>{truncate(op.detail ?? status.detail ?? '', detailWidth)}</Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NodeDoctor({ config, onBack, variant = 'screen' }: NodeDoctorProps): React.ReactElement {
+  const api = React.useMemo(() => new ApiClient(config), [config]);
+  const { state } = useNodeDoctorSweep(api, config, { autoRun: true });
+
+  // Always call the hook (Rules of Hooks) — only act on it in 'screen'
+  // variant. 'overlay' relies entirely on the host screen's own key handling.
+  useInput((input, key) => {
+    if (variant !== 'screen') return;
+    if (key.escape || input === 'q') onBack();
+  });
+
+  const compact = variant === 'overlay';
+  const stepDone = (step: DoctorStepKey): boolean => state.completedSteps.includes(step);
+
+  return (
+    <Box
+      borderStyle={BOX_BORDER}
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={2}
+      paddingY={compact ? 0 : 1}
+    >
+      <Text bold color="cyan">Worker Node — Doctor</Text>
+
+      {/* Step-by-step running log — full screen only. */}
+      {!compact && (
+        <Box flexDirection="column" marginTop={1}>
+          {DOCTOR_STEP_ORDER.map((step) => {
+            const done = stepDone(step);
+            const active = state.currentStep === step;
+            return (
+              <Box key={step} flexDirection="row" gap={1}>
+                <Text color={done ? 'green' : active ? 'cyan' : undefined} dimColor={!done && !active}>
+                  {done ? '✔' : active ? <Spinner type="dots" /> : '·'}
+                </Text>
+                <Text color={active ? 'cyan' : undefined} dimColor={!done && !active}>
+                  {DOCTOR_STEP_LABELS[step]}
+                </Text>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      {/* API Access detail — full screen only, once available. */}
+      {!compact && state.apiAccess && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold color="cyan">API Access</Text>
+          <Text color={state.apiAccess.authOk ? 'green' : 'red'}>
+            {state.apiAccess.authOk ? '✔' : '✖'} {truncate(state.apiAccess.authDetail, 84)}
+          </Text>
+          {state.apiAccess.nodeRegistrationOk !== null ? (
+            <Text color={state.apiAccess.nodeRegistrationOk ? 'green' : 'yellow'}>
+              {state.apiAccess.nodeRegistrationOk ? '✔' : '⚠'}{' '}
+              {truncate(state.apiAccess.nodeRegistrationDetail, 84)}
+            </Text>
+          ) : (
+            <Text dimColor>· {truncate(state.apiAccess.nodeRegistrationDetail, 84)}</Text>
+          )}
+          <Text color={state.apiAccess.manifestOk ? 'green' : 'yellow'}>
+            {state.apiAccess.manifestOk ? '✔' : '⚠'} {truncate(state.apiAccess.manifestDetail, 84)}
+          </Text>
+        </Box>
+      )}
+
+      {/* Capability table — both variants, once available. */}
+      {state.caps && state.operationalCaps && (
+        <Box flexDirection="column" marginTop={1}>
+          {!compact && <Text bold color="cyan">Capabilities</Text>}
+          <CapabilityTable caps={state.caps} operational={state.operationalCaps} detailWidth={compact ? 40 : 60} />
+        </Box>
+      )}
+
+      {/* Job-type readiness. */}
+      {state.jobReadiness && (
+        <Box flexDirection="column" marginTop={1}>
+          {!compact && <Text bold color="cyan">Job-type readiness</Text>}
+          {state.jobReadiness.length === 0 && (
+            <Text color="yellow">⚠ No eligible job types configured/supported on this machine.</Text>
+          )}
+          {state.jobReadiness.map((row) => (
+            <Text key={row.type} color={row.ready ? 'green' : 'red'}>
+              {row.ready ? '✔' : '✖'} {row.type}
+              {!row.ready && <Text dimColor> — missing {row.missing.join(', ')}</Text>}
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      {/* Models — full screen only. */}
+      {!compact && state.models && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold color="cyan">Models</Text>
+          {state.models.error ? (
+            <Text color="yellow">⚠ Could not verify models: {truncate(state.models.error, 84)}</Text>
+          ) : state.models.manifestCount === 0 ? (
+            <Text dimColor>Server manifest lists no model files.</Text>
+          ) : state.models.failed.length > 0 ? (
+            <Box flexDirection="column">
+              {state.models.failed.map((f) => (
+                <Text key={f.name} color="red">✖ Model {f.name}: {truncate(f.error, 76)}</Text>
+              ))}
+            </Box>
+          ) : (
+            <Text color="green">
+              ✔ All {state.models.manifestCount} model file(s) present/downloaded
+              {state.models.targetDir ? ` in ${state.models.targetDir}` : ''}.
+            </Text>
+          )}
+        </Box>
+      )}
+
+      {/* Daemon — full screen only, informational. */}
+      {!compact && state.daemon && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold color="cyan">Daemon</Text>
+          <Text color={state.daemon.running ? 'green' : state.daemon.stalePidfile ? 'yellow' : undefined} dimColor={!state.daemon.running && !state.daemon.stalePidfile}>
+            {state.daemon.running ? '✔' : state.daemon.stalePidfile ? '⚠' : '·'} {truncate(state.daemon.detail, 90)}
+          </Text>
+        </Box>
+      )}
+
+      {/* Final summary. */}
+      {state.done && (
+        <Box marginTop={1}>
+          {state.hasError ? (
+            <Text color="red" bold>✖ Doctor found problems — this node cannot fully process its eligible types.</Text>
+          ) : (
+            <Text color="green" bold>✔ Doctor: all checks passed.</Text>
+          )}
+        </Box>
+      )}
+
+      {!compact && (
+        <Box marginTop={1}>
+          <Text dimColor>[Esc/q] back</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/NodeList.tsx
+++ b/apps/cli/src/tui/NodeList.tsx
@@ -1,0 +1,231 @@
+/**
+ * tui/NodeList.tsx — Ink screen listing registered worker nodes.
+ *
+ * Reuses the exact same call + response-shape handling as `listCmd()` in
+ * commands/node.ts: `GET /api/nodes` (owner-scoped — lists nodes registered
+ * by the caller), tolerating both a bare array response and an
+ * `{ items: [] }` envelope, and the same 403/404 tolerance that falls back to
+ * showing the machine's local node config when the endpoint isn't available
+ * with the current token (older server, or a token without permission).
+ *
+ * Rendered as an Ink Box/Text grid (padEnd-aligned columns) rather than
+ * cli-table3 — matching the convention already established by JobsDashboard
+ * and NodeDoctor's capability table; cli-table3 (used by the plain-CLI
+ * `node list`/`node doctor` commands) is a stdout-only renderer and isn't
+ * used anywhere inside the Ink TUI screens.
+ *
+ * Keys: [r] refresh, [Esc/q] back.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+
+import { ApiClient, ApiError } from '../api.js';
+import type { CliConfig } from '../config.js';
+import { BOX_BORDER } from './theme.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NodeListProps {
+  config: CliConfig;
+  onBack: () => void;
+}
+
+/** Loosely typed — the server owns the full node schema; only these fields
+ *  are relied on for display, mirroring listCmd()'s own loose typing. */
+interface NodeRow {
+  id: string;
+  name: string;
+  status: string;
+  platform: string;
+  concurrency?: number;
+  eligibleTypes?: string[];
+  lastHeartbeatAt?: string | null;
+}
+
+type Step = 'loading' | 'ready' | 'empty' | 'fallback' | 'error';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+function shortId(id: string): string {
+  return id.length <= 8 ? id : id.slice(0, 8);
+}
+
+/** "3s ago" / "4m ago" / "2h ago" / "3d ago" relative time from an ISO timestamp. */
+function relTime(iso: string | null | undefined, nowMs: number): string {
+  if (!iso) return '—';
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return '—';
+  const secs = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/** Normalize the two response shapes listCmd() tolerates: a bare array, or
+ *  an `{ items: [] }` envelope. */
+function normalizeNodes(res: unknown): NodeRow[] {
+  const raw = Array.isArray(res)
+    ? (res as Array<Record<string, unknown>>)
+    : ((res as { items?: Array<Record<string, unknown>> })?.items ?? []);
+  return raw.map((n) => ({
+    id: String(n['id'] ?? n['nodeId'] ?? ''),
+    name: String(n['name'] ?? ''),
+    status: String(n['status'] ?? ''),
+    platform: String(n['platform'] ?? ''),
+    concurrency: typeof n['concurrency'] === 'number' ? (n['concurrency'] as number) : undefined,
+    eligibleTypes: Array.isArray(n['eligibleTypes']) ? (n['eligibleTypes'] as string[]) : undefined,
+    lastHeartbeatAt:
+      typeof n['lastHeartbeatAt'] === 'string' ? (n['lastHeartbeatAt'] as string) : null,
+  }));
+}
+
+function statusColor(status: string): string | undefined {
+  switch (status) {
+    case 'online':
+      return 'green';
+    case 'draining':
+      return 'yellow';
+    case 'offline':
+    case 'disabled':
+      return 'red';
+    default:
+      return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NodeList({ config, onBack }: NodeListProps): React.ReactElement {
+  const [step, setStep] = useState<Step>('loading');
+  const [nodes, setNodes] = useState<NodeRow[]>([]);
+  const [message, setMessage] = useState<string>('');
+  const [, setTick] = useState<number>(0);
+
+  const load = useCallback((): void => {
+    setStep('loading');
+    const api = new ApiClient(config);
+    void (async () => {
+      try {
+        const res = await api.get<unknown>('/api/nodes');
+        const rows = normalizeNodes(res);
+        if (rows.length === 0) {
+          setNodes([]);
+          setStep('empty');
+        } else {
+          setNodes(rows);
+          setStep('ready');
+        }
+      } catch (err) {
+        if (err instanceof ApiError && (err.status === 403 || err.status === 404)) {
+          setMessage(
+            'Listing worker nodes is not available with this token (or the endpoint is not exposed). ' +
+              'Showing local config only.',
+          );
+          setStep('fallback');
+          return;
+        }
+        setMessage(`Failed to list nodes: ${err instanceof Error ? err.message : String(err)}`);
+        setStep('error');
+      }
+    })();
+  }, [config]);
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 1s ticker so "Xs ago" heartbeat labels stay fresh.
+  useEffect(() => {
+    const timer = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  useInput((input, key) => {
+    if (input === 'r') {
+      load();
+      return;
+    }
+    if (key.escape || input === 'q') onBack();
+  });
+
+  const now = Date.now();
+
+  return (
+    <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+      <Text bold color="cyan">Worker Nodes</Text>
+
+      {step === 'loading' && (
+        <Box marginTop={1}>
+          <Text color="cyan"><Spinner type="dots" /> Loading registered nodes…</Text>
+        </Box>
+      )}
+
+      {step === 'empty' && (
+        <Box marginTop={1}>
+          <Text dimColor>No worker nodes registered.</Text>
+        </Box>
+      )}
+
+      {step === 'fallback' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow">⚠ {message}</Text>
+          <Text dimColor>
+            This node: {config.nodeId ?? '(not registered)'} — {config.node?.name ?? ''}
+          </Text>
+        </Box>
+      )}
+
+      {step === 'error' && (
+        <Box marginTop={1}>
+          <Text color="red">✖ {message}</Text>
+        </Box>
+      )}
+
+      {step === 'ready' && (
+        <Box flexDirection="column" marginTop={1}>
+          <Box flexDirection="row">
+            <Text bold dimColor>{'Name'.padEnd(20)}</Text>
+            <Text bold dimColor>{'ID'.padEnd(10)}</Text>
+            <Text bold dimColor>{'Status'.padEnd(10)}</Text>
+            <Text bold dimColor>{'Conc.'.padEnd(6)}</Text>
+            <Text bold dimColor>{'Heartbeat'.padEnd(11)}</Text>
+            <Text bold dimColor>Types</Text>
+          </Box>
+          {nodes.map((n) => (
+            <Box key={n.id} flexDirection="row">
+              <Text>{truncate(n.name || '(unnamed)', 19).padEnd(20)}</Text>
+              <Text dimColor>{shortId(n.id).padEnd(10)}</Text>
+              <Text color={statusColor(n.status)} dimColor={!statusColor(n.status)}>
+                {(n.status || '—').padEnd(10)}
+              </Text>
+              <Text dimColor>{String(n.concurrency ?? '—').padEnd(6)}</Text>
+              <Text dimColor>{relTime(n.lastHeartbeatAt, now).padEnd(11)}</Text>
+              <Text dimColor>{truncate((n.eligibleTypes ?? []).join(', ') || '(none)', 40)}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <Box marginTop={1}>
+        <Text dimColor>[r] refresh   [Esc/q] back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/NodeLogs.tsx
+++ b/apps/cli/src/tui/NodeLogs.tsx
@@ -1,0 +1,257 @@
+/**
+ * tui/NodeLogs.tsx — live JSONL tail viewer for the worker-node log.
+ *
+ * The CLI already has `memoriahub node logs [-n <n>] [--follow]` (see
+ * `logsCmd()` in commands/node.ts), backed by `node/logger.ts`'s
+ * `readLastLines`/`followLog`. This screen is the TUI equivalent: it loads a
+ * trailing window on mount, then keeps it live via `followLog` — a genuine
+ * `tail -f`, not a static dump — until the operator backs out, at which point
+ * the returned stop function is called so the underlying `fs.watch` handle is
+ * released (no leaked watchers across screen visits).
+ *
+ * The visible window size ("tail size") is adjustable with [+]/[-] the same
+ * way `-n` is on the CLI; changing it re-reads `readLastLines(tailSize)` from
+ * disk (cheap — JSONL logs are rotated at 5 MB, see logger.ts) so widening the
+ * window can reveal more already-persisted history, not just newly-appended
+ * lines. `[c]` clears the pane cosmetically (never touches the file) — handy
+ * before triggering an action elsewhere and wanting a clean view of what
+ * happens next.
+ *
+ * Each raw JSONL line is parsed by the pure, independently-testable
+ * `parseLogLine()` into a `{ level, time, text }` triple and rendered as one
+ * row, colored by level (error=red, warn=yellow, info=default, debug=dim) —
+ * matching the log-pane convention established by NodeDashboard.tsx.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+import { followLog, nodeLogPath, readLastLines, type NodeLogLevel } from '../node/logger.js';
+import { BOX_BORDER } from './theme.js';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface NodeLogsProps {
+  /** Pop back to the previous screen/menu. */
+  onBack: () => void;
+  /** Override the log directory — used by tests; defaults to the standard logs dir. */
+  dir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tail-size bounds (mirrors the CLI's `-n, --lines` default of 50)
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TAIL_SIZE = 50;
+export const MIN_TAIL_SIZE = 10;
+export const MAX_TAIL_SIZE = 500;
+const TAIL_STEP = 10;
+
+// ---------------------------------------------------------------------------
+// Line parsing/formatting (pure — unit-testable without Ink)
+// ---------------------------------------------------------------------------
+
+export interface ParsedLogLine {
+  level: NodeLogLevel;
+  /** HH:MM:SS extracted from the line's `ts` field, or null if absent/unparseable. */
+  time: string | null;
+  /** Human-readable rendering of the line (msg / ev / extra fields). */
+  text: string;
+  /** True when the raw line was not valid JSON (rendered as-is, defensively). */
+  malformed: boolean;
+}
+
+const GLYPH_BY_LEVEL: Record<NodeLogLevel, string> = {
+  error: '✖',
+  warn: '⚠',
+  info: '·',
+  debug: '·',
+};
+
+function isNodeLogLevel(v: unknown): v is NodeLogLevel {
+  return v === 'error' || v === 'warn' || v === 'info' || v === 'debug';
+}
+
+function formatFieldValue(v: unknown): string {
+  if (v === null || v === undefined) return String(v);
+  if (typeof v === 'object') {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return '[unserializable]';
+    }
+  }
+  return String(v);
+}
+
+/**
+ * Parse one raw JSONL line written by node/logger.ts (`{ ts, level, ev?,
+ * msg?, ...payload }`) into a readable row. Falls back to rendering the raw
+ * line (level 'info', malformed:true) when it isn't valid JSON — logger.ts
+ * always writes valid JSON in practice, but a torn line mid-rotation/mid-write
+ * is possible and must never crash the screen.
+ */
+export function parseLogLine(raw: string): ParsedLogLine {
+  let obj: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { level: 'info', time: null, text: raw, malformed: true };
+    }
+    obj = parsed as Record<string, unknown>;
+  } catch {
+    return { level: 'info', time: null, text: raw, malformed: true };
+  }
+
+  const level: NodeLogLevel = isNodeLogLevel(obj.level) ? obj.level : 'info';
+
+  let time: string | null = null;
+  if (typeof obj.ts === 'string') {
+    const parsedDate = new Date(obj.ts);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      time = parsedDate.toTimeString().slice(0, 8);
+    }
+  }
+
+  const rest: Record<string, unknown> = { ...obj };
+  delete rest.ts;
+  delete rest.level;
+  const msg = typeof rest.msg === 'string' ? rest.msg : null;
+  delete rest.msg;
+  const ev = typeof rest.ev === 'string' ? rest.ev : null;
+  delete rest.ev;
+
+  const extra = Object.keys(rest)
+    .map((k) => `${k}=${formatFieldValue(rest[k])}`)
+    .join(' ');
+
+  let text: string;
+  if (msg && ev) text = `[${ev}] ${msg}`;
+  else if (msg) text = msg;
+  else if (ev) text = ev;
+  else text = '(no message)';
+  if (extra) text += `  ${extra}`;
+
+  return { level, time, text, malformed: false };
+}
+
+function levelColor(level: NodeLogLevel): string | undefined {
+  switch (level) {
+    case 'error':
+      return 'red';
+    case 'warn':
+      return 'yellow';
+    default:
+      return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local line-record model (stable React keys across an append-only buffer)
+// ---------------------------------------------------------------------------
+
+interface LineRecord {
+  id: number;
+  raw: string;
+}
+
+let lineSeq = 0;
+function toRecords(rawLines: string[]): LineRecord[] {
+  return rawLines.map((raw) => ({ id: ++lineSeq, raw }));
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NodeLogs({ onBack, dir }: NodeLogsProps): React.ReactElement {
+  const [tailSize, setTailSize] = useState<number>(DEFAULT_TAIL_SIZE);
+  const [lines, setLines] = useState<LineRecord[]>(() => toRecords(readLastLines(DEFAULT_TAIL_SIZE, dir)));
+  const tailSizeRef = useRef(tailSize);
+  tailSizeRef.current = tailSize;
+
+  const isFirstRender = useRef(true);
+
+  // Re-read the buffer from disk whenever the tail size changes (widening can
+  // reveal more already-persisted history; narrowing just trims the view).
+  // Skipped on the very first render since the initial `useState` already did it.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setLines(toRecords(readLastLines(tailSize, dir)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tailSize, dir]);
+
+  // Live tail: start once on mount, stop on unmount. New lines are appended
+  // and the buffer is trimmed to the CURRENT tail size (via ref, so this
+  // effect doesn't need to restart every time the operator presses +/-).
+  useEffect(() => {
+    const stop = followLog((line) => {
+      setLines((prev) => [...prev, { id: ++lineSeq, raw: line }].slice(-tailSizeRef.current));
+    }, dir);
+    return () => stop();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dir]);
+
+  const clearView = useCallback((): void => {
+    setLines([]);
+  }, []);
+
+  useInput((input, key) => {
+    if (input === 'q' || key.escape) {
+      onBack();
+    } else if (input === 'c') {
+      clearView();
+    } else if (input === '+' || input === '=') {
+      setTailSize((n) => Math.min(MAX_TAIL_SIZE, n + TAIL_STEP));
+    } else if (input === '-' || input === '_') {
+      setTailSize((n) => Math.max(MIN_TAIL_SIZE, n - TAIL_STEP));
+    }
+  });
+
+  const logPath = nodeLogPath(dir);
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={0}>
+        <Text bold color="cyan">Worker Node — Logs</Text>
+        <Text dimColor>
+          {logPath}   tail: {tailSize} lines
+        </Text>
+      </Box>
+
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={0}>
+        {lines.length === 0 ? (
+          <Text dimColor>No log lines yet ({logPath}).</Text>
+        ) : (
+          lines.map((rec) => {
+            const parsed = parseLogLine(rec.raw);
+            const color = levelColor(parsed.level);
+            const dimmed = parsed.level === 'debug' || parsed.malformed;
+            return (
+              <Box key={rec.id} flexDirection="row" gap={1}>
+                <Text dimColor>{parsed.time ?? '--:--:--'}</Text>
+                <Text color={color} dimColor={dimmed}>
+                  {GLYPH_BY_LEVEL[parsed.level]}
+                </Text>
+                <Text color={color} dimColor={dimmed}>
+                  {parsed.text}
+                </Text>
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      <Box paddingX={2}>
+        <Text dimColor>
+          [+/-] tail size ({tailSize})   [c] clear view   [q] back
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/NodeRegister.tsx
+++ b/apps/cli/src/tui/NodeRegister.tsx
@@ -1,0 +1,370 @@
+/**
+ * tui/NodeRegister.tsx — Ink screen wrapping `memoriahub node register`.
+ *
+ * Reuses the exact same business logic as `registerCmd()` in
+ * commands/node.ts: `detectCapabilities()` to auto-detect the default
+ * eligible-type set, `api.registerNode(...)` to register server-side, and
+ * `saveConfig(...)` to persist the assigned nodeId + node config locally. This
+ * screen only adds an Ink form/wizard around that same sequence — no
+ * registration business logic is reimplemented here.
+ *
+ * Steps:
+ *   'detecting'  — capability auto-detection on mount (spinner)
+ *   'confirm'    — only shown when `config.nodeId` is already set: registering
+ *                  again REPLACES the current registration server-side and
+ *                  locally, so this is a consequential action requiring a
+ *                  y/n confirm (mirrors NodeDashboard's stop-daemon confirm)
+ *   'form'       — three-field wizard: name, concurrency, eligible types
+ *                  (comma-separated). Tab/↓ moves focus forward, ↑ moves
+ *                  back; Enter on the first two fields advances focus, Enter
+ *                  on the last field (types) submits.
+ *   'submitting' — calling the API (spinner)
+ *   'success'    — assigned node ID + eligible types, CLI messaging tone
+ *   'error'      — failure message; [Enter/r] retry (back to form), [Esc/q] cancel
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import TextInput from 'ink-text-input';
+import * as os from 'node:os';
+import { createRequire } from 'node:module';
+
+import { ApiClient, ApiError, type NodeRegisterResult } from '../api.js';
+import { saveConfig, type CliConfig, type NodeConfig } from '../config.js';
+import {
+  detectCapabilities,
+  isNodeJobType,
+  missingRequirements,
+  NODE_JOB_TYPES,
+  type CapabilityStatus,
+} from '../node/capabilities.js';
+import { BOX_BORDER } from './theme.js';
+
+// ---------------------------------------------------------------------------
+// Defaults (mirror commands/node.ts)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_POLL_MS = 5000;
+const DEFAULT_CONCURRENCY = 1;
+
+const require = createRequire(import.meta.url);
+
+/**
+ * CLI version read from package.json at runtime — mirrors the private
+ * `cliVersion()` helper in commands/node.ts (not exported, so duplicated here
+ * verbatim rather than reaching across module boundaries for an 8-line
+ * metadata read).
+ */
+function cliVersion(): string {
+  try {
+    const pkg = require('../../package.json') as { version: string };
+    return pkg.version;
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/** Job types whose required capabilities are all satisfied by `caps` —
+ *  mirrors the private `supportedTypes()` helper in commands/node.ts. */
+function supportedTypes(caps: Record<string, CapabilityStatus>): string[] {
+  return NODE_JOB_TYPES.filter((t) => missingRequirements(t, caps).length === 0);
+}
+
+// ---------------------------------------------------------------------------
+// Props + local types
+// ---------------------------------------------------------------------------
+
+export interface NodeRegisterProps {
+  config: CliConfig;
+  /** Called with the newly-saved config after a successful registration. */
+  onRegistered?: (config: CliConfig) => void;
+  onBack: () => void;
+}
+
+type Step = 'detecting' | 'confirm' | 'form' | 'submitting' | 'success' | 'error';
+type Field = 'name' | 'concurrency' | 'types';
+const FIELD_ORDER: Field[] = ['name', 'concurrency', 'types'];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NodeRegister({ config, onRegistered, onBack }: NodeRegisterProps): React.ReactElement {
+  const [step, setStep] = useState<Step>(config.nodeId ? 'confirm' : 'detecting');
+
+  const [name, setName] = useState<string>('');
+  const [concurrencyStr, setConcurrencyStr] = useState<string>(String(DEFAULT_CONCURRENCY));
+  const [typesStr, setTypesStr] = useState<string>('');
+  const [field, setField] = useState<Field>('name');
+  const [fieldError, setFieldError] = useState<string>('');
+
+  const [result, setResult] = useState<NodeRegisterResult | null>(null);
+  const [registeredTypes, setRegisteredTypes] = useState<string[]>([]);
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  // ---- capability auto-detection on mount (also runs after a 'confirm' yes) ----
+  const runDetection = useCallback((): void => {
+    setStep('detecting');
+    void detectCapabilities().then((caps) => {
+      setName(os.hostname());
+      setConcurrencyStr(String(config.node?.concurrency ?? DEFAULT_CONCURRENCY));
+      setTypesStr(
+        config.node?.eligibleTypes && config.node.eligibleTypes.length > 0
+          ? config.node.eligibleTypes.join(', ')
+          : supportedTypes(caps).join(', '),
+      );
+      setField('name');
+      setStep('form');
+    });
+  }, [config.node]);
+
+  useEffect(() => {
+    if (step === 'detecting') runDetection();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- submit registration — same sequence as registerCmd()'s action ----
+  const submit = useCallback((): void => {
+    const trimmedName = name.trim() || os.hostname();
+    const concurrency = Math.max(1, parseInt(concurrencyStr, 10) || DEFAULT_CONCURRENCY);
+    const requested = typesStr
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    setStep('submitting');
+    setErrorMsg('');
+
+    const api = new ApiClient(config);
+    void (async () => {
+      try {
+        const res = await api.registerNode({
+          name: trimmedName,
+          hostname: os.hostname(),
+          platform: os.platform(),
+          cliVersion: cliVersion(),
+          eligibleTypes: requested,
+          concurrency,
+        });
+        const node: NodeConfig = {
+          name: trimmedName,
+          concurrency,
+          eligibleTypes: requested,
+          pollIntervalMs: config.node?.pollIntervalMs ?? DEFAULT_POLL_MS,
+        };
+        const newConfig: CliConfig = { ...config, nodeId: res.nodeId, node };
+        saveConfig(newConfig);
+        setResult(res);
+        setRegisteredTypes(requested);
+        setStep('success');
+        onRegistered?.(newConfig);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 403) {
+          setErrorMsg('This command requires a token permitted to register worker nodes.');
+        } else {
+          setErrorMsg(`Failed to register node: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        setStep('error');
+      }
+    })();
+  }, [name, concurrencyStr, typesStr, config, onRegistered]);
+
+  // ---- validate + advance/submit on Enter, per field ----
+  const advanceOrSubmit = useCallback((): void => {
+    if (field === 'name') {
+      setFieldError('');
+      setField('concurrency');
+      return;
+    }
+    if (field === 'concurrency') {
+      const n = parseInt(concurrencyStr.trim(), 10);
+      if (isNaN(n) || n < 1 || n > 64 || String(n) !== concurrencyStr.trim()) {
+        setFieldError(`Concurrency must be an integer between 1 and 64 (got "${concurrencyStr}").`);
+        return;
+      }
+      setFieldError('');
+      setField('types');
+      return;
+    }
+    // types
+    const requested = typesStr
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const invalid = requested.filter((t) => !isNodeJobType(t));
+    if (invalid.length > 0) {
+      setFieldError(
+        `Unknown job type(s): ${invalid.join(', ')}. Valid types: ${NODE_JOB_TYPES.join(', ')}`,
+      );
+      return;
+    }
+    setFieldError('');
+    submit();
+  }, [field, concurrencyStr, typesStr, submit]);
+
+  // ---- confirm step keys ----
+  useInput((input, key) => {
+    if (step !== 'confirm') return;
+    if (input === 'y') {
+      runDetection();
+    } else if (input === 'n' || key.escape || input === 'q') {
+      onBack();
+    }
+  });
+
+  // ---- form step: Tab/arrows move focus; typing goes to the focused TextInput ----
+  useInput((input, key) => {
+    if (step !== 'form') return;
+    if (key.escape || input === 'q') {
+      onBack();
+      return;
+    }
+    if (key.tab || key.downArrow) {
+      setFieldError('');
+      setField((f) => FIELD_ORDER[(FIELD_ORDER.indexOf(f) + 1) % FIELD_ORDER.length]);
+      return;
+    }
+    if (key.upArrow) {
+      setFieldError('');
+      setField((f) => FIELD_ORDER[(FIELD_ORDER.indexOf(f) - 1 + FIELD_ORDER.length) % FIELD_ORDER.length]);
+    }
+  });
+
+  // ---- error step: Enter/r retries (back to form), Esc/q cancels ----
+  useInput((input, key) => {
+    if (step !== 'error') return;
+    if (input === 'r' || key.return) {
+      setStep('form');
+    } else if (key.escape || input === 'q') {
+      onBack();
+    }
+  });
+
+  // ---- success step: any key goes back ----
+  useInput((_input, key) => {
+    if (step !== 'success') return;
+    if (key.escape || _input === 'q' || key.return) onBack();
+  });
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  if (step === 'detecting') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Register</Text>
+        <Box marginTop={1}>
+          <Text color="cyan"><Spinner type="dots" /> Detecting local capabilities…</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'confirm') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="yellow" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="yellow">Worker Node — Register</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow">
+            ⚠ This machine is already registered as{' '}
+            <Text bold>{config.node?.name ?? '(unnamed)'}</Text> ({config.nodeId}).
+          </Text>
+          <Text color="yellow">Registering again will REPLACE the current registration.</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text bold>Continue? [y] yes  [n] no</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'submitting') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Register</Text>
+        <Box marginTop={1}>
+          <Text color="cyan"><Spinner type="dots" /> Registering with the server…</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'success') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Register</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text color="green">
+            ✔ Registered as worker node: {name} ({result?.nodeId})
+          </Text>
+          <Text dimColor>
+            Eligible types: {registeredTypes.length > 0 ? registeredTypes.join(', ') : '(none)'}
+          </Text>
+          <Text dimColor>Run `memoriahub node start` (or the Worker Node dashboard) to begin processing jobs.</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[Enter/Esc/q] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'error') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="red" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Register</Text>
+        <Box marginTop={1}>
+          <Text color="red">✖ {errorMsg}</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[Enter/r] retry   [Esc/q] cancel</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // 'form'
+  return (
+    <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+      <Text bold color="cyan">Worker Node — Register</Text>
+      <Text dimColor>Review the fields below, then submit on the last field.</Text>
+
+      <Box flexDirection="row" gap={1} marginTop={1}>
+        <Text color={field === 'name' ? 'cyan' : undefined}>{field === 'name' ? '❯' : ' '}</Text>
+        <Text color={field === 'name' ? 'cyan' : undefined}>{'Name'.padEnd(12)}</Text>
+        <TextInput value={name} onChange={setName} onSubmit={advanceOrSubmit} focus={field === 'name'} />
+      </Box>
+
+      <Box flexDirection="row" gap={1}>
+        <Text color={field === 'concurrency' ? 'cyan' : undefined}>{field === 'concurrency' ? '❯' : ' '}</Text>
+        <Text color={field === 'concurrency' ? 'cyan' : undefined}>{'Concurrency'.padEnd(12)}</Text>
+        <TextInput
+          value={concurrencyStr}
+          onChange={setConcurrencyStr}
+          onSubmit={advanceOrSubmit}
+          focus={field === 'concurrency'}
+        />
+      </Box>
+
+      <Box flexDirection="row" gap={1}>
+        <Text color={field === 'types' ? 'cyan' : undefined}>{field === 'types' ? '❯' : ' '}</Text>
+        <Text color={field === 'types' ? 'cyan' : undefined}>{'Types'.padEnd(12)}</Text>
+        <TextInput value={typesStr} onChange={setTypesStr} onSubmit={advanceOrSubmit} focus={field === 'types'} />
+      </Box>
+
+      {fieldError ? (
+        <Box marginTop={1}>
+          <Text color="red">✖ {fieldError}</Text>
+        </Box>
+      ) : null}
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          [Tab/↑/↓] move field  [Enter] next / submit on last field  [Esc/q] cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/NodeService.tsx
+++ b/apps/cli/src/tui/NodeService.tsx
@@ -1,0 +1,377 @@
+/**
+ * tui/NodeService.tsx — Ink screen for the systemd user unit that keeps the
+ * worker node always on (install / uninstall / status).
+ *
+ * Mirrors `serviceCmd()` in commands/node.ts exactly: same unit-file template,
+ * same `~/.config/systemd/user/memoriahub-node.service` path, same
+ * WSL/Windows guidance, same "status exit 3 is not a failure" handling.
+ *
+ * IMPORTANT — Ink/stdio adaptation (deliberate, not a deviation to avoid):
+ * `serviceCmd()`'s `systemctlUser()` helper runs
+ * `spawnSync('systemctl', [...], { stdio: 'inherit' })`, handing the child
+ * process direct control of the terminal. That is fine for a plain CLI
+ * command where nothing else owns the terminal, but it WOULD CONFLICT here —
+ * Ink owns stdout/stdin/raw-mode for its own render loop, and `inherit` would
+ * race with (and likely corrupt) that render loop. This screen instead runs
+ * every `systemctl --user ...` call with `{ encoding: 'utf8' }` (captures
+ * stdout/stderr instead of inheriting the terminal — see `runSystemctlUser`
+ * below) and renders the captured output as Ink `<Text>` rows in the screen's
+ * own layout.
+ *
+ * The small unit-file template string is intentionally DUPLICATED here rather
+ * than extracted into a shared module — this screen owns exactly two new
+ * files by design (see the task boundary), and the template is a handful of
+ * static lines that rarely change. If `serviceCmd()`'s template in
+ * commands/node.ts ever changes, `unitFileContent()` below must be updated to
+ * match.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { BOX_BORDER } from './theme.js';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface NodeServiceProps {
+  /** Pop back to the previous screen/menu. */
+  onBack: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants (mirror commands/node.ts's serviceCmd — see file header)
+// ---------------------------------------------------------------------------
+
+export const SERVICE_UNIT = 'memoriahub-node.service';
+
+export function systemdUserDir(): string {
+  return path.join(os.homedir(), '.config', 'systemd', 'user');
+}
+
+/** The exact unit-file template `node service install` writes. */
+export function unitFileContent(): string {
+  const entry = path.resolve(process.argv[1] ?? '');
+  return [
+    '[Unit]',
+    'Description=MemoriaHub worker node',
+    'After=network-online.target',
+    '',
+    '[Service]',
+    `ExecStart=${process.execPath} ${entry} node start`,
+    'Restart=on-failure',
+    'RestartSec=5',
+    'Environment=NODE_ENV=production',
+    '',
+    '[Install]',
+    'WantedBy=default.target',
+    '',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// systemctl helpers — output-CAPTURING, not stdio:'inherit' (see file header)
+// ---------------------------------------------------------------------------
+
+export interface SystemctlResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** True when a per-user systemd instance is reachable. */
+export function hasUserSystemd(): boolean {
+  try {
+    const res = spawnSync('systemctl', ['--user', 'show-environment'], { encoding: 'utf8' });
+    return res.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Run `systemctl --user <args>`, capturing output instead of inheriting the terminal. */
+export function runSystemctlUser(args: string[]): SystemctlResult {
+  try {
+    const res = spawnSync('systemctl', ['--user', ...args], { encoding: 'utf8' });
+    return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+  } catch (err) {
+    return { status: null, stdout: '', stderr: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function splitNonEmpty(s: string): string[] {
+  return s
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Action reports — pure(ish) orchestration, unit-testable with a mocked spawnSync
+// ---------------------------------------------------------------------------
+
+export type ReportTone = 'info' | 'success' | 'error' | 'dim';
+
+export interface ReportLine {
+  text: string;
+  tone: ReportTone;
+}
+
+export interface ServiceActionReport {
+  lines: ReportLine[];
+  ok: boolean;
+}
+
+function noUserSystemdLines(): ReportLine[] {
+  return [
+    { text: 'No per-user systemd instance is available.', tone: 'error' },
+    {
+      text:
+        'On WSL, enable systemd by adding "[boot]\\nsystemd=true" to /etc/wsl.conf and restarting ' +
+        'the distro (`wsl --shutdown`), or skip systemd entirely with `memoriahub node start --daemon`.',
+      tone: 'info',
+    },
+  ];
+}
+
+function pushSystemctlOutput(lines: ReportLine[], label: string, res: SystemctlResult): void {
+  const ok = res.status === 0;
+  lines.push({ text: `$ systemctl --user ${label}`, tone: 'dim' });
+  for (const l of splitNonEmpty(res.stdout)) lines.push({ text: l, tone: 'info' });
+  for (const l of splitNonEmpty(res.stderr)) lines.push({ text: l, tone: ok ? 'dim' : 'error' });
+  lines.push({
+    text: ok ? '✔ succeeded (exit 0)' : `✖ failed (exit ${res.status ?? 'signal'})`,
+    tone: ok ? 'success' : 'error',
+  });
+}
+
+/** Write the unit file, daemon-reload, and enable --now — same sequence as `node service install`. */
+export function runInstall(): ServiceActionReport {
+  const lines: ReportLine[] = [];
+
+  if (os.platform() === 'win32') {
+    lines.push({
+      text: 'systemd services are not available on Windows — use `node start --daemon`.',
+      tone: 'error',
+    });
+    return { lines, ok: false };
+  }
+  if (!hasUserSystemd()) {
+    return { lines: noUserSystemdLines(), ok: false };
+  }
+
+  const dir = systemdUserDir();
+  const unitPath = path.join(dir, SERVICE_UNIT);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(unitPath, unitFileContent());
+    lines.push({ text: `Wrote ${unitPath}`, tone: 'success' });
+  } catch (err) {
+    lines.push({
+      text: `Failed to write unit file: ${err instanceof Error ? err.message : String(err)}`,
+      tone: 'error',
+    });
+    return { lines, ok: false };
+  }
+
+  const reload = runSystemctlUser(['daemon-reload']);
+  pushSystemctlOutput(lines, 'daemon-reload', reload);
+  if (reload.status !== 0) return { lines, ok: false };
+
+  const enable = runSystemctlUser(['enable', '--now', SERVICE_UNIT]);
+  pushSystemctlOutput(lines, `enable --now ${SERVICE_UNIT}`, enable);
+  if (enable.status !== 0) return { lines, ok: false };
+
+  lines.push({ text: 'Service enabled and started.', tone: 'success' });
+  lines.push({
+    text:
+      'Follow logs with `memoriahub node logs --follow`, the Node Logs TUI screen, or ' +
+      `\`journalctl --user -u ${SERVICE_UNIT} -f\`.`,
+    tone: 'dim',
+  });
+  lines.push({
+    text: 'Tip: `loginctl enable-linger $USER` keeps the service running after you log out.',
+    tone: 'dim',
+  });
+  return { lines, ok: true };
+}
+
+/** Disable + remove the unit — same sequence as `node service uninstall`. */
+export function runUninstall(): ServiceActionReport {
+  if (!hasUserSystemd()) {
+    return { lines: noUserSystemdLines(), ok: false };
+  }
+  const lines: ReportLine[] = [];
+  const unitPath = path.join(systemdUserDir(), SERVICE_UNIT);
+
+  // Best-effort, mirrors the CLI: the unit may already be gone.
+  const disable = runSystemctlUser(['disable', '--now', SERVICE_UNIT]);
+  pushSystemctlOutput(lines, `disable --now ${SERVICE_UNIT}`, disable);
+
+  try {
+    fs.unlinkSync(unitPath);
+    lines.push({ text: `Removed ${unitPath}`, tone: 'success' });
+  } catch {
+    lines.push({ text: `Unit file not present (${unitPath}).`, tone: 'info' });
+  }
+
+  const reload = runSystemctlUser(['daemon-reload']);
+  pushSystemctlOutput(lines, 'daemon-reload', reload);
+  if (reload.status !== 0) return { lines, ok: false };
+
+  lines.push({ text: 'Service uninstalled.', tone: 'success' });
+  return { lines, ok: true };
+}
+
+/** `systemctl --user status memoriahub-node.service --no-pager` — same as `node service status`. */
+export function runStatus(): ServiceActionReport {
+  if (!hasUserSystemd()) {
+    return { lines: noUserSystemdLines(), ok: false };
+  }
+  const lines: ReportLine[] = [];
+  // Exit code 3 = unit inactive — still useful output, never treated as a hard failure.
+  const res = runSystemctlUser(['status', SERVICE_UNIT, '--no-pager']);
+  lines.push({ text: `$ systemctl --user status ${SERVICE_UNIT} --no-pager`, tone: 'dim' });
+  for (const l of splitNonEmpty(res.stdout)) lines.push({ text: l, tone: 'info' });
+  for (const l of splitNonEmpty(res.stderr)) lines.push({ text: l, tone: 'error' });
+  lines.push({
+    text: `(exit ${res.status ?? 'signal'} — nonzero is normal for an inactive/not-installed unit)`,
+    tone: 'dim',
+  });
+  return { lines, ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+type Screen = 'menu' | 'result';
+type ActionKind = 'install' | 'uninstall' | 'status';
+
+function toneColor(tone: ReportTone): string | undefined {
+  switch (tone) {
+    case 'success':
+      return 'green';
+    case 'error':
+      return 'red';
+    default:
+      return undefined;
+  }
+}
+
+function actionLabel(a: ActionKind): string {
+  switch (a) {
+    case 'install':
+      return 'Install';
+    case 'uninstall':
+      return 'Uninstall';
+    case 'status':
+      return 'Status';
+  }
+}
+
+export function NodeService({ onBack }: NodeServiceProps): React.ReactElement {
+  const [screen, setScreen] = useState<Screen>('menu');
+  const [action, setAction] = useState<ActionKind | null>(null);
+  const [running, setRunning] = useState<boolean>(false);
+  const [report, setReport] = useState<ServiceActionReport | null>(null);
+
+  const runAction = useCallback((kind: ActionKind): void => {
+    setAction(kind);
+    setReport(null);
+    setRunning(true);
+    setScreen('result');
+    // spawnSync is synchronous; defer one tick so the "running…" spinner has
+    // a chance to paint before the (normally sub-second) systemctl calls
+    // resolve and the report replaces it.
+    setTimeout(() => {
+      let result: ServiceActionReport;
+      try {
+        result = kind === 'install' ? runInstall() : kind === 'uninstall' ? runUninstall() : runStatus();
+      } catch (err) {
+        result = {
+          ok: false,
+          lines: [
+            { text: `Unexpected error: ${err instanceof Error ? err.message : String(err)}`, tone: 'error' },
+          ],
+        };
+      }
+      setReport(result);
+      setRunning(false);
+    }, 0);
+  }, []);
+
+  useInput((input, key) => {
+    if (screen === 'menu') {
+      if (input === 'i') runAction('install');
+      else if (input === 'u') runAction('uninstall');
+      else if (input === 's') runAction('status');
+      else if (input === 'q' || key.escape) onBack();
+      return;
+    }
+    // 'result' screen: ignore input while the (near-instant) action is running.
+    if (running) return;
+    if (input === 'b') {
+      setScreen('menu');
+      setAction(null);
+      setReport(null);
+    } else if (input === 'q' || key.escape) {
+      onBack();
+    }
+  });
+
+  if (screen === 'menu') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={0}>
+          <Text bold color="cyan">Worker Node — Service</Text>
+          <Text dimColor>Manage the {SERVICE_UNIT} systemd user unit that keeps the worker node always on.</Text>
+        </Box>
+        <Box paddingX={2}>
+          <Text dimColor>[i] install   [u] uninstall   [s] status   [q] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={0}>
+        <Text bold color="cyan">Worker Node — Service — {action ? actionLabel(action) : ''}</Text>
+        {running && (
+          <Box>
+            <Text color="cyan">
+              <Spinner type="dots" /> running…
+            </Text>
+          </Box>
+        )}
+      </Box>
+
+      {report && (
+        <Box
+          borderStyle={BOX_BORDER}
+          borderColor={report.ok ? 'cyan' : 'red'}
+          flexDirection="column"
+          paddingX={2}
+          paddingY={0}
+        >
+          {report.lines.map((l, i) => (
+            <Text key={i} color={toneColor(l.tone)} dimColor={l.tone === 'dim'}>
+              {l.text}
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      <Box paddingX={2}>
+        <Text dimColor>{running ? 'please wait…' : '[b] back to menu   [q] back'}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -41,6 +41,11 @@ import { BackupScreen } from './BackupScreen.js';
 import { JobsDashboard } from './JobsDashboard.js';
 import { NodeDashboard } from './NodeDashboard.js';
 import { NodeConfig } from './NodeConfig.js';
+import { NodeDoctor } from './NodeDoctor.js';
+import { NodeRegister } from './NodeRegister.js';
+import { NodeList } from './NodeList.js';
+import { NodeLogs } from './NodeLogs.js';
+import { NodeService } from './NodeService.js';
 import { BOX_BORDER } from './theme.js';
 import {
   MENU_TREE,
@@ -74,7 +79,12 @@ type Screen =
   | { kind: 'jobs' }
   | { kind: 'backup' }
   | { kind: 'nodeDashboard' }
-  | { kind: 'nodeConfig' };
+  | { kind: 'nodeConfig' }
+  | { kind: 'nodeDoctor' }
+  | { kind: 'nodeRegister' }
+  | { kind: 'nodeList' }
+  | { kind: 'nodeLogs' }
+  | { kind: 'nodeService' };
 
 type NavFrame =
   | { kind: 'menu'; menuId: string }
@@ -248,6 +258,21 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
         break;
       case 'node-config':
         push({ kind: 'screen', screen: { kind: 'nodeConfig' } });
+        break;
+      case 'node-doctor':
+        push({ kind: 'screen', screen: { kind: 'nodeDoctor' } });
+        break;
+      case 'node-register':
+        push({ kind: 'screen', screen: { kind: 'nodeRegister' } });
+        break;
+      case 'node-list':
+        push({ kind: 'screen', screen: { kind: 'nodeList' } });
+        break;
+      case 'node-logs':
+        push({ kind: 'screen', screen: { kind: 'nodeLogs' } });
+        break;
+      case 'node-service':
+        push({ kind: 'screen', screen: { kind: 'nodeService' } });
         break;
       case 'help':
         push({ kind: 'screen', screen: { kind: 'help' } });
@@ -591,6 +616,54 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
           onBack={pop}
         />
       );
+
+    case 'nodeDoctor':
+      if (!config) {
+        return (
+          <Box paddingX={1} flexDirection="column" gap={1}>
+            <Text color="yellow">Not logged in. Please login first.</Text>
+            <Text dimColor>Press q to go back.</Text>
+            <KeyHandler onBack={pop} />
+          </Box>
+        );
+      }
+      return <NodeDoctor config={config} onBack={pop} />;
+
+    case 'nodeRegister':
+      if (!config) {
+        return (
+          <Box paddingX={1} flexDirection="column" gap={1}>
+            <Text color="yellow">Not logged in. Please login first.</Text>
+            <Text dimColor>Press q to go back.</Text>
+            <KeyHandler onBack={pop} />
+          </Box>
+        );
+      }
+      return (
+        <NodeRegister
+          config={config}
+          onRegistered={(cfg) => setAppState((prev) => ({ ...prev, config: cfg }))}
+          onBack={pop}
+        />
+      );
+
+    case 'nodeList':
+      if (!config) {
+        return (
+          <Box paddingX={1} flexDirection="column" gap={1}>
+            <Text color="yellow">Not logged in. Please login first.</Text>
+            <Text dimColor>Press q to go back.</Text>
+            <KeyHandler onBack={pop} />
+          </Box>
+        );
+      }
+      return <NodeList config={config} onBack={pop} />;
+
+    case 'nodeLogs':
+      return <NodeLogs onBack={pop} />;
+
+    case 'nodeService':
+      return <NodeService onBack={pop} />;
 
     case 'settings':
       return <SettingsScreen db={db} onBack={pop} />;

--- a/apps/cli/src/tui/menu-config.ts
+++ b/apps/cli/src/tui/menu-config.ts
@@ -32,6 +32,11 @@ export type MenuActionId =
   | 'backup'
   | 'node-dashboard'
   | 'node-config'
+  | 'node-doctor'
+  | 'node-register'
+  | 'node-list'
+  | 'node-logs'
+  | 'node-service'
   | 'help'
   | 'quit'
   | `report:${string}`;
@@ -140,7 +145,12 @@ export const MENU_TREE: MenuSubmenu = {
           label: 'Worker Node',
           children: [
             { kind: 'action', label: 'Node dashboard', action: 'node-dashboard' },
+            { kind: 'action', label: 'Register node', action: 'node-register' },
             { kind: 'action', label: 'Node config', action: 'node-config' },
+            { kind: 'action', label: 'List nodes', action: 'node-list' },
+            { kind: 'action', label: 'Node doctor', action: 'node-doctor' },
+            { kind: 'action', label: 'Node logs', action: 'node-logs' },
+            { kind: 'action', label: 'Node service (systemd)', action: 'node-service' },
           ],
         },
       ],

--- a/apps/cli/src/tui/useNodeDoctorSweep.ts
+++ b/apps/cli/src/tui/useNodeDoctorSweep.ts
@@ -1,0 +1,350 @@
+/**
+ * tui/useNodeDoctorSweep.ts — shared operational doctor sweep for the TUI.
+ *
+ * `memoriahub node doctor` (commands/node.ts's `doctorCmd()`) runs SIX health
+ * checks in sequence: API access, installed-capability presence, real
+ * operational self-tests, job-type readiness (gated on the operational
+ * result), model presence/download, and daemon liveness. Two TUI surfaces
+ * need that exact same sweep:
+ *
+ *   - tui/NodeDoctor.tsx        — full screen, menu-reachable
+ *   - tui/NodeDashboard.tsx     — the `[r]` doctor overlay (compact, in-context)
+ *
+ * This module is the single source of truth for the sweep so neither surface
+ * re-implements (or drifts from) `doctorCmd()`'s logic. It exports:
+ *
+ *   - `runNodeDoctorSweep(api, cfg, onProgress?)` — a plain async function
+ *     with NO React/Ink dependency. Directly unit-testable and directly
+ *     invokable headlessly (e.g. from a throwaway script) against a real
+ *     machine. Reports incremental progress via `onProgress`, called after
+ *     every step transition (entering AND finishing a step) so a caller can
+ *     render a live step-by-step log.
+ *   - `useNodeDoctorSweep(api, cfg, options?)` — a thin Ink/React hook that
+ *     wraps the function above: `{ state, running, run }`. `run()` (re)starts
+ *     the sweep; `options.autoRun` (default false) starts it once on mount.
+ *
+ * Never throws. Every step is individually wrapped in try/catch (mirroring
+ * self-test.ts's per-capability isolation) — a broken capability, a thrown
+ * exception from an API-access check, an unreachable model manifest, etc.
+ * never prevents the rest of the sweep from completing and never crashes the
+ * TUI process. Unlike the CLI command, this module never calls
+ * `process.exit()` — the "did everything pass" verdict is surfaced only as
+ * `state.hasError` for the caller to render.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { ApiClient } from '../api.js';
+import type { CliConfig } from '../config.js';
+import {
+  detectCapabilities,
+  missingRequirements,
+  NODE_JOB_TYPES,
+  isNodeJobType,
+  type CapabilityStatus,
+  type NodeJobType,
+} from '../node/capabilities.js';
+import { ensureModels } from '../node/models.js';
+import { runOperationalSelfTests } from '../node/self-test.js';
+import {
+  runApiAccessChecks,
+  checkDaemonLiveness,
+  type ApiAccessCheckResult,
+  type DaemonLivenessResult,
+} from '../node/doctor-checks.js';
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DoctorStepKey =
+  | 'apiAccess'
+  | 'capabilities'
+  | 'selfTest'
+  | 'jobReadiness'
+  | 'models'
+  | 'daemon';
+
+/** Sweep step order — mirrors doctorCmd()'s six sections, in order. */
+export const DOCTOR_STEP_ORDER: DoctorStepKey[] = [
+  'apiAccess',
+  'capabilities',
+  'selfTest',
+  'jobReadiness',
+  'models',
+  'daemon',
+];
+
+export const DOCTOR_STEP_LABELS: Record<DoctorStepKey, string> = {
+  apiAccess: 'API Access',
+  capabilities: 'Capabilities (installed)',
+  selfTest: 'Operational self-tests',
+  jobReadiness: 'Job-type readiness',
+  models: 'Models',
+  daemon: 'Daemon',
+};
+
+export interface JobReadinessRow {
+  type: NodeJobType;
+  ready: boolean;
+  missing: string[];
+}
+
+export interface ModelsSweepResult {
+  /** Number of files listed in the server manifest. */
+  manifestCount: number;
+  downloaded: string[];
+  present: string[];
+  failed: Array<{ name: string; error: string }>;
+  targetDir: string | null;
+  /** Set only when the manifest fetch itself failed (never affects hasError). */
+  error: string | null;
+}
+
+export interface DoctorSweepState {
+  /** Step currently running, or null before start / once the sweep is done. */
+  currentStep: DoctorStepKey | null;
+  /** Steps that have finished (success or failure), in completion order. */
+  completedSteps: DoctorStepKey[];
+  apiAccess: ApiAccessCheckResult | null;
+  /** Presence-only probe — `detectCapabilities()`. */
+  caps: Record<string, CapabilityStatus> | null;
+  /** Real self-test result — `runOperationalSelfTests()`. */
+  operationalCaps: Record<string, CapabilityStatus> | null;
+  jobReadiness: JobReadinessRow[] | null;
+  models: ModelsSweepResult | null;
+  daemon: DaemonLivenessResult | null;
+  /** True once every step has finished (success or failure). */
+  done: boolean;
+  /**
+   * Aggregate pass/fail, mirroring doctorCmd()'s `hasError` flag: true when
+   * auth failed, a configured/supported job type is missing a required
+   * operational capability, or a model file failed to download/verify.
+   * Daemon liveness and node-registration/manifest reachability are
+   * informational only and never set this.
+   */
+  hasError: boolean;
+}
+
+export function initialDoctorSweepState(): DoctorSweepState {
+  return {
+    currentStep: null,
+    completedSteps: [],
+    apiAccess: null,
+    caps: null,
+    operationalCaps: null,
+    jobReadiness: null,
+    models: null,
+    daemon: null,
+    done: false,
+    hasError: false,
+  };
+}
+
+/** The slice of CliConfig the sweep actually needs — keeps the function easy
+ *  to call headlessly without constructing a full CliConfig. */
+export type DoctorSweepConfig = Pick<CliConfig, 'nodeId' | 'node'>;
+
+// ---------------------------------------------------------------------------
+// Plain async sweep function (no React/Ink dependency)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full six-step doctor sweep once, reporting incremental progress.
+ * Resolves with the final state; never rejects.
+ */
+export async function runNodeDoctorSweep(
+  api: ApiClient,
+  cfg: DoctorSweepConfig,
+  onProgress?: (state: DoctorSweepState) => void,
+): Promise<DoctorSweepState> {
+  let state = initialDoctorSweepState();
+  let hasError = false;
+  const emit = (): void => onProgress?.(state);
+
+  const enterStep = (step: DoctorStepKey): void => {
+    state = { ...state, currentStep: step };
+    emit();
+  };
+  const leaveStep = (step: DoctorStepKey, patch: Partial<DoctorSweepState>): void => {
+    state = {
+      ...state,
+      ...patch,
+      currentStep: null,
+      completedSteps: [...state.completedSteps, step],
+      hasError,
+    };
+    emit();
+  };
+
+  // 1. API Access — auth roundtrip, node-registration validity, model-manifest
+  //    reachability. Only an auth failure counts toward hasError (mirrors
+  //    doctorCmd(): registration/manifest problems are warnings only).
+  enterStep('apiAccess');
+  let access: ApiAccessCheckResult;
+  try {
+    access = await runApiAccessChecks(api, cfg.nodeId);
+  } catch (err) {
+    access = {
+      authOk: false,
+      authDetail: `API access check threw: ${errMsg(err)}`,
+      nodeRegistrationOk: null,
+      nodeRegistrationDetail: 'not checked — API access check failed',
+      manifestOk: false,
+      manifestDetail: 'not checked — API access check failed',
+    };
+  }
+  if (!access.authOk) hasError = true;
+  leaveStep('apiAccess', { apiAccess: access });
+
+  // 2. Capabilities (installed) — presence probe only, no side effects.
+  enterStep('capabilities');
+  let caps: Record<string, CapabilityStatus>;
+  try {
+    caps = await detectCapabilities();
+  } catch (err) {
+    caps = { _error: { available: false, detail: `capability detection failed: ${errMsg(err)}` } };
+  }
+  leaveStep('capabilities', { caps });
+
+  // 3. Operational self-tests — a real decode/embed/detect/OCR-init pass for
+  //    every capability reported present above.
+  enterStep('selfTest');
+  let operationalCaps: Record<string, CapabilityStatus>;
+  try {
+    operationalCaps = await runOperationalSelfTests(caps);
+  } catch (err) {
+    // runOperationalSelfTests already isolates every individual self-test;
+    // this catch only guards against something unexpected in its own control
+    // flow so the sweep can never crash the caller.
+    operationalCaps = caps;
+    state = {
+      ...state,
+      caps: {
+        ...caps,
+        _selfTestError: { available: false, detail: `operational self-tests failed: ${errMsg(err)}` },
+      },
+    };
+  }
+  leaveStep('selfTest', { operationalCaps });
+
+  // 4. Job-type readiness — gated on the OPERATIONAL result, not mere
+  //    presence, so a node whose sharp binary resolves but crashes on first
+  //    use (or whose models aren't downloaded yet) is correctly not-ready.
+  enterStep('jobReadiness');
+  const configuredTypes = (cfg.node?.eligibleTypes ?? []).filter(isNodeJobType);
+  const eligibleTypes: NodeJobType[] =
+    configuredTypes.length > 0
+      ? configuredTypes
+      : NODE_JOB_TYPES.filter((t) => missingRequirements(t, operationalCaps).length === 0);
+  const jobReadiness: JobReadinessRow[] = eligibleTypes.map((t) => {
+    const missing = missingRequirements(t, operationalCaps);
+    if (missing.length > 0) hasError = true;
+    return { type: t, ready: missing.length === 0, missing };
+  });
+  leaveStep('jobReadiness', { jobReadiness });
+
+  // 5. Models — download-and-verify, as `node start` does.
+  enterStep('models');
+  let models: ModelsSweepResult;
+  try {
+    const manifest = await api.getModelManifest();
+    if (manifest.length === 0) {
+      models = { manifestCount: 0, downloaded: [], present: [], failed: [], targetDir: null, error: null };
+    } else {
+      const res = await ensureModels(manifest);
+      if (res.failed.length > 0) hasError = true;
+      models = {
+        manifestCount: manifest.length,
+        downloaded: res.downloaded,
+        present: res.present,
+        failed: res.failed,
+        targetDir: res.targetDir,
+        error: null,
+      };
+    }
+  } catch (err) {
+    // Manifest unreachable: warning only, never affects hasError (mirrors
+    // doctorCmd()'s `ui.warn` branch here).
+    models = { manifestCount: 0, downloaded: [], present: [], failed: [], targetDir: null, error: errMsg(err) };
+  }
+  leaveStep('models', { models });
+
+  // 6. Daemon liveness — informational only, never affects hasError.
+  enterStep('daemon');
+  let daemon: DaemonLivenessResult;
+  try {
+    daemon = await checkDaemonLiveness();
+  } catch (err) {
+    daemon = {
+      running: false,
+      stalePidfile: false,
+      pidInfo: null,
+      snapshot: null,
+      detail: `daemon liveness check failed: ${errMsg(err)}`,
+    };
+  }
+  leaveStep('daemon', { daemon });
+
+  state = { ...state, done: true, hasError };
+  emit();
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// React hook wrapper
+// ---------------------------------------------------------------------------
+
+export interface UseNodeDoctorSweepOptions {
+  /** Start the sweep once automatically when the hook first mounts. */
+  autoRun?: boolean;
+}
+
+export interface UseNodeDoctorSweepResult {
+  state: DoctorSweepState;
+  /** True while a sweep is in flight. */
+  running: boolean;
+  /** (Re)start the sweep. No-op while one is already running. */
+  run: () => void;
+}
+
+/**
+ * Ink/React hook wrapper over {@link runNodeDoctorSweep}. `api`/`cfg` are read
+ * fresh on every `run()` call via refs, so callers don't need to memoize them.
+ */
+export function useNodeDoctorSweep(
+  api: ApiClient,
+  cfg: DoctorSweepConfig,
+  options?: UseNodeDoctorSweepOptions,
+): UseNodeDoctorSweepResult {
+  const [state, setState] = useState<DoctorSweepState>(initialDoctorSweepState);
+  const [running, setRunning] = useState<boolean>(false);
+  const runningRef = useRef<boolean>(false);
+  const apiRef = useRef(api);
+  apiRef.current = api;
+  const cfgRef = useRef(cfg);
+  cfgRef.current = cfg;
+
+  const run = useCallback((): void => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setRunning(true);
+    setState(initialDoctorSweepState());
+    void runNodeDoctorSweep(apiRef.current, cfgRef.current, setState).finally(() => {
+      runningRef.current = false;
+      setRunning(false);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (options?.autoRun) run();
+    // Intentionally run once on mount only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { state, running, run };
+}

--- a/apps/cli/test/menu-config.spec.ts
+++ b/apps/cli/test/menu-config.spec.ts
@@ -90,7 +90,7 @@ describe('menu-config', () => {
       expect(labels(nodes)).toEqual(['Convert videos to MP4', 'Organize folder by date']);
     });
 
-    it('within Tools when logged in, all four tools are visible in order', () => {
+    it('within Tools when logged in, all five tools are visible in order', () => {
       const tools = findSubmenu('tools')!;
       const nodes = visibleChildren(tools, true);
       expect(labels(nodes)).toEqual([
@@ -98,6 +98,7 @@ describe('menu-config', () => {
         'Organize folder by date',
         'Job queue monitor',
         'Backup',
+        'Worker Node',
       ]);
     });
   });

--- a/apps/cli/test/tui/node-doctor-sweep.spec.ts
+++ b/apps/cli/test/tui/node-doctor-sweep.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * test/tui/node-doctor-sweep.spec.ts
+ *
+ * Unit tests for the shared sweep function in tui/useNodeDoctorSweep.ts —
+ * `runNodeDoctorSweep()`, the plain async function BOTH tui/NodeDoctor.tsx
+ * (full screen) and tui/NodeDashboard.tsx (the `[r]` doctor overlay) call.
+ * No Ink rendering here (see test/tui/node-dashboard-source.spec.ts for the
+ * project's established "pure function, no pty" pattern this mirrors) — only
+ * the sweep's data-shaping/aggregation logic and its never-throws error
+ * isolation are under test.
+ *
+ * All four collaborator modules (node/capabilities.ts, node/self-test.ts,
+ * node/doctor-checks.ts, node/models.ts) are mocked via
+ * jest.unstable_mockModule so every test controls exactly what each of the
+ * six sweep steps sees, deterministically and without touching the real
+ * filesystem, network, or native model libraries.
+ */
+
+import { jest } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Mocks — registered BEFORE importing the module under test.
+// ---------------------------------------------------------------------------
+
+const NODE_JOB_TYPES = ['face_detection', 'auto_tagging'] as const;
+
+const mockDetectCapabilities = jest.fn();
+const mockMissingRequirements = jest.fn();
+jest.unstable_mockModule('../../src/node/capabilities.js', () => ({
+  NODE_JOB_TYPES,
+  isNodeJobType: (t: string) => (NODE_JOB_TYPES as readonly string[]).includes(t),
+  detectCapabilities: mockDetectCapabilities,
+  missingRequirements: mockMissingRequirements,
+}));
+
+const mockRunOperationalSelfTests = jest.fn();
+jest.unstable_mockModule('../../src/node/self-test.js', () => ({
+  runOperationalSelfTests: mockRunOperationalSelfTests,
+}));
+
+const mockRunApiAccessChecks = jest.fn();
+const mockCheckDaemonLiveness = jest.fn();
+jest.unstable_mockModule('../../src/node/doctor-checks.js', () => ({
+  runApiAccessChecks: mockRunApiAccessChecks,
+  checkDaemonLiveness: mockCheckDaemonLiveness,
+}));
+
+const mockEnsureModels = jest.fn();
+jest.unstable_mockModule('../../src/node/models.js', () => ({
+  ensureModels: mockEnsureModels,
+}));
+
+const { runNodeDoctorSweep, initialDoctorSweepState, DOCTOR_STEP_ORDER } = await import(
+  '../../src/tui/useNodeDoctorSweep.js'
+);
+type ApiClientLike = { getModelManifest: () => Promise<Array<{ name: string }>> };
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OK_ACCESS = {
+  authOk: true,
+  authDetail: 'token valid',
+  nodeRegistrationOk: null as boolean | null,
+  nodeRegistrationDetail: 'skipped',
+  manifestOk: true,
+  manifestDetail: 'reachable',
+};
+
+const OK_DAEMON = {
+  running: false,
+  stalePidfile: false,
+  pidInfo: null,
+  snapshot: null,
+  detail: 'no worker-node daemon running on this machine',
+};
+
+function fakeApi(manifest: Array<{ name: string }> = [{ name: 'm1' }]): ApiClientLike {
+  return { getModelManifest: jest.fn(async () => manifest) };
+}
+
+beforeEach(() => {
+  mockDetectCapabilities.mockReset().mockResolvedValue({
+    sharp: { available: true, detail: 'sharp' },
+    human: { available: false, detail: 'human not installed' },
+  });
+  mockMissingRequirements.mockReset().mockReturnValue([]);
+  mockRunOperationalSelfTests.mockReset().mockImplementation(async (caps: unknown) => caps);
+  mockRunApiAccessChecks.mockReset().mockResolvedValue(OK_ACCESS);
+  mockCheckDaemonLiveness.mockReset().mockResolvedValue(OK_DAEMON);
+  mockEnsureModels.mockReset().mockResolvedValue({
+    targetDir: '/tmp/models',
+    downloaded: [],
+    present: ['m1'],
+    failed: [],
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initialDoctorSweepState
+// ---------------------------------------------------------------------------
+
+describe('initialDoctorSweepState', () => {
+  it('starts empty, not done, no error', () => {
+    const state = initialDoctorSweepState();
+    expect(state.currentStep).toBeNull();
+    expect(state.completedSteps).toEqual([]);
+    expect(state.apiAccess).toBeNull();
+    expect(state.caps).toBeNull();
+    expect(state.operationalCaps).toBeNull();
+    expect(state.jobReadiness).toBeNull();
+    expect(state.models).toBeNull();
+    expect(state.daemon).toBeNull();
+    expect(state.done).toBe(false);
+    expect(state.hasError).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('runNodeDoctorSweep — happy path', () => {
+  it('runs all six steps in order and aggregates their results with hasError=false', async () => {
+    const api = fakeApi();
+    const result = await runNodeDoctorSweep(api as never, { nodeId: 'node-1', node: undefined });
+
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+    expect(result.currentStep).toBeNull();
+    expect(result.done).toBe(true);
+    expect(result.hasError).toBe(false);
+
+    expect(result.apiAccess).toEqual(OK_ACCESS);
+    expect(result.caps).toEqual({
+      sharp: { available: true, detail: 'sharp' },
+      human: { available: false, detail: 'human not installed' },
+    });
+    expect(result.operationalCaps).toEqual(result.caps);
+    expect(result.jobReadiness).toEqual([
+      { type: 'face_detection', ready: true, missing: [] },
+      { type: 'auto_tagging', ready: true, missing: [] },
+    ]);
+    expect(result.models).toEqual({
+      manifestCount: 1,
+      downloaded: [],
+      present: ['m1'],
+      failed: [],
+      targetDir: '/tmp/models',
+      error: null,
+    });
+    expect(result.daemon).toEqual(OK_DAEMON);
+  });
+
+  it('reports incremental progress: currentStep set while a step runs, then folded into completedSteps', async () => {
+    const seen: Array<{ currentStep: string | null; completedSteps: string[] }> = [];
+    await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined }, (s) => {
+      seen.push({ currentStep: s.currentStep, completedSteps: [...s.completedSteps] });
+    });
+
+    // First progress event enters step 1.
+    expect(seen[0].currentStep).toBe('apiAccess');
+    // At some point apiAccess finishes (currentStep cleared, folded into completedSteps)
+    // before capabilities starts.
+    const apiAccessDoneIdx = seen.findIndex((s) => s.completedSteps.includes('apiAccess'));
+    const capsStartIdx = seen.findIndex((s) => s.currentStep === 'capabilities');
+    expect(apiAccessDoneIdx).toBeGreaterThan(-1);
+    expect(capsStartIdx).toBeGreaterThan(apiAccessDoneIdx);
+    // Final event has every step completed, in the canonical order.
+    expect(seen[seen.length - 1].completedSteps).toEqual(DOCTOR_STEP_ORDER);
+    expect(seen[seen.length - 1].currentStep).toBeNull();
+  });
+
+  it('falls back to auto-detected supported types when no eligibleTypes are configured', async () => {
+    mockMissingRequirements.mockImplementation((t: string) => (t === 'auto_tagging' ? ['sharp'] : []));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    // auto_tagging is excluded from the auto-detected set (not fully supported);
+    // only face_detection is both eligible and ready.
+    expect(result.jobReadiness).toEqual([{ type: 'face_detection', ready: true, missing: [] }]);
+    expect(result.hasError).toBe(false);
+  });
+
+  it('uses the configured eligibleTypes list (filtered to known types) instead of auto-detecting', async () => {
+    mockMissingRequirements.mockImplementation((t: string) => (t === 'face_detection' ? ['human'] : []));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, {
+      nodeId: undefined,
+      node: { eligibleTypes: ['face_detection', 'not_a_real_type'] },
+    });
+
+    expect(result.jobReadiness).toEqual([{ type: 'face_detection', ready: false, missing: ['human'] }]);
+    expect(result.hasError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasError aggregation
+// ---------------------------------------------------------------------------
+
+describe('runNodeDoctorSweep — hasError aggregation', () => {
+  it('sets hasError when auth fails, but still completes every step', async () => {
+    mockRunApiAccessChecks.mockResolvedValue({
+      authOk: false,
+      authDetail: 'invalid token',
+      nodeRegistrationOk: null,
+      nodeRegistrationDetail: 'skipped',
+      manifestOk: false,
+      manifestDetail: 'unreachable',
+    });
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.hasError).toBe(true);
+    expect(result.done).toBe(true);
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+
+  it('does NOT set hasError from node-registration or manifest problems alone (warnings only)', async () => {
+    mockRunApiAccessChecks.mockResolvedValue({
+      authOk: true,
+      authDetail: 'token valid',
+      nodeRegistrationOk: false,
+      nodeRegistrationDetail: 'not found',
+      manifestOk: false,
+      manifestDetail: 'unreachable',
+    });
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: 'gone', node: undefined });
+    expect(result.hasError).toBe(false);
+  });
+
+  it('sets hasError when a model fails to download/verify', async () => {
+    mockEnsureModels.mockResolvedValue({
+      targetDir: '/tmp/models',
+      downloaded: [],
+      present: [],
+      failed: [{ name: 'm1', error: 'checksum mismatch' }],
+    });
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+    expect(result.hasError).toBe(true);
+    expect(result.models?.failed).toEqual([{ name: 'm1', error: 'checksum mismatch' }]);
+  });
+
+  it('does NOT set hasError when the model manifest fetch itself throws (warning only)', async () => {
+    const api = { getModelManifest: jest.fn(async () => { throw new Error('manifest down'); }) };
+
+    const result = await runNodeDoctorSweep(api as never, { nodeId: undefined, node: undefined });
+    expect(result.hasError).toBe(false);
+    expect(result.models?.error).toBe('manifest down');
+  });
+
+  it('never sets hasError from daemon liveness (informational only)', async () => {
+    mockCheckDaemonLiveness.mockResolvedValue({
+      running: false,
+      stalePidfile: true,
+      pidInfo: { pid: 999_999_999, startedAt: new Date().toISOString(), socketPath: '/tmp/x.sock' },
+      snapshot: null,
+      detail: 'stale pidfile found',
+    });
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+    expect(result.hasError).toBe(false);
+    expect(result.daemon?.stalePidfile).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Never-throws error isolation
+// ---------------------------------------------------------------------------
+
+describe('runNodeDoctorSweep — never throws, degrades per step', () => {
+  it('degrades gracefully when runApiAccessChecks rejects, and still completes the remaining steps', async () => {
+    mockRunApiAccessChecks.mockRejectedValue(new Error('network unreachable'));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.done).toBe(true);
+    expect(result.hasError).toBe(true);
+    expect(result.apiAccess?.authOk).toBe(false);
+    expect(result.apiAccess?.authDetail).toMatch(/network unreachable/);
+    // The sweep continued past the failure — every later step still ran.
+    expect(result.caps).not.toBeNull();
+    expect(result.operationalCaps).not.toBeNull();
+    expect(result.jobReadiness).not.toBeNull();
+    expect(result.models).not.toBeNull();
+    expect(result.daemon).not.toBeNull();
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+
+  it('degrades gracefully when detectCapabilities rejects', async () => {
+    mockDetectCapabilities.mockRejectedValue(new Error('probe crashed'));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.done).toBe(true);
+    expect(result.caps).toBeTruthy();
+    expect(result.caps?.['_error']?.available).toBe(false);
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+
+  it('degrades gracefully when runOperationalSelfTests rejects', async () => {
+    mockRunOperationalSelfTests.mockRejectedValue(new Error('self-test harness crashed'));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.done).toBe(true);
+    // Falls back to the presence-only caps snapshot when the self-test step itself throws.
+    expect(result.operationalCaps).toEqual(
+      expect.objectContaining({ sharp: { available: true, detail: 'sharp' } }),
+    );
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+
+  it('degrades gracefully when checkDaemonLiveness rejects', async () => {
+    mockCheckDaemonLiveness.mockRejectedValue(new Error('ipc probe crashed'));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.done).toBe(true);
+    expect(result.daemon?.running).toBe(false);
+    expect(result.daemon?.detail).toMatch(/ipc probe crashed/);
+    expect(result.hasError).toBe(false);
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+
+  it('degrades gracefully when ensureModels rejects', async () => {
+    mockEnsureModels.mockRejectedValue(new Error('download failed mid-stream'));
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.done).toBe(true);
+    expect(result.models?.error).toMatch(/download failed mid-stream/);
+    expect(result.hasError).toBe(false);
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+});

--- a/apps/cli/test/tui/node-logs.spec.tsx
+++ b/apps/cli/test/tui/node-logs.spec.tsx
@@ -1,0 +1,248 @@
+/**
+ * test/tui/node-logs.spec.tsx
+ *
+ * Tests for NodeLogs.tsx:
+ *   - parseLogLine: pure JSONL-line → renderable-row parsing (no Ink needed).
+ *   - Component-level smoke tests using a real temp log directory (via the
+ *     `dir` prop) with the actual node/logger.ts read/follow helpers, so we
+ *     exercise the same code path the real screen uses — no daemon/network
+ *     required.
+ *
+ * Note on async rendering: Ink re-renders asynchronously in response to
+ * setState calls (including the mount-time useEffect that starts followLog
+ * and the fs.watch-driven append). We wait a tick with a short setTimeout so
+ * React/Ink can flush state updates before asserting, matching the pattern
+ * used throughout test/tui/*.spec.tsx.
+ */
+
+import { jest } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+
+import {
+  NodeLogs,
+  parseLogLine,
+  DEFAULT_TAIL_SIZE,
+  MIN_TAIL_SIZE,
+  MAX_TAIL_SIZE,
+} from '../../src/tui/NodeLogs.js';
+import { NODE_LOG_FILENAME } from '../../src/node/logger.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function flushAsync(ms = 50): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mh-node-logs-tui-'));
+}
+
+function writeLine(dir: string, obj: Record<string, unknown>): void {
+  fs.appendFileSync(path.join(dir, NODE_LOG_FILENAME), JSON.stringify(obj) + '\n');
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// parseLogLine (pure)
+// ---------------------------------------------------------------------------
+
+describe('parseLogLine', () => {
+  it('renders a plain info message with a formatted time', () => {
+    const parsed = parseLogLine(JSON.stringify({ ts: '2026-07-10T12:00:00.000Z', level: 'info', msg: 'hello' }));
+    expect(parsed.level).toBe('info');
+    expect(parsed.text).toBe('hello');
+    expect(parsed.time).not.toBeNull();
+    expect(parsed.malformed).toBe(false);
+  });
+
+  it('defaults to level info when the field is missing or unrecognized', () => {
+    expect(parseLogLine(JSON.stringify({ msg: 'no level' })).level).toBe('info');
+    expect(parseLogLine(JSON.stringify({ level: 'bogus', msg: 'x' })).level).toBe('info');
+  });
+
+  it('passes through error, warn, and debug levels', () => {
+    expect(parseLogLine(JSON.stringify({ level: 'error', msg: 'boom' })).level).toBe('error');
+    expect(parseLogLine(JSON.stringify({ level: 'warn', msg: 'careful' })).level).toBe('warn');
+    expect(parseLogLine(JSON.stringify({ level: 'debug', msg: 'trace' })).level).toBe('debug');
+  });
+
+  it('renders an event name in brackets when both ev and msg are present', () => {
+    const parsed = parseLogLine(JSON.stringify({ ev: 'job.start', msg: 'starting job', level: 'info' }));
+    expect(parsed.text).toBe('[job.start] starting job');
+  });
+
+  it('falls back to the event name alone when msg is absent', () => {
+    const parsed = parseLogLine(JSON.stringify({ ev: 'heartbeat.ok', level: 'info' }));
+    expect(parsed.text).toBe('heartbeat.ok');
+  });
+
+  it('appends extra payload fields as key=value pairs', () => {
+    const parsed = parseLogLine(
+      JSON.stringify({ ev: 'job.start', jobId: 'abc123', type: 'face_detection', level: 'info' }),
+    );
+    expect(parsed.text).toContain('job.start');
+    expect(parsed.text).toContain('jobId=abc123');
+    expect(parsed.text).toContain('type=face_detection');
+  });
+
+  it('renders "(no message)" when there is neither msg nor ev', () => {
+    const parsed = parseLogLine(JSON.stringify({ level: 'info', foo: 'bar' }));
+    expect(parsed.text).toContain('(no message)');
+    expect(parsed.text).toContain('foo=bar');
+  });
+
+  it('serializes object-valued extra fields as compact JSON', () => {
+    const parsed = parseLogLine(JSON.stringify({ msg: 'payload', nested: { a: 1, b: 'two' } }));
+    expect(parsed.text).toContain('nested={"a":1,"b":"two"}');
+  });
+
+  it('falls back to raw text and malformed:true for invalid JSON', () => {
+    const parsed = parseLogLine('not json at all {');
+    expect(parsed.malformed).toBe(true);
+    expect(parsed.level).toBe('info');
+    expect(parsed.text).toBe('not json at all {');
+  });
+
+  it('falls back to raw text for valid-JSON-but-non-object values (e.g. an array or number)', () => {
+    expect(parseLogLine('[1,2,3]').malformed).toBe(true);
+    expect(parseLogLine('42').malformed).toBe(true);
+  });
+
+  it('returns null time for a missing or unparseable ts field', () => {
+    expect(parseLogLine(JSON.stringify({ msg: 'x' })).time).toBeNull();
+    expect(parseLogLine(JSON.stringify({ ts: 'not-a-date', msg: 'x' })).time).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component smoke tests (real temp log dir, real logger.ts helpers)
+// ---------------------------------------------------------------------------
+
+describe('NodeLogs component', () => {
+  it('shows the exact "No log lines yet" message (matching the CLI) when the log is empty', () => {
+    const dir = mkTmpDir();
+    const { lastFrame, unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('No log lines yet');
+    expect(plain).toContain(path.join(dir, NODE_LOG_FILENAME));
+    unmount();
+  });
+
+  it('renders pre-existing lines on mount via readLastLines', () => {
+    const dir = mkTmpDir();
+    writeLine(dir, { ts: new Date().toISOString(), level: 'info', msg: 'first line' });
+    writeLine(dir, { ts: new Date().toISOString(), level: 'error', msg: 'second line failed' });
+
+    const { lastFrame, unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('first line');
+    expect(plain).toContain('second line failed');
+    unmount();
+  });
+
+  it('live-tails newly appended lines via followLog', async () => {
+    const dir = mkTmpDir();
+    writeLine(dir, { ts: new Date().toISOString(), level: 'info', msg: 'initial' });
+
+    const { lastFrame, unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+    await flushAsync();
+
+    writeLine(dir, { ts: new Date().toISOString(), level: 'warn', msg: 'appended later' });
+    // fs.watch delivery + the follow drain loop are async; give it a beat.
+    await flushAsync(300);
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('appended later');
+    unmount();
+  });
+
+  it('stops following on unmount (no leaked fs.watch handle / no crash on late writes)', async () => {
+    const dir = mkTmpDir();
+    const { unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+    await flushAsync();
+    unmount();
+    // A write after unmount must not throw synchronously or asynchronously.
+    expect(() => writeLine(dir, { level: 'info', msg: 'after unmount' })).not.toThrow();
+    await flushAsync(200);
+  });
+
+  it('calls onBack on q and Escape', async () => {
+    const dir = mkTmpDir();
+    const onBack = jest.fn();
+    const { stdin, unmount } = render(<NodeLogs onBack={onBack} dir={dir} />);
+    stdin.write('q');
+    await flushAsync();
+    expect(onBack).toHaveBeenCalledTimes(1);
+    stdin.write('\x1B');
+    await flushAsync();
+    expect(onBack).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('clears the visible pane on "c" without touching the file', async () => {
+    const dir = mkTmpDir();
+    writeLine(dir, { level: 'info', msg: 'will be hidden' });
+    const { lastFrame, stdin, unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+    expect(stripAnsi(lastFrame()!)).toContain('will be hidden');
+
+    stdin.write('c');
+    await flushAsync();
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).not.toContain('will be hidden');
+    expect(plain).toContain('No log lines yet');
+
+    // File on disk is untouched.
+    const onDisk = fs.readFileSync(path.join(dir, NODE_LOG_FILENAME), 'utf-8');
+    expect(onDisk).toContain('will be hidden');
+    unmount();
+  });
+
+  it('adjusts the tail-size window with + and - and shows it in the header', async () => {
+    const dir = mkTmpDir();
+    const { lastFrame, stdin, unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+    expect(stripAnsi(lastFrame()!)).toContain(`tail: ${DEFAULT_TAIL_SIZE} lines`);
+
+    stdin.write('+');
+    await flushAsync();
+    expect(stripAnsi(lastFrame()!)).toContain(`tail: ${DEFAULT_TAIL_SIZE + 10} lines`);
+
+    stdin.write('-');
+    await flushAsync();
+    stdin.write('-');
+    await flushAsync();
+    expect(stripAnsi(lastFrame()!)).toContain(`tail: ${DEFAULT_TAIL_SIZE - 10} lines`);
+    unmount();
+  });
+
+  it('clamps tail size to [MIN_TAIL_SIZE, MAX_TAIL_SIZE]', async () => {
+    const dir = mkTmpDir();
+    const { lastFrame, stdin, unmount } = render(<NodeLogs onBack={() => {}} dir={dir} />);
+
+    for (let i = 0; i < 20; i++) {
+      stdin.write('-');
+      await flushAsync(10);
+    }
+    expect(stripAnsi(lastFrame()!)).toContain(`tail: ${MIN_TAIL_SIZE} lines`);
+
+    for (let i = 0; i < 80; i++) {
+      stdin.write('+');
+      await flushAsync(10);
+    }
+    expect(stripAnsi(lastFrame()!)).toContain(`tail: ${MAX_TAIL_SIZE} lines`);
+    unmount();
+  });
+});

--- a/apps/cli/test/tui/node-service.spec.tsx
+++ b/apps/cli/test/tui/node-service.spec.tsx
@@ -1,0 +1,351 @@
+/**
+ * test/tui/node-service.spec.tsx
+ *
+ * Tests for NodeService.tsx (install/uninstall/status of the systemd user
+ * unit), with `node:child_process`'s spawnSync MOCKED throughout — the real
+ * `systemctl` binary is never invoked during this test run. `node:os`'s
+ * `homedir`/`platform` are also mocked (same pattern as
+ * test/node/doctor-checks.spec.ts) so any real filesystem writes the action
+ * handlers perform (unit-file write/unlink) land under a throwaway temp
+ * directory instead of the real `~/.config/systemd/user/`.
+ *
+ * Mock modules must be registered with jest.unstable_mockModule BEFORE the
+ * module under test is imported, so both are dynamically imported via
+ * `await import(...)` at module scope (ESM + ts-jest convention used
+ * elsewhere in this test suite).
+ */
+
+import { jest } from '@jest/globals';
+import * as fs from 'fs';
+import * as osActual from 'os';
+import * as path from 'path';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+
+// ---------------------------------------------------------------------------
+// Mocks (registered before importing the module under test)
+// ---------------------------------------------------------------------------
+
+interface SpawnSyncReturn {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+const spawnSyncMock = jest.fn<(...args: unknown[]) => SpawnSyncReturn>();
+
+jest.unstable_mockModule('node:child_process', () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+let fakeHome = '';
+let fakePlatform: string | null = null;
+
+jest.unstable_mockModule('node:os', () => ({
+  ...osActual,
+  homedir: jest.fn(() => (fakeHome !== '' ? fakeHome : osActual.homedir())),
+  platform: jest.fn(() => fakePlatform ?? osActual.platform()),
+}));
+
+const {
+  NodeService,
+  hasUserSystemd,
+  runSystemctlUser,
+  runInstall,
+  runUninstall,
+  runStatus,
+  unitFileContent,
+  systemdUserDir,
+  SERVICE_UNIT,
+} = await import('../../src/tui/NodeService.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function flushAsync(ms = 50): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function ok(stdout = '', stderr = ''): SpawnSyncReturn {
+  return { status: 0, stdout, stderr };
+}
+
+function fail(status = 1, stdout = '', stderr = ''): SpawnSyncReturn {
+  return { status, stdout, stderr };
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  fakeHome = fs.mkdtempSync(path.join(osActual.tmpdir(), 'mh-node-service-'));
+  fakePlatform = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// hasUserSystemd / runSystemctlUser
+// ---------------------------------------------------------------------------
+
+describe('hasUserSystemd', () => {
+  it('returns true when `systemctl --user show-environment` exits 0', () => {
+    spawnSyncMock.mockReturnValueOnce(ok('VAR=1\n'));
+    expect(hasUserSystemd()).toBe(true);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'systemctl',
+      ['--user', 'show-environment'],
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
+  });
+
+  it('returns false when the probe exits non-zero', () => {
+    spawnSyncMock.mockReturnValueOnce(fail(1));
+    expect(hasUserSystemd()).toBe(false);
+  });
+
+  it('returns false when spawnSync throws (e.g. systemctl not on PATH)', () => {
+    spawnSyncMock.mockImplementationOnce(() => {
+      throw new Error('ENOENT');
+    });
+    expect(hasUserSystemd()).toBe(false);
+  });
+});
+
+describe('runSystemctlUser', () => {
+  it('captures stdout/stderr/status instead of inheriting the terminal', () => {
+    spawnSyncMock.mockReturnValueOnce(ok('active (running)\n', ''));
+    const res = runSystemctlUser(['status', SERVICE_UNIT, '--no-pager']);
+    expect(res).toEqual({ status: 0, stdout: 'active (running)\n', stderr: '' });
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'systemctl',
+      ['--user', 'status', SERVICE_UNIT, '--no-pager'],
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
+  });
+
+  it('normalizes a thrown error into a null-status result rather than throwing', () => {
+    spawnSyncMock.mockImplementationOnce(() => {
+      throw new Error('spawn failure');
+    });
+    const res = runSystemctlUser(['daemon-reload']);
+    expect(res.status).toBeNull();
+    expect(res.stderr).toContain('spawn failure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runInstall
+// ---------------------------------------------------------------------------
+
+describe('runInstall', () => {
+  it('short-circuits on win32 without ever probing systemd', () => {
+    fakePlatform = 'win32';
+    const report = runInstall();
+    expect(report.ok).toBe(false);
+    expect(report.lines.some((l) => l.text.includes('Windows'))).toBe(true);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('reports "no user systemd" guidance when the probe fails', () => {
+    spawnSyncMock.mockReturnValueOnce(fail(1)); // show-environment
+    const report = runInstall();
+    expect(report.ok).toBe(false);
+    expect(report.lines.some((l) => l.text.includes('No per-user systemd instance'))).toBe(true);
+  });
+
+  it('writes the unit file and runs daemon-reload + enable --now on the happy path', () => {
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment (hasUserSystemd)
+      .mockReturnValueOnce(ok('')) // daemon-reload
+      .mockReturnValueOnce(ok('Created symlink ...\n')); // enable --now
+
+    const report = runInstall();
+
+    expect(report.ok).toBe(true);
+    expect(report.lines.some((l) => l.text.includes('Wrote'))).toBe(true);
+    expect(report.lines.some((l) => l.text.includes('Service enabled and started.'))).toBe(true);
+
+    const unitPath = path.join(systemdUserDir(), SERVICE_UNIT);
+    expect(fs.existsSync(unitPath)).toBe(true);
+    expect(fs.readFileSync(unitPath, 'utf-8')).toBe(unitFileContent());
+
+    // 3 systemctl calls total: probe, daemon-reload, enable --now.
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'systemctl',
+      ['--user', 'daemon-reload'],
+      expect.anything(),
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      3,
+      'systemctl',
+      ['--user', 'enable', '--now', SERVICE_UNIT],
+      expect.anything(),
+    );
+  });
+
+  it('stops after daemon-reload fails and never calls enable --now', () => {
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment
+      .mockReturnValueOnce(fail(1, '', 'reload failed')); // daemon-reload
+
+    const report = runInstall();
+    expect(report.ok).toBe(false);
+    expect(report.lines.some((l) => l.text.includes('reload failed'))).toBe(true);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runUninstall
+// ---------------------------------------------------------------------------
+
+describe('runUninstall', () => {
+  it('reports "no user systemd" guidance when the probe fails', () => {
+    spawnSyncMock.mockReturnValueOnce(fail(1));
+    const report = runUninstall();
+    expect(report.ok).toBe(false);
+    expect(report.lines.some((l) => l.text.includes('No per-user systemd instance'))).toBe(true);
+  });
+
+  it('removes an existing unit file and reports success', () => {
+    const dir = systemdUserDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const unitPath = path.join(dir, SERVICE_UNIT);
+    fs.writeFileSync(unitPath, unitFileContent());
+
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment (hasUserSystemd)
+      .mockReturnValueOnce(ok()) // disable --now
+      .mockReturnValueOnce(ok()); // daemon-reload
+
+    const report = runUninstall();
+    expect(report.ok).toBe(true);
+    expect(fs.existsSync(unitPath)).toBe(false);
+    expect(report.lines.some((l) => l.text.includes('Removed'))).toBe(true);
+    expect(report.lines.some((l) => l.text.includes('Service uninstalled.'))).toBe(true);
+  });
+
+  it('is best-effort about disable failing and about a missing unit file', () => {
+    // No unit file was ever created in this fakeHome.
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment (hasUserSystemd)
+      .mockReturnValueOnce(fail(5, '', 'Unit not loaded.')) // disable --now (best-effort)
+      .mockReturnValueOnce(ok()); // daemon-reload still runs and succeeds
+
+    const report = runUninstall();
+    expect(report.ok).toBe(true);
+    expect(report.lines.some((l) => l.text.includes('Unit file not present'))).toBe(true);
+  });
+
+  it('propagates a daemon-reload failure as ok:false', () => {
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment (hasUserSystemd)
+      .mockReturnValueOnce(ok()) // disable --now
+      .mockReturnValueOnce(fail(1, '', 'reload broke')); // daemon-reload
+
+    const report = runUninstall();
+    expect(report.ok).toBe(false);
+    expect(report.lines.some((l) => l.text.includes('reload broke'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStatus
+// ---------------------------------------------------------------------------
+
+describe('runStatus', () => {
+  it('reports "no user systemd" guidance when the probe fails', () => {
+    spawnSyncMock.mockReturnValueOnce(fail(1));
+    const report = runStatus();
+    expect(report.ok).toBe(false);
+  });
+
+  it('treats a non-zero exit (inactive unit) as a normal result, not a failure', () => {
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment probe
+      .mockReturnValueOnce(fail(3, '○ memoriahub-node.service - MemoriaHub worker node\n   Active: inactive (dead)\n'));
+
+    const report = runStatus();
+    expect(report.ok).toBe(true); // status is never a hard failure (mirrors the CLI comment)
+    expect(report.lines.some((l) => l.text.includes('inactive (dead)'))).toBe(true);
+    expect(report.lines.some((l) => l.text.includes('exit 3'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component: NodeService (Ink render + key handling)
+// ---------------------------------------------------------------------------
+
+describe('NodeService component', () => {
+  it('renders the action menu on mount', () => {
+    const { lastFrame, unmount } = render(<NodeService onBack={() => {}} />);
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('Worker Node — Service');
+    expect(plain).toContain('[i] install');
+    expect(plain).toContain('[u] uninstall');
+    expect(plain).toContain('[s] status');
+    unmount();
+  });
+
+  it('calls onBack from the menu on q', () => {
+    const onBack = jest.fn();
+    const { stdin, unmount } = render(<NodeService onBack={onBack} />);
+    stdin.write('q');
+    expect(onBack).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('runs install via "i" and renders the captured output without touching the real terminal', async () => {
+    spawnSyncMock
+      .mockReturnValueOnce(ok()) // show-environment
+      .mockReturnValueOnce(ok()) // daemon-reload
+      .mockReturnValueOnce(ok('Created symlink ...\n')); // enable --now
+
+    const { lastFrame, stdin, unmount } = render(<NodeService onBack={() => {}} />);
+    stdin.write('i');
+    await flushAsync(100);
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('Install');
+    expect(plain).toContain('Service enabled and started.');
+    unmount();
+  });
+
+  it('runs status via "s" and renders inactive-unit output as a non-error', async () => {
+    spawnSyncMock
+      .mockReturnValueOnce(ok())
+      .mockReturnValueOnce(fail(3, 'Active: inactive (dead)\n'));
+
+    const { lastFrame, stdin, unmount } = render(<NodeService onBack={() => {}} />);
+    stdin.write('s');
+    await flushAsync(100);
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('Active: inactive (dead)');
+    unmount();
+  });
+
+  it('returns to the menu on "b" from the result screen', async () => {
+    spawnSyncMock.mockReturnValueOnce(fail(1)); // no user systemd -> fast, deterministic result
+
+    const { lastFrame, stdin, unmount } = render(<NodeService onBack={() => {}} />);
+    stdin.write('u');
+    await flushAsync(100);
+    expect(stripAnsi(lastFrame()!)).toContain('Uninstall');
+
+    stdin.write('b');
+    await flushAsync();
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('[i] install');
+    unmount();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",
@@ -8841,7 +8841,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16956,7 +16956,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -19822,7 +19822,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
## Summary
- Fixes the TUI's node doctor overlay, which previously only checked presence of capabilities instead of running the same operational self-test sweep (`node doctor` on the CLI) — now runs the real 6-step sweep (API access, installed capabilities, operational self-tests, job-type readiness, models, daemon state).
- Adds four screens that previously had no TUI entry point at all: node register (registration wizard), node list, node logs (live tail), and node service (systemd install/uninstall/status).
- Wires all five screens into `Tools ▸ Worker Node` in the interactive menu.
- Bumps `apps/cli` to 1.1.31 per the mandatory CLI versioning rule.

## Test plan
- [x] `npm run typecheck --workspace=@memoriahub/cli` — clean
- [x] `npm run build --workspace=@memoriahub/enrichment-compute` + `npm run build --workspace=@memoriahub/cli` — clean
- [x] Full CLI test suite (934 tests): only the 4 pre-existing, unrelated failing suites remain (db/migrations, migration-v6, sync-engine-date-range, scan-export); fixed one stale test (`menu-config.spec.ts`) that never accounted for the "Worker Node" submenu added in an earlier commit
- [x] 54 new tests added across doctor sweep, logs, and service screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198UdgN5sQVABzcDJ9vvrqy