### PR TITLE
test(web): fix two stale/broken CI test failures

### DIFF
--- a/apps/web/src/__tests__/pages/FaceSettingsVideoCard.test.tsx
+++ b/apps/web/src/__tests__/pages/FaceSettingsVideoCard.test.tsx
@@ -260,9 +260,23 @@ describe('FaceSettingsPage — Video Face Detection card', () => {
       // empty-string states and the final value would still be the initial 5.
       fireEvent.change(intervalField, { target: { value: '15' } });
 
-      // Find and click save
+      // Find and click save, scoped to the Paper containing the video settings
+      // fields. The naive "last Save button on the page" approach is wrong here:
+      // the Auto-Archive card's Save button renders after this card's and is
+      // disabled (pointer-events: none) whenever faceAutoArchive is off, which
+      // throws when userEvent tries to click it.
       const saveButtons = screen.getAllByRole('button', { name: /save/i });
-      await user.click(saveButtons[saveButtons.length - 1]);
+      const paper = intervalField.closest('.MuiPaper-root') ?? intervalField.closest('div[class*="Paper"]');
+      const saveBtn = paper
+        ? Array.from(paper.querySelectorAll('button')).find((b) => b.textContent?.match(/^save$/i))
+        : saveButtons[saveButtons.length - 1];
+
+      if (saveBtn) {
+        await user.click(saveBtn);
+      } else {
+        // Fallback: click the last Save button
+        await user.click(saveButtons[saveButtons.length - 1]);
+      }
 
       await waitFor(() => {
         expect(updateSettings).toHaveBeenCalledWith(

--- a/apps/web/src/__tests__/services/media.test.ts
+++ b/apps/web/src/__tests__/services/media.test.ts
@@ -441,29 +441,24 @@ describe('getLocationExtent', () => {
     expect(params.get('capturedAtTo')).toBe('2024-12-31T23:59:59.999Z');
   });
 
-  // KNOWN DEFECT (pre-existing in `services/api.ts`, not introduced by the
-  // map-extent-fix branch): `ApiService`'s response unwrapping —
-  // `return data.data ?? data;` — only substitutes the envelope when
-  // `data.data` is `undefined`. When the server legitimately responds with
+  // Regression coverage for the fix in commit `e041dab` ("fix(web): correctly
+  // unwrap a legitimate null data payload from the API envelope").
+  // `ApiService`'s response unwrapping previously did
+  // `return data.data ?? data;`, which only substituted the envelope when
+  // `data.data` was `undefined`. When the server legitimately responds with
   // `{ data: null }` (as `TransformInterceptor` produces for this endpoint
   // when a circle has zero geotagged items — see media.service.ts
-  // `getLocationsExtent`), `null ?? data` evaluates to `data`, so the raw
-  // envelope object round-trips instead of `null`. `getLocationExtent()`
-  // therefore currently returns a truthy `{ data: null }` object rather
-  // than `null` for the "no geotagged items" case documented in this
-  // endpoint's contract. Downstream, `MediaMapPage`'s `FitToExtent` only
-  // guards with `if (!extent) return;`, so this truthy envelope slips past
-  // that guard and destructures to `{ minLat: undefined, ... }`, then
-  // (since `undefined === undefined`) calls
-  // `map.setView([undefined, undefined], 13)` instead of leaving the map
-  // unframed. This test asserts the CURRENT (buggy) behavior so the suite
-  // documents the gap rather than silently passing over it — see the
-  // component-level tests in MediaMapPage.test.tsx, which mock
-  // `services/media` directly and so do not exercise this envelope bug.
-  // Fix: change the unwrap to something like
-  // `'data' in data ? data.data : data` (or equivalent `in`/hasOwnProperty
-  // check) in `apps/web/src/services/api.ts`, via frontend-dev.
-  it('KNOWN DEFECT: currently returns the raw { data: null } envelope, not null, when the server response has a legitimately-null data field', async () => {
+  // `getLocationsExtent`), `null ?? data` evaluated to `data`, so the raw
+  // envelope object round-tripped instead of `null`. That bug has been fixed
+  // by explicitly checking `'data' in data` before unwrapping, so
+  // `getLocationExtent()` now correctly returns `null` for the "no geotagged
+  // items" case documented in this endpoint's contract. Downstream,
+  // `MediaMapPage`'s `FitToExtent` guards with `if (!extent) return;`, so a
+  // `null` result correctly leaves the map unframed instead of calling
+  // `map.setView([undefined, undefined], 13)`. See also the component-level
+  // tests in MediaMapPage.test.tsx, which mock `services/media` directly and
+  // so do not exercise this envelope-unwrapping behavior.
+  it('returns null, not the raw envelope, when the server response has a legitimately-null data field', async () => {
     server.use(
       http.get('*/api/media/locations/extent', () => {
         return HttpResponse.json({ data: null });
@@ -471,7 +466,7 @@ describe('getLocationExtent', () => {
     );
 
     const result = await getLocationExtent();
-    expect(result).toEqual({ data: null });
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- `services/media.test.ts`: the `getLocationExtent` "KNOWN DEFECT" test asserted the old, buggy envelope-unwrapping behavior (`{ data: null }`) that was already fixed in `e041dab` (`api.ts` now correctly unwraps a legitimate `null` payload). Updated the test to assert the fixed behavior (`null`) and reworded it as regression coverage instead of a documented defect.
- `FaceSettingsVideoCard.test.tsx`: the `submits updated sampleIntervalSeconds` test blindly clicked the last "Save"-labeled button on the page, but the Auto-Archive card's Save button (disabled by default, `pointer-events: none`) now renders after the Video Face Detection card's Save button — causing a pointer-interaction error. Scoped the button lookup to the Paper containing the video settings fields, matching the pattern already used in the sibling test above it.

Both were the sole two failures in the `main` CI run (https://github.com/marinoscar/MemoriaHub/actions/runs/29375658529) after PR #107 merged.

## Test plan
- [x] `npm run test:ci --workspace=web` — 142 test files / 2864 tests, all passing