### PR TITLE
fix(ui): improve mobile top bar full-width layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1062,6 +1062,7 @@ See also: [Worker Node Setup & Troubleshooting](docs/worker-node-setup.md) — a
 
 Post-implementation audit records live under `docs/audits/`:
 - [Search Overhaul](docs/audits/search-audit.md) — root causes and fixes for filter-collision bugs, missing thumbnail signing, geocode data gaps, and person-name search; documents the `near` map-radius filter and `facets/locations` endpoint added in this sprint
+- [Mobile Top Bar](docs/audits/mobile-topbar-audit.md) — root cause and fix for GitHub issue #95 (collapsed phone search button missing `flexGrow: 1`, leaving the AppBar's icons packed to the left with unused space on the right)
 
 ## Specialized Subagents (MANDATORY)
 

--- a/apps/web/src/components/search/TopbarSearch.tsx
+++ b/apps/web/src/components/search/TopbarSearch.tsx
@@ -150,15 +150,20 @@ export function TopbarSearch() {
   if (isPhone) {
     return (
       <>
-        {/* Collapsed state: single icon button */}
+        {/* Collapsed state: single icon button. Wrapped in a flex-growing Box so
+            it claims the Toolbar's remaining width on phone, matching the
+            desktop pill's own flexGrow wrapper below — otherwise every phone
+            toolbar icon packs to the left with dead space on the right. */}
         {!phoneExpanded && (
-          <IconButton
-            color="inherit"
-            aria-label="Open search"
-            onClick={() => setPhoneExpanded(true)}
-          >
-            <SearchIcon />
-          </IconButton>
+          <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}>
+            <IconButton
+              color="inherit"
+              aria-label="Open search"
+              onClick={() => setPhoneExpanded(true)}
+            >
+              <SearchIcon />
+            </IconButton>
+          </Box>
         )}
 
         {/* Expanded overlay: covers the full toolbar row */}

--- a/apps/web/src/components/search/__tests__/TopbarSearch.test.tsx
+++ b/apps/web/src/components/search/__tests__/TopbarSearch.test.tsx
@@ -334,6 +334,26 @@ describe('TopbarSearch', () => {
       expect(screen.getByRole('button', { name: /open search/i })).toBeInTheDocument();
     });
 
+    // Regression test for #95 (mobile top bar not using full screen width): the
+    // "Open search" icon button must be wrapped in a flex-growing Box so it is
+    // pushed to the end of the Toolbar instead of leaving unused space beside it.
+    // jsdom does not run real flexbox layout, so `getComputedStyle` cannot verify
+    // that pixels actually shift; it only proves the emotion-generated CSS rule
+    // (flex-grow: 1) is matched against the wrapping element, which is why we
+    // also assert structurally that a distinct wrapping DIV exists around the button.
+    it('wraps the "Open search" button in a flex-growing container', () => {
+      simulatePhone = true;
+      render(<TopbarSearch />);
+
+      const button = screen.getByRole('button', { name: /open search/i });
+      const wrapper = button.parentElement;
+
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.tagName).toBe('DIV');
+      expect(wrapper).not.toBe(wrapper?.parentElement);
+      expect(getComputedStyle(wrapper as Element).flexGrow).toBe('1');
+    });
+
     it('expands the overlay when the phone search button is clicked', async () => {
       simulatePhone = true;
 

--- a/docs/audits/mobile-topbar-audit.md
+++ b/docs/audits/mobile-topbar-audit.md
@@ -1,0 +1,61 @@
+# Mobile Top Bar — Audit and Fix Record
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-07-14 |
+| **Issue** | [#95 — "\[Feature]: Improve mobile view top bar"](https://github.com/marinoscar/MemoriaHub/issues/95) |
+| **Status** | Implemented |
+
+---
+
+This document records the mobile top bar layout issue reported in GitHub issue #95, its root cause, the fix applied, and the follow-ups explicitly deferred out of scope. It is written as a permanent reference so future contributors understand why `TopbarSearch` is shaped the way it is on phone-width viewports.
+
+---
+
+## Table of Contents
+
+1. [Symptom](#1-symptom)
+2. [Root Cause](#2-root-cause)
+3. [Fix Applied](#3-fix-applied)
+4. [Deferred Follow-Ups](#4-deferred-follow-ups)
+
+---
+
+## 1. Symptom
+
+GitHub issue #95, "[Feature]: Improve mobile view top bar," reported that on mobile/phone-width viewports the top bar didn't render well and wasn't using the full width ("real estate") of the screen. A screenshot attached to the issue showed the AppBar's icons visibly clustered on one side (the left edge) with a large unused gap of empty space on the right.
+
+---
+
+## 2. Root Cause
+
+**File:** `apps/web/src/components/search/TopbarSearch.tsx`
+
+The phone branch of `TopbarSearch` (`isPhone`, driven by `theme.breakpoints.down('sm')`, i.e. <600px) rendered the collapsed search state as a bare `IconButton` with no flex sizing applied to it or its container.
+
+The desktop/tablet branch of the same component already handles this correctly: its search pill is wrapped in a `Box` with `sx={{ flexGrow: 1, ... }}`. As a flex child of the AppBar's `Toolbar` (`apps/web/src/components/navigation/AppBar.tsx`), that `flexGrow: 1` box absorbs all of the Toolbar's remaining horizontal space and pushes the trailing icon cluster (upload, theme toggle, avatar) to the right edge.
+
+On phone, nothing claimed that space. The hamburger, logo, search icon, upload icon, theme toggle, and avatar all packed against the Toolbar's left edge with only the default 8px inter-item gaps between them, leaving the entire right side of the bar empty — exactly what the issue's screenshot showed.
+
+Only the *collapsed* phone state was affected. The expanded phone search overlay is `position: absolute` and already spans the full Toolbar width regardless of flex sizing, so it was never part of the reported symptom.
+
+---
+
+## 3. Fix Applied
+
+The collapsed-phone `IconButton` in `TopbarSearch.tsx` was wrapped in a `Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}`, mirroring the existing desktop pattern so the phone branch claims the Toolbar's remaining space the same way the desktop/tablet branch does.
+
+This was a minimal, single-component fix. No changes were needed in `AppBar.tsx`, `Layout.tsx`, `BottomNav.tsx`, `index.html`, or any theme files.
+
+A regression test was added to `apps/web/src/components/search/__tests__/TopbarSearch.test.tsx` asserting that the button's wrapper carries `flexGrow: 1` (checked via `getComputedStyle`, since the test environment's `ThemeContextProvider` + `CssBaseline` inject real emotion stylesheets that jsdom can match against), plus a structural check confirming a distinct wrapping element exists around the button.
+
+---
+
+## 4. Deferred Follow-Ups
+
+The following were identified during this fix but explicitly scoped out by product decision, to keep the change narrowly targeted at the reported "full real estate" complaint:
+
+- **Small touch targets.** The search pill's icon buttons (search/clear/tune) use `size="small"` with `p: 0.75`/`p: 0.5` padding (roughly 30px), below the ~44px recommended minimum touch target size. This is most relevant in the phone-expanded search overlay, where interaction is touch-only.
+- **Missing safe-area-inset handling.** `apps/web/index.html`'s viewport meta tag lacks `viewport-fit=cover`, and neither the sticky AppBar nor the fixed-position `BottomNav` (`apps/web/src/components/navigation/BottomNav.tsx`) pad for `env(safe-area-inset-top)` / `env(safe-area-inset-bottom)`. On notched or home-indicator phones, these bars can sit flush against system chrome.
+
+Recommend tracking these as separate follow-up issues if pursued later.


### PR DESCRIPTION
## Summary

On phone-width viewports (<600px), the collapsed search icon in the top bar (`TopbarSearch.tsx`) had no flex sizing, so every AppBar icon (hamburger, logo, search, upload, theme toggle, avatar) packed to the left edge, leaving the right side of the bar empty. This fix wraps that icon in a `flexGrow: 1` container, mirroring the pattern the desktop search pill already uses, so the icon cluster now reaches the right edge and the bar uses the full screen width.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #95

## Changes Made

- Wrapped the collapsed-phone search `IconButton` in `apps/web/src/components/search/TopbarSearch.tsx` with a `Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}`, matching the existing desktop pill pattern.
- Added a regression test in `apps/web/src/components/search/__tests__/TopbarSearch.test.tsx` asserting the button's wrapper carries `flexGrow: 1`.
- Added `docs/audits/mobile-topbar-audit.md` documenting the symptom, root cause, fix, and explicitly deferred follow-ups, plus an index entry in `CLAUDE.md`'s Audits section.

## Testing

- [x] Unit tests pass (`npm test`) — full `TopbarSearch.test.tsx` suite: 18/18 passing
- [ ] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

### Test Instructions

1. Run the dev stack (`cd infra/compose && docker compose -f base.compose.yml -f dev.compose.yml up`), open http://localhost:3535.
2. Open browser dev tools device toolbar at a phone width (e.g. 375–390px).
3. Confirm the collapsed search icon plus upload/theme/avatar icons sit flush against the right edge of the top bar with no dead space, both with and without an active circle.

## Additional Notes

Two related mobile-polish items surfaced during investigation but were explicitly deferred (confirmed with the reporter) to keep this fix narrowly scoped:
- Small touch targets (~30px) on the search pill's icon buttons, below the ~44px recommended minimum.
- Missing `env(safe-area-inset-*)` handling for notched/home-indicator phones.

Both are documented in `docs/audits/mobile-topbar-audit.md` as candidate follow-up work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzQ7sNSz72wqQ57CQwuUCx)_