### PR TITLE
fix: worker nodes fail jobs with ENOENT open '' on not-ready objects

### DIFF
--- a/apps/api/src/nodes/nodes.service.spec.ts
+++ b/apps/api/src/nodes/nodes.service.spec.ts
@@ -87,6 +87,7 @@ describe('NodesService — result/failure ingestion', () => {
   let mockActiveProvider: { getSignedPutUrl: jest.Mock; getBucket: jest.Mock };
   let mockClaimService: { claim: jest.Mock };
   let mockSystemSettings: { getSettings: jest.Mock };
+  let mockObjects: { getDownloadUrl: jest.Mock; getInternalDownloadUrl: jest.Mock };
 
   beforeEach(async () => {
     mockPrisma = createMockPrismaService();
@@ -114,7 +115,13 @@ describe('NodesService — result/failure ingestion', () => {
         { provide: EnrichmentClaimService, useValue: mockClaimService },
         { provide: EnrichmentHandlerRegistry, useValue: mockRegistry },
         { provide: EnrichmentTerminalService, useValue: mockTerminal },
-        { provide: ObjectsService, useValue: { getDownloadUrl: jest.fn() } },
+        {
+          provide: ObjectsService,
+          useValue: {
+            getDownloadUrl: jest.fn(),
+            getInternalDownloadUrl: jest.fn(),
+          },
+        },
         { provide: StorageProviderResolver, useValue: mockResolver },
         // getJobCredentials dependencies (auto_tagging/geocode transient
         // credentials) — not exercised by this spec file's existing coverage
@@ -128,6 +135,7 @@ describe('NodesService — result/failure ingestion', () => {
     }).compile();
 
     service = module.get(NodesService);
+    mockObjects = module.get(ObjectsService);
 
     // Default: node exists and is owned by the caller.
     (mockPrisma.workerNode.findUnique as jest.Mock).mockResolvedValue(makeNode());
@@ -433,6 +441,72 @@ describe('NodesService — result/failure ingestion', () => {
         sampleIntervalSeconds: 7,
         maxFramesPerVideo: 42,
       });
+    });
+
+    // -----------------------------------------------------------------------
+    // inputUrl resolution (resolveInputUrl)
+    // -----------------------------------------------------------------------
+
+    it('presigns via getInternalDownloadUrl for a still-processing object (regression: used to return null)', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({
+        storageObjectId: 'object-1',
+      });
+      // getInternalDownloadUrl deliberately skips the ready+auth checks that
+      // made the old getDownloadUrl path throw (and swallow to null) while the
+      // object was still status='processing'.
+      mockObjects.getInternalDownloadUrl.mockResolvedValue(
+        'https://mock-presigned-url.example/get',
+      );
+      mockClaimService.claim.mockResolvedValue([
+        claimedJob({ type: 'duplicate_detection', mediaItemId: 'media-1', payload: null }),
+      ]);
+
+      const { jobs } = await service.claim(USER_ID, NODE_ID, 1, ['duplicate_detection']);
+
+      expect(jobs[0].inputUrl).toBe('https://mock-presigned-url.example/get');
+      expect(mockObjects.getInternalDownloadUrl).toHaveBeenCalledWith('object-1');
+      // The user-facing, ready+auth-gated path must NOT be used for node claims.
+      expect(mockObjects.getDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns null inputUrl for a global/system job with no mediaItemId', async () => {
+      mockClaimService.claim.mockResolvedValue([
+        claimedJob({ type: 'duplicate_detection', mediaItemId: null, payload: null }),
+      ]);
+
+      const { jobs } = await service.claim(USER_ID, NODE_ID, 1, ['duplicate_detection']);
+
+      expect(jobs[0].inputUrl).toBeNull();
+      expect(mockPrisma.mediaItem.findUnique).not.toHaveBeenCalled();
+      expect(mockObjects.getInternalDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns null inputUrl when the media item has no storageObjectId', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({
+        storageObjectId: null,
+      });
+      mockClaimService.claim.mockResolvedValue([
+        claimedJob({ type: 'duplicate_detection', mediaItemId: 'media-1', payload: null }),
+      ]);
+
+      const { jobs } = await service.claim(USER_ID, NODE_ID, 1, ['duplicate_detection']);
+
+      expect(jobs[0].inputUrl).toBeNull();
+      expect(mockObjects.getInternalDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns null inputUrl when the object row is absent (getInternalDownloadUrl → null)', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({
+        storageObjectId: 'missing-object',
+      });
+      mockObjects.getInternalDownloadUrl.mockResolvedValue(null);
+      mockClaimService.claim.mockResolvedValue([
+        claimedJob({ type: 'duplicate_detection', mediaItemId: 'media-1', payload: null }),
+      ]);
+
+      const { jobs } = await service.claim(USER_ID, NODE_ID, 1, ['duplicate_detection']);
+
+      expect(jobs[0].inputUrl).toBeNull();
     });
   });
 

--- a/apps/api/src/nodes/nodes.service.ts
+++ b/apps/api/src/nodes/nodes.service.ts
@@ -199,7 +199,7 @@ export class NodesService {
     const jobs = await Promise.all(
       claimed.map(async (job) => ({
         job,
-        inputUrl: await this.resolveInputUrl(job, userId, /* userPermissions */ []),
+        inputUrl: await this.resolveInputUrl(job),
         params: await this.resolveJobParams(job),
       })),
     );
@@ -241,19 +241,21 @@ export class NodesService {
   /**
    * Best-effort presigned download URL for a claimed job's source object.
    *
-   * KNOWN LIMITATION: ObjectsService.getDownloadUrl performs a per-user
-   * ownership/circle-membership auth check keyed to the node owner. A node
-   * owner's PAT may not have access to every job's media (e.g. system/global
-   * jobs, or media in circles the owner isn't a member of), in which case the
-   * presign throws. We swallow any error and return null so a single
-   * inaccessible object never fails the whole claim. A trusted node executor
-   * should ideally bypass per-user auth here — deferred.
+   * A worker node is a TRUSTED INTERNAL EXECUTOR, so this uses
+   * ObjectsService.getInternalDownloadUrl — which deliberately skips both the
+   * `status === 'ready'` gate and the per-user ownership/circle-membership auth
+   * check, mirroring how the in-process enrichment worker reads the raw
+   * uploaded bytes directly (`provider.download(storageKey)`). This matters
+   * during bulk imports: a freshly-uploaded object sits at `status='processing'`
+   * for a few seconds while its enrichment jobs are already claimable, so the
+   * old user-facing getDownloadUrl path threw (not-ready) and swallowed to
+   * null, producing an empty input path on the node and permanently failing
+   * otherwise-good jobs. A still-`processing` object now yields a valid URL.
+   *
+   * We keep the try/catch returning null on genuine errors so a single
+   * inaccessible object never fails the whole claim.
    */
-  private async resolveInputUrl(
-    job: EnrichmentJob,
-    userId: string,
-    userPermissions: string[],
-  ): Promise<string | null> {
+  private async resolveInputUrl(job: EnrichmentJob): Promise<string | null> {
     // Global/system jobs have no media item — nothing to presign.
     if (!job.mediaItemId) {
       return null;
@@ -267,15 +269,11 @@ export class NodesService {
       if (!mediaItem?.storageObjectId) {
         return null;
       }
-      const result = await this.objectsService.getDownloadUrl(
+      return await this.objectsService.getInternalDownloadUrl(
         mediaItem.storageObjectId,
-        userId,
-        undefined,
-        userPermissions,
       );
-      return result.url;
     } catch {
-      // Inaccessible / not-ready object — continue without an input URL.
+      // Genuine error resolving the object — continue without an input URL.
       return null;
     }
   }

--- a/apps/api/src/storage/objects/objects.service.spec.ts
+++ b/apps/api/src/storage/objects/objects.service.spec.ts
@@ -833,6 +833,51 @@ describe('ObjectsService', () => {
     });
   });
 
+  describe('getInternalDownloadUrl', () => {
+    it('presigns a still-processing object without the ready gate or an auth check', async () => {
+      mockPrisma.storageObject.findUnique.mockResolvedValue({
+        storageKey: mockStorageObject.storageKey,
+        storageProvider: mockStorageObject.storageProvider,
+        bucket: mockStorageObject.bucket,
+        status: 'processing',
+      } as any);
+      mockConfig.get.mockReturnValue(3600);
+      mockStorageProvider.getSignedDownloadUrl.mockResolvedValue(
+        'https://signed-url.com/internal',
+      );
+
+      const url = await service.getInternalDownloadUrl(mockStorageObject.id);
+
+      expect(url).toBe('https://signed-url.com/internal');
+      expect(mockStorageProvider.getSignedDownloadUrl).toHaveBeenCalledWith(
+        mockStorageObject.storageKey,
+        { expiresIn: 3600 },
+      );
+    });
+
+    it('returns null when the object row is missing', async () => {
+      mockPrisma.storageObject.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.getInternalDownloadUrl('missing-object'),
+      ).resolves.toBeNull();
+      expect(mockStorageProvider.getSignedDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the object has no storageKey', async () => {
+      mockPrisma.storageObject.findUnique.mockResolvedValue({
+        storageKey: '',
+        storageProvider: mockStorageObject.storageProvider,
+        bucket: mockStorageObject.bucket,
+      } as any);
+
+      await expect(
+        service.getInternalDownloadUrl(mockStorageObject.id),
+      ).resolves.toBeNull();
+      expect(mockStorageProvider.getSignedDownloadUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe('delete', () => {
     it('should delete from storage and database', async () => {
       mockPrisma.storageObject.findUnique.mockResolvedValue(mockStorageObject as any);

--- a/apps/api/src/storage/objects/objects.service.ts
+++ b/apps/api/src/storage/objects/objects.service.ts
@@ -571,6 +571,51 @@ export class ObjectsService {
   }
 
   /**
+   * Presign a download URL for a storage object for a TRUSTED INTERNAL EXECUTOR.
+   *
+   * This deliberately differs from {@link getDownloadUrl} in two ways:
+   *   1. It does NOT gate on `status === 'ready'`. The raw uploaded bytes exist
+   *      at `storageKey` the moment the upload completes — long before the
+   *      in-process processing pipeline flips the object to `ready`. The
+   *      in-process enrichment worker reads those bytes directly via
+   *      `provider.download(storageKey)` with no status check (e.g.
+   *      FaceDetectionService), so a distributed worker node claiming the same
+   *      job must be able to presign the same bytes even while the object is
+   *      still `status='processing'`.
+   *   2. It does NOT run any per-user ownership/circle-membership auth check.
+   *      This is for server-trusted callers only (worker node job claiming),
+   *      mirroring the in-process worker's unauthenticated byte access. NEVER
+   *      expose this on a user-facing route — the public download path
+   *      ({@link getDownloadUrl}) keeps its ready + auth guards.
+   *
+   * @returns a presigned GET URL, or `null` when the object row is missing or
+   *          has no `storageKey`.
+   */
+  async getInternalDownloadUrl(
+    objectId: string,
+    expiresIn?: number,
+  ): Promise<string | null> {
+    const object = await this.prisma.storageObject.findUnique({
+      where: { id: objectId },
+      select: { storageKey: true, storageProvider: true, bucket: true },
+    });
+
+    if (!object || !object.storageKey) {
+      return null;
+    }
+
+    const provider = await this.resolver.getProviderFor(
+      object.storageProvider,
+      object.bucket,
+    );
+
+    return provider.getSignedDownloadUrl(object.storageKey, {
+      expiresIn:
+        expiresIn ?? this.config.get<number>('storage.signedUrlExpiry', 3600),
+    });
+  }
+
+  /**
    * Delete object from storage and database
    */
   async delete(id: string, userId: string, userPermissions: string[]): Promise<void> {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/node/node-engine.ts
+++ b/apps/cli/src/node/node-engine.ts
@@ -115,6 +115,27 @@ export interface EngineSnapshot {
 /** Ring-buffer capacity for the completed-job history. */
 const HISTORY_LIMIT = 50;
 
+/**
+ * Job types whose compute module reads the downloaded input file (via
+ * `fs.readFile(inputPath)` / `sharp(buffer)`). For these, a falsy `inputUrl`
+ * from the claim means the server could not presign the source object, so we
+ * must NOT invoke compute with an empty path — that surfaces as the opaque
+ * `ENOENT: no such file or directory, open ''`. Instead we fail the job with a
+ * descriptive error and let the server requeue it (a transient not-ready object
+ * will presign on a later claim). Types NOT listed here are input-less
+ * (`geocode` reads stored lat/lng; the global `thumbnail_repair` sweep has no
+ * media item) and legitimately run with an empty input path.
+ */
+const INPUT_REQUIRED_TYPES = new Set<string>([
+  'face_detection',
+  'video_face_detection',
+  'duplicate_detection',
+  'metadata_extraction',
+  'social_media_detection',
+  'thumbnail_regen',
+  'auto_tagging',
+]);
+
 type Resolved = Required<Pick<NodeEngineDeps, 'downloadFn' | 'detectFn' | 'tmpDir'>>;
 
 export class NodeEngine extends NodeTypedEmitter {
@@ -331,6 +352,13 @@ export class NodeEngine extends NodeTypedEmitter {
       if (inputUrl) {
         await this.resolved.downloadFn(inputUrl, tmpPath);
         downloaded = true;
+      } else if (INPUT_REQUIRED_TYPES.has(type)) {
+        // Server returned no presigned URL for a job whose compute reads the
+        // input file. Fail cleanly instead of calling compute with '' (which
+        // would throw the opaque `ENOENT ... open ''`); the server requeues.
+        throw new Error(
+          `input bytes unavailable for job ${jobId} (${type}): server returned no download URL`,
+        );
       }
 
       const result = await this.dispatcher.compute(type, downloaded ? tmpPath : '', params ?? {}, {

--- a/apps/cli/test/node/engine-snapshot.spec.ts
+++ b/apps/cli/test/node/engine-snapshot.spec.ts
@@ -14,9 +14,15 @@ import { NODE_EV } from '../../src/node/node-events.js';
 import type { ApiClient, ClaimedNodeJob } from '../../src/api.js';
 import type { ComputeDispatcher } from '../../src/node/capabilities.js';
 
-/** Build a claimed job with no input download. */
-function claim(id: string, type: string): ClaimedNodeJob {
-  return { job: { id, type }, inputUrl: null, params: {} };
+/**
+ * Build a claimed job. Defaults to `inputUrl: null`. face_detection is one
+ * of the INPUT_REQUIRED_TYPES in node-engine.ts — a null inputUrl now makes
+ * processJob fail BEFORE dispatch (see node-engine-input-guard.spec.ts), so
+ * any face_detection case here that means to exercise compute must pass a
+ * non-null inputUrl explicitly.
+ */
+function claim(id: string, type: string, inputUrl: string | null = null): ClaimedNodeJob {
+  return { job: { id, type }, inputUrl, params: {} };
 }
 
 interface StubApi {
@@ -67,9 +73,10 @@ function buildEngine(batches: ClaimedNodeJob[][], concurrency = 2): NodeEngine {
       heartbeatIntervalMs: 60_000,
     },
     detectFn: async () => ({}),
-    downloadFn: async () => {
-      throw new Error('no downloads expected (inputUrl is null)');
-    },
+    // No-op: face_detection cases below now pass a non-null inputUrl (it's
+    // an INPUT_REQUIRED_TYPES entry) so the guard lets them reach the
+    // dispatcher, which requires downloadFn to succeed rather than throw.
+    downloadFn: async () => 0,
   });
 }
 
@@ -84,7 +91,11 @@ async function runUntilIdle(engine: NodeEngine): Promise<void> {
 describe('NodeEngine snapshot & counters', () => {
   it('tracks claimed/succeeded/failed counters and the history ring', async () => {
     const engine = buildEngine([
-      [claim('j1', 'face_detection'), claim('j2', 'bad_type'), claim('j3', 'face_detection')],
+      [
+        claim('j1', 'face_detection', 'https://storage.example.com/signed/j1'),
+        claim('j2', 'bad_type'),
+        claim('j3', 'face_detection', 'https://storage.example.com/signed/j3'),
+      ],
     ]);
     await runUntilIdle(engine);
     const snap: EngineSnapshot = engine.getSnapshot();
@@ -110,7 +121,9 @@ describe('NodeEngine snapshot & counters', () => {
   });
 
   it('caps the history ring buffer at 50 entries, evicting the oldest', async () => {
-    const jobs = Array.from({ length: 60 }, (_, i) => claim(`j${i}`, 'face_detection'));
+    const jobs = Array.from({ length: 60 }, (_, i) =>
+      claim(`j${i}`, 'face_detection', `https://storage.example.com/signed/j${i}`),
+    );
     const engine = buildEngine([jobs], 8);
     await runUntilIdle(engine);
     const snap = engine.getSnapshot();

--- a/apps/cli/test/node/node-engine-failure.spec.ts
+++ b/apps/cli/test/node/node-engine-failure.spec.ts
@@ -19,9 +19,16 @@ import { ProviderRateLimitError } from '@memoriahub/enrichment-compute/rate-limi
 import type { ApiClient, ClaimedNodeJob } from '../../src/api.js';
 import type { ComputeDispatcher } from '../../src/node/capabilities.js';
 
-/** Build a claimed job with no input download. */
-function claim(id: string, type: string): ClaimedNodeJob {
-  return { job: { id, type }, inputUrl: null, params: {} };
+/**
+ * Build a claimed job. Defaults to `inputUrl: null` (no input download) for
+ * job types that don't need one (e.g. geocode). auto_tagging is one of the
+ * INPUT_REQUIRED_TYPES in node-engine.ts — a null inputUrl now makes
+ * processJob fail BEFORE dispatch (see node-engine-input-guard.spec.ts), so
+ * any auto_tagging case here that means to exercise the dispatcher/failure
+ * path must pass a non-null inputUrl explicitly.
+ */
+function claim(id: string, type: string, inputUrl: string | null = null): ClaimedNodeJob {
+  return { job: { id, type }, inputUrl, params: {} };
 }
 
 interface FailureCall {
@@ -74,9 +81,11 @@ function buildEngine(batch: ClaimedNodeJob[], computeThrows: () => unknown): { e
       heartbeatIntervalMs: 60_000,
     },
     detectFn: async () => ({}),
-    downloadFn: async () => {
-      throw new Error('no downloads expected (inputUrl is null)');
-    },
+    // No-op: geocode cases keep inputUrl:null (never reaches downloadFn);
+    // auto_tagging cases below now pass a non-null inputUrl so the
+    // INPUT_REQUIRED_TYPES guard lets them reach the dispatcher, which
+    // requires downloadFn to succeed rather than throw.
+    downloadFn: async () => 0,
   });
   return { engine, failureCalls };
 }
@@ -91,7 +100,7 @@ async function runUntilIdle(engine: NodeEngine): Promise<void> {
 describe('NodeEngine rate-limit failure classification', () => {
   it('forwards rateLimited:true and retryAfterMs when the compute module throws ProviderRateLimitError', async () => {
     const { engine, failureCalls } = buildEngine(
-      [claim('j1', 'auto_tagging')],
+      [claim('j1', 'auto_tagging', 'https://storage.example.com/signed/j1')],
       () => new ProviderRateLimitError('Anthropic rate limit / overload (HTTP 429): slow down', 'anthropic', 5000),
     );
 
@@ -127,7 +136,7 @@ describe('NodeEngine rate-limit failure classification', () => {
 
   it('omits rateLimited entirely for a plain Error — no regression on the existing failure path', async () => {
     const { engine, failureCalls } = buildEngine(
-      [claim('j1', 'auto_tagging')],
+      [claim('j1', 'auto_tagging', 'https://storage.example.com/signed/j1')],
       () => new Error('some unrelated compute failure'),
     );
 

--- a/apps/cli/test/node/node-engine-input-guard.spec.ts
+++ b/apps/cli/test/node/node-engine-input-guard.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * test/node/node-engine-input-guard.spec.ts
+ *
+ * Unit tests for the INPUT_REQUIRED_TYPES guard in NodeEngine.processJob
+ * (apps/cli/src/node/node-engine.ts). Before this guard existed, a claimed
+ * job whose compute reads the downloaded input file (face_detection,
+ * video_face_detection, duplicate_detection, metadata_extraction,
+ * social_media_detection, thumbnail_regen, auto_tagging) but whose claim
+ * carried `inputUrl: null` (the server could not presign the source object)
+ * was dispatched to compute with an empty-string path, surfacing as the
+ * opaque `ENOENT: no such file or directory, open ''`. The fix fails such
+ * jobs cleanly BEFORE calling compute, with a descriptive error, so the
+ * server requeues them instead.
+ *
+ * Input-less job types (geocode, and the global thumbnail_repair sweep)
+ * are NOT in INPUT_REQUIRED_TYPES and must keep dispatching to compute with
+ * an empty input path when inputUrl is null — this is normal, not a bug.
+ *
+ * Mirrors the stubbed ApiClient + ComputeDispatcher harness used by
+ * test/node/engine-snapshot.spec.ts and test/node/node-engine-failure.spec.ts
+ * — no network, no real filesystem downloads.
+ */
+
+import { NodeEngine } from '../../src/node/node-engine.js';
+import { NODE_EV } from '../../src/node/node-events.js';
+import type { ApiClient, ClaimedNodeJob } from '../../src/api.js';
+import type { ComputeDispatcher } from '../../src/node/capabilities.js';
+
+/** Build a claimed job, optionally with a presigned inputUrl. */
+function claim(id: string, type: string, inputUrl: string | null = null): ClaimedNodeJob {
+  return { job: { id, type }, inputUrl, params: {} };
+}
+
+interface FailureCall {
+  nodeId: string;
+  jobId: string;
+  body: { error: string; willRetry?: boolean };
+}
+
+interface ComputeCall {
+  type: string;
+  inputPath: string;
+}
+
+interface DownloadCall {
+  url: string;
+  destPath: string;
+}
+
+interface StubResult {
+  api: ApiClient;
+  dispatcher: ComputeDispatcher;
+  failureCalls: FailureCall[];
+  computeCalls: ComputeCall[];
+  downloadCalls: DownloadCall[];
+  submitCalls: number;
+}
+
+/**
+ * Stub API + dispatcher: serves one claim batch, records every downstream
+ * call the engine makes so each test can assert on call presence/absence
+ * and exact arguments.
+ */
+function stubHarness(batch: ClaimedNodeJob[]): StubResult {
+  let served = false;
+  const failureCalls: FailureCall[] = [];
+  const computeCalls: ComputeCall[] = [];
+  const downloadCalls: DownloadCall[] = [];
+  let submitCalls = 0;
+
+  const api = {
+    claimNodeJobs: async () => {
+      if (served) return { jobs: [] };
+      served = true;
+      return { jobs: batch };
+    },
+    heartbeatNode: async () => ({}),
+    deregisterNode: async () => ({}),
+    renewLease: async () => ({}),
+    submitJobResult: async () => {
+      submitCalls += 1;
+      return {};
+    },
+    reportJobFailure: async (nodeId: string, jobId: string, body: FailureCall['body']) => {
+      failureCalls.push({ nodeId, jobId, body });
+      return {};
+    },
+  } as unknown as ApiClient;
+
+  const dispatcher = {
+    compute: async (type: string, inputPath: string) => {
+      computeCalls.push({ type, inputPath });
+      return { ok: true };
+    },
+  } as unknown as ComputeDispatcher;
+
+  return { api, dispatcher, failureCalls, computeCalls, downloadCalls, submitCalls: 0 };
+}
+
+function buildEngine(
+  batch: ClaimedNodeJob[],
+  eligibleTypes: string[],
+  downloadCalls: DownloadCall[],
+): { engine: NodeEngine; stub: StubResult } {
+  const stub = stubHarness(batch);
+  const engine = new NodeEngine({
+    api: stub.api,
+    dispatcher: stub.dispatcher,
+    nodeId: 'node-1',
+    options: {
+      concurrency: 1,
+      eligibleTypes,
+      pollIntervalMs: 5,
+      heartbeatIntervalMs: 60_000,
+    },
+    detectFn: async () => ({}),
+    downloadFn: async (url: string, destPath: string) => {
+      downloadCalls.push({ url, destPath });
+      return 1234;
+    },
+    tmpDir: () => '/tmp/node-engine-input-guard-test',
+  });
+  return { engine, stub };
+}
+
+async function runUntilIdle(engine: NodeEngine): Promise<void> {
+  await new Promise<void>((resolve) => {
+    engine.once(NODE_EV.IDLE, () => resolve());
+    void engine.start();
+  });
+}
+
+describe('NodeEngine INPUT_REQUIRED_TYPES guard', () => {
+  it('face_detection with inputUrl:null fails cleanly WITHOUT calling compute or downloadFn', async () => {
+    const downloadCalls: DownloadCall[] = [];
+    const errorEvents: Array<{ jobId: string; type: string; error: string; willRetry: boolean }> = [];
+    const { engine, stub } = buildEngine(
+      [claim('j1', 'face_detection', null)],
+      ['face_detection'],
+      downloadCalls,
+    );
+    engine.on(NODE_EV.JOB_ERROR, (payload) => errorEvents.push(payload));
+
+    await runUntilIdle(engine);
+    await engine.stop('test');
+
+    // No download attempted, no compute call — the guard fires before dispatch.
+    expect(downloadCalls).toHaveLength(0);
+    expect(stub.computeCalls).toHaveLength(0);
+
+    // Failure reported with willRetry:true and a descriptive message.
+    expect(stub.failureCalls).toHaveLength(1);
+    expect(stub.failureCalls[0]?.nodeId).toBe('node-1');
+    expect(stub.failureCalls[0]?.jobId).toBe('j1');
+    expect(stub.failureCalls[0]?.body.willRetry).toBe(true);
+    expect(stub.failureCalls[0]?.body.error).toContain('input bytes unavailable');
+    expect(stub.failureCalls[0]?.body.error).toContain('j1');
+    expect(stub.failureCalls[0]?.body.error).toContain('face_detection');
+    // Must NOT be the opaque raw ENOENT that motivated this fix.
+    expect(stub.failureCalls[0]?.body.error).not.toMatch(/ENOENT/);
+    expect(stub.failureCalls[0]?.body.error).not.toMatch(/open ''/);
+
+    // JOB_ERROR event emitted with the same descriptive message.
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0]?.jobId).toBe('j1');
+    expect(errorEvents[0]?.type).toBe('face_detection');
+    expect(errorEvents[0]?.willRetry).toBe(true);
+    expect(errorEvents[0]?.error).toContain('input bytes unavailable');
+  });
+
+  it.each(['video_face_detection', 'duplicate_detection', 'metadata_extraction', 'social_media_detection', 'thumbnail_regen', 'auto_tagging'])(
+    '%s with inputUrl:null also fails cleanly without calling compute',
+    async (type) => {
+      const downloadCalls: DownloadCall[] = [];
+      const { engine, stub } = buildEngine([claim('j1', type, null)], [type], downloadCalls);
+
+      await runUntilIdle(engine);
+      await engine.stop('test');
+
+      expect(downloadCalls).toHaveLength(0);
+      expect(stub.computeCalls).toHaveLength(0);
+      expect(stub.failureCalls).toHaveLength(1);
+      expect(stub.failureCalls[0]?.body.error).toContain('input bytes unavailable');
+    },
+  );
+
+  it('geocode with inputUrl:null still dispatches to compute with an empty input path and succeeds', async () => {
+    const downloadCalls: DownloadCall[] = [];
+    const doneEvents: Array<{ jobId: string; type: string; submitted: boolean }> = [];
+    const { engine, stub } = buildEngine([claim('j1', 'geocode', null)], ['geocode'], downloadCalls);
+    engine.on(NODE_EV.JOB_DONE, (payload) => doneEvents.push(payload));
+
+    await runUntilIdle(engine);
+    await engine.stop('test');
+
+    // No download for an input-less job type.
+    expect(downloadCalls).toHaveLength(0);
+
+    // compute WAS called, with an empty-string input path — this is the
+    // pre-existing, correct behaviour for input-less job types and must not
+    // regress when the input-required guard was added.
+    expect(stub.computeCalls).toHaveLength(1);
+    expect(stub.computeCalls[0]).toEqual({ type: 'geocode', inputPath: '' });
+
+    // No failure reported; job completes successfully.
+    expect(stub.failureCalls).toHaveLength(0);
+    expect(doneEvents).toHaveLength(1);
+    expect(doneEvents[0]?.jobId).toBe('j1');
+    expect(doneEvents[0]?.submitted).toBe(true);
+  });
+
+  it('face_detection WITH a non-null inputUrl downloads to the temp path and calls compute with that path (regression guard)', async () => {
+    const downloadCalls: DownloadCall[] = [];
+    const doneEvents: Array<{ jobId: string; type: string; submitted: boolean }> = [];
+    const { engine, stub } = buildEngine(
+      [claim('j1', 'face_detection', 'https://storage.example.com/signed/j1')],
+      ['face_detection'],
+      downloadCalls,
+    );
+    engine.on(NODE_EV.JOB_DONE, (payload) => doneEvents.push(payload));
+
+    await runUntilIdle(engine);
+    await engine.stop('test');
+
+    // Download WAS attempted with the presigned URL.
+    expect(downloadCalls).toHaveLength(1);
+    expect(downloadCalls[0]?.url).toBe('https://storage.example.com/signed/j1');
+    expect(downloadCalls[0]?.destPath).toMatch(/^\/tmp\/node-engine-input-guard-test\/memoriahub-node-j1-/);
+
+    // compute was called with the exact same temp path the download wrote to.
+    expect(stub.computeCalls).toHaveLength(1);
+    expect(stub.computeCalls[0]?.type).toBe('face_detection');
+    expect(stub.computeCalls[0]?.inputPath).toBe(downloadCalls[0]?.destPath);
+
+    expect(stub.failureCalls).toHaveLength(0);
+    expect(doneEvents).toHaveLength(1);
+    expect(doneEvents[0]?.submitted).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.1.39",
+      "version": "1.1.40",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Problem

Distributed worker nodes flooded with `ENOENT: no such file or directory, open ''` during bulk imports (131+ in one daemon run). Legitimate enrichment jobs (`face_detection`, `duplicate_detection`, `auto_tagging`) were being marked **permanently failed**.

## Root cause

A design mismatch between the two job-claim paths:

- The **in-process server worker** reads media bytes directly via `provider.download(storageKey)` with **no `status` check** — the raw uploaded bytes exist at `storageKey` before the processing pipeline flips the object to `ready`.
- The **node path** presigned via `ObjectsService.getDownloadUrl`, which throws `BadRequestException` when `status !== 'ready'`. `NodesService.resolveInputUrl` swallowed that to `null`, and the node engine coerced `null → ''` and called compute with an empty path → `open ''`.

During a bulk import, freshly-uploaded objects sit at `status='processing'` for a few seconds while their enrichment jobs are already claimable. Because `attempts` is charged at **claim** time, those good jobs exhausted `ENRICHMENT_MAX_ATTEMPTS` and were permanently failed before the object ever finished processing.

## Fix

- **API:** new `ObjectsService.getInternalDownloadUrl` — a documented trusted-executor presign that skips the `ready` gate and the per-user auth check, mirroring the in-process worker's direct byte access. `resolveInputUrl` now uses it, so a still-`processing` object yields a valid URL. (`getDownloadUrl` unchanged for the user-facing route.) Also fixes a latent second bug where a node returned `null` for media in a circle the node-owner wasn't a member of.
- **CLI:** node engine now fails input-requiring job types cleanly (`"input bytes unavailable"`) instead of `open ''` when a URL is genuinely missing; input-less types (`geocode`, `thumbnail_repair`) still run. CLI bumped to 1.1.40.

## Tests
- API: 84 tests pass (regression: presign succeeds for a `processing` object; `getDownloadUrl` never used on the node path).
- CLI: node suite 159/159 pass, including the new `INPUT_REQUIRED_TYPES` guard coverage and two pre-existing suites updated for the guard. Typecheck clean both sides.

## Post-merge recovery
Bulk-retry the jobs this bug failed: `POST /api/admin/jobs/retry-failed` (or the Retry-failed button in `/admin/settings/jobs`). Rebuild the API and deploy CLI 1.1.40 to the nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)