### PR TITLE
fix(jobs): preserve executor audit field on terminal job writes

### DIFF
--- a/apps/api/src/enrichment/enrichment-terminal.service.ts
+++ b/apps/api/src/enrichment/enrichment-terminal.service.ts
@@ -84,10 +84,11 @@ export class EnrichmentTerminalService {
     await this.safeTerminalUpdate(job.id, job.type, {
       status: JobStatus.succeeded,
       finishedAt: new Date(),
-      // Release the claim/lease so the terminal row is unowned.
+      // Release the claim/lease so the terminal row is unowned. `executor` is
+      // intentionally NOT nulled here — succeeded is always terminal, so the
+      // audit value of which side (server/node) ran the job must be preserved.
       claimedByNode: { disconnect: true },
       leaseExpiresAt: null,
-      executor: null,
     });
 
     this.logger.log(
@@ -161,7 +162,10 @@ export class EnrichmentTerminalService {
         // Release the claim/lease so a requeued (or failed) job is unowned.
         claimedByNode: { disconnect: true },
         leaseExpiresAt: null,
-        executor: null,
+        // `executor` is only cleared when the job is being released back to
+        // pending for a fresh, unowned claim. A given-up (terminal) failure
+        // must preserve the audit value of which side ran the job.
+        ...(giveUp ? {} : { executor: null }),
         ...(giveUp ? { finishedAt: new Date() } : {}),
       });
 
@@ -189,7 +193,10 @@ export class EnrichmentTerminalService {
         // Release the claim/lease so a requeued (or failed) job is unowned.
         claimedByNode: { disconnect: true },
         leaseExpiresAt: null,
-        executor: null,
+        // `executor` is only cleared when the job is being released back to
+        // pending for a fresh, unowned claim. A given-up (terminal) failure
+        // must preserve the audit value of which side ran the job.
+        ...(shouldRetry ? { executor: null } : {}),
         ...(!shouldRetry ? { finishedAt: new Date() } : {}),
       });
 


### PR DESCRIPTION
## Summary
- The admin Job Queue "Node" column always showed "—" even for jobs completed by the server's own in-process worker — root cause was in the data layer, not the UI.
- `EnrichmentTerminalService` unconditionally nulled the `executor` column (`'server'`|`'node'`, set correctly at claim time) on every terminal write — `completeSucceeded`, and both terminal branches of `completeFailed` — destroying the audit record of who actually ran the job.
- `executor` is now only cleared when a job is genuinely released back to `pending` for a fresh, unowned claim (a non-give-up rate-limit deferral, or a normal-retry requeue) — mirroring the distinction `EnrichmentAdminService.resetStuck` already correctly makes between its exhausted-attempts (terminal, preserved) and requeue (pending, cleared) branches.
- No frontend change needed — `JobsPage.tsx`'s rendering logic was already correct; it just never received a non-null value.

## Test plan
- [x] No existing spec asserted the old (buggy) terminal-write behavior — confirmed by checking every spec referencing `completeSucceeded`/`completeFailed`/`executor`
- [x] `npx tsc --noEmit` in `apps/api` — clean
- [x] `enrichment-job.worker.spec.ts`, `nodes.service.spec.ts`, `nodes.service.credentials.spec.ts`, `face-job.worker.spec.ts` — all pass unchanged
- [x] Full `apps/api` suite (4099 tests) — 4070 pass; the 29 failures are pre-existing/unrelated (ESM cookie-parsing in integration specs, unrelated OCR/dimensions specs, a pre-existing DI gap) — none reference `enrichment-terminal`, `executor`, `EnrichmentAdminService`, or `NodesService`

**Note:** this only fixes the field going forward — historical succeeded/failed job rows already written with `executor: null` before this fix have no way to recover which side ran them; that audit info was already lost.

https://claude.ai/code/session_0198UdgN5sQVABzcDJ9vvrqy