### PR TITLE
fix(web): instant upload preview + thumbnail reconcile (#89)

### DIFF
--- a/apps/api/src/media/media.controller.ts
+++ b/apps/api/src/media/media.controller.ts
@@ -863,8 +863,12 @@ export class MediaController {
    *   If `contentHash` is supplied in the request body the server checks whether
    *   the caller already owns an active MediaItem with the same hash.  If so,
    *   the redundant StorageObject is cleaned up and the EXISTING MediaItem is
-   *   returned with HTTP 200 and `{ deduplicated: true }`.  A fresh create
-   *   returns HTTP 201 with `{ deduplicated: false }`.
+   *   returned with HTTP 200 and `{ deduplicated: true, mediaItemId }`.  A fresh
+   *   create returns HTTP 201 with `{ deduplicated: false, mediaItemId }`.
+   *
+   *   In both cases the response includes `mediaItemId` — the id of the created
+   *   (or existing deduplicated) MediaItem — so clients can attach an instant
+   *   local upload preview to the correct item.
    *
    *   The same dedup logic fires at the DB level via a partial unique index on
    *   (owner_id, content_hash) as a server-side backstop, even when the client
@@ -877,16 +881,21 @@ export class MediaController {
     description:
       'The referenced StorageObject must be owned by the caller. ' +
       'Returns the created (or existing deduplicated) MediaItem record. ' +
+      'The response always includes `mediaItemId` — the id of the created or ' +
+      'existing MediaItem — alongside the `deduplicated` flag. ' +
       'When `contentHash` is provided the server deduplicates by (ownerId, contentHash): ' +
       'if an active item with that hash already exists the existing item is returned ' +
       'with HTTP 200 and `deduplicated: true`. A fresh create returns HTTP 201 with ' +
       '`deduplicated: false`. The redundant StorageObject blob is cleaned up best-effort.',
   })
-  @ApiResponse({ status: 201, description: 'MediaItem created (fresh)' })
+  @ApiResponse({
+    status: 201,
+    description: 'MediaItem created (fresh) — body includes `deduplicated: false` and `mediaItemId`',
+  })
   @ApiResponse({
     status: 200,
     description:
-      'Duplicate detected — existing MediaItem returned (deduplicated: true). ' +
+      'Duplicate detected — existing MediaItem returned (`deduplicated: true`, `mediaItemId`). ' +
       'The redundant StorageObject has been cleaned up best-effort.',
   })
   @ApiResponse({ status: 400, description: 'StorageObject already linked' })

--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -292,6 +292,10 @@ describe('MediaService', () => {
       // Fresh create: result is the created item spread with deduplicated: false
       expect(result).toMatchObject({ ...createdItem, deduplicated: false });
       expect(result.deduplicated).toBe(false);
+      // mediaItemId must be present and equal the created item's id (issue #89:
+      // the register response must carry mediaItemId so the client can
+      // reconcile the local preview it already rendered)
+      expect(result.mediaItemId).toBe(createdItem.id);
       expect(mockPrisma.storageObject.findUnique).toHaveBeenCalledWith({
         where: { id: dto.storageObjectId },
       });
@@ -475,6 +479,8 @@ describe('MediaService', () => {
 
       expect(result.deduplicated).toBe(true);
       expect(result.id).toBe(existingItem.id);
+      // mediaItemId must equal the existing (winning) item's id on the dedup path
+      expect(result.mediaItemId).toBe(existingItem.id);
       // A new MediaItem must NOT have been created
       expect(mockPrisma.mediaItem.create).not.toHaveBeenCalled();
       // Redundant blob should be cleaned up (best-effort)
@@ -513,6 +519,8 @@ describe('MediaService', () => {
 
       expect(result.deduplicated).toBe(true);
       expect(result.id).toBe(winnerItem.id);
+      // mediaItemId must equal the winner's id on the P2002 race dedup path
+      expect(result.mediaItemId).toBe(winnerItem.id);
       // Redundant blob should be cleaned up
       expect(mockStorageProvider.delete).toHaveBeenCalledWith(storageObject.storageKey);
     });

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -147,7 +147,7 @@ export class MediaService {
             `cleaning up redundant StorageObject ${dto.storageObjectId}`,
         );
         await this.cleanupRedundantStorageObject(dto.storageObjectId, storageObject.storageKey);
-        return { ...duplicate, deduplicated: true as const };
+        return { ...duplicate, deduplicated: true as const, mediaItemId: duplicate.id };
       }
     }
 
@@ -202,7 +202,7 @@ export class MediaService {
         }
 
         await this.cleanupRedundantStorageObject(dto.storageObjectId, storageObject.storageKey);
-        return { ...winner, deduplicated: true as const };
+        return { ...winner, deduplicated: true as const, mediaItemId: winner.id };
       }
 
       throw err;
@@ -274,7 +274,7 @@ export class MediaService {
       deletedAt: mediaItem.deletedAt,
     });
 
-    return { ...mediaItem, deduplicated: false as const };
+    return { ...mediaItem, deduplicated: false as const, mediaItemId: mediaItem.id };
   }
 
   /**

--- a/apps/web/src/__tests__/contexts/MediaPreviewContext.test.tsx
+++ b/apps/web/src/__tests__/contexts/MediaPreviewContext.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Unit tests — MediaPreviewContext
+ *
+ * MediaPreviewProvider maintains an in-memory Map<mediaItemId, objectURL>
+ * (backed by a ref, not state) so the gallery can show an instant local
+ * preview of a just-uploaded photo/video before the server thumbnail is
+ * ready. Covers issue #89 (upload tile stuck on "Processing…" until refresh).
+ *
+ * jsdom does not implement URL.createObjectURL / URL.revokeObjectURL, so
+ * both are stubbed with vi.fn() for every test in this file.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, render } from '@testing-library/react';
+import {
+  MediaPreviewProvider,
+  useMediaPreview,
+} from '../../contexts/MediaPreviewContext';
+
+// ---------------------------------------------------------------------------
+// URL.createObjectURL / revokeObjectURL stubs
+// ---------------------------------------------------------------------------
+
+let createObjectURLMock: ReturnType<typeof vi.fn>;
+let revokeObjectURLMock: ReturnType<typeof vi.fn>;
+let urlCounter = 0;
+
+function makeFile(name = 'photo.jpg'): File {
+  return new File(['fake-bytes'], name, { type: 'image/jpeg' });
+}
+
+beforeEach(() => {
+  urlCounter = 0;
+  createObjectURLMock = vi.fn(() => `blob:mock-${++urlCounter}`);
+  revokeObjectURLMock = vi.fn();
+  (global as any).URL.createObjectURL = createObjectURLMock;
+  (global as any).URL.revokeObjectURL = revokeObjectURLMock;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderMediaPreview() {
+  return renderHook(() => useMediaPreview(), {
+    wrapper: MediaPreviewProvider,
+  });
+}
+
+describe('MediaPreviewContext', () => {
+  describe('addPreview / getPreview', () => {
+    it('creates an object URL for the file and stores it under the media item id', () => {
+      const { result } = renderMediaPreview();
+      const file = makeFile();
+
+      act(() => {
+        result.current.addPreview('item-1', file);
+      });
+
+      expect(createObjectURLMock).toHaveBeenCalledWith(file);
+      expect(result.current.getPreview('item-1')).toBe('blob:mock-1');
+    });
+
+    it('returns undefined for an id with no stored preview', () => {
+      const { result } = renderMediaPreview();
+      expect(result.current.getPreview('missing')).toBeUndefined();
+    });
+
+    it('increments version on add so reactive consumers can re-render', () => {
+      const { result } = renderMediaPreview();
+      const versionBefore = result.current.version;
+
+      act(() => {
+        result.current.addPreview('item-1', makeFile());
+      });
+
+      expect(result.current.version).toBe(versionBefore + 1);
+    });
+  });
+
+  describe('removePreview', () => {
+    it('revokes the object URL and drops it from the store', () => {
+      const { result } = renderMediaPreview();
+
+      act(() => {
+        result.current.addPreview('item-1', makeFile());
+      });
+      const url = result.current.getPreview('item-1');
+
+      act(() => {
+        result.current.removePreview('item-1');
+      });
+
+      expect(revokeObjectURLMock).toHaveBeenCalledWith(url);
+      expect(result.current.getPreview('item-1')).toBeUndefined();
+    });
+
+    it('is a no-op when the id has no stored preview', () => {
+      const { result } = renderMediaPreview();
+
+      act(() => {
+        result.current.removePreview('never-added');
+      });
+
+      expect(revokeObjectURLMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('duplicate id handling', () => {
+    it('revokes the stale URL before storing the new one when addPreview is called twice for the same id', () => {
+      const { result } = renderMediaPreview();
+
+      act(() => {
+        result.current.addPreview('item-1', makeFile('first.jpg'));
+      });
+      const firstUrl = result.current.getPreview('item-1');
+      expect(firstUrl).toBe('blob:mock-1');
+
+      act(() => {
+        result.current.addPreview('item-1', makeFile('second.jpg'));
+      });
+
+      expect(revokeObjectURLMock).toHaveBeenCalledWith(firstUrl);
+      expect(result.current.getPreview('item-1')).toBe('blob:mock-2');
+    });
+  });
+
+  describe('50-entry cap', () => {
+    it('evicts the oldest inserted entry (revoking its URL) once the cap is exceeded', () => {
+      const { result } = renderMediaPreview();
+
+      act(() => {
+        for (let i = 0; i < 50; i++) {
+          result.current.addPreview(`item-${i}`, makeFile());
+        }
+      });
+
+      // At the cap: nothing evicted yet.
+      expect(result.current.getPreview('item-0')).toBe('blob:mock-1');
+      expect(revokeObjectURLMock).not.toHaveBeenCalled();
+
+      act(() => {
+        result.current.addPreview('item-50', makeFile());
+      });
+
+      // Oldest (item-0) is evicted and its URL revoked.
+      expect(result.current.getPreview('item-0')).toBeUndefined();
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-1');
+      // The newest entry is retained.
+      expect(result.current.getPreview('item-50')).toBe('blob:mock-51');
+      // The rest of the window (item-1..item-49) survives.
+      expect(result.current.getPreview('item-1')).toBe('blob:mock-2');
+    });
+  });
+
+  describe('provider unmount', () => {
+    it('revokes every stored object URL when the provider unmounts', () => {
+      let addPreview!: (id: string, file: File) => void;
+
+      function Capture() {
+        const ctx = useMediaPreview();
+        addPreview = ctx.addPreview;
+        return null;
+      }
+
+      const { unmount } = render(
+        <MediaPreviewProvider>
+          <Capture />
+        </MediaPreviewProvider>,
+      );
+
+      act(() => {
+        addPreview('item-1', makeFile('a.jpg'));
+        addPreview('item-2', makeFile('b.jpg'));
+      });
+
+      expect(revokeObjectURLMock).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-1');
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-2');
+      expect(revokeObjectURLMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('without a provider (safe no-op defaults)', () => {
+    it('getPreview returns undefined and add/removePreview do not throw', () => {
+      const { result } = renderHook(() => useMediaPreview());
+
+      expect(result.current.getPreview('anything')).toBeUndefined();
+      expect(() => result.current.addPreview('x', makeFile())).not.toThrow();
+      expect(() => result.current.removePreview('x')).not.toThrow();
+      expect(createObjectURLMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/common/Layout.tsx
+++ b/apps/web/src/components/common/Layout.tsx
@@ -5,6 +5,7 @@ import { AppBar } from '../navigation/AppBar';
 import { Sidebar } from '../navigation/Sidebar';
 import { BottomNav } from '../navigation/BottomNav';
 import { MediaRefreshProvider } from '../../contexts/MediaRefreshContext';
+import { MediaPreviewProvider } from '../../contexts/MediaPreviewContext';
 import { SearchProvider } from '../../contexts/SearchContext';
 
 interface LayoutProps {
@@ -29,6 +30,7 @@ export function Layout({ fullBleed = false }: LayoutProps) {
 
   return (
     <MediaRefreshProvider>
+      <MediaPreviewProvider>
       <SearchProvider>
         <Box
           sx={{
@@ -64,6 +66,7 @@ export function Layout({ fullBleed = false }: LayoutProps) {
           <BottomNav onMore={() => setSidebarOpen(true)} />
         </Box>
       </SearchProvider>
+      </MediaPreviewProvider>
     </MediaRefreshProvider>
   );
 }

--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -42,6 +42,8 @@ import { useInfiniteMedia } from '../../hooks/useInfiniteMedia';
 import type { InfiniteMediaFetcher } from '../../hooks/useInfiniteMedia';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { useMediaRefresh } from '../../contexts/MediaRefreshContext';
+import { useMediaPreview } from '../../contexts/MediaPreviewContext';
+import { usePendingThumbnails } from '../../hooks/usePendingThumbnails';
 import { groupByDay } from '../../utils/groupByDay';
 import { isThumbnailStuck } from '../../utils/thumbnailTimeout';
 import { MediaDetailDrawer } from './MediaDetailDrawer';
@@ -90,6 +92,13 @@ const GalleryTile = memo(function GalleryTile({
   const theme = useTheme();
   const isMobileDevice = useMediaQuery(theme.breakpoints.down('sm'));
   const [imgError, setImgError] = useState(false);
+  const { getPreview } = useMediaPreview();
+
+  // Instant local upload preview (object URL) shown while the server thumbnail
+  // is still being generated. Only consulted when there is no server thumbnail
+  // yet and the image hasn't errored.
+  const preview =
+    !item.thumbnailUrl && !imgError ? getPreview(item.id) : undefined;
 
   return (
     <ImageListItem
@@ -147,6 +156,16 @@ const GalleryTile = memo(function GalleryTile({
             </Box>
           )}
         </Box>
+      ) : preview ? (
+        /* Instant local upload preview (object URL) while the server
+           thumbnail is generated; swapped out by the reconcile hook. */
+        <Box
+          component="img"
+          src={preview}
+          alt={item.originalFilename}
+          decoding="async"
+          sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        />
       ) : (item.type === 'photo' || item.type === 'video') && !imgError && !isThumbnailStuck(item.createdAt) ? (
         /* Awaiting thumbnail enrichment */
         <Box
@@ -418,6 +437,32 @@ export function MediaGallery({
       ),
     [baseItems, localPatches],
   );
+
+  // -------------------------------------------------------------------------
+  // Pending-thumbnail reconcile: poll for the optimized server thumbnail of
+  // freshly-uploaded items (shown via an instant local preview) and, once
+  // ready, patch the tile and free the local blob.
+  // -------------------------------------------------------------------------
+
+  const { removePreview } = useMediaPreview();
+
+  const applyThumbnails = useCallback(
+    (updates: Array<{ id: string; thumbnailUrl: string }>) => {
+      setLocalPatches((prev) => {
+        const next = { ...prev };
+        for (const { id, thumbnailUrl } of updates) {
+          next[id] = { ...next[id], thumbnailUrl };
+        }
+        return next;
+      });
+      for (const { id } of updates) {
+        removePreview(id);
+      }
+    },
+    [removePreview],
+  );
+
+  usePendingThumbnails(mergedItems, circleId, applyThumbnails);
 
   const grouped = useMemo(() => groupByDay(mergedItems), [mergedItems]);
 

--- a/apps/web/src/components/media/MediaUploadDialog.tsx
+++ b/apps/web/src/components/media/MediaUploadDialog.tsx
@@ -33,6 +33,7 @@ import {
   listMedia,
 } from '../../services/media';
 import { sha256File } from '../../utils/sha256';
+import { useMediaPreview } from '../../contexts/MediaPreviewContext';
 import type { UploadPart, MediaType } from '../../types/media';
 
 // ---------------------------------------------------------------------------
@@ -86,7 +87,7 @@ async function uploadFileWithRetry(
   contentHash: string | null,
   onProgress: (pct: number) => void,
   circleId?: string,
-): Promise<{ deduplicated: boolean }> {
+): Promise<{ deduplicated: boolean; mediaItemId: string }> {
   // 1. Init upload
   const { objectId, partSize, totalParts, presignedUrls } = await initUpload({
     name: file.name,
@@ -149,7 +150,10 @@ async function uploadFileWithRetry(
 
   onProgress(100);
 
-  return { deduplicated: response.deduplicated === true };
+  return {
+    deduplicated: response.deduplicated === true,
+    mediaItemId: response.mediaItemId,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +162,7 @@ async function uploadFileWithRetry(
 
 export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaUploadDialogProps) {
   const theme = useTheme();
+  const { addPreview } = useMediaPreview();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [fileStates, setFileStates] = useState<FileState[]>([]);
   const [isUploading, setIsUploading] = useState(false);
@@ -242,8 +247,9 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
         }
 
         // --- Upload + register
-        const { deduplicated } = await uploadFileWithRetry(
-          fileStates[i].file,
+        const file = fileStates[i].file;
+        const { deduplicated, mediaItemId } = await uploadFileWithRetry(
+          file,
           contentHash,
           (pct) => {
             updateFileState(i, { progress: pct });
@@ -255,6 +261,13 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
         if (deduplicated) {
           updateFileState(i, { status: 'duplicate', progress: 100 });
         } else {
+          // Capture an instant local preview from the uploaded bytes so the new
+          // gallery tile renders immediately instead of a "Processing…" spinner
+          // while the server thumbnail is generated. Photos only — videos can't
+          // be cheaply previewed from a File and are handled by the reconcile.
+          if (mediaItemId && file.type.startsWith('image/')) {
+            addPreview(mediaItemId, file);
+          }
           updateFileState(i, { status: 'success', progress: 100 });
         }
       } catch (err) {
@@ -275,7 +288,7 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
       }
       return current;
     });
-  }, [fileStates, onSuccess, updateFileState]);
+  }, [fileStates, onSuccess, updateFileState, addPreview]);
 
   const handleRetry = useCallback(
     async (index: number) => {

--- a/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
@@ -58,11 +58,15 @@ vi.mock('../../album/AddToAlbumDialog', () => ({
   AddToAlbumDialog: vi.fn(() => null),
 }));
 
-// Mock patchMedia so favourite toggles don't hit the network.
+// Mock patchMedia so favourite toggles don't hit the network. getThumbnails
+// is stubbed too since usePendingThumbnails (invoked internally by
+// MediaGallery) resolves from this same module — see the "instant upload
+// preview" describe block below.
 vi.mock('../../../services/media', () => ({
   patchMedia: vi.fn().mockResolvedValue({}),
   removeAlbumItem: vi.fn().mockResolvedValue(undefined),
   listMedia: vi.fn(),
+  getThumbnails: vi.fn().mockResolvedValue([]),
 }));
 
 // Mock useIntersectionObserver so the infinite-scroll sentinel never triggers.
@@ -70,13 +74,22 @@ vi.mock('../../../hooks/useIntersectionObserver', () => ({
   useIntersectionObserver: vi.fn(),
 }));
 
+// Mock MediaPreviewContext so GalleryTile's instant-preview lookup is
+// controllable per test (issue #89: upload tile stuck on "Processing…").
+// Default (set in beforeEach) has no stored preview for any id.
+vi.mock('../../../contexts/MediaPreviewContext', () => ({
+  useMediaPreview: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
 import { listMedia } from '../../../services/media';
+import { useMediaPreview } from '../../../contexts/MediaPreviewContext';
 
 const mockListMedia = vi.mocked(listMedia);
+const mockUseMediaPreview = vi.mocked(useMediaPreview);
 
 // ---------------------------------------------------------------------------
 // Factories
@@ -135,6 +148,13 @@ describe('MediaGallery', () => {
     mockListMedia.mockResolvedValue({
       items: [],
       meta: { page: 1, pageSize: 50, totalItems: 0, totalPages: 1 },
+    });
+    // Default MediaPreviewContext: no stored preview for any id, no-op writers.
+    mockUseMediaPreview.mockReturnValue({
+      addPreview: vi.fn(),
+      getPreview: vi.fn(() => undefined),
+      removePreview: vi.fn(),
+      version: 0,
     });
   });
 
@@ -269,6 +289,82 @@ describe('MediaGallery', () => {
 
       expect(screen.getByAltText('old-ready.jpg')).toBeInTheDocument();
       expect(screen.queryByLabelText('Thumbnail unavailable')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (a.2) Instant upload preview (issue #89) — local object-URL preview
+  // renders while there is no server thumbnail, and is superseded once the
+  // real thumbnailUrl arrives.
+  // -------------------------------------------------------------------------
+  describe('instant upload preview (issue #89)', () => {
+    it('renders the local object-URL preview when there is no server thumbnailUrl yet', () => {
+      mockUseMediaPreview.mockReturnValue({
+        addPreview: vi.fn(),
+        getPreview: vi.fn((id: string) => (id === 'uploading-1' ? 'blob:mock-preview-url' : undefined)),
+        removePreview: vi.fn(),
+        version: 0,
+      });
+
+      const items = [
+        makeItem('uploading-1', {
+          thumbnailUrl: null,
+          originalFilename: 'just-uploaded.jpg',
+          createdAt: new Date().toISOString(),
+        }),
+      ];
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      const img = screen.getByAltText('just-uploaded.jpg') as HTMLImageElement;
+      expect(img.src).toBe('blob:mock-preview-url');
+      // The "awaiting thumbnail" spinner must not render — the preview takes
+      // precedence while it is available.
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the processing spinner when there is no thumbnailUrl and no stored preview', () => {
+      // Default mock (set in beforeEach) returns undefined for every id.
+      const items = [
+        makeItem('no-preview', {
+          thumbnailUrl: null,
+          originalFilename: 'no-preview.jpg',
+          createdAt: new Date().toISOString(),
+        }),
+      ];
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      expect(screen.queryByAltText('no-preview.jpg')).not.toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('prefers the real server thumbnailUrl over a stored local preview once it is set', () => {
+      mockUseMediaPreview.mockReturnValue({
+        addPreview: vi.fn(),
+        getPreview: vi.fn((id: string) => (id === 'resolved-1' ? 'blob:mock-stale-preview' : undefined)),
+        removePreview: vi.fn(),
+        version: 0,
+      });
+
+      const items = [
+        makeItem('resolved-1', {
+          thumbnailUrl: 'https://cdn.example.com/resolved-1.jpg',
+          originalFilename: 'resolved.jpg',
+        }),
+      ];
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      const img = screen.getByAltText('resolved.jpg') as HTMLImageElement;
+      expect(img.src).toBe('https://cdn.example.com/resolved-1.jpg');
+      expect(img.src).not.toBe('blob:mock-stale-preview');
     });
   });
 

--- a/apps/web/src/contexts/MediaPreviewContext.tsx
+++ b/apps/web/src/contexts/MediaPreviewContext.tsx
@@ -1,0 +1,122 @@
+import {
+  createContext,
+  useContext,
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  ReactNode,
+} from 'react';
+
+/**
+ * MediaPreviewContext — an in-memory object-URL store keyed by media item id.
+ *
+ * When a photo is uploaded from the browser we already hold its `File` bytes,
+ * so we can create an object URL and show it instantly as the gallery tile
+ * while the server-side thumbnail is still being generated. A light background
+ * reconcile (see `usePendingThumbnails`) then swaps in the optimized server
+ * thumbnail and calls `removePreview` to free the blob.
+ *
+ * Object URLs are stored in a ref (not state) so adding a preview does not
+ * force a re-render of every gallery tile. A small `version` counter is
+ * exposed for consumers that DO want to react to add/remove.
+ */
+
+/** Maximum number of live object URLs retained; oldest inserted are evicted. */
+const MAX_PREVIEWS = 50;
+
+interface MediaPreviewContextValue {
+  /** Create + store an object URL for `file`, keyed by `mediaItemId`. */
+  addPreview: (mediaItemId: string, file: File) => void;
+  /** Return the stored object URL for `mediaItemId`, or undefined. */
+  getPreview: (mediaItemId: string) => string | undefined;
+  /** Revoke + delete the stored object URL for `mediaItemId`. */
+  removePreview: (mediaItemId: string) => void;
+  /** Increments on every add/remove — for consumers that want reactivity. */
+  version: number;
+}
+
+const defaultValue: MediaPreviewContextValue = {
+  addPreview: () => {},
+  getPreview: () => undefined,
+  removePreview: () => {},
+  version: 0,
+};
+
+export const MediaPreviewContext =
+  createContext<MediaPreviewContextValue>(defaultValue);
+
+interface MediaPreviewProviderProps {
+  children: ReactNode;
+}
+
+export function MediaPreviewProvider({ children }: MediaPreviewProviderProps) {
+  // id → objectURL. Map preserves insertion order, so the first key is the
+  // oldest inserted entry (used for cap eviction).
+  const previewsRef = useRef<Map<string, string>>(new Map());
+  const [version, setVersion] = useState(0);
+
+  const addPreview = useCallback((mediaItemId: string, file: File) => {
+    const map = previewsRef.current;
+
+    // Replace any existing entry for this id (revoke the stale URL first).
+    const existing = map.get(mediaItemId);
+    if (existing) {
+      URL.revokeObjectURL(existing);
+      map.delete(mediaItemId);
+    }
+
+    const url = URL.createObjectURL(file);
+    map.set(mediaItemId, url);
+
+    // Enforce the cap: evict oldest inserted entries beyond MAX_PREVIEWS.
+    while (map.size > MAX_PREVIEWS) {
+      const oldestKey = map.keys().next().value as string | undefined;
+      if (oldestKey === undefined) break;
+      const oldestUrl = map.get(oldestKey);
+      if (oldestUrl) URL.revokeObjectURL(oldestUrl);
+      map.delete(oldestKey);
+    }
+
+    setVersion((v) => v + 1);
+  }, []);
+
+  const getPreview = useCallback(
+    (mediaItemId: string): string | undefined =>
+      previewsRef.current.get(mediaItemId),
+    [],
+  );
+
+  const removePreview = useCallback((mediaItemId: string) => {
+    const map = previewsRef.current;
+    const url = map.get(mediaItemId);
+    if (url) {
+      URL.revokeObjectURL(url);
+      map.delete(mediaItemId);
+      setVersion((v) => v + 1);
+    }
+  }, []);
+
+  // Revoke every stored URL when the provider unmounts.
+  useEffect(() => {
+    const map = previewsRef.current;
+    return () => {
+      for (const url of map.values()) {
+        URL.revokeObjectURL(url);
+      }
+      map.clear();
+    };
+  }, []);
+
+  return (
+    <MediaPreviewContext.Provider
+      value={{ addPreview, getPreview, removePreview, version }}
+    >
+      {children}
+    </MediaPreviewContext.Provider>
+  );
+}
+
+export function useMediaPreview(): MediaPreviewContextValue {
+  return useContext(MediaPreviewContext);
+}

--- a/apps/web/src/hooks/__tests__/usePendingThumbnails.test.ts
+++ b/apps/web/src/hooks/__tests__/usePendingThumbnails.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests — usePendingThumbnails
+ *
+ * Background reconcile hook for issue #89 (upload tile stuck on
+ * "Processing…" spinner until refresh): polls GET /api/media/thumbnails
+ * with light backoff for items that have no thumbnailUrl yet, and hands
+ * resolved URLs to `onResolved` so the caller can patch the tile and free
+ * the local object-URL preview.
+ *
+ * Uses fake timers throughout since the hook self-schedules via setTimeout.
+ * `getThumbnails` (services/media) is mocked so no network call is made.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePendingThumbnails } from '../usePendingThumbnails';
+import { getThumbnails } from '../../services/media';
+import type { MediaItem } from '../../types/media';
+
+vi.mock('../../services/media', () => ({
+  getThumbnails: vi.fn(),
+}));
+
+const mockGetThumbnails = vi.mocked(getThumbnails);
+
+const CIRCLE_ID = 'circle-1';
+const INITIAL_BACKOFF_MS = 2500;
+const BACKOFF_FACTOR = 1.6;
+
+function makeItem(id: string, overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    id,
+    storageObjectId: `storage-${id}`,
+    addedById: 'user-1',
+    circleId: CIRCLE_ID,
+    type: 'photo',
+    capturedAt: null,
+    capturedAtOffset: null,
+    importedAt: null,
+    source: 'web',
+    contentHash: null,
+    width: null,
+    height: null,
+    durationMs: null,
+    orientation: null,
+    takenLat: null,
+    takenLng: null,
+    takenAltitude: null,
+    cameraMake: null,
+    cameraModel: null,
+    originalFilename: `${id}.jpg`,
+    description: null,
+    favorite: false,
+    geoCountry: null,
+    geoCountryCode: null,
+    geoAdmin1: null,
+    geoAdmin2: null,
+    geoLocality: null,
+    geoPlaceName: null,
+    geoSource: null,
+    geocodedAt: null,
+    coordSource: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    deletedAt: null,
+    archivedAt: null,
+    metadata: null,
+    thumbnailUrl: null,
+    ...overrides,
+  } as MediaItem;
+}
+
+describe('usePendingThumbnails', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetThumbnails.mockReset();
+    mockGetThumbnails.mockResolvedValue([]);
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls only pending photo/video items (excludes items that already have a thumbnailUrl and items past the stuck threshold)', async () => {
+    const stuckCreatedAt = new Date(Date.now() - 20 * 60 * 1000).toISOString(); // 20 min ago > 15 min threshold
+    const items = [
+      makeItem('has-thumb', { thumbnailUrl: 'https://cdn.example.com/has-thumb.jpg' }),
+      makeItem('stuck', { thumbnailUrl: null, createdAt: stuckCreatedAt }),
+      makeItem('pending-1', { thumbnailUrl: null }),
+      makeItem('pending-2', { thumbnailUrl: null, type: 'video' }),
+    ];
+    const onResolved = vi.fn();
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+    expect(mockGetThumbnails).toHaveBeenCalledWith(CIRCLE_ID, ['pending-1', 'pending-2']);
+  });
+
+  it('calls onResolved with {id, thumbnailUrl} for non-null results and removes them from the next poll', async () => {
+    const items = [makeItem('a', { thumbnailUrl: null }), makeItem('b', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    mockGetThumbnails.mockResolvedValueOnce([
+      { id: 'a', thumbnailUrl: 'https://cdn.example.com/a.jpg' },
+      { id: 'b', thumbnailUrl: null },
+    ]);
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledWith([
+      { id: 'a', thumbnailUrl: 'https://cdn.example.com/a.jpg' },
+    ]);
+  });
+
+  it('ignores null results and keeps polling with the same pending set', async () => {
+    const items = [makeItem('a', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    mockGetThumbnails.mockResolvedValue([{ id: 'a', thumbnailUrl: null }]);
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+    expect(onResolved).not.toHaveBeenCalled();
+
+    // Second tick fires after the (grown) backoff — still polls the same id.
+    const secondBackoff = INITIAL_BACKOFF_MS * BACKOFF_FACTOR;
+    await vi.advanceTimersByTimeAsync(secondBackoff);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(2);
+    expect(mockGetThumbnails).toHaveBeenLastCalledWith(CIRCLE_ID, ['a']);
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+
+  it('does not schedule any request when nothing is pending', async () => {
+    const items = [makeItem('has-thumb', { thumbnailUrl: 'https://cdn.example.com/x.jpg' })];
+    const onResolved = vi.fn();
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS * 2);
+
+    expect(mockGetThumbnails).not.toHaveBeenCalled();
+  });
+
+  it('self-terminates once a resolved item empties the pending set (no further polling for it)', async () => {
+    const items = [makeItem('a', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    mockGetThumbnails.mockResolvedValueOnce([
+      { id: 'a', thumbnailUrl: 'https://cdn.example.com/a.jpg' },
+    ]);
+
+    const { rerender } = renderHook(
+      ({ items: currentItems }) => usePendingThumbnails(currentItems, CIRCLE_ID, onResolved),
+      { initialProps: { items } },
+    );
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+
+    // Simulate the caller patching the item with the resolved thumbnailUrl,
+    // which the real MediaGallery does inside onResolved.
+    rerender({
+      items: [makeItem('a', { thumbnailUrl: 'https://cdn.example.com/a.jpg' })],
+    });
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS * 5);
+    // No further calls — the pending set is now empty.
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps the polled id list at 200 even when more items are pending', async () => {
+    const items = Array.from({ length: 250 }, (_, i) => makeItem(`p-${i}`, { thumbnailUrl: null }));
+    const onResolved = vi.fn();
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+    const [, ids] = mockGetThumbnails.mock.calls[0];
+    expect(ids).toHaveLength(200);
+    expect(ids[0]).toBe('p-0');
+    expect(ids[199]).toBe('p-199');
+  });
+
+  it('does not poll while document.hidden is true, and resumes on visibilitychange', async () => {
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => true,
+    });
+
+    const items = [makeItem('a', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+    expect(mockGetThumbnails).not.toHaveBeenCalled();
+
+    // Tab becomes visible again — the visibilitychange handler resumes polling immediately.
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => false,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not overlap in-flight requests', async () => {
+    const items = [makeItem('a', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    let resolveFetch!: (v: Array<{ id: string; thumbnailUrl: string | null }>) => void;
+    mockGetThumbnails.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    // First tick starts the in-flight request but never resolves it yet.
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+
+    // A visibility "resume" fires while the first request is still in flight —
+    // the guard must prevent a second concurrent call.
+    document.dispatchEvent(new Event('visibilitychange'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+
+    // Resolve the original request; no crash, no extra call synchronously.
+    resolveFetch([{ id: 'a', thumbnailUrl: null }]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGetThumbnails).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up (stops polling) on unmount', async () => {
+    const items = [makeItem('a', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    const { unmount } = renderHook(() => usePendingThumbnails(items, CIRCLE_ID, onResolved));
+
+    unmount();
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS * 3);
+    expect(mockGetThumbnails).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when circleId is undefined', async () => {
+    const items = [makeItem('a', { thumbnailUrl: null })];
+    const onResolved = vi.fn();
+
+    renderHook(() => usePendingThumbnails(items, undefined, onResolved));
+
+    await vi.advanceTimersByTimeAsync(INITIAL_BACKOFF_MS * 3);
+    expect(mockGetThumbnails).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/usePendingThumbnails.ts
+++ b/apps/web/src/hooks/usePendingThumbnails.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { getThumbnails } from '../services/media';
+import { isThumbnailStuck } from '../utils/thumbnailTimeout';
+import type { MediaItem } from '../types/media';
+
+/**
+ * usePendingThumbnails — background reconcile for media tiles whose optimized
+ * server thumbnail is not yet ready.
+ *
+ * On upload the gallery shows a local object-URL preview instantly (see
+ * `MediaPreviewContext`). This hook then polls `GET /api/media/thumbnails`
+ * with a light exponential backoff until each pending item's `thumbnailUrl`
+ * becomes available, at which point it hands the resolved URLs to
+ * `onResolved` (which patches the tile and frees the local blob).
+ *
+ * Behaviour:
+ *  - Pending = photo/video items with no `thumbnailUrl` that are not yet
+ *    "stuck" (past the recovery window). Capped at the first 200.
+ *  - Backoff starts at ~2.5s and grows ~1.6x up to a ~15s cap. It resets
+ *    whenever the pending set changes (the effect re-keys on the id set).
+ *  - Polling pauses while the tab is hidden and resumes on `visibilitychange`.
+ *  - Overlapping in-flight requests are prevented with a guard flag.
+ *  - Self-terminating: stops scheduling once nothing is pending.
+ */
+
+const INITIAL_BACKOFF_MS = 2500;
+const BACKOFF_FACTOR = 1.6;
+const MAX_BACKOFF_MS = 15000;
+const MAX_PENDING = 200;
+
+export function usePendingThumbnails(
+  items: MediaItem[],
+  circleId: string | undefined,
+  onResolved: (updates: Array<{ id: string; thumbnailUrl: string }>) => void,
+): void {
+  // Pending ids for the current render, capped. Recomputed only when `items`
+  // change; the joined key drives the effect so it re-keys when the set moves.
+  const pendingIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const item of items) {
+      if (
+        (item.type === 'photo' || item.type === 'video') &&
+        !item.thumbnailUrl &&
+        !isThumbnailStuck(item.createdAt)
+      ) {
+        ids.push(item.id);
+        if (ids.length >= MAX_PENDING) break;
+      }
+    }
+    return ids;
+  }, [items]);
+
+  const pendingKey = pendingIds.join(',');
+
+  // Latest values read inside the self-scheduling loop without re-keying it.
+  const pendingIdsRef = useRef(pendingIds);
+  pendingIdsRef.current = pendingIds;
+  const onResolvedRef = useRef(onResolved);
+  onResolvedRef.current = onResolved;
+
+  useEffect(() => {
+    if (!circleId || pendingKey === '') return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let inFlight = false;
+    let backoff = INITIAL_BACKOFF_MS;
+
+    const schedule = (ms: number) => {
+      timer = setTimeout(() => void runTick(), ms);
+    };
+
+    const runTick = async () => {
+      if (cancelled) return;
+      // Paused while hidden — the visibility handler resumes us.
+      if (document.hidden) return;
+      // Never overlap requests; try again after the current backoff.
+      if (inFlight) {
+        schedule(backoff);
+        return;
+      }
+
+      const ids = pendingIdsRef.current;
+      if (ids.length === 0) return; // self-terminate
+
+      inFlight = true;
+      try {
+        const results = await getThumbnails(circleId, ids);
+        if (!cancelled) {
+          const updates = results
+            .filter(
+              (r): r is { id: string; thumbnailUrl: string } =>
+                r.thumbnailUrl != null,
+            )
+            .map((r) => ({ id: r.id, thumbnailUrl: r.thumbnailUrl }));
+          if (updates.length > 0) onResolvedRef.current(updates);
+        }
+      } catch {
+        // Swallow — retry on the next tick with a longer backoff.
+      } finally {
+        inFlight = false;
+      }
+
+      if (cancelled) return;
+      backoff = Math.min(backoff * BACKOFF_FACTOR, MAX_BACKOFF_MS);
+      schedule(backoff);
+    };
+
+    const handleVisibility = () => {
+      if (!document.hidden && !cancelled) {
+        if (timer) clearTimeout(timer);
+        schedule(0);
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    schedule(INITIAL_BACKOFF_MS);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [pendingKey, circleId]);
+}

--- a/apps/web/src/types/media.ts
+++ b/apps/web/src/types/media.ts
@@ -188,6 +188,11 @@ export interface RegisterMediaDto {
  */
 export interface RegisterMediaResponse extends MediaItem {
   deduplicated?: boolean;
+  /**
+   * Id of the created (or existing deduplicated) MediaItem. Always present so
+   * the client can attach an instant local upload preview to the right item.
+   */
+  mediaItemId: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #89 — uploaded media tile stuck on the "Processing…" placeholder until a full page refresh.

## Root cause
On upload success the gallery refetches the media list **exactly once**, immediately (`triggerRefresh` → `feedReset` → `listMedia`). At that instant the backend hasn't finished async thumbnail generation, so the new item returns `thumbnailUrl: null` and `GalleryTile` shows the spinner. Nothing re-fetches after that (no polling; the refresh fires only once), so the tile stays a placeholder until a manual refresh. The 15-minute `isThumbnailStuck` check only swaps spinner → broken-image and never re-checks for a now-ready thumbnail.

## Fix — instant local preview + light reconcile
The browser already holds the uploaded file's bytes, so the tile shows the user's image instantly; a light background reconcile then swaps in the optimized server thumbnail and frees the blob.

- **`feat(api)`** `POST /api/media` register now returns `{ deduplicated, mediaItemId }` — the id lets the client attach a preview to the exact item.
- **`feat(web)` `MediaPreviewContext`** — ref-backed `Map<mediaItemId, objectURL>` (`addPreview`/`getPreview`/`removePreview`), 50-entry cap (revokes oldest), revoke-on-replace, revoke-all on unmount. Mounted in `Layout`.
- **`fix(web)`** the upload dialog calls `addPreview(mediaItemId, file)` on each non-deduplicated **image** upload; `GalleryTile` renders that local object URL when there's no server thumbnail yet — so photo tiles are never blank.
- **`feat(web)` `usePendingThumbnails`** — background reconcile: polls `GET /api/media/thumbnails` (reused from the map work) only for tiles still awaiting a thumbnail, with backoff (2.5s→15s), pausing on `document.hidden`, self-terminating when none are pending. On resolve it patches the real `thumbnailUrl` into the gallery's existing `localPatches` merge and revokes the local blob. This also covers cases with no local preview (videos, CLI / other-device uploads) and fixes the latent bug where `isThumbnailStuck` never re-evaluated.

No change to `useInfiniteMedia`; the reconcile reuses the gallery's existing optimistic-patch path.

## Tests
- Backend `media.service.spec.ts` — **202 passed** (register returns `mediaItemId` on fresh/dedup/P2002 paths).
- Frontend — **40 passed** across `MediaPreviewContext` (URL lifecycle, cap eviction, unmount revoke), `usePendingThumbnails` (pending filter, backoff, null-skip, self-terminate, 200 cap, hidden-pause, overlap guard), and `MediaGallery` (renders local preview when no thumbnail, prefers the real thumbnail once set). Upload-dialog suite (32) re-run green.
- Typecheck clean on both apps (only pre-existing unrelated errors remain).

## Deploy note
No DB migration — container rebuild/hot-reload is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
