### PR TITLE
fix(infra): load onnxruntime-node on glibc so server dedup uses CLIP (#110)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,10 @@ jobs:
       - name: Build and push API image
         uses: docker/build-push-action@v7
         with:
-          context: ./apps/api
+          # Repo root: apps/api depends on the @memoriahub/enrichment-compute
+          # workspace, so the Dockerfile needs root manifests + the workspace
+          # member visible (matches infra/compose context: ../..).
+          context: .
           file: apps/api/Dockerfile
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -20,10 +20,19 @@
 # -----------------------------------------------------------------------------
 # Base stage
 # -----------------------------------------------------------------------------
-FROM node:26-alpine AS base
+# glibc-based image (Debian) — REQUIRED: onnxruntime-node ships only
+# glibc-linked prebuilt binaries (libonnxruntime.so.1 needs ld-linux-x86-64.so.2),
+# which do not exist on Alpine/musl. Building on node:*-alpine here silently
+# degrades server-side CLIP visual embeddings (near-duplicate detection falls
+# back to hash-only). See GitHub issue #110.
+FROM node:26-slim AS base
 WORKDIR /app
-# Install OpenSSL for Prisma compatibility and ffmpeg for video processing
-RUN apk add --no-cache openssl openssl-dev ffmpeg
+# OpenSSL for Prisma; ffmpeg for video processing; wget + ca-certificates for
+# the Human model download below (busybox wget is builtin on Alpine but absent
+# on Debian slim, and HTTPS fetches need the CA bundle).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openssl ffmpeg wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------
 # Dependencies stage

--- a/apps/api/src/dedup/visual-embedding.service.spec.ts
+++ b/apps/api/src/dedup/visual-embedding.service.spec.ts
@@ -77,6 +77,7 @@ jest.mock('fs', () => ({
 // ---------------------------------------------------------------------------
 
 import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
 import {
   VisualEmbeddingService,
   preprocessImageForClip,
@@ -293,8 +294,140 @@ describe('VisualEmbeddingService — degraded mode', () => {
     expect(result).toBeNull();
     expect(mockOrtInferenceSessionCreate).not.toHaveBeenCalled();
   });
+
+  it('logs the degraded-mode message at error level (not warn) — GitHub issue #110 loudness regression guard', async () => {
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    mockOrtInferenceSessionCreate.mockRejectedValue(new Error('unsupported platform'));
+
+    await service.embedImage(Buffer.from('irrelevant'));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('VisualEmbeddingService running in degraded mode'),
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('VisualEmbeddingService running in degraded mode'),
+    );
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });
 
+// ---------------------------------------------------------------------------
+// Section B.2: onApplicationBootstrap — eager boot-time native-runtime probe
+// added for GitHub issue #110 (musl/glibc mismatch silently degrading CLIP
+// dedup until the first lazy embed call). See the method's own doc comment
+// in visual-embedding.service.ts for the rationale.
+// ---------------------------------------------------------------------------
+
+describe('VisualEmbeddingService — onApplicationBootstrap', () => {
+  let service: VisualEmbeddingService;
+  let mockPrisma: MockPrismaService;
+  const ORIGINAL_NODE_ENV = process.env['NODE_ENV'];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPrisma = createMockPrismaService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VisualEmbeddingService, { provide: PrismaService, useValue: mockPrisma }],
+    }).compile();
+
+    service = module.get<VisualEmbeddingService>(VisualEmbeddingService);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    process.env['NODE_ENV'] = ORIGINAL_NODE_ENV;
+  });
+
+  it('is a no-op under NODE_ENV=test: isAvailable() stays true and no bootstrap log is emitted', async () => {
+    process.env['NODE_ENV'] = 'test';
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    await service.onApplicationBootstrap();
+
+    expect(service.isAvailable()).toBe(true);
+    // Returns before reaching either the success-log or failure-log branch.
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('onnxruntime native runtime'));
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('onnxruntime native runtime'));
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('logs success and leaves isAvailable() true when the dynamic import resolves (NODE_ENV != test)', async () => {
+    process.env['NODE_ENV'] = 'production';
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+
+    // The file-level jest.mock('onnxruntime-node', ...) factory (top of this
+    // file) resolves successfully, so `await import('onnxruntime-node')`
+    // succeeds for this instance.
+    await service.onApplicationBootstrap();
+
+    expect(service.isAvailable()).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('onnxruntime native runtime loaded'),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('sets degraded state and logs at error when the dynamic import rejects (NODE_ENV != test)', async () => {
+    // The shared top-of-file `jest.mock('onnxruntime-node', ...)` always
+    // resolves, so exercising the rejection branch requires temporarily
+    // swapping the module registry's mock factory for 'onnxruntime-node' to
+    // a throwing one, then re-requiring a fresh VisualEmbeddingService class
+    // bound to it. NOTE: an earlier attempt wrapped this in
+    // `jest.isolateModulesAsync` to scope the throwing mock to just this
+    // instance, but the sandbox did not reliably hold across the `await
+    // import(...)` microtask boundary inside `onApplicationBootstrap` — the
+    // fresh instance kept observing the shared success mock instead of the
+    // throwing one. `jest.resetModules()` + `jest.doMock()` on the shared
+    // (non-sandboxed) registry is used instead, with the original mock
+    // restored immediately after via `finally` so no other test in this file
+    // is affected.
+    jest.resetModules();
+    jest.doMock('onnxruntime-node', () => {
+      throw new Error('libonnxruntime.so.1: cannot open shared object file (musl/glibc mismatch)');
+    });
+
+    let errorSpy: jest.SpyInstance | undefined;
+    try {
+      const freshModule = require('./visual-embedding.service') as typeof import('./visual-embedding.service');
+      // `jest.resetModules()` above also gives '@nestjs/common' a fresh
+      // module instance, so `freshModule`'s internal `new Logger(...)` binds
+      // to a DIFFERENT class object than the `Logger` imported at the top of
+      // this file. Spy on the Logger class from the SAME (reset) registry
+      // freshModule resolved against, or the spy silently never intercepts
+      // (and the real logger prints to the console instead).
+      const freshCommon = require('@nestjs/common') as typeof import('@nestjs/common');
+      errorSpy = jest.spyOn(freshCommon.Logger.prototype, 'error').mockImplementation();
+
+      const freshService = new freshModule.VisualEmbeddingService(mockPrisma as unknown as PrismaService);
+      process.env['NODE_ENV'] = 'production';
+
+      await freshService.onApplicationBootstrap();
+
+      expect(freshService.isAvailable()).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('onnxruntime native runtime failed to load'),
+      );
+    } finally {
+      errorSpy?.mockRestore();
+      // Restore the shared success mock and module registry so every test
+      // after this one in the file (and the top-level `service` instance
+      // constructed from the original module binding) keeps working.
+      jest.resetModules();
+      jest.doMock('onnxruntime-node', () => ({
+        InferenceSession: { create: (...args: unknown[]) => mockOrtInferenceSessionCreate(...args) },
+        Tensor: (...args: unknown[]) => mockOrtTensor(...args),
+      }));
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Section C: persistence half (hasEmbedding / persistEmbedding)

--- a/apps/api/src/dedup/visual-embedding.service.ts
+++ b/apps/api/src/dedup/visual-embedding.service.ts
@@ -28,7 +28,12 @@
  * through `embedImage`, then persists via `persistEmbedding`.
  */
 
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import type { InferenceSession } from 'onnxruntime-node';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -73,7 +78,7 @@ const IDLE_RELEASE_MS = 5 * 60 * 1000; // 5 minutes
 // -----------------------------------------------------------------------------
 
 @Injectable()
-export class VisualEmbeddingService implements OnModuleDestroy {
+export class VisualEmbeddingService implements OnApplicationBootstrap, OnModuleDestroy {
   private readonly logger = new Logger(VisualEmbeddingService.name);
 
   private session: InferenceSession | null = null;
@@ -83,6 +88,36 @@ export class VisualEmbeddingService implements OnModuleDestroy {
   private degradedWarned = false;
 
   constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Boot-time native-runtime probe. Loud regression guard for GitHub issue #110:
+   * a musl/glibc mismatch in the container image silently disabled CLIP visual
+   * dedup because the onnxruntime-node native addon only failed to dlopen
+   * lazily, on the first embed call. Probe eagerly at startup so the failure is
+   * visible in boot logs immediately rather than degrading silently.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    // The unit test suite mocks onnxruntime; an eager real probe would fight it.
+    if (process.env['NODE_ENV'] === 'test') return;
+
+    try {
+      // Bare import triggers the native addon's dlopen of libonnxruntime.so.1
+      // without needing the ~85MB model download, so startup timing is
+      // unchanged on success. Do NOT create an InferenceSession here.
+      await import('onnxruntime-node');
+      this.logger.log('onnxruntime native runtime loaded — CLIP visual embeddings available');
+    } catch (err) {
+      this.degraded = true;
+      // Suppress the lazy path's duplicate log (it uses the same guard).
+      this.degradedWarned = true;
+      this.logger.error(
+        `onnxruntime native runtime failed to load — CLIP visual embeddings unavailable, ` +
+          `near-duplicate detection will run hash-only. This usually means a libc mismatch in ` +
+          `the container image (onnxruntime-node needs glibc, not musl/Alpine). ` +
+          `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
 
   onModuleDestroy(): void {
     if (this.idleTimer) {
@@ -186,7 +221,7 @@ export class VisualEmbeddingService implements OnModuleDestroy {
       this.degraded = true;
       if (!this.degradedWarned) {
         this.degradedWarned = true;
-        this.logger.warn(
+        this.logger.error(
           `VisualEmbeddingService running in degraded mode (visual embeddings unavailable, ` +
             `dedup will fall back to hash-only matching): ${err instanceof Error ? err.message : String(err)}`,
         );

--- a/apps/api/src/doctor/doctor.module.ts
+++ b/apps/api/src/doctor/doctor.module.ts
@@ -9,6 +9,7 @@ import { GeoModule } from '../geo/geo.module';
 import { StorageSettingsModule } from '../storage-settings/storage-settings.module';
 import { EnrichmentModule } from '../enrichment/enrichment.module';
 import { SocialMediaModule } from '../social-media/social-media.module';
+import { DedupModule } from '../dedup/dedup.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { SocialMediaModule } from '../social-media/social-media.module';
     StorageSettingsModule,
     EnrichmentModule,
     SocialMediaModule,
+    DedupModule,
   ],
   controllers: [DoctorController],
   providers: [DoctorService],

--- a/apps/api/src/doctor/doctor.service.spec.ts
+++ b/apps/api/src/doctor/doctor.service.spec.ts
@@ -23,6 +23,7 @@ import { GeoSettingsService } from '../geo/geo-settings.service';
 import { StorageSettingsService } from '../storage-settings/storage-settings.service';
 import { EnrichmentAdminService } from '../enrichment/enrichment-admin.service';
 import { SocialMediaOcrService } from '../social-media/social-media-ocr.service';
+import { VisualEmbeddingService } from '../dedup/visual-embedding.service';
 import {
   createMockPrismaService,
   MockPrismaService,
@@ -168,6 +169,7 @@ describe('DoctorService', () => {
   let mockStorageSettings: jest.Mocked<Pick<StorageSettingsService, 'testConnection'>>;
   let mockEnrichmentAdmin: jest.Mocked<Pick<EnrichmentAdminService, 'getStats'>>;
   let mockSocialMediaOcr: jest.Mocked<Pick<SocialMediaOcrService, 'getStatus'>>;
+  let mockVisualEmbeddingService: jest.Mocked<Pick<VisualEmbeddingService, 'isAvailable'>>;
   const ORIGINAL_ENV = { ...process.env };
 
   beforeEach(async () => {
@@ -179,6 +181,7 @@ describe('DoctorService', () => {
     mockStorageSettings = { testConnection: jest.fn() };
     mockEnrichmentAdmin = { getStats: jest.fn() };
     mockSocialMediaOcr = { getStatus: jest.fn() };
+    mockVisualEmbeddingService = { isAvailable: jest.fn().mockReturnValue(true) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -191,6 +194,7 @@ describe('DoctorService', () => {
         { provide: StorageSettingsService, useValue: mockStorageSettings },
         { provide: EnrichmentAdminService, useValue: mockEnrichmentAdmin },
         { provide: SocialMediaOcrService, useValue: mockSocialMediaOcr },
+        { provide: VisualEmbeddingService, useValue: mockVisualEmbeddingService },
       ],
     }).compile();
 
@@ -272,7 +276,7 @@ describe('DoctorService', () => {
       }
     });
 
-    it('includes all 25 documented checks across the 8 sections', async () => {
+    it('includes all 26 documented checks across the 8 sections', async () => {
       const report = await service.runDiagnostics();
 
       const allKeys = report.sections.flatMap((s) => s.checks.map((c) => c.key));
@@ -292,6 +296,7 @@ describe('DoctorService', () => {
         'ai.embedding',
         'ai.flagConsistency',
         'ai.socialMedia',
+        'ai.duplicateDetection',
         'face.detection',
         'face.flagConsistency',
         'geo.reverseProvider',
@@ -345,7 +350,7 @@ describe('DoctorService', () => {
       // Unrelated checks are unaffected.
       expect(findCheck(report, 'core.database').status).toBe('ok');
       expect(findCheck(report, 'ai.search').status).toBe('ok');
-      expect(report.summary.total).toBe(25);
+      expect(report.summary.total).toBe(26);
     });
   });
 
@@ -385,7 +390,7 @@ describe('DoctorService', () => {
         // The rest of the report still completed normally.
         expect(findCheck(report, 'core.database').status).toBe('ok');
         expect(findCheck(report, 'ai.search').status).toBe('ok');
-        expect(report.summary.total).toBe(25);
+        expect(report.summary.total).toBe(26);
       } finally {
         jest.useRealTimers();
       }
@@ -666,6 +671,72 @@ describe('DoctorService', () => {
       const check = findCheck(report, 'ai.socialMedia');
       expect(check.status).toBe('warning');
       expect(check.message).toContain('degraded');
+    });
+  });
+
+  describe('ai.duplicateDetection', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockNoWorkerNodes(mockPrisma);
+    });
+
+    it('is status:skipped when duplicate detection is disabled, and does not consult VisualEmbeddingService', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings());
+
+      const report = await service.runDiagnostics();
+      expect(findCheck(report, 'ai.duplicateDetection').status).toBe('skipped');
+      expect(mockVisualEmbeddingService.isAvailable).not.toHaveBeenCalled();
+    });
+
+    it('is status:ok (two-tier operational) when the feature is on and the CLIP model is available', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: {
+            autoTagging: false,
+            faceRecognition: false,
+            burstDetection: false,
+            duplicateDetection: true,
+          } as any,
+        }),
+      );
+      mockVisualEmbeddingService.isAvailable.mockReturnValue(true);
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'ai.duplicateDetection');
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('Two-tier');
+    });
+
+    it('is status:warning (degraded) when the feature is on but the CLIP model is unavailable', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({
+          features: {
+            autoTagging: false,
+            faceRecognition: false,
+            burstDetection: false,
+            duplicateDetection: true,
+          } as any,
+        }),
+      );
+      mockVisualEmbeddingService.isAvailable.mockReturnValue(false);
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'ai.duplicateDetection');
+      expect(check.status).toBe('warning');
+      expect(check.message).toContain('dHash-only');
+      expect(check.actionItem).toBeTruthy();
     });
   });
 

--- a/apps/api/src/doctor/doctor.service.ts
+++ b/apps/api/src/doctor/doctor.service.ts
@@ -21,6 +21,7 @@ import { StorageSettingsService } from '../storage-settings/storage-settings.ser
 import { EnrichmentAdminService } from '../enrichment/enrichment-admin.service';
 import { isEnrichmentWorkerEnabled } from '../enrichment/enrichment-job.worker';
 import { SocialMediaOcrService } from '../social-media/social-media-ocr.service';
+import { VisualEmbeddingService } from '../dedup/visual-embedding.service';
 import {
   DoctorCheck,
   DoctorCheckStatus,
@@ -66,6 +67,7 @@ export class DoctorService {
     private readonly storageSettings: StorageSettingsService,
     private readonly enrichmentAdmin: EnrichmentAdminService,
     private readonly socialMediaOcr: SocialMediaOcrService,
+    private readonly visualEmbeddingService: VisualEmbeddingService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -113,6 +115,11 @@ export class DoctorService {
         key: 'ai.socialMedia',
         label: 'Social media detection',
         fn: () => this.checkSocialMedia(settings),
+      },
+      {
+        key: 'ai.duplicateDetection',
+        label: 'Duplicate detection (CLIP)',
+        fn: () => this.checkDuplicateDetection(settings),
       },
       // Face
       { key: 'face.detection', label: 'Face detection provider', fn: () => this.checkFaceDetection(settings) },
@@ -181,7 +188,14 @@ export class DoctorService {
       {
         key: 'ai',
         label: 'AI & Enrichment',
-        checkKeys: ['ai.search', 'ai.tagging', 'ai.embedding', 'ai.flagConsistency', 'ai.socialMedia'],
+        checkKeys: [
+          'ai.search',
+          'ai.tagging',
+          'ai.embedding',
+          'ai.flagConsistency',
+          'ai.socialMedia',
+          'ai.duplicateDetection',
+        ],
       },
       {
         key: 'face',
@@ -638,6 +652,29 @@ export class DoctorService {
       message: 'Running Tier-1 only — OCR model unavailable (degraded)',
       actionItem:
         'Ensure MODELS_DIR/tesseract is writable and traineddata can be fetched or pre-placed',
+    };
+  }
+
+  private async checkDuplicateDetection(settings: ResolvedSettings): Promise<CheckOutcome> {
+    if (settings.features?.['duplicateDetection'] !== true) {
+      return { status: 'skipped', message: 'Near-duplicate detection is disabled.' };
+    }
+
+    // dedup still functions hash-only when the CLIP model is unavailable, so a
+    // degraded runtime is a warning, never an error.
+    if (this.visualEmbeddingService.isAvailable()) {
+      return {
+        status: 'ok',
+        message: 'Two-tier operational (CLIP visual embeddings + dHash).',
+      };
+    }
+
+    return {
+      status: 'warning',
+      message: 'Running dHash-only — CLIP visual embedding model unavailable (degraded).',
+      actionItem:
+        'onnxruntime native runtime failed to load; verify the API image uses a glibc base ' +
+        '(not Alpine/musl) and MODELS_DIR is writable/reachable.',
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #110 — the API image was built on `node:26-alpine` (musl libc), but `onnxruntime-node` ships **only glibc-linked** prebuilt binaries. At runtime `libonnxruntime.so.1` needs `ld-linux-x86-64.so.2`, which does not exist on Alpine, so `VisualEmbeddingService` silently flipped to degraded mode (a single WARN) and CLIP visual near-duplicate detection ran **hash-only**. This is isolated to duplicate detection — unrelated to face recognition / CompreFace.

## Changes

- **`fix(infra)`** — `apps/api/Dockerfile` base `node:26-alpine` → `node:26-slim` (Debian/glibc, the environment onnxruntime-node prebuilts target). Ports `apk add openssl openssl-dev ffmpeg` → `apt-get install openssl ffmpeg wget ca-certificates` (`wget`/`ca-certificates` are busybox-builtin on Alpine but absent on Debian slim and needed by the Human-model download).
- **`chore(infra)`** — corrects `deploy.yml` API build context `./apps/api` → repo root, matching the workspace requirement the compose files already use (the old context can't resolve `@memoriahub/enrichment-compute`).
- **`feat(api)`** — loud regression guard so this can't silently recur: a boot-time `onApplicationBootstrap` probe in `VisualEmbeddingService` that imports `onnxruntime-node` up front and logs at **ERROR** if the native addon can't load (no 85 MB model download needed); bumps the lazy degraded log WARN→ERROR; adds an `ai.duplicateDetection` Doctor check (ok / dHash-only-degraded / skipped) visible in `/admin/settings/doctor`. The probe no-ops under `NODE_ENV=test`.
- **`test(api)`** — covers the warn→error change, the boot probe (test-env no-op / success / native-import rejection), and the three Doctor-check outcomes.

## Verification

- API image **builds** on the glibc base (exit 0), including `apt-get`, `npm install`, `prisma generate`, and the wget Human-model step.
- **Native runtime loads** — ran the exact boot probe inside the built image: `import('onnxruntime-node')` resolves (`ort version 1.27.0`, exit 0), where the old Alpine image threw the `ld-linux-x86-64.so.2` loader error. This meets the issue's primary acceptance criterion (`VisualEmbeddingService` available, no degraded WARN).
- **Tests green**: 57/57 across `visual-embedding.service.spec.ts` and `doctor.service.spec.ts`; API typecheck clean.

## Acceptance criteria mapping

- [x] API starts with `VisualEmbeddingService` available; `onnxruntime-node` loads its native runtime.
- [x] CI/build guard + startup healthcheck surface a regression loudly (boot-time ERROR probe + Doctor check) so it can't silently degrade again.
- [ ] Behavioural check (re-encoded/resized pair flagged via CLIP tier) — best run against a live stack post-merge; the decisive layer (native runtime loads) is verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ryn77T2fRApGxxqW4wrzj5
