### PR TITLE
feat(cli): register + start worker node from the terminal UI

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/node.ts
+++ b/apps/cli/src/commands/node.ts
@@ -57,6 +57,7 @@ import {
 } from '../node/logger.js';
 import { startDaemonHost, readPidFile, isPidAlive } from '../node/daemon.js';
 import { connectToDaemon, isDaemonRunning, type DaemonMessage } from '../node/ipc-client.js';
+import { checkNodeAlreadyRunning } from '../node/daemon-launch.js';
 
 const require = createRequire(import.meta.url);
 
@@ -241,15 +242,15 @@ function startCmd(): Command {
         }
 
         // Refuse a second instance up front (pidfile OR live IPC socket).
-        const pidInfo = readPidFile(nodePidPath());
-        if (pidInfo && isPidAlive(pidInfo.pid)) {
+        const alreadyRunning = await checkNodeAlreadyRunning();
+        if (alreadyRunning.running && alreadyRunning.via === 'pidfile') {
           ui.error(
-            `A worker node is already running (pid ${pidInfo.pid}). ` +
+            `A worker node is already running (pid ${alreadyRunning.pid}). ` +
               'Use `memoriahub node status` or `memoriahub node stop`.',
           );
           process.exit(1);
         }
-        if (await isDaemonRunning()) {
+        if (alreadyRunning.running && alreadyRunning.via === 'ipc') {
           ui.error(
             'A worker node is already running (IPC socket is live). ' +
               'Use `memoriahub node status` or `memoriahub node stop`.',

--- a/apps/cli/src/node/daemon-launch.ts
+++ b/apps/cli/src/node/daemon-launch.ts
@@ -1,0 +1,126 @@
+/**
+ * node/daemon-launch.ts — Parameterized daemon launcher.
+ *
+ * `node start --daemon` (see commands/node.ts's `startCmd()`) re-spawns the
+ * CLI itself by forwarding `process.argv` verbatim minus the `--daemon` flag.
+ * That trick only works when the current process really was invoked as
+ * `memoriahub node start --daemon` — it breaks for any other entry point
+ * (e.g. a TUI screen invoked via a different argv) that wants to launch a
+ * detached worker-node daemon programmatically.
+ *
+ * This module is the argv-independent counterpart: it builds the `node
+ * start` argument list explicitly from parameters instead of forwarding
+ * `process.argv`, so callers like a future TUI "start as daemon" screen can
+ * spawn a daemon without depending on how they themselves were invoked.
+ *
+ * Deliberately separate from `daemon.ts` (the IPC *host* side — pidfile +
+ * socket server for an already-running engine) — this file is only about
+ * launching a new detached process and checking/waiting for one to come up.
+ */
+
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { logsDir } from '../paths.js';
+import { nodeLogPath } from './logger.js';
+import { readPidFile, isPidAlive } from './daemon.js';
+import { isDaemonRunning } from './ipc-client.js';
+
+export interface SpawnDaemonOptions {
+  /** Forwarded as `--concurrency <n>` when set. */
+  concurrency?: number;
+  /** Forwarded as `--types <csv>` when set (comma-joined). */
+  types?: string[];
+  /** Forwarded as `--poll <ms>` when set. */
+  poll?: number;
+}
+
+export interface SpawnedDaemonResult {
+  /** PID of the detached daemon process. */
+  pid: number;
+  /** Path of the redirected stdout/stderr file (process-level output). */
+  outPath: string;
+  /** Path of the structured JSONL worker-node log. */
+  logPath: string;
+}
+
+/**
+ * Spawn `memoriahub node start` as a detached background process, mirroring
+ * the `--daemon` branch of `startCmd()` in commands/node.ts but building its
+ * argv explicitly from `opts` instead of forwarding `process.argv` — safe to
+ * call from any entry point (e.g. a TUI screen), not just `node start
+ * --daemon` itself.
+ */
+export function spawnNodeStartDaemon(opts: SpawnDaemonOptions = {}): SpawnedDaemonResult {
+  const outPath = path.join(logsDir(), 'node.out.log');
+  const logFd = fs.openSync(outPath, 'a');
+
+  const args = ['node', 'start'];
+  if (opts.concurrency !== undefined) {
+    args.push('--concurrency', String(opts.concurrency));
+  }
+  if (opts.types !== undefined) {
+    args.push('--types', opts.types.join(','));
+  }
+  if (opts.poll !== undefined) {
+    args.push('--poll', String(opts.poll));
+  }
+
+  const child = spawn(process.execPath, [process.argv[1], ...args], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+  });
+  child.unref();
+  fs.closeSync(logFd);
+
+  return { pid: child.pid!, outPath, logPath: nodeLogPath() };
+}
+
+export interface AlreadyRunningCheck {
+  running: boolean;
+  pid?: number;
+  via?: 'pidfile' | 'ipc';
+}
+
+/**
+ * Check whether a worker-node daemon is already running, via the same
+ * pidfile-then-IPC guard `startCmd()` runs up front — refactored out so it
+ * can be reused from a non-CLI caller (e.g. a React/Ink TUI screen) that must
+ * never print to stdout or call `process.exit`.
+ */
+export async function checkNodeAlreadyRunning(): Promise<AlreadyRunningCheck> {
+  const pidInfo = readPidFile();
+  if (pidInfo && isPidAlive(pidInfo.pid)) {
+    return { running: true, pid: pidInfo.pid, via: 'pidfile' };
+  }
+  if (await isDaemonRunning()) {
+    return { running: true, via: 'ipc' };
+  }
+  return { running: false };
+}
+
+/** Promise-based delay, used by waitForDaemonReady's polling loop. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    t.unref?.();
+  });
+}
+
+/**
+ * Poll `isDaemonRunning()` every `intervalMs` until it reports true or
+ * `timeoutMs` elapses. Used right after `spawnNodeStartDaemon()` to confirm
+ * the detached process actually came up and started hosting its IPC socket,
+ * without busy-looping.
+ */
+export async function waitForDaemonReady(
+  timeoutMs = 8000,
+  intervalMs = 300,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await isDaemonRunning()) return true;
+    if (Date.now() >= deadline) return false;
+    await delay(intervalMs);
+  }
+}

--- a/apps/cli/src/tui/NodeStart.tsx
+++ b/apps/cli/src/tui/NodeStart.tsx
@@ -1,0 +1,447 @@
+/**
+ * tui/NodeStart.tsx — Ink screen that launches a real background worker-node
+ * daemon (`memoriahub node start --daemon`) from the TUI.
+ *
+ * NodeDashboard.tsx can run the engine EMBEDDED (tied to that screen's
+ * lifetime) or ATTACH to a daemon that is already running, but until now
+ * nothing in the TUI could actually START a persistent background daemon —
+ * only the shell command could. This screen wraps node/daemon-launch.ts's
+ * argv-independent spawn helper so an operator can start one from here, then
+ * hand off to the dashboard (which auto-attaches over IPC).
+ *
+ * Steps:
+ *   'checking'         — on mount, only reached when the machine IS
+ *                         registered: checkNodeAlreadyRunning() (spinner)
+ *   'not-registered'   — config.nodeId is unset; short-circuits with
+ *                         guidance to register first. Does not embed the
+ *                         registration wizard.
+ *   'already-running'  — a daemon is already up (pidfile or IPC); offers to
+ *                         jump straight to the dashboard instead of starting
+ *                         a second one
+ *   'form'             — concurrency + eligible-types confirmation, prefilled
+ *                         from config.node; concurrency mirrors NodeConfig.tsx's
+ *                         TextInput-with-validation field (typed digits) plus
+ *                         an up/down-arrow stepper in the spirit of
+ *                         NodeLogs.tsx's +/- tail-size adjuster (arrows are
+ *                         used instead of literal +/- because ink-text-input
+ *                         only no-ops on arrow keys, not on printable chars —
+ *                         see the in-line comment on the form-step handler);
+ *                         eligible types reuse NodeConfig.tsx's checkbox-list
+ *                         (↑/↓ move, space toggle)
+ *   'starting'         — spawnNodeStartDaemon() + waitForDaemonReady() (spinner)
+ *   'success'          — daemon confirmed ready; mirrors NodeRegister.tsx's
+ *                         'success' step (Enter/Esc/q proceeds)
+ *   'timeout'          — spawned but readiness wasn't confirmed in time;
+ *                         offers to open the dashboard anyway or go back
+ *   'error'            — spawnNodeStartDaemon() threw synchronously
+ */
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import TextInput from 'ink-text-input';
+
+import type { CliConfig } from '../config.js';
+import { NODE_JOB_TYPES } from '../node/capabilities.js';
+import {
+  spawnNodeStartDaemon,
+  checkNodeAlreadyRunning,
+  waitForDaemonReady,
+  type AlreadyRunningCheck,
+  type SpawnedDaemonResult,
+} from '../node/daemon-launch.js';
+import { BOX_BORDER } from './theme.js';
+
+// ---------------------------------------------------------------------------
+// Defaults (mirror commands/node.ts / NodeConfig.tsx)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONCURRENCY = 1;
+const MIN_CONCURRENCY = 1;
+const MAX_CONCURRENCY = 64;
+
+// ---------------------------------------------------------------------------
+// Props + local types
+// ---------------------------------------------------------------------------
+
+export interface NodeStartProps {
+  config: CliConfig;
+  /** Called once the daemon is confirmed running — caller should navigate to the dashboard (which auto-attaches). */
+  onStarted: () => void;
+  onBack: () => void;
+}
+
+type Step =
+  | 'checking'
+  | 'not-registered'
+  | 'already-running'
+  | 'form'
+  | 'starting'
+  | 'success'
+  | 'timeout'
+  | 'error';
+
+type FormFocus = 'concurrency' | 'types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function initialConcurrency(config: CliConfig): number {
+  return Math.max(MIN_CONCURRENCY, config.node?.concurrency ?? DEFAULT_CONCURRENCY);
+}
+
+function initialTypes(config: CliConfig): string[] {
+  return config.node?.eligibleTypes && config.node.eligibleTypes.length > 0
+    ? config.node.eligibleTypes.filter((t) => (NODE_JOB_TYPES as readonly string[]).includes(t))
+    : [...NODE_JOB_TYPES];
+}
+
+// ---------------------------------------------------------------------------
+// NodeStart component
+// ---------------------------------------------------------------------------
+
+export function NodeStart({ config, onStarted, onBack }: NodeStartProps): React.ReactElement {
+  const [step, setStep] = useState<Step>(config.nodeId ? 'checking' : 'not-registered');
+  const [already, setAlready] = useState<AlreadyRunningCheck | null>(null);
+
+  const [concurrencyStr, setConcurrencyStr] = useState<string>(String(initialConcurrency(config)));
+  const [selectedTypes, setSelectedTypes] = useState<Set<string>>(new Set(initialTypes(config)));
+  const [focus, setFocus] = useState<FormFocus>('concurrency');
+  const [typeCursor, setTypeCursor] = useState<number>(0);
+  const [fieldError, setFieldError] = useState<string>('');
+
+  const [spawnResult, setSpawnResult] = useState<SpawnedDaemonResult | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  const mountedRef = useRef<boolean>(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // ---- mount-time gate: registration + already-running check ----
+  useEffect(() => {
+    if (step !== 'checking') return;
+    void checkNodeAlreadyRunning().then((res) => {
+      if (!mountedRef.current) return;
+      if (res.running) {
+        setAlready(res);
+        setStep('already-running');
+      } else {
+        setStep('form');
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- spawn the daemon + wait for readiness ----
+  const startDaemon = useCallback((concurrency: number, types: string[]): void => {
+    setStep('starting');
+    try {
+      const result = spawnNodeStartDaemon({ concurrency, types });
+      setSpawnResult(result);
+      void waitForDaemonReady().then((ready) => {
+        if (!mountedRef.current) return;
+        setStep(ready ? 'success' : 'timeout');
+      });
+    } catch (err) {
+      setErrorMsg(`Failed to start worker daemon: ${err instanceof Error ? err.message : String(err)}`);
+      setStep('error');
+    }
+  }, []);
+
+  // ---- concurrency validation + adjustment ----
+  const validateConcurrency = useCallback((): number | null => {
+    const trimmed = concurrencyStr.trim();
+    const n = parseInt(trimmed, 10);
+    if (isNaN(n) || n < MIN_CONCURRENCY || n > MAX_CONCURRENCY || String(n) !== trimmed) {
+      setFieldError(
+        `Concurrency must be an integer between ${MIN_CONCURRENCY} and ${MAX_CONCURRENCY} (got "${trimmed}").`,
+      );
+      return null;
+    }
+    return n;
+  }, [concurrencyStr]);
+
+  const adjustConcurrency = useCallback((delta: number): void => {
+    setFieldError('');
+    setConcurrencyStr((prev) => {
+      const n = parseInt(prev, 10);
+      const base = isNaN(n) ? DEFAULT_CONCURRENCY : n;
+      return String(Math.min(MAX_CONCURRENCY, Math.max(MIN_CONCURRENCY, base + delta)));
+    });
+  }, []);
+
+  const advanceFromConcurrency = useCallback((): void => {
+    if (validateConcurrency() === null) return;
+    setFieldError('');
+    setFocus('types');
+  }, [validateConcurrency]);
+
+  const submitForm = useCallback((): void => {
+    const n = validateConcurrency();
+    if (n === null) {
+      setFocus('concurrency');
+      return;
+    }
+    if (selectedTypes.size === 0) {
+      setFieldError('Select at least one job type (space to toggle).');
+      return;
+    }
+    setFieldError('');
+    const ordered = NODE_JOB_TYPES.filter((t) => selectedTypes.has(t));
+    startDaemon(n, [...ordered]);
+  }, [validateConcurrency, selectedTypes, startDaemon]);
+
+  // ---- not-registered step ----
+  useInput((input, key) => {
+    if (step !== 'not-registered') return;
+    if (key.return || input === 'b' || key.escape || input === 'q') onBack();
+  });
+
+  // ---- already-running step ----
+  useInput((input, key) => {
+    if (step !== 'already-running') return;
+    if (key.return) {
+      onStarted();
+      return;
+    }
+    if (input === 'b' || key.escape || input === 'q') onBack();
+  });
+
+  // ---- form step ----
+  useInput((input, key) => {
+    if (step !== 'form') return;
+    if (key.escape || input === 'b') {
+      onBack();
+      return;
+    }
+    if (key.tab) {
+      setFieldError('');
+      setFocus((f) => (f === 'concurrency' ? 'types' : 'concurrency'));
+      return;
+    }
+    if (focus === 'concurrency') {
+      // ink-text-input's own useInput no-ops on upArrow/downArrow/tab (it only
+      // consumes left/right/backspace/delete/printable chars/return), so it's
+      // safe to use the arrow keys here for a NodeLogs.tsx-style +/- stepper
+      // without fighting the focused TextInput over the keystroke. Printable
+      // '+'/'-' are deliberately NOT bound here — those chars ARE consumed by
+      // TextInput (inserted into the value), which would race this handler.
+      if (key.upArrow) {
+        adjustConcurrency(1);
+        return;
+      }
+      if (key.downArrow) {
+        adjustConcurrency(-1);
+        return;
+      }
+      return;
+    }
+    // focus === 'types'
+    if (key.upArrow) {
+      setTypeCursor((c) => (c - 1 + NODE_JOB_TYPES.length) % NODE_JOB_TYPES.length);
+      return;
+    }
+    if (key.downArrow) {
+      setTypeCursor((c) => (c + 1) % NODE_JOB_TYPES.length);
+      return;
+    }
+    if (input === ' ') {
+      setFieldError('');
+      setSelectedTypes((prev) => {
+        const next = new Set(prev);
+        const t = NODE_JOB_TYPES[typeCursor];
+        if (next.has(t)) next.delete(t);
+        else next.add(t);
+        return next;
+      });
+      return;
+    }
+    if (key.return) {
+      submitForm();
+    }
+  });
+
+  // ---- success step (mirrors NodeRegister's success step) ----
+  useInput((input, key) => {
+    if (step !== 'success') return;
+    if (key.return || input === 'q' || key.escape) onStarted();
+  });
+
+  // ---- timeout step ----
+  useInput((input, key) => {
+    if (step !== 'timeout') return;
+    if (key.return) {
+      onStarted();
+      return;
+    }
+    if (input === 'b' || key.escape || input === 'q') onBack();
+  });
+
+  // ---- error step ----
+  useInput((input, key) => {
+    if (step !== 'error') return;
+    if (input === 'b' || key.escape || input === 'q' || key.return) onBack();
+  });
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  if (step === 'checking') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Start</Text>
+        <Box marginTop={1}>
+          <Text color="cyan"><Spinner type="dots" /> Checking for an existing daemon…</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'not-registered') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="yellow" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="yellow">Worker Node — Start</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow">⚠ This machine is not registered as a worker node.</Text>
+          <Text dimColor>Run Register node first, then come back here to start the daemon.</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[Enter/b] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'already-running') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="yellow" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="yellow">Worker Node — Start</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow">
+            ⚠ A worker-node daemon is already running (pid {already?.pid ?? '?'}, via {already?.via ?? '?'}).
+          </Text>
+          <Text dimColor>Open the dashboard to attach to it instead of starting a second one.</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[Enter] go to dashboard   [b] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'starting') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Start</Text>
+        <Box marginTop={1}>
+          <Text color="cyan"><Spinner type="dots" /> Starting worker daemon…</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'success') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Start</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text color="green">✔ Worker daemon started (pid {spawnResult?.pid ?? '?'}).</Text>
+          <Text dimColor>Log: {spawnResult?.logPath ?? '?'}</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[Enter/Esc/q] open dashboard</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'timeout') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="yellow" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="yellow">Worker Node — Start</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow">
+            ⚠ Daemon process started (pid {spawnResult?.pid ?? '?'}) but didn't confirm readiness in time.
+          </Text>
+          <Text dimColor>Output log: {spawnResult?.outPath ?? '?'}</Text>
+          <Text dimColor>Node log: {spawnResult?.logPath ?? '?'}</Text>
+          <Text dimColor>Investigate the logs above if this persists.</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[Enter] open dashboard anyway   [b] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (step === 'error') {
+    return (
+      <Box borderStyle={BOX_BORDER} borderColor="red" flexDirection="column" paddingX={2} paddingY={1}>
+        <Text bold color="cyan">Worker Node — Start</Text>
+        <Box marginTop={1}>
+          <Text color="red">✖ {errorMsg}</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[b] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // 'form'
+  return (
+    <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
+      <Text bold color="cyan">Worker Node — Start</Text>
+      <Text dimColor>Confirm concurrency and eligible job types, then start the background daemon.</Text>
+
+      <Box flexDirection="row" gap={1} marginTop={1}>
+        <Text color={focus === 'concurrency' ? 'cyan' : undefined}>{focus === 'concurrency' ? '❯' : ' '}</Text>
+        <Text color={focus === 'concurrency' ? 'cyan' : undefined}>{'Concurrency'.padEnd(14)}</Text>
+        <TextInput
+          value={concurrencyStr}
+          onChange={setConcurrencyStr}
+          onSubmit={advanceFromConcurrency}
+          focus={focus === 'concurrency'}
+        />
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Box flexDirection="row" gap={1}>
+          <Text color={focus === 'types' ? 'cyan' : undefined}>{focus === 'types' ? '❯' : ' '}</Text>
+          <Text color={focus === 'types' ? 'cyan' : undefined}>
+            {'Eligible types'.padEnd(14)} ({selectedTypes.size}/{NODE_JOB_TYPES.length})
+          </Text>
+        </Box>
+        {NODE_JOB_TYPES.map((t, i) => {
+          const checked = selectedTypes.has(t);
+          const isCursor = focus === 'types' && i === typeCursor;
+          return (
+            <Box key={t} flexDirection="row" gap={1} marginLeft={2}>
+              <Text color={isCursor ? 'cyan' : undefined}>{isCursor ? '❯' : ' '}</Text>
+              <Text color={checked ? 'green' : undefined}>{checked ? '[x]' : '[ ]'}</Text>
+              <Text color={isCursor ? 'cyan' : undefined}>{t}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {fieldError ? (
+        <Box marginTop={1}>
+          <Text color="red">✖ {fieldError}</Text>
+        </Box>
+      ) : null}
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          [Tab] switch field  [↑/↓] adjust concurrency / move types  [space] toggle type  [Enter] confirm & start  [Esc/b] back
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -41,6 +41,7 @@ import { BackupScreen } from './BackupScreen.js';
 import { JobsDashboard } from './JobsDashboard.js';
 import { NodeDashboard } from './NodeDashboard.js';
 import { NodeConfig } from './NodeConfig.js';
+import { NodeStart } from './NodeStart.js';
 import { NodeDoctor } from './NodeDoctor.js';
 import { NodeRegister } from './NodeRegister.js';
 import { NodeList } from './NodeList.js';
@@ -80,6 +81,7 @@ type Screen =
   | { kind: 'backup' }
   | { kind: 'nodeDashboard' }
   | { kind: 'nodeConfig' }
+  | { kind: 'nodeStart' }
   | { kind: 'nodeDoctor' }
   | { kind: 'nodeRegister' }
   | { kind: 'nodeList' }
@@ -188,6 +190,11 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
     setStack((prev) => (prev.length > 1 ? prev.slice(0, -1) : prev));
   }
 
+  /** Replace the top frame in place (e.g. Start Worker → Dashboard on success). */
+  function replaceTop(frame: NavFrame): void {
+    setStack((prev) => [...prev.slice(0, -1), frame]);
+  }
+
   function resetToRoot(): void {
     setStack([{ kind: 'menu', menuId: 'root' }]);
   }
@@ -258,6 +265,9 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
         break;
       case 'node-config':
         push({ kind: 'screen', screen: { kind: 'nodeConfig' } });
+        break;
+      case 'node-start':
+        push({ kind: 'screen', screen: { kind: 'nodeStart' } });
         break;
       case 'node-doctor':
         push({ kind: 'screen', screen: { kind: 'nodeDoctor' } });
@@ -613,6 +623,24 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
         <NodeConfig
           config={config}
           onSaved={(cfg) => setAppState((prev) => ({ ...prev, config: cfg }))}
+          onBack={pop}
+        />
+      );
+
+    case 'nodeStart':
+      if (!config) {
+        return (
+          <Box paddingX={1} flexDirection="column" gap={1}>
+            <Text color="yellow">Not logged in. Please login first.</Text>
+            <Text dimColor>Press q to go back.</Text>
+            <KeyHandler onBack={pop} />
+          </Box>
+        );
+      }
+      return (
+        <NodeStart
+          config={config}
+          onStarted={() => replaceTop({ kind: 'screen', screen: { kind: 'nodeDashboard' } })}
           onBack={pop}
         />
       );

--- a/apps/cli/src/tui/menu-config.ts
+++ b/apps/cli/src/tui/menu-config.ts
@@ -32,6 +32,7 @@ export type MenuActionId =
   | 'backup'
   | 'node-dashboard'
   | 'node-config'
+  | 'node-start'
   | 'node-doctor'
   | 'node-register'
   | 'node-list'
@@ -146,6 +147,7 @@ export const MENU_TREE: MenuSubmenu = {
           children: [
             { kind: 'action', label: 'Node dashboard', action: 'node-dashboard' },
             { kind: 'action', label: 'Register node', action: 'node-register' },
+            { kind: 'action', label: 'Start worker (background)', action: 'node-start' },
             { kind: 'action', label: 'Node config', action: 'node-config' },
             { kind: 'action', label: 'List nodes', action: 'node-list' },
             { kind: 'action', label: 'Node doctor', action: 'node-doctor' },

--- a/apps/cli/test/node/daemon-launch.spec.ts
+++ b/apps/cli/test/node/daemon-launch.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * test/node/daemon-launch.spec.ts
+ *
+ * Unit tests for node/daemon-launch.ts — the argv-independent daemon
+ * launcher used by both a future TUI "start as daemon" screen and (after
+ * refactor) commands/node.ts's startCmd() up-front already-running guard.
+ *
+ * Strategy:
+ *   - `spawnNodeStartDaemon`: mock 'node:child_process' (jest.unstable_mockModule)
+ *     so no real process is spawned; assert on the constructed argv and that
+ *     `child.unref()` is called. Also mock 'os' (same pattern as
+ *     test/reset.spec.ts / test/node/doctor-checks.spec.ts) so paths.ts's
+ *     logsDir()/nodeLogPath() resolve under a throwaway temp directory
+ *     instead of the real ~/.memoriahub.
+ *   - `checkNodeAlreadyRunning`: mock './daemon.js' (readPidFile/isPidAlive)
+ *     and './ipc-client.js' (isDaemonRunning) directly — no real pidfile or
+ *     socket involved.
+ *   - `waitForDaemonReady`: mock './ipc-client.js' only; use short
+ *     timeout/interval values so the "never becomes ready" case doesn't
+ *     actually wait the real default 8s.
+ *
+ * Mock modules must be registered with jest.unstable_mockModule BEFORE the
+ * module under test is imported, so everything is dynamically imported via
+ * `await import(...)` at module scope (ESM + ts-jest convention used
+ * elsewhere in this test suite).
+ */
+
+import { jest } from '@jest/globals';
+import * as fs from 'fs';
+import * as actualOs from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Mocks (registered before importing the module under test)
+// ---------------------------------------------------------------------------
+
+interface FakeChild {
+  pid: number;
+  unref: jest.Mock;
+}
+
+const spawnMock = jest.fn<(...args: unknown[]) => FakeChild>();
+
+jest.unstable_mockModule('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+let fakeHome = '';
+
+jest.unstable_mockModule('os', () => ({
+  ...actualOs,
+  homedir: jest.fn(() => (fakeHome !== '' ? fakeHome : actualOs.homedir())),
+}));
+
+const readPidFileMock = jest.fn();
+const isPidAliveMock = jest.fn();
+
+jest.unstable_mockModule('../../src/node/daemon.js', () => ({
+  readPidFile: readPidFileMock,
+  isPidAlive: isPidAliveMock,
+}));
+
+const isDaemonRunningMock = jest.fn<() => Promise<boolean>>();
+
+jest.unstable_mockModule('../../src/node/ipc-client.js', () => ({
+  isDaemonRunning: isDaemonRunningMock,
+}));
+
+const { spawnNodeStartDaemon, checkNodeAlreadyRunning, waitForDaemonReady } = await import(
+  '../../src/node/daemon-launch.js'
+);
+const { logsDir, nodePidPath, nodeSocketPath } = await import('../../src/paths.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeChild(pid = 4242): FakeChild {
+  return { pid, unref: jest.fn() };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('spawnNodeStartDaemon', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(actualOs.tmpdir(), 'mh-daemon-launch-'));
+    fakeHome = tmpDir;
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(fakeChild());
+  });
+
+  afterEach(() => {
+    fakeHome = '';
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  it('builds argv [node, start] with no flags when no options are given', () => {
+    const result = spawnNodeStartDaemon();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [execPath, argv, opts] = spawnMock.mock.calls[0] as [string, string[], Record<string, unknown>];
+    expect(execPath).toBe(process.execPath);
+    expect(argv).toEqual([process.argv[1], 'node', 'start']);
+    expect(opts['detached']).toBe(true);
+    expect(Array.isArray(opts['stdio'])).toBe(true);
+    expect((opts['stdio'] as unknown[])[0]).toBe('ignore');
+
+    expect(result.pid).toBe(4242);
+    expect(result.outPath).toBe(path.join(logsDir(), 'node.out.log'));
+  });
+
+  it('appends --concurrency <n> when concurrency is given', () => {
+    spawnNodeStartDaemon({ concurrency: 3 });
+    const [, argv] = spawnMock.mock.calls[0] as [string, string[], unknown];
+    expect(argv).toEqual([process.argv[1], 'node', 'start', '--concurrency', '3']);
+  });
+
+  it('appends --types <csv> when types is given', () => {
+    spawnNodeStartDaemon({ types: ['auto_tagging', 'geocode'] });
+    const [, argv] = spawnMock.mock.calls[0] as [string, string[], unknown];
+    expect(argv).toEqual([process.argv[1], 'node', 'start', '--types', 'auto_tagging,geocode']);
+  });
+
+  it('appends --poll <ms> when poll is given', () => {
+    spawnNodeStartDaemon({ poll: 10000 });
+    const [, argv] = spawnMock.mock.calls[0] as [string, string[], unknown];
+    expect(argv).toEqual([process.argv[1], 'node', 'start', '--poll', '10000']);
+  });
+
+  it('appends all three flags in order when all options are given', () => {
+    spawnNodeStartDaemon({ concurrency: 2, types: ['face_detection'], poll: 5000 });
+    const [, argv] = spawnMock.mock.calls[0] as [string, string[], unknown];
+    expect(argv).toEqual([
+      process.argv[1],
+      'node',
+      'start',
+      '--concurrency',
+      '2',
+      '--types',
+      'face_detection',
+      '--poll',
+      '5000',
+    ]);
+  });
+
+  it('calls child.unref()', () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    spawnNodeStartDaemon();
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('checkNodeAlreadyRunning', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns {running:false} when neither the pidfile nor IPC show a live process', async () => {
+    readPidFileMock.mockReturnValue(null);
+    isDaemonRunningMock.mockResolvedValue(false);
+
+    const result = await checkNodeAlreadyRunning();
+
+    expect(result).toEqual({ running: false });
+  });
+
+  it("returns {running:true, via:'pidfile'} when a live pidfile exists", async () => {
+    readPidFileMock.mockReturnValue({ pid: 777, startedAt: new Date().toISOString(), socketPath: nodeSocketPath() });
+    isPidAliveMock.mockReturnValue(true);
+    isDaemonRunningMock.mockResolvedValue(false);
+
+    const result = await checkNodeAlreadyRunning();
+
+    expect(result).toEqual({ running: true, pid: 777, via: 'pidfile' });
+    // IPC is never consulted once the pidfile guard already found a live pid.
+    expect(isDaemonRunningMock).not.toHaveBeenCalled();
+  });
+
+  it("returns {running:true, via:'ipc'} when only the IPC socket is live", async () => {
+    readPidFileMock.mockReturnValue(null);
+    isDaemonRunningMock.mockResolvedValue(true);
+
+    const result = await checkNodeAlreadyRunning();
+
+    expect(result).toEqual({ running: true, via: 'ipc' });
+  });
+
+  it('falls through to the IPC check when the pidfile exists but its pid is dead', async () => {
+    readPidFileMock.mockReturnValue({ pid: 999, startedAt: new Date().toISOString(), socketPath: nodeSocketPath() });
+    isPidAliveMock.mockReturnValue(false);
+    isDaemonRunningMock.mockResolvedValue(true);
+
+    const result = await checkNodeAlreadyRunning();
+
+    expect(result).toEqual({ running: true, via: 'ipc' });
+  });
+
+  it('uses the real nodePidPath()/nodeSocketPath() helpers (sanity check paths.js import)', () => {
+    expect(typeof nodePidPath()).toBe('string');
+  });
+});
+
+describe('waitForDaemonReady', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves true quickly when isDaemonRunning already returns true', async () => {
+    isDaemonRunningMock.mockResolvedValue(true);
+
+    const start = Date.now();
+    const ready = await waitForDaemonReady(200, 50);
+    const elapsed = Date.now() - start;
+
+    expect(ready).toBe(true);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('resolves false after the timeout when isDaemonRunning never returns true', async () => {
+    isDaemonRunningMock.mockResolvedValue(false);
+
+    const ready = await waitForDaemonReady(200, 50);
+
+    expect(ready).toBe(false);
+    expect(isDaemonRunningMock.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/apps/cli/test/tui/node-start.spec.tsx
+++ b/apps/cli/test/tui/node-start.spec.tsx
@@ -1,0 +1,379 @@
+/**
+ * test/tui/node-start.spec.tsx
+ *
+ * Tests for NodeStart.tsx — the TUI screen that launches a real background
+ * worker-node daemon via node/daemon-launch.ts. That module is mocked
+ * entirely (jest.unstable_mockModule) so no real child process is spawned
+ * and no real pidfile/IPC socket is touched — mirrors the mocking style of
+ * test/tui/node-service.spec.tsx (spawnSync mocked) and
+ * test/node/daemon-launch.spec.ts (the module's own unit tests).
+ *
+ * Mock modules must be registered with jest.unstable_mockModule BEFORE the
+ * module under test is imported, so both are dynamically imported via
+ * `await import(...)` at module scope (ESM + ts-jest convention used
+ * elsewhere in this test suite).
+ */
+
+import { jest } from '@jest/globals';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+
+import type { CliConfig } from '../../src/config.js';
+
+// ---------------------------------------------------------------------------
+// Mocks (registered before importing the module under test)
+// ---------------------------------------------------------------------------
+
+interface FakeAlreadyRunning {
+  running: boolean;
+  pid?: number;
+  via?: 'pidfile' | 'ipc';
+}
+
+interface FakeSpawnResult {
+  pid: number;
+  outPath: string;
+  logPath: string;
+}
+
+const spawnNodeStartDaemonMock = jest.fn<(...args: unknown[]) => FakeSpawnResult>();
+const checkNodeAlreadyRunningMock = jest.fn<() => Promise<FakeAlreadyRunning>>();
+const waitForDaemonReadyMock = jest.fn<(...args: unknown[]) => Promise<boolean>>();
+
+jest.unstable_mockModule('../../src/node/daemon-launch.js', () => ({
+  spawnNodeStartDaemon: spawnNodeStartDaemonMock,
+  checkNodeAlreadyRunning: checkNodeAlreadyRunningMock,
+  waitForDaemonReady: waitForDaemonReadyMock,
+}));
+
+const { NodeStart } = await import('../../src/tui/NodeStart.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function flushAsync(ms = 50): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function fakeSpawnResult(overrides: Partial<FakeSpawnResult> = {}): FakeSpawnResult {
+  return { pid: 4242, outPath: '/tmp/node.out.log', logPath: '/tmp/node.log', ...overrides };
+}
+
+const registeredConfig: CliConfig = {
+  serverUrl: 'https://example.test',
+  pat: 'pat_abc',
+  nodeId: 'node-123',
+  node: {
+    name: 'test-node',
+    concurrency: 2,
+    eligibleTypes: ['auto_tagging', 'geocode'],
+    pollIntervalMs: 5000,
+  },
+};
+
+const unregisteredConfig: CliConfig = {
+  serverUrl: 'https://example.test',
+  pat: 'pat_abc',
+};
+
+beforeEach(() => {
+  spawnNodeStartDaemonMock.mockReset();
+  checkNodeAlreadyRunningMock.mockReset();
+  waitForDaemonReadyMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Not-registered short-circuit
+// ---------------------------------------------------------------------------
+
+describe('NodeStart — not registered', () => {
+  it('renders the not-registered message without ever probing for a running daemon', async () => {
+    const { lastFrame, unmount } = render(
+      <NodeStart config={unregisteredConfig} onStarted={() => {}} onBack={() => {}} />,
+    );
+    await flushAsync();
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('not registered');
+    expect(checkNodeAlreadyRunningMock).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('calls onBack on Enter', async () => {
+    const onBack = jest.fn();
+    const { stdin, unmount } = render(
+      <NodeStart config={unregisteredConfig} onStarted={() => {}} onBack={onBack} />,
+    );
+    stdin.write('\r');
+    await flushAsync();
+    expect(onBack).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('calls onBack on "b"', async () => {
+    const onBack = jest.fn();
+    const { stdin, unmount } = render(
+      <NodeStart config={unregisteredConfig} onStarted={() => {}} onBack={onBack} />,
+    );
+    stdin.write('b');
+    await flushAsync();
+    expect(onBack).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Already-running
+// ---------------------------------------------------------------------------
+
+describe('NodeStart — already running', () => {
+  it('renders the already-running state with pid and source', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: true, via: 'pidfile', pid: 123 });
+
+    const { lastFrame, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={() => {}} onBack={() => {}} />,
+    );
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('already running');
+    expect(plain).toContain('123');
+    expect(plain).toContain('pidfile');
+    unmount();
+  });
+
+  it('calls onStarted on Enter', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: true, via: 'ipc', pid: 999 });
+    const onStarted = jest.fn();
+
+    const { stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={onStarted} onBack={() => {}} />,
+    );
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+
+    expect(onStarted).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('calls onBack on "b" instead of starting a second daemon', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: true, via: 'ipc' });
+    const onBack = jest.fn();
+
+    const { stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={() => {}} onBack={onBack} />,
+    );
+    await flushAsync();
+    stdin.write('b');
+    await flushAsync();
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(spawnNodeStartDaemonMock).not.toHaveBeenCalled();
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path: form -> starting -> success
+// ---------------------------------------------------------------------------
+
+describe('NodeStart — happy path', () => {
+  it('renders the form prefilled from config.node once no daemon is already running', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+
+    const { lastFrame, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={() => {}} onBack={() => {}} />,
+    );
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('Concurrency');
+    expect(plain).toContain('2'); // prefilled from config.node.concurrency
+    expect(plain).toContain('auto_tagging');
+    expect(plain).toContain('geocode');
+    unmount();
+  });
+
+  it('spawns the daemon and reaches success once waitForDaemonReady resolves true', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+    spawnNodeStartDaemonMock.mockReturnValue(fakeSpawnResult({ pid: 555 }));
+    waitForDaemonReadyMock.mockResolvedValue(true);
+    const onStarted = jest.fn();
+
+    const { lastFrame, stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={onStarted} onBack={() => {}} />,
+    );
+    await flushAsync();
+
+    // Enter on the concurrency field advances focus to the types list.
+    stdin.write('\r');
+    await flushAsync();
+    // Enter on the types list (default selection carried over from config) submits.
+    stdin.write('\r');
+    await flushAsync();
+
+    expect(spawnNodeStartDaemonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ concurrency: 2 }),
+    );
+    expect(waitForDaemonReadyMock).toHaveBeenCalledTimes(1);
+
+    let plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('started');
+    expect(plain).toContain('555');
+
+    stdin.write('\r');
+    await flushAsync();
+    expect(onStarted).toHaveBeenCalledTimes(1);
+
+    plain = stripAnsi(lastFrame()!);
+    unmount();
+  });
+
+  it('catches a synchronous spawn failure and shows the error step', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+    spawnNodeStartDaemonMock.mockImplementation(() => {
+      throw new Error('EPERM: spawn not permitted');
+    });
+    const onBack = jest.fn();
+
+    const { lastFrame, stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={() => {}} onBack={onBack} />,
+    );
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('EPERM');
+
+    stdin.write('b');
+    await flushAsync();
+    expect(onBack).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout path
+// ---------------------------------------------------------------------------
+
+describe('NodeStart — timeout', () => {
+  it('shows the timeout warning with pid/log paths, and onStarted still fires on "open anyway"', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+    spawnNodeStartDaemonMock.mockReturnValue(
+      fakeSpawnResult({ pid: 777, outPath: '/tmp/out.log', logPath: '/tmp/node-777.log' }),
+    );
+    waitForDaemonReadyMock.mockResolvedValue(false);
+    const onStarted = jest.fn();
+
+    const { lastFrame, stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={onStarted} onBack={() => {}} />,
+    );
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+
+    const plain = stripAnsi(lastFrame()!);
+    expect(plain).toContain('777');
+    expect(plain).toContain('/tmp/out.log');
+    expect(plain).toContain('/tmp/node-777.log');
+
+    stdin.write('\r');
+    await flushAsync();
+    expect(onStarted).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('goes back without calling onStarted on "b"', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+    spawnNodeStartDaemonMock.mockReturnValue(fakeSpawnResult());
+    waitForDaemonReadyMock.mockResolvedValue(false);
+    const onStarted = jest.fn();
+    const onBack = jest.fn();
+
+    const { stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={onStarted} onBack={onBack} />,
+    );
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+
+    stdin.write('b');
+    await flushAsync();
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(onStarted).not.toHaveBeenCalled();
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency / types field editing
+// ---------------------------------------------------------------------------
+
+describe('NodeStart — form field editing', () => {
+  it('adjusts concurrency up/down with arrow keys (NodeLogs.tsx-style stepper)', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+
+    const { lastFrame, stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={() => {}} onBack={() => {}} />,
+    );
+    await flushAsync();
+    expect(stripAnsi(lastFrame()!)).toContain('Concurrency    2');
+
+    stdin.write('\x1B[A'); // up arrow
+    await flushAsync();
+    expect(stripAnsi(lastFrame()!)).toContain('Concurrency    3');
+
+    stdin.write('\x1B[B'); // down arrow
+    await flushAsync();
+    stdin.write('\x1B[B');
+    await flushAsync();
+    expect(stripAnsi(lastFrame()!)).toContain('Concurrency    1');
+    unmount();
+  });
+
+  it('toggles a job type with space after moving focus to the types list', async () => {
+    checkNodeAlreadyRunningMock.mockResolvedValue({ running: false });
+    spawnNodeStartDaemonMock.mockReturnValue(fakeSpawnResult());
+    waitForDaemonReadyMock.mockResolvedValue(true);
+
+    const { stdin, unmount } = render(
+      <NodeStart config={registeredConfig} onStarted={() => {}} onBack={() => {}} />,
+    );
+    await flushAsync();
+
+    // Move focus to the types list, then toggle the cursor item (the first
+    // NODE_JOB_TYPES entry, not part of registeredConfig's selection) on and
+    // back off — net no-op on the selection, but exercises the space-toggle
+    // interaction before submitting with the original config-derived set.
+    stdin.write('\t');
+    await flushAsync();
+    stdin.write(' ');
+    await flushAsync();
+    stdin.write(' ');
+    await flushAsync();
+    stdin.write('\r');
+    await flushAsync();
+
+    expect(spawnNodeStartDaemonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ concurrency: 2, types: ['auto_tagging', 'geocode'] }),
+    );
+    unmount();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.31",
+      "version": "1.1.32",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary
- Adds `spawnNodeStartDaemon`/`checkNodeAlreadyRunning`/`waitForDaemonReady` (`apps/cli/src/node/daemon-launch.ts`) — a parameterized way to launch the worker-node daemon and detect/await its readiness, extracted for reuse outside the `node start --daemon` CLI command's argv-forwarding path. `startCmd()`'s already-running guard now delegates to the same helper (behavior-preserving refactor).
- Adds a new `NodeStart` TUI screen: checks registration + already-running state, confirms concurrency/job types, spawns the daemon, waits for it to come up, and hands off to the dashboard (which auto-attaches).
- Wires "Start worker (background)" into Tools ▸ Worker Node, alongside the existing "Register node" entry — closing the gap where a user could register a node from the TUI but had no TUI path to actually put it to work (the dashboard's `[s]` embedded-start only runs while that screen stays open).
- Bumps `apps/cli` to 1.1.32 per the mandatory CLI versioning rule.

## Test plan
- [x] `npm run typecheck --workspace=@memoriahub/cli` — clean
- [x] `npm run build --workspace=@memoriahub/enrichment-compute` + `npm run build --workspace=@memoriahub/cli` — clean
- [x] Full CLI test suite (960 tests): only the 4 pre-existing, unrelated failing suites remain (db/migrations, migration-v6, sync-engine-date-range, scan-export)
- [x] 26 new tests added across `daemon-launch.spec.ts` and `node-start.spec.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198UdgN5sQVABzcDJ9vvrqy