### PR TITLE
Harden web API: bake resource limits + Prisma transaction/pool resilience (#102)

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -1,14 +1,16 @@
+import { buildDatabaseUrl } from './database-url.util';
+
 export default () => {
-  // Construct DATABASE_URL from individual PostgreSQL variables
+  // Individual PostgreSQL variables (kept for the `database` config object shape)
   const host = process.env.POSTGRES_HOST || 'localhost';
   const port = process.env.POSTGRES_PORT || '5432';
   const user = process.env.POSTGRES_USER || 'postgres';
   const password = process.env.POSTGRES_PASSWORD || 'postgres';
   const dbName = process.env.POSTGRES_DB || 'appdb';
   const ssl = process.env.POSTGRES_SSL === 'true';
-  const sslParam = ssl ? '?sslmode=require' : '';
 
-  const databaseUrl = `postgresql://${user}:${password}@${host}:${port}/${dbName}${sslParam}`;
+  // Construct DATABASE_URL (base + connection-pool params) from the shared helper
+  const databaseUrl = buildDatabaseUrl();
 
   // Set DATABASE_URL for Prisma
   process.env.DATABASE_URL = databaseUrl;

--- a/apps/api/src/config/database-url.util.spec.ts
+++ b/apps/api/src/config/database-url.util.spec.ts
@@ -1,0 +1,180 @@
+import {
+  buildBaseDatabaseUrl,
+  appendPoolParams,
+  buildDatabaseUrl,
+  resolvePoolConfig,
+} from './database-url.util';
+
+describe('buildBaseDatabaseUrl', () => {
+  it('builds postgresql://user:pass@host:port/db from POSTGRES_* vars', () => {
+    const env = {
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_PORT: '5433',
+      POSTGRES_USER: 'appuser',
+      POSTGRES_PASSWORD: 'secret',
+      POSTGRES_DB: 'mydb',
+    };
+    expect(buildBaseDatabaseUrl(env)).toBe(
+      'postgresql://appuser:secret@db.example.com:5433/mydb',
+    );
+  });
+
+  it('applies ?sslmode=require only when POSTGRES_SSL==="true"', () => {
+    const withSsl = buildBaseDatabaseUrl({
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_SSL: 'true',
+    });
+    expect(withSsl).toContain('?sslmode=require');
+
+    const withSslFalse = buildBaseDatabaseUrl({
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_SSL: 'false',
+    });
+    expect(withSslFalse).not.toContain('sslmode=require');
+
+    const withSslUnset = buildBaseDatabaseUrl({
+      POSTGRES_HOST: 'db.example.com',
+    });
+    expect(withSslUnset).not.toContain('sslmode=require');
+  });
+
+  it('URL-encodes the password when it contains @, :, and a space', () => {
+    const password = 'p@ss w:rd';
+    const url = buildBaseDatabaseUrl({
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_PASSWORD: password,
+    });
+    expect(url).toContain(encodeURIComponent(password));
+
+    const parsed = new URL(url);
+    expect(decodeURIComponent(parsed.password)).toBe(password);
+  });
+
+  it('returns env.DATABASE_URL verbatim when set, ignoring POSTGRES_* entirely', () => {
+    const env = {
+      DATABASE_URL: 'postgresql://verbatim:url@host/db',
+      POSTGRES_HOST: 'ignored-host',
+      POSTGRES_PORT: '9999',
+      POSTGRES_USER: 'ignored-user',
+      POSTGRES_PASSWORD: 'ignored-password',
+      POSTGRES_DB: 'ignored-db',
+    };
+    expect(buildBaseDatabaseUrl(env)).toBe('postgresql://verbatim:url@host/db');
+  });
+
+  it('uses documented defaults when POSTGRES_* and DATABASE_URL are all unset', () => {
+    expect(buildBaseDatabaseUrl({})).toBe(
+      'postgresql://postgres:postgres@localhost:5432/appdb',
+    );
+  });
+});
+
+describe('appendPoolParams', () => {
+  it('appends connection_limit and pool_timeout with a leading ? when the url has no query string yet', () => {
+    const result = appendPoolParams('postgresql://x/y', {
+      DB_CONNECTION_LIMIT: '25',
+      DB_POOL_TIMEOUT: '30',
+    });
+    expect(result).toBe('postgresql://x/y?connection_limit=25&pool_timeout=30');
+  });
+
+  it('uses & when the url already has a query string', () => {
+    const result = appendPoolParams('postgresql://x/y?sslmode=require', {
+      DB_CONNECTION_LIMIT: '25',
+      DB_POOL_TIMEOUT: '30',
+    });
+    expect(result).toBe(
+      'postgresql://x/y?sslmode=require&connection_limit=25&pool_timeout=30',
+    );
+  });
+
+  it('is idempotent: a url that already contains connection_limit= is returned completely unchanged', () => {
+    const url = 'postgresql://x/y?connection_limit=5';
+    const result = appendPoolParams(url, {
+      DB_CONNECTION_LIMIT: '999',
+      DB_POOL_TIMEOUT: '999',
+    });
+    expect(result).toBe(url);
+  });
+
+  it('applies defaults connection_limit=10 and pool_timeout=20 when unset', () => {
+    const result = appendPoolParams('postgresql://x/y', {});
+    expect(result).toBe('postgresql://x/y?connection_limit=10&pool_timeout=20');
+  });
+
+  it('honors explicit valid values', () => {
+    const result = appendPoolParams('postgresql://x/y', {
+      DB_CONNECTION_LIMIT: '25',
+      DB_POOL_TIMEOUT: '30',
+    });
+    expect(result).toBe('postgresql://x/y?connection_limit=25&pool_timeout=30');
+  });
+
+  it('skips a param whose explicit value is invalid/non-positive/empty while still applying the other param default', () => {
+    for (const invalid of ['abc', '0', '']) {
+      const result = appendPoolParams('postgresql://x/y', {
+        DB_CONNECTION_LIMIT: invalid,
+      });
+      expect(result).toContain('pool_timeout=20');
+      expect(result).not.toContain('connection_limit=');
+    }
+  });
+});
+
+describe('buildDatabaseUrl', () => {
+  it('composes base url + pool params with ssl and explicit pool overrides', () => {
+    const env = {
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_PORT: '5433',
+      POSTGRES_USER: 'appuser',
+      POSTGRES_PASSWORD: 'secret',
+      POSTGRES_DB: 'mydb',
+      POSTGRES_SSL: 'true',
+      DB_CONNECTION_LIMIT: '25',
+      DB_POOL_TIMEOUT: '30',
+    };
+    expect(buildDatabaseUrl(env)).toBe(
+      'postgresql://appuser:secret@db.example.com:5433/mydb?sslmode=require&connection_limit=25&pool_timeout=30',
+    );
+  });
+
+  it('produces the no-SSL/default-pool-params case with a leading ?', () => {
+    const env = {
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_PORT: '5432',
+      POSTGRES_USER: 'postgres',
+      POSTGRES_PASSWORD: 'postgres',
+      POSTGRES_DB: 'db',
+    };
+    expect(buildDatabaseUrl(env)).toBe(
+      'postgresql://postgres:postgres@db.example.com:5432/db?connection_limit=10&pool_timeout=20',
+    );
+  });
+});
+
+describe('resolvePoolConfig', () => {
+  it('returns defaults when env is empty', () => {
+    expect(resolvePoolConfig({})).toEqual({
+      max: 10,
+      connectionTimeoutMillis: 20000,
+    });
+  });
+
+  it('returns custom valid values, converting pool timeout seconds to ms', () => {
+    expect(
+      resolvePoolConfig({ DB_CONNECTION_LIMIT: '25', DB_POOL_TIMEOUT: '30' }),
+    ).toEqual({
+      max: 25,
+      connectionTimeoutMillis: 30000,
+    });
+  });
+
+  it('falls back to defaults when values are invalid/non-positive', () => {
+    expect(
+      resolvePoolConfig({ DB_CONNECTION_LIMIT: 'abc', DB_POOL_TIMEOUT: '-1' }),
+    ).toEqual({
+      max: 10,
+      connectionTimeoutMillis: 20000,
+    });
+  });
+});

--- a/apps/api/src/config/database-url.util.ts
+++ b/apps/api/src/config/database-url.util.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared, pure helpers for constructing the PostgreSQL connection URL used by
+ * Prisma. Extracted so both `configuration.ts` (which sets
+ * `process.env.DATABASE_URL` early) and `PrismaService` route through the same
+ * logic — including the connection-pool sizing params that make Prisma's
+ * pool behave predictably inside a CPU-limited container (Prisma's default
+ * `connection_limit` is host-derived, `num_cpus*2+1`, which is misleading in a
+ * container that pins CPU below the host count).
+ *
+ * These functions are intentionally pure and env-injectable for unit testing.
+ */
+
+type EnvLike = Record<string, string | undefined>;
+
+/** Default connection pool size when `DB_CONNECTION_LIMIT` is unset. */
+const DEFAULT_CONNECTION_LIMIT = 10;
+/** Default pool acquisition timeout (seconds) when `DB_POOL_TIMEOUT` is unset. */
+const DEFAULT_POOL_TIMEOUT = 20;
+
+/**
+ * Parse an env value into a positive integer.
+ * Returns `undefined` for empty/missing/invalid/non-positive values so callers
+ * can distinguish "unset" (apply default) from "explicitly bad" (skip).
+ */
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return undefined;
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    return undefined;
+  }
+  return n;
+}
+
+/**
+ * Build the base PostgreSQL URL from POSTGRES_* variables.
+ * If `env.DATABASE_URL` is already set, it is returned verbatim as the base.
+ * The password is URL-encoded to tolerate special characters.
+ */
+export function buildBaseDatabaseUrl(env: EnvLike = process.env): string {
+  if (env.DATABASE_URL) {
+    return env.DATABASE_URL;
+  }
+
+  const host = env.POSTGRES_HOST ?? 'localhost';
+  const port = env.POSTGRES_PORT ?? '5432';
+  const user = env.POSTGRES_USER ?? 'postgres';
+  const password = env.POSTGRES_PASSWORD ?? 'postgres';
+  const dbName = env.POSTGRES_DB ?? 'appdb';
+  const ssl = env.POSTGRES_SSL === 'true';
+  const sslParam = ssl ? '?sslmode=require' : '';
+
+  const encodedPassword = encodeURIComponent(password);
+
+  return `postgresql://${user}:${encodedPassword}@${host}:${port}/${dbName}${sslParam}`;
+}
+
+/**
+ * Append connection-pool params (`connection_limit`, `pool_timeout`) to a
+ * database URL.
+ *
+ * - Uses `?` if the URL has no query string yet, else `&`.
+ * - Idempotent: if `connection_limit=` is already present, the URL is returned
+ *   unchanged (so applying this in both `configuration.ts` and `PrismaService`
+ *   is safe — the second call is a no-op).
+ * - Each param is appended only when its env var yields a valid positive
+ *   integer; an empty/invalid value is skipped, but the documented default is
+ *   applied when the env var is unset entirely.
+ */
+export function appendPoolParams(url: string, env: EnvLike = process.env): string {
+  // Idempotency guard: never append pool params twice.
+  if (url.includes('connection_limit=')) {
+    return url;
+  }
+
+  const params: string[] = [];
+
+  const connLimitRaw = env.DB_CONNECTION_LIMIT;
+  const connLimit =
+    connLimitRaw === undefined
+      ? DEFAULT_CONNECTION_LIMIT
+      : parsePositiveInt(connLimitRaw);
+  if (connLimit !== undefined) {
+    params.push(`connection_limit=${connLimit}`);
+  }
+
+  const poolTimeoutRaw = env.DB_POOL_TIMEOUT;
+  const poolTimeout =
+    poolTimeoutRaw === undefined
+      ? DEFAULT_POOL_TIMEOUT
+      : parsePositiveInt(poolTimeoutRaw);
+  if (poolTimeout !== undefined) {
+    params.push(`pool_timeout=${poolTimeout}`);
+  }
+
+  if (params.length === 0) {
+    return url;
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}${params.join('&')}`;
+}
+
+/**
+ * Build the full PostgreSQL URL (base + pool params).
+ */
+export function buildDatabaseUrl(env: EnvLike = process.env): string {
+  return appendPoolParams(buildBaseDatabaseUrl(env), env);
+}
+
+/**
+ * Resolve the runtime `pg` pool configuration from the same env vars the URL
+ * pool params derive from.
+ *
+ * IMPORTANT: the `@prisma/adapter-pg` driver adapter runs on a real `pg.Pool`.
+ * When `PrismaPg` is given a bare connection STRING it does
+ * `new pg.Pool({ connectionString })` — and `pg` does NOT honor Prisma's
+ * `connection_limit` / `pool_timeout` URL query params (those only affect
+ * Prisma's own query engine, i.e. the CLI/migration path). So to actually size
+ * the runtime pool we must pass `pg.PoolConfig` fields:
+ *   - `max`                    ← the pg equivalent of `connection_limit`
+ *   - `connectionTimeoutMillis`← the pg equivalent of `pool_timeout` (seconds → ms)
+ *
+ * Defaults mirror `appendPoolParams`: 10 connections, 20s wait.
+ */
+export function resolvePoolConfig(env: EnvLike = process.env): {
+  max: number;
+  connectionTimeoutMillis: number;
+} {
+  const max = parsePositiveInt(env.DB_CONNECTION_LIMIT) ?? DEFAULT_CONNECTION_LIMIT;
+  const poolTimeoutSec = parsePositiveInt(env.DB_POOL_TIMEOUT) ?? DEFAULT_POOL_TIMEOUT;
+  return {
+    max,
+    connectionTimeoutMillis: poolTimeoutSec * 1000,
+  };
+}

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -1,31 +1,21 @@
 import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
+import { buildBaseDatabaseUrl, resolvePoolConfig } from '../config/database-url.util';
 
 /**
- * Builds a PostgreSQL connection string from individual environment variables,
+ * Builds the BASE PostgreSQL connection string (no Prisma pool query params),
  * falling back to DATABASE_URL when already provided.
  *
- * Mirrors the logic in src/config/configuration.ts and scripts/prisma-env.js
- * so PrismaService works regardless of NestJS module initialization order.
+ * The runtime pool sizing is applied separately, as `pg.PoolConfig` fields
+ * passed to the adapter (see the constructor) — NOT via URL query params. The
+ * `@prisma/adapter-pg` adapter runs on a real `pg.Pool`, and `pg` ignores
+ * Prisma's `connection_limit`/`pool_timeout` URL params (those only affect the
+ * Prisma query engine used by the CLI/migration path). So we hand pg the base
+ * URL and configure `max`/`connectionTimeoutMillis` explicitly.
  */
 function buildConnectionString(): string {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL;
-  }
-
-  const host = process.env.POSTGRES_HOST ?? 'localhost';
-  const port = process.env.POSTGRES_PORT ?? '5432';
-  const user = process.env.POSTGRES_USER ?? 'postgres';
-  const password = process.env.POSTGRES_PASSWORD ?? 'postgres';
-  const dbName = process.env.POSTGRES_DB ?? 'appdb';
-  const ssl = process.env.POSTGRES_SSL === 'true';
-  const sslParam = ssl ? '?sslmode=require' : '';
-
-  // URL-encode the password to handle special characters
-  const encodedPassword = encodeURIComponent(password);
-
-  return `postgresql://${user}:${encodedPassword}@${host}:${port}/${dbName}${sslParam}`;
+  return buildBaseDatabaseUrl();
 }
 
 @Injectable()
@@ -36,9 +26,26 @@ export class PrismaService
   private readonly logger = new Logger(PrismaService.name);
 
   constructor() {
-    const adapter = new PrismaPg(buildConnectionString());
+    // Pass a pg.PoolConfig OBJECT (not a bare string) so the runtime pg pool is
+    // actually sized — `max` is the real connection_limit for the adapter, and
+    // `connectionTimeoutMillis` is pg's pool-acquisition timeout.
+    const { max, connectionTimeoutMillis } = resolvePoolConfig();
+    const adapter = new PrismaPg({
+      connectionString: buildConnectionString(),
+      max,
+      connectionTimeoutMillis,
+    });
     super({
       adapter,
+      // Raise the interactive-transaction budget above Prisma's 5s default.
+      // Under bulk-import load the default timeout expired ("expired
+      // transaction") and the pool starved ("Unable to start a transaction in
+      // the given time"). timeout = max wall-clock a tx body may run;
+      // maxWait = max time to wait for a pooled connection to start the tx.
+      transactionOptions: {
+        timeout: parseInt(process.env.PRISMA_TX_TIMEOUT_MS || '15000', 10),
+        maxWait: parseInt(process.env.PRISMA_TX_MAX_WAIT_MS || '5000', 10),
+      },
       // perceptualHash is an internal 64-bit dHash field used exclusively by
       // burst detection. It is not part of the public API surface and is omitted
       // globally to keep MediaItem responses clean. Burst detection code that

--- a/apps/api/src/tagging/auto-tagging.service.ts
+++ b/apps/api/src/tagging/auto-tagging.service.ts
@@ -404,6 +404,21 @@ export class AutoTaggingService {
       (item) => labelByLower.get(item.toLowerCase()) ?? item,
     );
 
+    // Resolve Tag rows OUTSIDE the transaction. Tag creation is an idempotent
+    // find-or-create keyed on (circleId, name) and does not need to be atomic
+    // with the mediaTag reconciliation below — keeping these upserts out of the
+    // critical section shrinks the interactive transaction (which under
+    // bulk-import load was blowing the tx timeout and starving the pool).
+    const tagIdByLabel = new Map<string, string>();
+    for (const labelName of normalizedLabels) {
+      const tag = await this.prisma.tag.upsert({
+        where: { circleId_name: { circleId: mediaItem.circleId, name: labelName } },
+        create: { addedById: mediaItem.addedById, circleId: mediaItem.circleId, name: labelName },
+        update: {},
+      });
+      tagIdByLabel.set(labelName, tag.id);
+    }
+
     // Reconcile AI tags: remove stale AI tags, upsert current labels with source=ai.
     // Also persist description when parseOk is true.
     await this.prisma.$transaction(async (tx) => {
@@ -415,16 +430,14 @@ export class AutoTaggingService {
           tag: { name: { notIn: normalizedLabels } },
         },
       });
-      // Upsert current labels as AI tags (never downgrade manual to ai)
+      // Upsert current labels as AI tags (never downgrade manual to ai),
+      // using the tagIds resolved before the transaction opened.
       for (const labelName of normalizedLabels) {
-        const tag = await tx.tag.upsert({
-          where: { circleId_name: { circleId: mediaItem.circleId, name: labelName } },
-          create: { addedById: mediaItem.addedById, circleId: mediaItem.circleId, name: labelName },
-          update: {},
-        });
+        const tagId = tagIdByLabel.get(labelName);
+        if (!tagId) continue;
         await tx.mediaTag.upsert({
-          where: { tagId_mediaItemId: { tagId: tag.id, mediaItemId: mediaItem.id } },
-          create: { tagId: tag.id, mediaItemId: mediaItem.id, source: MediaTagSource.ai },
+          where: { tagId_mediaItemId: { tagId, mediaItemId: mediaItem.id } },
+          create: { tagId, mediaItemId: mediaItem.id, source: MediaTagSource.ai },
           update: {}, // do NOT downgrade manual tag to ai
         });
       }

--- a/docs/specs/bulk-upload-vps-tuning.md
+++ b/docs/specs/bulk-upload-vps-tuning.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 1.0 |
+| **Version** | 1.2 |
 | **Last Updated** | July 2026 |
 
 Running MemoriaHub on an inexpensive, memory-constrained VPS is a core design goal. But a **bulk upload of thousands of photos** is the single most demanding thing the app does: each photo fans out into ~5 enrichment jobs (face detection, auto-tagging, burst detection, duplicate detection, location inference), all processed **in-process** by the enrichment worker, and the AI/image work is memory-heavy. On a small container this can push the process into an **out-of-memory (OOM) crash loop** that manifests as `502 Bad Gateway` across the whole app.
@@ -15,13 +15,16 @@ Cross-references: [Bulk Import Resilience](bulk-import-resilience.md) (retry/bac
 
 ## TL;DR — if your API is 502-ing during a bulk import
 
-It is almost certainly an OOM kill, not an app bug. Do this, in order:
+It is almost certainly an OOM kill, not an app bug — but there are **two different OOM failure modes with opposite fixes** (see §3, lever 1 and §6). Do this, in order:
 
-1. **Set a heap cap** (the single most effective change):
-   `NODE_OPTIONS=--max-old-space-size=<~55% of the container's memory limit>` (e.g. `320` for a 512MB container).
-2. **Keep concurrency at 1** on a 512MB container: `ENRICHMENT_WORKER_CONCURRENCY=1`.
+1. **Check which OOM you actually have** before touching the heap cap — getting this backwards makes things worse:
+   - **Small container (≤ ~1 GB):** set a MODEST heap cap — `NODE_OPTIONS=--max-old-space-size=<~55% of the container's memory limit>` (e.g. `320` for a 512MB container) — to force proactive GC and stop the JS heap from crowding out the off-heap pool.
+   - **Larger container (≥ 2 GB):** set a GENEROUS heap cap — `NODE_OPTIONS=--max-old-space-size=<container_MB − 1024>` (e.g. `5120` for a 6G container). Too low a cap here FATAL-crashes the process at V8's own heap limit long before the container's memory limit is ever reached.
+2. **Keep concurrency at 1** on a 512MB container: `ENRICHMENT_WORKER_CONCURRENCY=1`. On the committed production default (6G container / 4 CPUs), `4` is fine.
 3. Restart the API (env change only — no rebuild needed) and watch it survive past ~60s.
 4. Once stable, recover any casualties: `POST /api/admin/jobs/reset-stuck {"olderThanMinutes":5}` then `POST /api/admin/jobs/retry-failed`.
+
+If your symptom is `Unable to start a transaction in the given time` or `expired transaction` errors rather than a crash loop, that's a *different* failure mode — see §4 (Database & CPU resilience).
 
 Everything below is *why* those work and how to size them for larger boxes.
 
@@ -40,6 +43,8 @@ The container's **cgroup memory limit** (the `deploy.resources.limits.memory` in
 
 **Key consequence:** the memory that *bulk-import concurrency* consumes is almost entirely **off-heap** (decoded images + model inference). So raising or lowering `--max-old-space-size` does **not** directly control the cost of concurrency — but it *does* keep the JS heap from crowding out the room the off-heap pool needs, and (crucially) it forces V8 to garbage-collect proactively instead of lazily.
 
+**A third failure mode hides in this model: the heap cap can itself become the ceiling.** cgroup OOM (the kernel killing the container for exceeding total RSS) is not the only way a bulk import goes down. If `--max-old-space-size` is set too low for how much *legitimate* JS-heap work a busy request/response graph and the enrichment worker actually need, V8 FATAL-crashes at its own limit — `FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory` — with total process RSS nowhere near the container's memory limit. This is a *heap* OOM, not a *container* OOM, and it needs the opposite fix: a HIGHER cap, not a lower one. It's why the single "~55% of the container" rule below is correct for tiny boxes but wrong for large ones — see §3, lever 1 for the two regimes, and §6 for how to tell the two OOM types apart from their symptoms.
+
 ---
 
 ## 2. Why bulk imports specifically trigger this
@@ -54,8 +59,12 @@ The container's **cgroup memory limit** (the `deploy.resources.limits.memory` in
 
 Set these in `infra/compose/.env` (they take effect on an API restart — no image rebuild needed).
 
-1. **`NODE_OPTIONS=--max-old-space-size=<MB>`** — the highest-leverage knob.
-   Set it to roughly **50–60% of the container's memory limit**. This forces proactive GC and prevents the JS heap from starving the off-heap pool. On a 512MB container, `320` is a good value.
+1. **`NODE_OPTIONS=--max-old-space-size=<MB>`** — the highest-leverage knob, but **the right value flips between small and large containers.** There are two regimes:
+
+   - **Small / memory-constrained (≤ ~1 GB):** the risk is the JS heap crowding out the off-heap pool until the cgroup kills the whole container. Keep the heap MODEST — roughly **55% of the container's memory limit**. On a 512MB container, `320` is a good value. `container_MB − 1024` does not apply at this size (it goes to zero or negative).
+   - **Larger production hosts (≥ 2 GB):** the risk flips. Too LOW a heap cap FATAL-crashes the Node process at V8's own old-space limit — `FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory` — regardless of how much container memory is available; the process exits before the cgroup limit is ever approached. Size the heap GENEROUSLY instead: **`max-old-space-size ≈ container_MB − 1024`**, leaving roughly 1 GB of headroom for the off-heap pool (decoded images, `sharp`/onnxruntime buffers, Prisma's native engine). The committed production default is **6 G container / 5120 MB heap** — see §5.
+
+   **Container memory ≥ 2 G is necessary but not sufficient.** Without a matching heap cap, the process still fatal-crashes at the V8 limit long before the container's cgroup limit is reached — the two must be sized together and kept consistent. See the diagnosis signatures in §6.
 
 2. **`ENRICHMENT_WORKER_CONCURRENCY`** — the primary *memory multiplier*.
    This is how many jobs run at once, and therefore how many decoded-image + inference buffers are resident simultaneously. **On 512MB, keep this at `1`.** Raising it is the fastest way back into an OOM loop on a small box.
@@ -67,25 +76,63 @@ Set these in `infra/compose/.env` (they take effect on an API restart — no ima
    Concurrency scales with this. If you want concurrency 4, you need the limit high enough to hold baseline + 4× per-job — realistically ~1–1.25 GB.
 
 5. **`VIDEO_ENRICHMENT_MAX_BYTES`** — the video-specific escape hatch.
-   Photo levers above don't help with video: a `video_face_detection` / `social_media_detection` job streams the whole video to a `memoriaHub-*` temp file, so its dominant cost is **disk** (temp space), not the JS heap. Set a byte cap (e.g. a few hundred MB) to skip huge videos entirely — no download — in both handlers. `0` (default) processes all sizes. A disk-space pre-flight guard (free space `>= size × 1.2`) and an hourly `TempFileJanitorTask` orphan sweep back this up (see §6), but a cap is what keeps a multi-GB clip from ever touching the disk. If, conversely, large *legitimate* videos are being killed as "timed out", raise `ENRICHMENT_VIDEO_JOB_TIMEOUT_MS` (default 20 min, vs. the 10-min `ENRICHMENT_JOB_TIMEOUT_MS` for non-video jobs) rather than the photo levers.
+   Photo levers above don't help with video: a `video_face_detection` / `social_media_detection` job streams the whole video to a `memoriaHub-*` temp file, so its dominant cost is **disk** (temp space), not the JS heap. Set a byte cap (e.g. a few hundred MB) to skip huge videos entirely — no download — in both handlers. `0` (default) processes all sizes. A disk-space pre-flight guard (free space `>= size × 1.2`) and an hourly `TempFileJanitorTask` orphan sweep back this up (see §7), but a cap is what keeps a multi-GB clip from ever touching the disk. If, conversely, large *legitimate* videos are being killed as "timed out", raise `ENRICHMENT_VIDEO_JOB_TIMEOUT_MS` (default 20 min, vs. the 10-min `ENRICHMENT_JOB_TIMEOUT_MS` for non-video jobs) rather than the photo levers.
 
 > **A heap cap does not make higher concurrency safe by itself.** Concurrency's cost is off-heap; the only things that make concurrency > 1 safe are a bigger container limit and/or smaller per-job buffers (`*_MAX_IMAGE_DIM`). Video cost is different again — it's temp disk, bounded by `VIDEO_ENRICHMENT_MAX_BYTES`, not RAM.
 
----
-
-## 4. Recommended presets by container size
-
-| Container limit | `ENRICHMENT_WORKER_CONCURRENCY` | `NODE_OPTIONS=--max-old-space-size` | `*_MAX_IMAGE_DIM` | Notes |
-|---|---|---|---|---|
-| **512 MB** (cheap VPS) | `1` | `320` | `1024` | Field-proven stable for a ~20k-job import. Slower but resilient. |
-| **1 GB** | `2` | `576` | `1024`–`1568` | Step up gradually; watch `dmesg` after each bump. |
-| **2 GB+** | `4` | `1024` | `1568` (default) | Comfortable for aggressive throughput. |
-
-Rule of thumb: `--max-old-space-size` ≈ **55% of the container limit**, leaving the rest for the resident models + `concurrency ×` per-job image buffers. When raising concurrency, **step up one at a time** (1 → 2 → 3), watching `dmesg` for a few minutes at each step, rather than jumping straight to 4.
+> **Production posture — worker off when nodes are present:** when distributed worker nodes (`apps/cli node start`) are handling enrichment compute, set `ENRICHMENT_WORKER_ENABLED=false` on the API tier so in-process enrichment jobs don't compete with inbound HTTP requests for the same CPU budget and Prisma connection pool during a bulk import — see §4.3.
 
 ---
 
-## 5. Diagnosing an OOM crash loop
+## 4. Database & CPU resilience (a different failure mode — not memory)
+
+Everything in §1–§3 addresses memory sizing. A **separate, unrelated failure mode** hit production on **2026-07-14** — the day before the heap-OOM crash loop described in §6 — and it's easy to conflate the two because both surfaced as instability during a bulk import. Keep them distinct:
+
+- **The heap-OOM crash loop (§6, 2026-07-15)** is a *memory-sizing* problem: V8's heap cap crashes the process outright, `dmesg`/`OOMKilled` tell you which kind.
+- **This CPU/transaction brownout (2026-07-14, below)** is a *scheduling* problem: the API process stays alive the whole time — it just starts throwing Prisma transaction errors under load.
+
+### 4.1 The CPU limit
+
+Pinning the API container to a single CPU core (`API_CPU_LIMIT=1.0`, the incident value) saturated the Node event loop during a bulk import. Enrichment work and inbound HTTP requests compete for the same single-threaded event loop; once it's pegged, Prisma's own bookkeeping (starting and committing interactive transactions) gets delayed past its timeout budget, producing errors like:
+
+```
+Error: Transaction API error: Transaction already closed: A query cannot be executed on an expired transaction.
+Error: Unable to start a transaction in the given time.
+```
+
+The committed default is now **`API_CPU_LIMIT=4.0`** (`infra/compose/prod.compose.yml` / `.env.example`) — size it to the host's actual core count; a single core is not enough for a production import. In the reference incident, raising `1.0 → 4.0` dropped CPU utilization from pinned-at-100% to roughly 8%, and the transaction-error rate from steady to zero.
+
+### 4.2 Prisma transaction and pool knobs
+
+Two pairs of settings, both new in `.env.example`:
+
+- **`PRISMA_TX_TIMEOUT_MS`** (default `15000`) / **`PRISMA_TX_MAX_WAIT_MS`** (default `5000`) — the interactive-transaction wall-clock budget, and the max wait to *begin* one. Prisma's own default (5s timeout) was aborting auto-tagging and node-result-persist transactions under load — both do multiple round-trips inside a single `$transaction` call, and a CPU-starved event loop was enough to blow through 5 seconds routinely.
+- **`DB_CONNECTION_LIMIT`** (default `10`) / **`DB_POOL_TIMEOUT`** (default `20`, seconds) — explicit connection-pool sizing. Prisma's host-derived default is `num_cpus * 2 + 1`, computed from the **host's** CPU count — not the container's `cpus:` limit. That's exactly wrong in a CPU-limited container: it sizes the pool as though every core on the host is available to this one container, oversubscribing the pool relative to the CPU budget the cgroup actually enforces. Set both explicitly, sized to the container's CPU allotment rather than trusting the derived default. `DB_POOL_TIMEOUT` is how long a query waits for a free pooled connection before erroring with "Unable to start a transaction in the given time."
+
+### 4.3 Production posture: worker off when distributed nodes are present
+
+When distributed worker nodes are registered and handling enrichment compute (see the [Distributed Nodes spec](docs/specs/distributed-nodes.md)), set **`ENRICHMENT_WORKER_ENABLED=false`** on the API tier. This keeps the API's CPU and connection-pool budget dedicated to serving requests during a bulk import instead of competing with in-process enrichment jobs for the same core(s) and the same Prisma pool.
+
+---
+
+## 5. Recommended presets by container size
+
+| Container limit | `ENRICHMENT_WORKER_CONCURRENCY` | `NODE_OPTIONS=--max-old-space-size` | `*_MAX_IMAGE_DIM` | Heap regime | Notes |
+|---|---|---|---|---|---|
+| **512 MB** (cheap VPS) | `1` | `320` | `1024` | small (~55%) | Field-proven stable for a ~20k-job import. Slower but resilient. |
+| **1 GB** | `2` | `576` | `1024`–`1568` | small (~55%) | Step up gradually; watch `dmesg` after each bump. |
+| **2 GB** | `4` | `1024` | `1568` (default) | large (`container − 1G`) | Comfortable for aggressive throughput on a modest box; also pair with `API_CPU_LIMIT` sized to the host (§4.1). |
+| **6 GB** (production default) | `4` | `5120` | `1568` (default) | large (`container − 1G`) | Committed default in `prod.compose.yml` / `.env.example`. Pair with `API_CPU_LIMIT=4.0` — see §4.1. |
+
+Rule of thumb — **two different formulas depending on container size** (full rationale in §3, lever 1):
+- **≤ ~1 GB:** `--max-old-space-size` ≈ **55% of the container limit**, leaving the rest for the resident models + `concurrency ×` per-job image buffers.
+- **≥ 2 GB:** `--max-old-space-size` ≈ **container limit (MB) − 1024**, leaving ~1 GB of headroom for the off-heap pool. A cap sized with the small-box formula on a large container risks the V8 heap-OOM crash described in §6.
+
+When raising concurrency, **step up one at a time** (1 → 2 → 3), watching `dmesg` for a few minutes at each step, rather than jumping straight to 4.
+
+---
+
+## 6. Diagnosing OOM crash loops (cgroup kill vs. V8 heap crash)
 
 The symptom is `502 Bad Gateway` on `/api/...` requests — because Nginx has no healthy API container to proxy to. Confirm it's memory:
 
@@ -103,6 +150,28 @@ An OOM kill looks like this, and the tell is `node-MainThread` with `anon-rss` l
 Memory cgroup out of memory: Killed process 3466723 (node-MainThread) total-vm:18433032kB, anon-rss:496944kB, file-rss:77952kB ... oom_score_adj:0
 ```
 
+**If `dmesg` shows nothing, don't conclude it isn't memory — check the API's own log for the *other* OOM signature.** A V8 heap crash never touches the kernel OOM killer at all, because the process kills itself:
+
+```bash
+sudo docker compose -f base.compose.yml -f prod.compose.yml logs api | grep -i -A5 "heap out of memory\|mark-compacts"
+```
+
+```
+<--- Last few GCs --->
+...
+FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
+```
+
+This is exactly what hit production on **2026-07-15**: a ~15-minute crash loop with `--max-old-space-size=320` on a 2 G container. `docker inspect` showed `OOMKilled: false` and RSS at time of death was only ~360 MB — nowhere near the 2 G container limit. The heap cap ITSELF was the ceiling, not the cgroup. Recovery was raising the pairing: container `2G → 6G`, heap `320 → 5120` (see the "large" regime in §3, lever 1 and the 6 GB preset in §5).
+
+| Signal | Cgroup OOM-kill | Node heap OOM |
+|---|---|---|
+| `dmesg` | Shows `Killed process ... (node-MainThread)` | Silent — nothing |
+| `docker inspect` → `OOMKilled` | `true` | `false` |
+| RSS at time of death | At/near the container memory limit | Can be a small fraction of the container limit (e.g. ~360 MB in a 2G container) |
+| How the process ends | `SIGKILL` from the kernel — no log line, no stack trace | Node exits on its own with a V8 fatal-error stack trace in the API log |
+| Fix | Raise the container memory limit and/or lower concurrency | Raise `--max-old-space-size` (§3, lever 1, "large" regime) |
+
 Also confirm the boot line shows the concurrency you expect (the worker logs it on startup):
 
 ```bash
@@ -114,7 +183,7 @@ sudo docker compose -f base.compose.yml -f prod.compose.yml logs api | grep "poo
 
 ---
 
-## 6. Recovering after a rough run
+## 7. Recovering after a rough run
 
 Restarts and OOM kills leave debris. None of it is lost data — jobs live in Postgres and the handlers are idempotent — but you may need to nudge things:
 
@@ -131,7 +200,7 @@ The video thumbnail/probe path has also been hardened since the reference run be
 
 ---
 
-## 7. What a real bulk run looks like (reference numbers)
+## 8. What a real bulk run looks like (reference numbers)
 
 These are measured figures from a production import of ~4,200 photos on a **512 MB** container at **`ENRICHMENT_WORKER_CONCURRENCY=1`** with the heap cap in place — roughly **19–20k enrichment jobs total** (~5 per photo). Use them to sanity-check your own run and set expectations.
 
@@ -161,21 +230,23 @@ These are measured figures from a production import of ~4,200 photos on a **512 
 - **`auto_tagging` dominates the wall-clock.** It was ~99% of the remaining backlog and the slowest high-volume type (avg 2s, because it round-trips to OpenAI for tags **and** an embedding per photo). The whole-queue ETA tracks auto-tagging almost exactly. The lightweight types (`burst`, `location_inference`, `duplicate`) drain quickly and are rarely the bottleneck.
 - **Most heavy work is I/O-bound, not CPU-bound.** `auto_tagging` waits on OpenAI; `face_detection` waits on the CompreFace sidecar. That's *why* concurrency helps throughput so much on a bigger box — the slots spend most of their time waiting on the network, not pegging the single JS thread — but each waiting slot still holds a decoded image buffer, which is *why* it costs memory even while idle-waiting.
 - **Sustained throughput at concurrency 1** was ~13/min for tagging → a ~1,000-job tagging backlog is ~38 minutes. Scale roughly linearly with concurrency once you have the RAM to raise it.
-- **The 116 failures** were almost entirely operational, not data problems: a boot-time handler-registration race (since fixed — see §8) plus jobs interrupted by the OOM kills. All were recoverable via `retry-failed`.
+- **The 116 failures** were almost entirely operational, not data problems: a boot-time handler-registration race (since fixed — see §9) plus jobs interrupted by the OOM kills. All were recoverable via `retry-failed`.
 
 ---
 
-## 8. Postmortem lessons (things learned the hard way)
+## 9. Postmortem lessons (things learned the hard way)
 
-- **Continuous processing removed the GC breathing room.** The worker pool claims jobs back-to-back with no idle gap. Without a heap cap forcing eager GC, decoded-image/model buffers accumulated faster than they were reclaimed and the container OOM-looped. `NODE_OPTIONS=--max-old-space-size` set well below the container limit is what compensates.
-- **cgroup OOM kills are invisible from inside the app.** The process just vanishes (`SIGKILL`); there's no catchable error and nothing in the app logs. Always check `dmesg` — it's the only place the truth shows up.
+- **Continuous processing removed the GC breathing room.** The worker pool claims jobs back-to-back with no idle gap. Without a heap cap forcing eager GC, decoded-image/model buffers accumulated faster than they were reclaimed and the container OOM-looped. `NODE_OPTIONS=--max-old-space-size` set well below the container limit is what compensates — **on a small container.**
+- **cgroup OOM kills are invisible from inside the app; V8 heap OOMs are the opposite.** A cgroup kill just vanishes the process (`SIGKILL`); there's no catchable error and nothing in the app logs — always check `dmesg`. A V8 heap OOM is the mirror image: it writes a fatal-error stack trace straight to the API log and never touches `dmesg` at all, because the kernel never intervenes. Checking only one of the two will make you misdiagnose the other (see §6).
+- **A heap cap sized for a small box will crash a large one.** The "~55% of container" rule that keeps a 512MB box stable actively causes the FATAL heap-OOM crash on a multi-GB production container, because it artificially starves V8 of heap the process legitimately needs. Heap sizing is not one universal formula — it is two regimes, and picking the wrong one for the container size is itself the bug (2026-07-15 incident, §3 lever 1 and §6).
 - **No graceful shutdown.** `main.ts` does not call `enableShutdownHooks()`, so any restart (deploy, OOM, manual) kills in-flight jobs mid-processing. They're recoverable (`reset-stuck`), but expect to run that after every restart during a big import.
 - **Concurrency is a memory decision, not just a speed decision.** On a fixed container limit, the safe concurrency is whatever leaves headroom above `baseline + concurrency × per-job`. Treat `ENRICHMENT_WORKER_CONCURRENCY` and the container `memory:` limit as a *matched pair*.
 - **`*_MAX_IMAGE_DIM` is the underused lever.** Shrinking decoded-image size is often a better trade than throttling to concurrency 1, because it lets multiple slots coexist in the same budget.
+- **A CPU limit is not just a throughput knob — it can break correctness-adjacent timeouts.** Pinning the API to a single core (2026-07-14 incident) didn't just slow things down; it starved the event loop badly enough that Prisma interactive transactions blew past their timeout mid-flight, surfacing as `expired transaction` errors that look like a database or code bug rather than a resource-allocation one. When you see Prisma transaction timeouts under load, check `API_CPU_LIMIT` before you go looking in application code (§4).
 
 ---
 
-## 9. Related configuration
+## 10. Related configuration
 
 All the environment variables referenced here are documented in full in [Enrichment Queue → §13 Configuration](enrichment-queue.md#13-configuration), including the retry/backoff and rate-limit knobs. The provider rate-limit classification matrix and CLI-side resilience live in [Bulk Import Resilience](bulk-import-resilience.md).
 
@@ -187,3 +258,4 @@ All the environment variables referenced here are documented in full in [Enrichm
 |---|---|---|---|
 | 1.0 | July 2026 | AI Assistant | Initial runbook: two-pool memory model (V8 heap vs off-heap), why bulk imports OOM, the four tuning levers, per-container-size presets, OOM diagnosis via dmesg, post-run recovery, and reference throughput/failure numbers from a real ~20k-job / ~4,200-photo import on a 512MB container |
 | 1.1 | July 2026 | AI Assistant | Added the video-specific tuning lever (§3 lever 5): `VIDEO_ENRICHMENT_MAX_BYTES` size cap (skip huge videos, no download) and `ENRICHMENT_VIDEO_JOB_TIMEOUT_MS` (20-min per-type video timeout); documented the temp-disk guards in §6 — `assertDiskSpaceForDownload` disk pre-flight and the `TempFileJanitorTask` orphan sweep |
+| 1.2 | July 2026 | AI Assistant | Reconciled heap sizing into two regimes — small (≤1GB): ~55% of container; large (≥2GB): `container − 1G` — after the 2026-07-15 V8 heap-OOM crash loop (`--max-old-space-size=320` pinned on a 2G container, `OOMKilled=false`, RSS only ~360MB); added the 6G/5120MB/concurrency-4 production preset and distinguished cgroup-kill vs. V8-heap-OOM diagnosis signatures (§6); added §4 "Database & CPU resilience" covering the separate 2026-07-14 CPU-starvation brownout (`API_CPU_LIMIT`, `PRISMA_TX_TIMEOUT_MS`/`PRISMA_TX_MAX_WAIT_MS`, `DB_CONNECTION_LIMIT`/`DB_POOL_TIMEOUT`) and the `ENRICHMENT_WORKER_ENABLED=false` posture for API instances running alongside distributed worker nodes; renumbered §4–§9 to §5–§10 |

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -42,6 +42,25 @@ PORT=3000
 APP_URL=http://localhost:3535
 
 # -----------------------------------------------------------------------------
+# Container Resource Limits (production — prod.compose.yml / installer)
+# -----------------------------------------------------------------------------
+# These size the API/web containers on a production host. The committed compose
+# defaults (6G / 4.0 CPU) match the live VPS; override here per host. See #102.
+#
+# IMPORTANT — two independent ceilings that MUST be sized together:
+#   1. API_MEMORY_LIMIT — the container (cgroup) memory limit.
+#   2. NODE_OPTIONS=--max-old-space-size — the Node.js V8 old-space heap cap.
+# Without a matching heap cap the API FATAL-crashes at V8's old-space limit
+# (JavaScript heap OOM) long before the cgroup limit, regardless of how much
+# container memory you grant. Rule of thumb: size the heap ≈ container_MB − 1024,
+# leaving ~1 GB for off-heap/native buffers (image decode, sharp, onnxruntime).
+# Current live pairing: 6 G container / 5120 MB heap.
+API_MEMORY_LIMIT=6G
+API_CPU_LIMIT=4.0
+WEB_MEMORY_LIMIT=128M
+NODE_OPTIONS=--max-old-space-size=5120
+
+# -----------------------------------------------------------------------------
 # Database (PostgreSQL)
 # -----------------------------------------------------------------------------
 # External database connection (DATABASE_URL is constructed from these at runtime)
@@ -51,6 +70,21 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=appdb
 POSTGRES_SSL=false
+
+# Prisma connection-pool sizing. Appended to the constructed DATABASE_URL.
+# Prisma's default connection_limit is host-derived (num_cpus * 2 + 1), which is
+# misleading inside a CPU-limited container — set it explicitly. pool_timeout is
+# in seconds; raising it avoids "Unable to start a transaction in the given time"
+# pool-starvation errors under sustained bulk-import load. See issue #102.
+DB_CONNECTION_LIMIT=10
+DB_POOL_TIMEOUT=20
+
+# Prisma interactive-transaction timeouts (milliseconds). The Prisma default of
+# 5000 ms is too tight under bulk-import load — event-loop contention makes
+# auto-tagging / node-result-persist transactions exceed 5 s and abort with
+# "expired transaction". maxWait bounds how long a txn waits for a pool slot.
+PRISMA_TX_TIMEOUT_MS=15000
+PRISMA_TX_MAX_WAIT_MS=5000
 
 # -----------------------------------------------------------------------------
 # JWT / Session
@@ -267,7 +301,11 @@ FACE_HUMAN_MODEL_PATH=/app/models/human
 FACE_MAX_IMAGE_DIM=2000
 
 # Enrichment Job Queue (generic worker — replaces face-specific FaceJobWorker)
-ENRICHMENT_WORKER_ENABLED=true          # Set to 'false' to disable the worker
+# Production posture (issue #102): when distributed worker NODES handle
+# enrichment, run the in-process worker OFF (ENRICHMENT_WORKER_ENABLED=false) so
+# the API tier stays responsive during bulk imports — with the in-process worker
+# on, API CPU competes with node-result persistence and starves the event loop.
+ENRICHMENT_WORKER_ENABLED=true          # Set to 'false' to disable the worker (recommended when nodes are present)
 ENRICHMENT_JOB_POLL_MS=5000            # Poll interval in ms (default: 5000)
 ENRICHMENT_WORKER_CONCURRENCY=1        # Concurrent job slots (default: 1)
 # Job priority scheme: lower number = higher priority

--- a/infra/compose/prod.compose.yml
+++ b/infra/compose/prod.compose.yml
@@ -16,11 +16,22 @@ services:
       target: production
     environment:
       - NODE_ENV=production
+      # Node.js V8 old-space heap cap. This is a SEPARATE ceiling from the
+      # container `memory` limit below: without it the process FATAL-crashes at
+      # V8's old-space limit (JS heap OOM) long before the cgroup limit, even
+      # with plenty of container memory. Size it UNDER the container limit,
+      # leaving ~1 GB of headroom for off-heap/native buffers (image decode,
+      # sharp, onnxruntime): max-old-space-size ≈ container_mem_MB − 1024.
+      # Current live pairing: 6 G container / 5120 MB heap.
+      - NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=5120}
     restart: unless-stopped
     deploy:
       resources:
         limits:
-          memory: 512M
+          # Sized to real production load. `.env`-parameterized so a host can
+          # override without editing this file. See issue #102.
+          memory: ${API_MEMORY_LIMIT:-6G}
+          cpus: "${API_CPU_LIMIT:-4.0}"
 
   # ---------------------------------------------------------------------------
   # Web - Production settings
@@ -32,7 +43,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128M
+          memory: ${WEB_MEMORY_LIMIT:-128M}
 
   # ---------------------------------------------------------------------------
   # Nginx - Production settings

--- a/infra/deploy/install.sh
+++ b/infra/deploy/install.sh
@@ -337,11 +337,19 @@ services:
       target: production
     env_file:
       - .env
+    environment:
+      # Node.js V8 old-space heap cap — a SEPARATE ceiling from the container
+      # `memory` limit below. Size it under the container limit with ~1 GB of
+      # off-heap headroom: max-old-space-size ≈ container_mem_MB − 1024. See #102.
+      - NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=5120}
     restart: unless-stopped
     deploy:
       resources:
         limits:
-          memory: 512M
+          # `.env`-parameterized (Docker Compose auto-reads the sibling .env for
+          # ${VAR} interpolation). Defaults sized to real production load. See #102.
+          memory: ${API_MEMORY_LIMIT:-6G}
+          cpus: "${API_CPU_LIMIT:-4.0}"
     networks:
       - memoriahub-internal
 
@@ -358,7 +366,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128M
+          memory: ${WEB_MEMORY_LIMIT:-128M}
     networks:
       - memoriahub-internal
 


### PR DESCRIPTION
## Summary

Bakes the manually-applied production settings from two VPS incidents into committed, `.env`-parameterized defaults so a reinstall no longer reverts them, and hardens Prisma against the transaction/pool brownout. Addresses **#102**.

### 1. Resource limits + Node V8 heap cap (committed defaults, `.env`-parameterized)
- `infra/compose/prod.compose.yml` **and** the installer-generated compose (`infra/deploy/install.sh`): API `memory 512M → ${API_MEMORY_LIMIT:-6G}`, add `cpus "${API_CPU_LIMIT:-4.0}"`, add `NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=5120}`, web `→ ${WEB_MEMORY_LIMIT:-128M}`.
- The Node V8 old-space cap was **absent from the entire repo** — the direct cause of the 2026-07-15 heap-OOM crash loop. It's now baked in and documented as a separate ceiling that must be sized under the container memory (`≈ container_MB − 1024`).
- Repo prod compose + installer output now agree with the live VPS (no drift on memory, CPU, or the heap flag).

### 2. Prisma transaction robustness
- `PrismaClient` `transactionOptions` (`timeout=PRISMA_TX_TIMEOUT_MS` default 15000, `maxWait=PRISMA_TX_MAX_WAIT_MS` default 5000) — raised from Prisma's 5 s default that was aborting `auto_tagging` / node-result-persist transactions under load.
- Shrank `AutoTaggingService.persistAutoTagging`'s interactive transaction (resolve `Tag` rows before the tx opens) — this is both the in-process **and** node-result persist path.

### 3. Connection-pool sizing (sized to the container, not the host)
- Explicit `DB_CONNECTION_LIMIT` (default 10) / `DB_POOL_TIMEOUT` (default 20 s). **Note:** this codebase uses the `@prisma/adapter-pg` driver adapter, whose runtime pool is a real `pg.Pool` that ignores Prisma's URL `connection_limit`/`pool_timeout` params — so the pool is sized directly via `pg.PoolConfig` (`max` / `connectionTimeoutMillis`), while `configuration.ts` still appends the URL params for the CLI/migration path that does honor them. Extracted a shared, unit-tested `database-url.util.ts`.

### 4. Enrichment worker vs API contention
- Documented `ENRICHMENT_WORKER_ENABLED=false` as the recommended production posture when distributed worker nodes are present.

### 5. Docs
- `docs/specs/bulk-upload-vps-tuning.md`: reconciled the two heap-sizing regimes (small ≤1G ≈55%; large ≥2G `container−1024`), added a Database & CPU resilience section, and distinguished the cgroup-kill vs. V8-heap-OOM signatures.

## Acceptance criteria
- [x] Fresh deploy has API memory **≥ 2G** and CPU **> 1** by default, no manual edit (defaults 6G / 4.0).
- [x] Fresh deploy sets `--max-old-space-size` paired to container memory (default 5120 for the 6G default), no manual edit.
- [x] Repo prod compose and installer output match the live VPS (memory, CPU, heap flag).
- [x] `auto_tagging` / node-result transactions no longer bounded by the 5 s default (raised + shrunk).
- [x] Pool sizing set explicitly (sized to the container, via the adapter's `pg.Pool`).
- [ ] **Operator verification:** re-run a large import on the VPS to confirm zero 5 s transaction-timeout / pool-starvation errors and no ~15-min heap-OOM restart cycle (cannot be exercised from CI — the code paths are covered by unit + existing tests).

## Testing
- New `database-url.util.spec.ts` — 16/16 pass (URL build, pool-param separator/idempotency/defaults/skip-invalid, seconds→ms).
- Existing tagging suite — 135/135 pass after the transaction shrink.
- API typecheck (`tsc --noEmit`) clean.
- Compose interpolation + installer heredoc validated as YAML with the new `${VAR}` tokens (Docker Compose not available in CI to run `config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #102