### PR TITLE
feat(cli): harden CompreFace worker defaults + fix node-start provider race (#103)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/node.ts
+++ b/apps/cli/src/commands/node.ts
@@ -76,6 +76,7 @@ import {
   ensureComprefaceContainer,
   verifyCompreface,
   type InstallStepResult,
+  type ComprefaceContainerOptions,
 } from '../node/install-deps.js';
 
 const require = createRequire(import.meta.url);
@@ -377,6 +378,47 @@ function startCmd(): Command {
           parseInt(opts.poll ?? String(cfg.node?.pollIntervalMs ?? DEFAULT_POLL_MS), 10) ||
           DEFAULT_POLL_MS;
 
+        // Resolve the effective face provider (flag > persisted config > default)
+        // and, when it is CompreFace and this node claims face jobs, BLOCK until
+        // the sidecar's /status reports healthy before building the engine. This
+        // closes the warm-up race (issue #103): CompreFace takes ~15–30s to load
+        // its model, and claiming face jobs before then would run them on the
+        // wrong provider. We never silently fall back to Human — an unready
+        // sidecar is a hard start failure.
+        const resolvedFaceProvider: 'human' | 'compreface' =
+          validatedFaceProvider ?? cfg.node?.faceProvider ?? 'human';
+        const resolvedComprefaceUrl =
+          opts.comprefaceUrl ?? cfg.node?.comprefaceUrl ?? DEFAULT_COMPREFACE_URL;
+        const claimsFaceJobs =
+          eligibleTypes.includes('face_detection') ||
+          eligibleTypes.includes('video_face_detection');
+
+        if (resolvedFaceProvider === 'compreface' && claimsFaceJobs) {
+          ui.step(
+            `Face provider is 'compreface' — waiting for the sidecar at ${resolvedComprefaceUrl} ` +
+              'to become healthy before claiming face jobs…',
+          );
+          // ~40s budget (20 × 2s) to cover CompreFace's cold-start model load.
+          const health = await verifyCompreface(resolvedComprefaceUrl, {
+            retries: 20,
+            retryDelayMs: 2000,
+          });
+          if (health.status !== 'installed') {
+            ui.error(
+              `CompreFace at ${resolvedComprefaceUrl} did not become healthy: ${health.detail}\n` +
+                'Refusing to start rather than silently falling back to the Human provider. ' +
+                'Start/verify the sidecar (`memoriahub node install-deps`) and retry, ' +
+                'or start with `--face-provider human`.',
+            );
+            process.exit(1);
+          }
+          ui.success(`CompreFace healthy at ${resolvedComprefaceUrl}.`);
+        }
+        ui.info(
+          `Active face provider: ${resolvedFaceProvider}` +
+            (resolvedFaceProvider === 'compreface' ? ` (${resolvedComprefaceUrl})` : ''),
+        );
+
         // 1. Ensure models are present before processing.
         try {
           const manifest = await api.getModelManifest();
@@ -402,7 +444,15 @@ function startCmd(): Command {
         // 2. Build the engine with file logging and the IPC daemon host, so
         //    every run (foreground or daemonized) is attachable by a second
         //    CLI instance.
-        const options: NodeEngineOptions = { concurrency, eligibleTypes, pollIntervalMs };
+        const options: NodeEngineOptions = {
+          concurrency,
+          eligibleTypes,
+          pollIntervalMs,
+          faceProvider: resolvedFaceProvider,
+          ...(resolvedFaceProvider === 'compreface'
+            ? { comprefaceUrl: resolvedComprefaceUrl }
+            : {}),
+        };
         const engine = new NodeEngine({
           api,
           dispatcher: new ComputeDispatcher(),
@@ -575,6 +625,10 @@ function renderSnapshot(snap: EngineSnapshot): void {
       `${inFlight} in-flight, ${idle} idle`,
   );
   ui.line(`  Eligible types: ${snap.eligibleTypes.join(', ') || '(none)'}`);
+  ui.line(
+    `  Face provider : ${snap.faceProvider}` +
+      (snap.faceProvider === 'compreface' && snap.comprefaceUrl ? ` (${snap.comprefaceUrl})` : ''),
+  );
   ui.line(`  Last heartbeat: ${hbAge}`);
   ui.line(
     `  Jobs          : ${snap.counters.claimed} claimed, ` +
@@ -656,10 +710,20 @@ function statusCmd(): Command {
       ui.line(`  Concurrency   : ${cfg.node?.concurrency ?? DEFAULT_CONCURRENCY}`);
       ui.line(`  Poll interval : ${cfg.node?.pollIntervalMs ?? DEFAULT_POLL_MS}ms`);
       ui.line(`  Eligible types: ${cfg.node?.eligibleTypes?.join(', ') ?? chalk.dim('(all)')}`);
+      const cfgFaceProvider = cfg.node?.faceProvider ?? 'human';
+      const cfgComprefaceUrl = cfg.node?.comprefaceUrl ?? DEFAULT_COMPREFACE_URL;
+      ui.line(
+        `  Face provider : ${cfgFaceProvider}` +
+          (cfgFaceProvider === 'compreface' ? ` (${cfgComprefaceUrl})` : ''),
+      );
       ui.blank();
 
       ui.step('Detected capabilities');
-      const caps = await detectCapabilities();
+      // Probe the node's ACTUAL sidecar (not the localhost default) so the
+      // compreface capability row reflects the configured URL.
+      const caps = await detectCapabilities(
+        cfgFaceProvider === 'compreface' ? { comprefaceUrl: cfgComprefaceUrl } : undefined,
+      );
       printCapabilityTable(caps);
 
       // Best-effort: fetch last-known server-side status if the API exposes it.
@@ -1146,8 +1210,34 @@ function installDepsCmd(): Command {
       'Port to expose the compreface-core sidecar on',
       String(DEFAULT_COMPREFACE_PORT),
     )
+    .option(
+      '--compreface-processes <n>',
+      'UWSGI_PROCESSES for the compreface-core sidecar (parallel face inference workers); ' +
+        'defaults to a core-aware value (cores - 2, capped at 6)',
+    )
+    .option(
+      '--compreface-memory <size>',
+      'docker --memory cap for the compreface-core sidecar (e.g. 4g); omitted → no cap',
+    )
+    .option(
+      '--compreface-cpus <n>',
+      'docker --cpus cap for the compreface-core sidecar (e.g. 4); omitted → no cap',
+    )
+    .option(
+      '--compreface-recreate',
+      'Remove and recreate the compreface-core container even if it is already running, ' +
+        'so new process/restart/resource settings take effect',
+    )
     .action(
-      async (opts: { dryRun?: boolean; skipCompreface?: boolean; comprefacePort?: string }) => {
+      async (opts: {
+        dryRun?: boolean;
+        skipCompreface?: boolean;
+        comprefacePort?: string;
+        comprefaceProcesses?: string;
+        comprefaceMemory?: string;
+        comprefaceCpus?: string;
+        comprefaceRecreate?: boolean;
+      }) => {
         // 1. Platform gate — this command is Linux-only for now.
         if (process.platform !== 'linux') {
           ui.error(
@@ -1172,6 +1262,22 @@ function installDepsCmd(): Command {
           parseInt(opts.comprefacePort ?? String(DEFAULT_COMPREFACE_PORT), 10) ||
             DEFAULT_COMPREFACE_PORT,
         );
+
+        // CompreFace sidecar tunables — undefined values fall back to the
+        // core-aware / no-cap defaults inside ensureComprefaceContainer.
+        const parsedProcesses =
+          opts.comprefaceProcesses !== undefined
+            ? parseInt(opts.comprefaceProcesses, 10)
+            : undefined;
+        const comprefaceContainerOpts: ComprefaceContainerOptions = {
+          dryRun,
+          ...(parsedProcesses !== undefined && Number.isFinite(parsedProcesses)
+            ? { processes: Math.max(1, parsedProcesses) }
+            : {}),
+          ...(opts.comprefaceMemory ? { memory: opts.comprefaceMemory } : {}),
+          ...(opts.comprefaceCpus ? { cpus: opts.comprefaceCpus } : {}),
+          ...(opts.comprefaceRecreate ? { recreate: true } : {}),
+        };
 
         const cfg = loadConfig();
         const comprefaceUrl = cfg?.node?.comprefaceUrl ?? `http://localhost:${port}`;
@@ -1216,7 +1322,9 @@ function installDepsCmd(): Command {
           const dockerHealthy = dockerResult.status === 'installed' || dockerResult.status === 'skipped';
 
           if (dockerHealthy) {
-            const containerResult = report(await ensureComprefaceContainer(port, { dryRun }));
+            const containerResult = report(
+              await ensureComprefaceContainer(port, comprefaceContainerOpts),
+            );
             const containerHealthy =
               containerResult.status === 'installed' || containerResult.status === 'skipped';
             if (containerHealthy && !dryRun) {

--- a/apps/cli/src/node/compute/face-detection.ts
+++ b/apps/cli/src/node/compute/face-detection.ts
@@ -97,7 +97,21 @@ function getFaceDetector(): Promise<FaceDetector> {
 const computeFaceDetection: ComputeFn = async (inputPath, _params) => {
   const buffer = fs.readFileSync(inputPath);
   const cfg = loadConfig();
-  const faceProvider = cfg?.node?.faceProvider ?? 'human';
+  if (!cfg) {
+    // Config could not be read at job time (missing/corrupt ~/.memoriahub/
+    // config.json). We cannot know which face provider this node was
+    // configured for, so fail the job — routed through the engine's normal
+    // /failure + retry/backoff path — rather than silently defaulting to
+    // Human, which on a CompreFace-configured node would silently write
+    // embeddings in the wrong (1024-d Human vs 128-d CompreFace) space.
+    throw new Error(
+      'face_detection: could not load node config to resolve the face provider — ' +
+        'refusing to silently fall back to Human.',
+    );
+  }
+  // A genuinely unset provider (node never opted into CompreFace) legitimately
+  // defaults to the in-process Human detector.
+  const faceProvider = cfg.node?.faceProvider ?? 'human';
 
   // Same EXIF-orientation + downscale step the server runs before detection.
   const prepared = await prepareImageForProcessing(buffer, { maxDim: FACE_MAX_IMAGE_DIM });

--- a/apps/cli/src/node/install-deps.ts
+++ b/apps/cli/src/node/install-deps.ts
@@ -556,11 +556,77 @@ function containerNamePresent(psOutput: string, name: string): boolean {
     .some((l) => l === name);
 }
 
+/** Hard cap on the core-aware default process count to bound sidecar memory. */
+const COMPREFACE_MAX_DEFAULT_PROCESSES = 6;
+
+/**
+ * Core-aware default for `UWSGI_PROCESSES`. CompreFace serves one request per
+ * uwsgi worker process, so a single process serializes all face detection on
+ * ~1 core no matter the node's concurrency. Default to `cores - 2` (leaving
+ * headroom for the node daemon + OS), clamped to [1, 6] so a big host doesn't
+ * spin up a model copy per core and blow past its RAM.
+ */
+export function defaultComprefaceProcesses(): number {
+  const cores =
+    typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length;
+  return Math.min(Math.max(cores - 2, 1), COMPREFACE_MAX_DEFAULT_PROCESSES);
+}
+
+/** Tunables for the compreface-core sidecar container. */
+export interface ComprefaceContainerOptions {
+  dryRun?: boolean;
+  /** `UWSGI_PROCESSES`; omitted → {@link defaultComprefaceProcesses}. */
+  processes?: number;
+  /** `UWSGI_THREADS`; omitted → 1 (threads hit the Python GIL; processes give real parallelism). */
+  threads?: number;
+  /** `docker run --memory` value (e.g. `4g`); omitted → no cap. */
+  memory?: string;
+  /** `docker run --cpus` value (e.g. `4`); omitted → no cap. */
+  cpus?: string;
+  /** Force `docker rm -f` + recreate even if the container is currently running. */
+  recreate?: boolean;
+}
+
+/**
+ * Build the `docker run` argument vector for the compreface-core sidecar,
+ * baking in multi-process inference, an auto-restart policy, and optional
+ * resource caps. Exported so tests can assert the exact flags without spawning
+ * docker.
+ */
+export function buildComprefaceRunArgs(port: number, opts?: ComprefaceContainerOptions): string[] {
+  const processes = Math.max(1, Math.floor(opts?.processes ?? defaultComprefaceProcesses()));
+  const threads = Math.max(1, Math.floor(opts?.threads ?? 1));
+  const args = [
+    'run',
+    '-d',
+    '--name',
+    COMPREFACE_CONTAINER_NAME,
+    // Survive a crash or host reboot without manual intervention.
+    '--restart',
+    'unless-stopped',
+    '-p',
+    `${port}:3000`,
+    '-e',
+    `UWSGI_PROCESSES=${processes}`,
+    '-e',
+    `UWSGI_THREADS=${threads}`,
+  ];
+  if (opts?.memory) {
+    args.push('--memory', opts.memory);
+  }
+  if (opts?.cpus) {
+    args.push('--cpus', opts.cpus);
+  }
+  args.push(COMPREFACE_IMAGE);
+  return args;
+}
+
 export async function ensureComprefaceContainer(
   port: number,
-  opts?: { dryRun?: boolean },
+  opts?: ComprefaceContainerOptions,
 ): Promise<InstallStepResult> {
   const step = 'CompreFace container';
+  const dryRun = opts?.dryRun;
 
   const running = await runWithSudoAnnounced('docker', [
     'ps',
@@ -568,9 +634,20 @@ export async function ensureComprefaceContainer(
     `name=${COMPREFACE_CONTAINER_NAME}`,
     '--format',
     '{{.Names}}',
-  ], opts);
-  if (running.ok && containerNamePresent(running.stdout, COMPREFACE_CONTAINER_NAME)) {
-    return { step, status: 'skipped', detail: `${COMPREFACE_CONTAINER_NAME} container is already running.` };
+  ], { dryRun });
+  const isRunning = running.ok && containerNamePresent(running.stdout, COMPREFACE_CONTAINER_NAME);
+
+  // A running container is left untouched unless --compreface-recreate is set,
+  // so an install-deps re-run never interrupts an in-flight sidecar just to
+  // change flags. Resource/restart/process settings only apply on (re)create.
+  if (isRunning && !opts?.recreate) {
+    return {
+      step,
+      status: 'skipped',
+      detail:
+        `${COMPREFACE_CONTAINER_NAME} container is already running. ` +
+        'Re-run with --compreface-recreate to apply new process/restart/resource settings.',
+    };
   }
 
   const all = await runWithSudoAnnounced('docker', [
@@ -580,30 +657,28 @@ export async function ensureComprefaceContainer(
     `name=${COMPREFACE_CONTAINER_NAME}`,
     '--format',
     '{{.Names}}',
-  ], opts);
+  ], { dryRun });
   const exists = all.ok && containerNamePresent(all.stdout, COMPREFACE_CONTAINER_NAME);
 
+  // Any existing container (a running one under --compreface-recreate, or any
+  // stopped one) is removed and recreated: `docker start` cannot change a
+  // container's flags, so a bare start would keep the old single-process /
+  // no-restart config. compreface-core is stateless (no volumes), so recreate
+  // is safe.
   if (exists) {
-    if (opts?.dryRun) {
-      return { step, status: 'installed', detail: 'Dry run — would start the existing (stopped) compreface-core container.' };
-    }
-    const start = await runWithSudoAnnounced('docker', ['start', COMPREFACE_CONTAINER_NAME], opts);
-    if (!start.ok) {
+    const rm = await runWithSudoAnnounced('docker', ['rm', '-f', COMPREFACE_CONTAINER_NAME], { dryRun });
+    if (!rm.ok) {
       return {
         step,
         status: 'failed',
-        detail: `Failed to start existing ${COMPREFACE_CONTAINER_NAME} container: ${start.stderr || start.stdout}`,
+        detail: `Failed to remove existing ${COMPREFACE_CONTAINER_NAME} container before recreate: ${rm.stderr || rm.stdout}`,
       };
     }
-    return { step, status: 'installed', detail: `Started existing ${COMPREFACE_CONTAINER_NAME} container.` };
   }
 
-  const inspect = await runWithSudoAnnounced('docker', ['image', 'inspect', COMPREFACE_IMAGE], opts);
+  const inspect = await runWithSudoAnnounced('docker', ['image', 'inspect', COMPREFACE_IMAGE], { dryRun });
   if (!inspect.ok) {
-    if (opts?.dryRun) {
-      return { step, status: 'installed', detail: `Dry run — would pull ${COMPREFACE_IMAGE} and start a new container on port ${port}.` };
-    }
-    const pull = await runWithSudoAnnounced('docker', ['pull', COMPREFACE_IMAGE], opts);
+    const pull = await runWithSudoAnnounced('docker', ['pull', COMPREFACE_IMAGE], { dryRun });
     if (!pull.ok) {
       return {
         step,
@@ -613,27 +688,8 @@ export async function ensureComprefaceContainer(
     }
   }
 
-  if (opts?.dryRun) {
-    return { step, status: 'installed', detail: `Dry run — would start a new ${COMPREFACE_CONTAINER_NAME} container on port ${port}.` };
-  }
-
-  const run = await runWithSudoAnnounced(
-    'docker',
-    [
-      'run',
-      '-d',
-      '--name',
-      COMPREFACE_CONTAINER_NAME,
-      '-p',
-      `${port}:3000`,
-      '-e',
-      'UWSGI_PROCESSES=1',
-      '-e',
-      'UWSGI_THREADS=1',
-      COMPREFACE_IMAGE,
-    ],
-    opts,
-  );
+  const processes = Math.max(1, Math.floor(opts?.processes ?? defaultComprefaceProcesses()));
+  const run = await runWithSudoAnnounced('docker', buildComprefaceRunArgs(port, opts), { dryRun });
   if (!run.ok) {
     return {
       step,
@@ -642,7 +698,18 @@ export async function ensureComprefaceContainer(
     };
   }
 
-  return { step, status: 'installed', detail: `Started a new ${COMPREFACE_CONTAINER_NAME} container on port ${port}.` };
+  const capsNote = [
+    opts?.memory ? `memory ${opts.memory}` : null,
+    opts?.cpus ? `cpus ${opts.cpus}` : null,
+  ].filter(Boolean).join(', ');
+  const detailSuffix = `with ${processes} uwsgi process(es), --restart unless-stopped${capsNote ? `, ${capsNote}` : ''}`;
+  return {
+    step,
+    status: 'installed',
+    detail: dryRun
+      ? `Dry run — would (re)create the ${COMPREFACE_CONTAINER_NAME} container on port ${port} ${detailSuffix}.`
+      : `Started a new ${COMPREFACE_CONTAINER_NAME} container on port ${port} ${detailSuffix}.`,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/node/node-engine.ts
+++ b/apps/cli/src/node/node-engine.ts
@@ -69,6 +69,15 @@ export interface NodeEngineOptions {
   leaseMs?: number;
   /** Max jobs claimed per poll. Default = concurrency. */
   maxClaim?: number;
+  /** Face-detection provider this node runs face jobs on. Surfaced in status. */
+  faceProvider?: 'human' | 'compreface';
+  /**
+   * Base URL of the local compreface-core sidecar (only meaningful when
+   * faceProvider === 'compreface'). Passed to the capability probe on every
+   * heartbeat so reported capabilities reflect the node's ACTUAL sidecar
+   * rather than the localhost default.
+   */
+  comprefaceUrl?: string;
 }
 
 export interface NodeEngineDeps {
@@ -79,7 +88,7 @@ export interface NodeEngineDeps {
   /** Injectable for tests — defaults to the real streaming download. */
   downloadFn?: typeof downloadToFile;
   /** Injectable for tests — defaults to the real capability probe. */
-  detectFn?: () => Promise<Record<string, CapabilityStatus>>;
+  detectFn?: (opts?: { comprefaceUrl?: string }) => Promise<Record<string, CapabilityStatus>>;
   /** Injectable temp directory (defaults to os.tmpdir()). */
   tmpDir?: () => string;
 }
@@ -109,6 +118,10 @@ export interface EngineSnapshot {
   /** Current live concurrency cap (see setConcurrency). */
   concurrency: number;
   eligibleTypes: string[];
+  /** Face-detection provider this node runs face jobs on ('human' | 'compreface'). */
+  faceProvider: 'human' | 'compreface';
+  /** Sidecar URL when faceProvider === 'compreface'; null otherwise. */
+  comprefaceUrl: string | null;
   activeJobs: ActiveJobInfo[];
   /** Last 50 completed/failed jobs, oldest first. */
   history: CompletedJobRecord[];
@@ -221,6 +234,11 @@ export class NodeEngine extends NodeTypedEmitter {
       startedAt: this.startedAtIso,
       concurrency: this.concurrencyCap,
       eligibleTypes: [...this.opts.eligibleTypes],
+      faceProvider: this.opts.faceProvider ?? 'human',
+      comprefaceUrl:
+        (this.opts.faceProvider ?? 'human') === 'compreface'
+          ? this.opts.comprefaceUrl ?? null
+          : null,
       activeJobs: [...this.activeJobs.values()],
       history: [...this.history],
       counters: { ...this.counters },
@@ -490,7 +508,9 @@ export class NodeEngine extends NodeTypedEmitter {
   /** Send one heartbeat with the current capability summary. */
   private async beat(): Promise<void> {
     try {
-      const capabilities = await this.resolved.detectFn();
+      const capabilities = await this.resolved.detectFn({
+        comprefaceUrl: this.opts.comprefaceUrl,
+      });
       await this.api.heartbeatNode(this.nodeId, {
         status: this.draining ? 'draining' : 'online',
         capabilities,

--- a/apps/cli/test/node/compute/face-detection.spec.ts
+++ b/apps/cli/test/node/compute/face-detection.spec.ts
@@ -22,6 +22,17 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+// getFaceDetector() in the module under test does a REAL `fs.existsSync()`
+// check on the Human model directory before calling the (mocked)
+// `createFaceDetector`, and short-circuits to a hard failure if the
+// directory isn't present on disk. This repo/CI environment doesn't ship
+// the downloaded Human model files, so point `FACE_HUMAN_MODEL_PATH` (the
+// module's highest-precedence override — see resolveModelBasePath()) at
+// `os.tmpdir()`, which always exists, so the existence check passes and
+// control reaches the mocked `createFaceDetector` for every Human-path test
+// below regardless of whether real model files are installed.
+process.env['FACE_HUMAN_MODEL_PATH'] = os.tmpdir();
+
 // ---------------------------------------------------------------------------
 // Mocks — registered BEFORE importing the module under test.
 // ---------------------------------------------------------------------------
@@ -87,7 +98,10 @@ afterEach(() => {
 
 describe('computeFaceDetection — human (default)', () => {
   it('uses the Human detector when faceProvider is omitted from config', async () => {
-    mockLoadConfig.mockReturnValue(null);
+    // A present-but-empty config (logged in, no node.faceProvider set) — NOT
+    // a null/missing config, which is now a hard failure (see the "throws"
+    // test below).
+    mockLoadConfig.mockReturnValue({});
     mockCreateFaceDetector.mockResolvedValue({
       detect: jest.fn().mockResolvedValue({
         width: 800,
@@ -116,6 +130,21 @@ describe('computeFaceDetection — human (default)', () => {
 
     const result = (await computeFaceDetection(inputPath, {})) as { providerKey: string };
     expect(result.providerKey).toBe('human');
+    expect(mockDetectComprefaceFaces).not.toHaveBeenCalled();
+  });
+
+  it('throws (does not silently default to human) when loadConfig() returns null', async () => {
+    // Previously a null/missing config silently defaulted the provider to
+    // 'human'. That's now a hard failure — on a CompreFace-configured node,
+    // silently falling back to Human would write embeddings in the wrong
+    // (1024-d Human vs 128-d CompreFace) vector space. The engine's normal
+    // job-failure + retry/backoff path handles the thrown error.
+    mockLoadConfig.mockReturnValue(null);
+
+    await expect(computeFaceDetection(inputPath, {})).rejects.toThrow(
+      /could not load node config/,
+    );
+    expect(mockCreateFaceDetector).not.toHaveBeenCalled();
     expect(mockDetectComprefaceFaces).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/test/node/engine-snapshot.spec.ts
+++ b/apps/cli/test/node/engine-snapshot.spec.ts
@@ -188,4 +188,88 @@ describe('NodeEngine snapshot & counters', () => {
     expect(snap.lastHeartbeatAt).not.toBeNull();
     expect(Number.isNaN(Date.parse(snap.lastHeartbeatAt as string))).toBe(false);
   });
+
+  it('getSnapshot defaults faceProvider to human with a null comprefaceUrl', () => {
+    const engine = new NodeEngine({
+      api: stubApi([]).api,
+      dispatcher: stubDispatcher(),
+      nodeId: 'node-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: ['face_detection'],
+        pollIntervalMs: 5,
+        heartbeatIntervalMs: 60_000,
+        // faceProvider/comprefaceUrl intentionally omitted.
+      },
+      detectFn: async () => ({}),
+    });
+
+    const snap = engine.getSnapshot();
+    expect(snap.faceProvider).toBe('human');
+    expect(snap.comprefaceUrl).toBeNull();
+  });
+
+  it('getSnapshot reports a null comprefaceUrl when faceProvider is explicitly "human" even if a URL is configured', () => {
+    const engine = new NodeEngine({
+      api: stubApi([]).api,
+      dispatcher: stubDispatcher(),
+      nodeId: 'node-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: ['face_detection'],
+        pollIntervalMs: 5,
+        heartbeatIntervalMs: 60_000,
+        faceProvider: 'human',
+        // comprefaceUrl is only surfaced when faceProvider === 'compreface'.
+        comprefaceUrl: 'http://localhost:9999',
+      },
+      detectFn: async () => ({}),
+    });
+
+    const snap = engine.getSnapshot();
+    expect(snap.faceProvider).toBe('human');
+    expect(snap.comprefaceUrl).toBeNull();
+  });
+
+  it('getSnapshot surfaces faceProvider "compreface" and its comprefaceUrl', () => {
+    const engine = new NodeEngine({
+      api: stubApi([]).api,
+      dispatcher: stubDispatcher(),
+      nodeId: 'node-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: ['face_detection'],
+        pollIntervalMs: 5,
+        heartbeatIntervalMs: 60_000,
+        faceProvider: 'compreface',
+        comprefaceUrl: 'http://localhost:3000',
+      },
+      detectFn: async () => ({}),
+    });
+
+    const snap = engine.getSnapshot();
+    expect(snap.faceProvider).toBe('compreface');
+    expect(snap.comprefaceUrl).toBe('http://localhost:3000');
+  });
+
+  it('getSnapshot reports a null comprefaceUrl when faceProvider is "compreface" but no URL was configured', () => {
+    const engine = new NodeEngine({
+      api: stubApi([]).api,
+      dispatcher: stubDispatcher(),
+      nodeId: 'node-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: ['face_detection'],
+        pollIntervalMs: 5,
+        heartbeatIntervalMs: 60_000,
+        faceProvider: 'compreface',
+        // comprefaceUrl intentionally omitted.
+      },
+      detectFn: async () => ({}),
+    });
+
+    const snap = engine.getSnapshot();
+    expect(snap.faceProvider).toBe('compreface');
+    expect(snap.comprefaceUrl).toBeNull();
+  });
 });

--- a/apps/cli/test/node/install-deps.spec.ts
+++ b/apps/cli/test/node/install-deps.spec.ts
@@ -94,9 +94,17 @@ jest.unstable_mockModule('node:fs', () => ({
 }));
 
 const userInfoMock = jest.fn(() => ({ username: 'testuser' }));
+// Controllable core-count for defaultComprefaceProcesses()'s cores-2 clamp
+// math. `install-deps.ts` prefers `os.availableParallelism()`; defaulting
+// this to the real core count keeps every other test in this file (which
+// doesn't care about core count) unaffected, while individual
+// `defaultComprefaceProcesses`/`buildComprefaceRunArgs` tests override it.
+let availableParallelismResult = osActual.cpus().length;
+const availableParallelismMock = jest.fn(() => availableParallelismResult);
 jest.unstable_mockModule('node:os', () => ({
   ...osActual,
   userInfo: userInfoMock,
+  availableParallelism: availableParallelismMock,
 }));
 
 const mockDetectCapabilities = jest.fn();
@@ -156,6 +164,8 @@ const {
   ensureComprefaceContainer,
   verifyCompreface,
   ensureModelsIfConfigured,
+  defaultComprefaceProcesses,
+  buildComprefaceRunArgs,
 } = await import('../../src/node/install-deps.js');
 
 type CapabilityStatus = { available: boolean; detail?: string };
@@ -190,6 +200,8 @@ beforeEach(() => {
   mockApiClientCtor.mockReset();
   mockCreateOcrEngine.mockReset();
   userInfoMock.mockClear();
+  availableParallelismResult = osActual.cpus().length;
+  availableParallelismMock.mockClear();
   originalGetuid = process.getuid;
   // Default: not root.
   (process as unknown as { getuid: () => number }).getuid = () => 1000;
@@ -601,7 +613,7 @@ describe('ensureDocker', () => {
 // ---------------------------------------------------------------------------
 
 describe('ensureComprefaceContainer', () => {
-  it('skips when the container is already running', async () => {
+  it('skips when the container is already running and recreate is not requested', async () => {
     (process as unknown as { getuid: () => number }).getuid = () => 0;
     spawnRouter = (cmd, args) =>
       cmd === 'docker' && args[0] === 'ps' && !args.includes('-a')
@@ -611,22 +623,58 @@ describe('ensureComprefaceContainer', () => {
     const res = await ensureComprefaceContainer(3000);
 
     expect(res.status).toBe('skipped');
+    expect(res.detail).toMatch(/--compreface-recreate/);
+    // The function returns immediately after the single running-check `ps`
+    // call — the `ps -a` existence check, `rm`, `run`, and `start` are never
+    // reached.
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.cmd).toBe('docker');
+    expect(spawnCalls[0]?.args[0]).toBe('ps');
+    expect(spawnCalls.some((c) => c.args[0] === 'rm')).toBe(false);
+    expect(spawnCalls.some((c) => c.args[0] === 'run')).toBe(false);
+    expect(spawnCalls.some((c) => c.args[0] === 'start')).toBe(false);
   });
 
-  it('starts an existing stopped container without pulling', async () => {
+  it('recreates a RUNNING container when opts.recreate is true (rm -f then run)', async () => {
+    (process as unknown as { getuid: () => number }).getuid = () => 0;
+    spawnRouter = (cmd, args) => {
+      if (cmd === 'docker' && args[0] === 'ps' && !args.includes('-a')) {
+        return { code: 0, stdout: 'compreface-core\n' };
+      }
+      if (cmd === 'docker' && args[0] === 'ps' && args.includes('-a')) {
+        return { code: 0, stdout: 'compreface-core\n' };
+      }
+      if (cmd === 'docker' && args[0] === 'image') return { code: 0 };
+      return { code: 0 };
+    };
+
+    const res = await ensureComprefaceContainer(3000, { recreate: true });
+
+    expect(res.status).toBe('installed');
+    expect(spawnCalls).toContainEqual({ cmd: 'docker', args: ['rm', '-f', 'compreface-core'] });
+    expect(spawnCalls.some((c) => c.cmd === 'docker' && c.args[0] === 'run')).toBe(true);
+  });
+
+  it('recreates an existing stopped container (docker rm -f then run, never docker start)', async () => {
     (process as unknown as { getuid: () => number }).getuid = () => 0;
     spawnRouter = (cmd, args) => {
       if (cmd === 'docker' && args[0] === 'ps' && !args.includes('-a')) return { code: 0, stdout: '' };
       if (cmd === 'docker' && args[0] === 'ps' && args.includes('-a')) {
         return { code: 0, stdout: 'compreface-core\n' };
       }
+      if (cmd === 'docker' && args[0] === 'image') return { code: 0 }; // already present locally
       return { code: 0 };
     };
 
     const res = await ensureComprefaceContainer(3000);
 
     expect(res.status).toBe('installed');
-    expect(spawnCalls).toContainEqual({ cmd: 'docker', args: ['start', 'compreface-core'] });
+    // `docker start` cannot change flags — a stopped container is now removed
+    // and recreated via `run`, not resumed via `start`.
+    expect(spawnCalls).toContainEqual({ cmd: 'docker', args: ['rm', '-f', 'compreface-core'] });
+    expect(spawnCalls.some((c) => c.cmd === 'docker' && c.args[0] === 'run')).toBe(true);
+    expect(spawnCalls.some((c) => c.cmd === 'docker' && c.args[0] === 'start')).toBe(false);
+    // The image was already present locally, so no pull was needed.
     expect(spawnCalls.some((c) => c.args[0] === 'pull')).toBe(false);
   });
 
@@ -671,6 +719,92 @@ describe('ensureComprefaceContainer', () => {
 
     expect(res.status).toBe('failed');
     expect(res.detail).toMatch(/port is already allocated/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultComprefaceProcesses
+// ---------------------------------------------------------------------------
+
+describe('defaultComprefaceProcesses', () => {
+  it('clamps a high core count down to the max of 6', () => {
+    availableParallelismResult = 8;
+    expect(defaultComprefaceProcesses()).toBe(6);
+  });
+
+  it('clamps a low core count up to the min of 1', () => {
+    availableParallelismResult = 2;
+    expect(defaultComprefaceProcesses()).toBe(1);
+  });
+
+  it('returns cores - 2 for a mid-range core count', () => {
+    availableParallelismResult = 4;
+    expect(defaultComprefaceProcesses()).toBe(2);
+  });
+
+  // The module prefers `os.availableParallelism()` and falls back to
+  // `os.cpus().length` only when `availableParallelism` isn't a function.
+  // This file's `node:os` mock always exports `availableParallelism` as a
+  // jest.fn (so `typeof os.availableParallelism === 'function'` is always
+  // true here) — cleanly forcing the fallback branch would require the mock
+  // to conditionally omit the export per-test, which isn't worth the
+  // complexity for one extra branch. Instead we assert the sanity bound that
+  // must hold regardless of which branch computed the value.
+  it('always returns an integer within [1, 6], regardless of the host core count', () => {
+    const n = defaultComprefaceProcesses();
+    expect(Number.isInteger(n)).toBe(true);
+    expect(n).toBeGreaterThanOrEqual(1);
+    expect(n).toBeLessThanOrEqual(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildComprefaceRunArgs
+// ---------------------------------------------------------------------------
+
+describe('buildComprefaceRunArgs', () => {
+  beforeEach(() => {
+    // Fix the core-aware default so assertions on UWSGI_PROCESSES are stable
+    // across hosts: 4 cores - 2 = 2.
+    availableParallelismResult = 4;
+  });
+
+  it('builds the default args: restart policy, port mapping, uwsgi env, image last', () => {
+    const args = buildComprefaceRunArgs(3000);
+
+    expect(args[0]).toBe('run');
+    expect(args).toEqual(expect.arrayContaining(['-d']));
+    expect(args).toEqual(expect.arrayContaining(['--restart', 'unless-stopped']));
+    expect(args).toEqual(expect.arrayContaining(['-p', '3000:3000']));
+    expect(args).toEqual(expect.arrayContaining(['-e', 'UWSGI_PROCESSES=2']));
+    expect(args).toEqual(expect.arrayContaining(['-e', 'UWSGI_THREADS=1']));
+    expect(args[args.length - 1]).toBe('exadel/compreface-core:1.2.0-mobilenet');
+    expect(args).not.toContain('--memory');
+    expect(args).not.toContain('--cpus');
+  });
+
+  it('uses an explicit processes count when provided', () => {
+    const args = buildComprefaceRunArgs(3000, { processes: 6 });
+    expect(args).toEqual(expect.arrayContaining(['-e', 'UWSGI_PROCESSES=6']));
+  });
+
+  it('includes --memory and --cpus only when provided, image still last', () => {
+    const args = buildComprefaceRunArgs(3000, { memory: '4g', cpus: '4' });
+    expect(args).toEqual(expect.arrayContaining(['--memory', '4g']));
+    expect(args).toEqual(expect.arrayContaining(['--cpus', '4']));
+    expect(args[args.length - 1]).toBe('exadel/compreface-core:1.2.0-mobilenet');
+  });
+
+  it('omits --memory/--cpus entirely when not provided', () => {
+    const args = buildComprefaceRunArgs(3000);
+    expect(args.includes('--memory')).toBe(false);
+    expect(args.includes('--cpus')).toBe(false);
+  });
+
+  it('floors and clamps processes/threads to a minimum of 1', () => {
+    const args = buildComprefaceRunArgs(3000, { processes: 0.4, threads: -3 });
+    expect(args).toEqual(expect.arrayContaining(['-e', 'UWSGI_PROCESSES=1']));
+    expect(args).toEqual(expect.arrayContaining(['-e', 'UWSGI_THREADS=1']));
   });
 });
 

--- a/apps/cli/test/node/node-engine-concurrency.spec.ts
+++ b/apps/cli/test/node/node-engine-concurrency.spec.ts
@@ -20,6 +20,7 @@
  * fully stubbed ApiClient + ComputeDispatcher, no network, no real downloads.
  */
 
+import { jest } from '@jest/globals';
 import { NodeEngine } from '../../src/node/node-engine.js';
 import { NODE_EV } from '../../src/node/node-events.js';
 import type { ApiClient, ClaimedNodeJob, NodeClaimBody, NodeHeartbeatBody } from '../../src/api.js';
@@ -202,6 +203,92 @@ describe('NodeEngine heartbeat concurrency sync', () => {
     expect(heartbeatCalls).toHaveLength(2);
     expect(heartbeatCalls[1]?.nodeId).toBe('node-1');
     expect(heartbeatCalls[1]?.body.concurrency).toBe(7);
+
+    await engine.stop('test');
+  });
+});
+
+describe('NodeEngine heartbeat face-provider detectFn wiring', () => {
+  it('invokes detectFn with the configured comprefaceUrl on every beat', async () => {
+    const api = {
+      claimNodeJobs: async () => ({ jobs: [] }),
+      heartbeatNode: async () => ({}),
+      deregisterNode: async () => ({}),
+      renewLease: async () => ({}),
+      submitJobResult: async () => ({}),
+      reportJobFailure: async () => ({}),
+    } as unknown as ApiClient;
+
+    const dispatcher = {
+      compute: async () => ({ ok: true }),
+    } as unknown as ComputeDispatcher;
+
+    const detectFn = jest.fn(async () => ({}));
+
+    const engine = new NodeEngine({
+      api,
+      dispatcher,
+      nodeId: 'node-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: [],
+        pollIntervalMs: 5,
+        heartbeatIntervalMs: 60_000,
+        faceProvider: 'compreface',
+        comprefaceUrl: 'http://localhost:4242',
+      },
+      detectFn,
+    });
+
+    const idle = new Promise<void>((resolve) => {
+      engine.once(NODE_EV.IDLE, () => resolve());
+    });
+    void engine.start();
+    await idle;
+
+    // start() triggers one initial beat() before entering the claim loop.
+    expect(detectFn).toHaveBeenCalledWith({ comprefaceUrl: 'http://localhost:4242' });
+
+    await engine.stop('test');
+  });
+
+  it('invokes detectFn with an undefined comprefaceUrl when the node was not configured for compreface', async () => {
+    const api = {
+      claimNodeJobs: async () => ({ jobs: [] }),
+      heartbeatNode: async () => ({}),
+      deregisterNode: async () => ({}),
+      renewLease: async () => ({}),
+      submitJobResult: async () => ({}),
+      reportJobFailure: async () => ({}),
+    } as unknown as ApiClient;
+
+    const dispatcher = {
+      compute: async () => ({ ok: true }),
+    } as unknown as ComputeDispatcher;
+
+    const detectFn = jest.fn(async () => ({}));
+
+    const engine = new NodeEngine({
+      api,
+      dispatcher,
+      nodeId: 'node-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: [],
+        pollIntervalMs: 5,
+        heartbeatIntervalMs: 60_000,
+        // faceProvider/comprefaceUrl intentionally omitted (default 'human').
+      },
+      detectFn,
+    });
+
+    const idle = new Promise<void>((resolve) => {
+      engine.once(NODE_EV.IDLE, () => resolve());
+    });
+    void engine.start();
+    await idle;
+
+    expect(detectFn).toHaveBeenCalledWith({ comprefaceUrl: undefined });
 
     await engine.stop('test');
   });

--- a/docs/worker-node-setup.md
+++ b/docs/worker-node-setup.md
@@ -134,11 +134,29 @@ Docker must be installed and running first — see §5.1.
 
 A node opting into CompreFace runs its OWN local `compreface-core` container — the same image the server itself runs (see `infra/compose/base.compose.yml`'s `compreface-core` service block). The node's compute calls this container directly at `http://localhost:<port>`, NOT proxied through the server: the server's own sidecar has no port exposed externally by design, and routing a node's face-detection calls through the server would defeat the whole point of a distributed worker.
 
-Start it once per node machine:
+**Multi-process inference is now the default.** `UWSGI_PROCESSES` now defaults to a core-aware value, `min(cores - 2, 6)`, instead of the previously-hardcoded `1`; `UWSGI_THREADS` stays `1`. This matters because CompreFace serves one request per uwsgi worker process — a single process serialized ALL face detection onto roughly one core regardless of the node's configured concurrency. Multiple processes give true parallelism; threads alone would just contend on Python's GIL, so they don't help here. Measured impact on an 8-core/32GB laptop: bumping to ~6 processes cut `face_detection` job time from roughly 17–20s down to roughly 2–3s — about an 8x improvement.
+
+**Auto-restart.** The container that `memoriahub node install-deps` creates now runs with `--restart unless-stopped`, so it survives a crash or host reboot without manual intervention.
+
+`memoriahub node install-deps` now sets all of this up automatically. The manual `docker run` recipe below remains the reference/manual path for people who want to do it by hand or customize further — consistent with how §2 frames the automated-vs-manual relationship elsewhere in this doc ("§3 onward — is the manual, step-by-step reference for exactly what this command automates").
+
+New `node install-deps` flags for CompreFace resource tuning:
+
+| Flag | Description |
+|------|-------------|
+| `--compreface-processes <n>` | Override the core-aware default (`min(cores - 2, 6)`) |
+| `--compreface-memory <size>` | e.g. `4g`; maps to Docker's `--memory` flag |
+| `--compreface-cpus <n>` | e.g. `4`; maps to Docker's `--cpus` flag |
+| `--compreface-recreate` | Remove and recreate an EXISTING container so new process/restart/resource settings actually take effect |
+
+**Recreate-vs-restart nuance.** This is easy to get wrong, so call it out explicitly: on a plain re-run of `node install-deps`, a currently-**running** container is left completely untouched — you must explicitly pass `--compreface-recreate` to pick up new settings (process count, restart policy, resource limits). A **stopped** container, however, IS now recreated automatically on a plain re-run; previously it was just `docker start`-ed, which cannot apply new flags at all, so recreation is required to change uwsgi process count, restart policy, or resource limits on a stopped container too. `compreface-core` is stateless (no volumes), so recreating it is always safe — no data is lost either way.
+
+`memoriahub node install-deps` now does all of the above automatically, so the manual recipe below is for people who want to do it by hand or customize further. Start it once per node machine, sizing `UWSGI_PROCESSES` to `min(cores - 2, 6)` for your machine (the example below uses 6, appropriate for an 8-core+ host):
 
 ```bash
 docker run -d --name compreface-core -p 3000:3000 \
-  -e UWSGI_PROCESSES=1 -e UWSGI_THREADS=1 \
+  --restart unless-stopped \
+  -e UWSGI_PROCESSES=6 -e UWSGI_THREADS=1 \
   exadel/compreface-core:1.2.0-mobilenet
 ```
 
@@ -178,9 +196,15 @@ The equivalent TUI path is Tools ▸ Worker Node ▸ Register node / Node config
 
 If a node is configured `faceProvider: 'compreface'` but its local sidecar is unreachable, `node doctor` reports the `compreface` capability unavailable, and `face_detection`/`video_face_detection` are **NOT READY** on that node — it simply stops advertising those job types as eligible, rather than silently falling back to Human. This is deliberate: a silent fallback would reintroduce the exact embedding-space mismatch this feature exists to prevent (see the overview above). See §9 (Troubleshooting) below for the exact symptom and fix.
 
+This same hard-fail principle also applies to the warm-up window at start time, not just to an already-known-unreachable sidecar. When a node's face provider is `compreface` and its eligible types include a face job (`face_detection`/`video_face_detection`), `node start` now **blocks** on a bounded wait (~40 seconds) polling CompreFace's `/status` endpoint until it reports healthy, before the node claims any jobs. This exists because CompreFace takes roughly 15–30 seconds to load its model on (re)create; starting immediately would let the node claim face jobs before the sidecar is actually ready. Previously this silently ran those jobs on the in-process Human provider instead — about 8x slower, with no error surfaced, and (per this section's whole premise) landing in the wrong embedding space vs. the rest of the circle.
+
+If CompreFace does not become healthy within the ~40s budget, `node start` now **fails outright** rather than silently falling back to Human. The operator must fix the sidecar (see §9 troubleshooting) or explicitly pass `--face-provider human` if that's the intended provider.
+
+The actively-selected face provider is now logged at start, and surfaced in `memoriahub node status` output as a new "Face provider" line — present in both the live/IPC status view (a running daemon) and the offline/config status view (reading local config when no daemon is running).
+
 ### 5.5 `node doctor` coverage
 
-`node doctor` (CLI and TUI) gains one new capability row, `compreface`, reported using the exact same installed-vs-operational model described in §8 for every other capability: **installed** means the configured `comprefaceUrl` responds at all to a `GET /status` call; **operational** means that response actually reports `status: 'OK'`. Like every other capability, a clean, fully-healthy node collapses this row into the one-line summary count; only a real problem expands it with detail.
+`node doctor` (CLI and TUI) gains one new capability row, `compreface`, reported using the exact same installed-vs-operational model described in §8 for every other capability: **installed** means the configured `comprefaceUrl` responds at all to a `GET /status` call; **operational** means that response actually reports `status: 'OK'`. Like every other capability, a clean, fully-healthy node collapses this row into the one-line summary count; only a real problem expands it with detail. (The `node start` warm-up wait described in §5.4 uses this same `/status` check.)
 
 ### 5.6 How this differs from the CLIP/Human model-file pattern
 
@@ -213,6 +237,10 @@ memoriahub node service install # always-on systemd user service
 
 Equivalent TUI menu items: Tools ▸ Worker Node ▸ Register node / Start worker (background) / Node service (systemd). See `apps/cli/README.md`'s ["Worker Nodes (distributed compute)"](../apps/cli/README.md#worker-nodes-distributed-compute) section for full command reference, flags, and the TUI dashboard's own doctor overlay — this document's job is dependency setup, not day-to-day operation.
 
+**Per-machine concurrency tuning.** `memoriahub node set-concurrency <n>` (and the `--concurrency` flag on `node register`/`node start`) lets you match a node's concurrency to the machine it runs on. Note that with the new multi-process CompreFace default (§5.2), face detection can now actually use multiple cores in parallel, which changes what a sensible concurrency value looks like on a given machine.
+
+**Each machine = its own node registration.** Every physical machine must run `node register` itself — do NOT clone `~/.memoriahub/config.json` from one machine to another. The config file embeds a `nodeId`; two machines sharing the same `nodeId` will fight over job leases, surfacing as `job not owned by this node` errors. This is the same lease-ownership guard documented elsewhere in the project (see CLAUDE.md's Distributed Nodes section) as protecting against late/duplicate submissions from a reaped node — a cloned config creates an analogous but self-inflicted conflict between two live machines, both alive at once.
+
 ---
 
 ## 8. Reading `node doctor` Output
@@ -240,3 +268,5 @@ Both the CLI command (`memoriahub node doctor`) and the TUI screen (Tools ▸ Wo
 | `node status`/`node list` shows the node as "not recognized by server" (a registered node ID the server 404s/403s on) | The node record was deleted or deregistered server-side — e.g. an admin removed it via `DELETE /api/admin/nodes/:id` on the Worker Nodes admin page, or another process ran `node deregister` for it | Run `memoriahub node register` again to create a fresh registration; the old node ID cannot be revived. |
 | `node service install` refuses, or reports systemd unavailable (WSL) | WSL distros often don't have a per-user systemd instance running by default (`systemctl --user show-environment` fails) | Enable systemd via `[boot]\nsystemd=true` in `/etc/wsl.conf`, then `wsl --shutdown` from Windows to restart the distro — or skip systemd entirely and use `memoriahub node start --daemon` instead. See [distributed-nodes.md §9.3](specs/distributed-nodes.md#93-worker-daemon-systemd-service-and-tui-attach) and `apps/cli/README.md`'s "Always-on service" section. |
 | `node service install` refuses on Windows outright | systemd has no Windows equivalent — `service install` is a no-op there by design, not a bug | Use `memoriahub node start --daemon` instead. |
+| Face jobs slow / appear to run on Human despite `--face-provider compreface` | The CompreFace warm-up race at start time, or the provider not actually being selected as configured | Check the "Face provider" line in `memoriahub node status` output to confirm which provider is actually active; confirm `node start` waited for CompreFace to report healthy before claiming jobs (see §5.4); verify the sidecar directly with `curl http://localhost:3000/status` (or the configured `comprefaceUrl`). |
+| `job not owned by this node` errors on a node that was recently set up | `~/.memoriahub/config.json` was copied/cloned from another machine instead of running `node register` fresh, so two machines share one `nodeId` and are fighting over job leases | Run `memoriahub node register` on the affected machine to get its own distinct node identity (do not reuse a cloned config across machines — see §7). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

Hardens the CLI worker's **non-container** path (`memoriahub node install-deps` + `node start`) so a fat worker node uses its hardware efficiently, survives crashes/reboots, and never silently runs face detection on the wrong provider. Scoped to the non-container path per issue #103's own comment (the containerized worker is covered by epic #108).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — silent wrong-provider race
- [x] Documentation update

## Related Issues

Fixes #103

## Changes Made

- **CompreFace container defaults** (`install-deps.ts`): `UWSGI_PROCESSES` now defaults to a core-aware `min(cores-2, 6)` instead of `1` (face detection was serializing on ~1 core → ~8× slower); adds `--restart unless-stopped`; adds optional `--memory`/`--cpus` caps. New `node install-deps` flags: `--compreface-processes`, `--compreface-memory`, `--compreface-cpus`, `--compreface-recreate`. A running container is left untouched unless `--compreface-recreate`; a stopped one is now recreated (bare `docker start` can't apply new flags; the sidecar is stateless).
- **Wait-for-healthy gate on `node start`**: when the resolved provider is `compreface` and the node claims face jobs, `node start` blocks on a bounded (~40s) `verifyCompreface` `/status` poll before building the engine, closing the warm-up race. On timeout it **fails outright rather than silently falling back to the in-process Human provider**.
- **No silent Human fallback in compute**: `computeFaceDetection` now throws when the node config can't be loaded instead of defaulting the provider to Human (which would write embeddings in the wrong space).
- **Face provider observability**: `EngineSnapshot` gains `faceProvider`/`comprefaceUrl`; `node status` renders an "Active face provider" line in both the live/IPC and offline/config views; the selected provider is logged at start. The heartbeat capability probe now uses the node's configured sidecar URL (was localhost-only).
- **Docs** (`worker-node-setup.md`): multi-process recipe + restart/resource flags (§5.2), warm-up race and no-silent-fallback + status line (§5.4/§5.5), per-machine concurrency tuning and the "each machine registers itself, never clone `config.json`" lease-fight rule (§7), troubleshooting rows (§9).
- **Version**: CLI bumped `1.2.0 → 1.2.1`, lockfile synced.

## Testing

- [x] Unit tests pass (75/75 across the 4 updated suites; full `test/node` dir — 178 tests — green as a regression check)
- [x] Type checks pass (`npm run typecheck` clean after building `@memoriahub/enrichment-compute`)
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — docker run argv shape verified via the unit suite (`--restart unless-stopped`, core-aware `UWSGI_PROCESSES`, recreate via `rm -f`)

### Test Instructions

1. `cd packages/enrichment-compute && npm run build` (so the CLI can resolve workspace subpaths), then `cd apps/cli && npm run typecheck`.
2. `cd apps/cli && NODE_OPTIONS=--experimental-vm-modules npx jest --config jest.config.js test/node/install-deps.spec.ts test/node/engine-snapshot.spec.ts test/node/node-engine-concurrency.spec.ts test/node/compute/face-detection.spec.ts`.
3. Dry-run: `memoriahub node install-deps --dry-run --compreface-processes 6 --compreface-memory 4g --compreface-cpus 4` → announced `docker run` shows the multi-process/restart/cap flags.
4. `memoriahub node start --face-provider compreface` right after (re)create → logs the wait, then "Active face provider: compreface"; `node status` shows the Face provider line.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

The `video_face_detection` compute path shares the same per-job provider resolution but its node compute is still a scaffold (server-only in practice), so the warm-up gate keys on `face_detection`/`video_face_detection` eligibility rather than end-to-end node execution of the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9bYMHaya3fLvKhzhXdnQq