### PR TITLE
fix(api): build HNSW indexes serially to survive small /dev/shm

### DIFF
--- a/apps/api/prisma/migrations/20260620030000_add_media_embeddings/migration.sql
+++ b/apps/api/prisma/migrations/20260620030000_add_media_embeddings/migration.sql
@@ -16,6 +16,13 @@ CREATE TABLE "media_item_embedding" (
 -- Index for circle-scoped queries (e.g. list all embeddings in a circle)
 CREATE INDEX "media_item_embedding_circle_idx" ON "media_item_embedding" ("circle_id");
 
+-- Force a serial (non-parallel) HNSW build. pgvector's parallel index build
+-- allocates dynamic shared memory in /dev/shm; on the Docker default 64MB shm
+-- this fails with "could not resize shared memory segment ... No space left on
+-- device" (SQLSTATE 53100). A serial build uses private maintenance_work_mem
+-- instead and is immune to a small /dev/shm. Session-scoped; resets on connect.
+SET max_parallel_maintenance_workers = 0;
+
 -- HNSW index for fast approximate cosine-similarity search via pgvector
 CREATE INDEX "media_item_embedding_hnsw_idx"
   ON "media_item_embedding" USING hnsw ("embedding" vector_cosine_ops);

--- a/apps/api/prisma/migrations/20260702000000_add_visual_embeddings_and_duplicate_groups/migration.sql
+++ b/apps/api/prisma/migrations/20260702000000_add_visual_embeddings_and_duplicate_groups/migration.sql
@@ -85,5 +85,13 @@ CREATE TABLE "media_visual_embedding" (
 );
 
 CREATE INDEX "media_visual_embedding_circle_idx" ON "media_visual_embedding" ("circle_id");
+
+-- Force a serial (non-parallel) HNSW build. pgvector's parallel index build
+-- allocates dynamic shared memory in /dev/shm; on the Docker default 64MB shm
+-- this fails with "could not resize shared memory segment ... No space left on
+-- device" (SQLSTATE 53100). A serial build uses private maintenance_work_mem
+-- instead and is immune to a small /dev/shm. Session-scoped; resets on connect.
+SET max_parallel_maintenance_workers = 0;
+
 CREATE INDEX "media_visual_embedding_hnsw_idx"
   ON "media_visual_embedding" USING hnsw ("embedding" vector_cosine_ops) WITH (m = 16, ef_construction = 64);

--- a/apps/api/prisma/migrations/20260715000000_add_face_embedding_vector/migration.sql
+++ b/apps/api/prisma/migrations/20260715000000_add_face_embedding_vector/migration.sql
@@ -115,7 +115,17 @@ WHERE array_length("embedding", 1) = 128;
 -- 6. Main HNSW index for general KNN face-similarity search (cosine distance),
 --    mirroring the m/ef_construction values used by the other HNSW indexes in
 --    this codebase (media_visual_embedding, media_item_embedding).
+--
+--    Force a serial (non-parallel) HNSW build first. pgvector's parallel index
+--    build allocates dynamic shared memory in /dev/shm; on the Docker default
+--    64MB shm this fails with "could not resize shared memory segment ... No
+--    space left on device" (SQLSTATE 53100) — which is exactly what took this
+--    migration (and the api) down on 2026-07-15. A serial build uses private
+--    maintenance_work_mem instead and is immune to a small /dev/shm. The setting
+--    is session-scoped, so it also covers the step-7 partial index below.
 -- -----------------------------------------------------------------------------
+SET max_parallel_maintenance_workers = 0;
+
 CREATE INDEX "faces_embedding_vec_hnsw_idx"
   ON "faces" USING hnsw ("embedding_vec" vector_cosine_ops) WITH (m = 16, ef_construction = 64);
 


### PR DESCRIPTION
## Problem

pgvector's **parallel** HNSW index build allocates dynamic shared memory in `/dev/shm`. On the Docker-default **64 MB** shm this fails with:

```
ERROR: could not resize shared memory segment "/PostgreSQL.*" to ~61MB:
       No space left on device  (SQLSTATE 53100)
```

On **2026-07-15** this took the MemoriaHub **api down**: migration `20260715000000_add_face_embedding_vector` failed mid-apply while building its two HNSW indexes, which aborted `update.sh` and left the api container stopped. (The prod DB was recovered by building the indexes serially by hand and marking the migration applied.)

## Fix

Prefix every HNSW-building migration with:

```sql
SET max_parallel_maintenance_workers = 0;
```

A serial build uses private `maintenance_work_mem` instead of shared memory, making it immune to a small `/dev/shm`. The setting is **session-scoped**, so one `SET` covers multiple HNSW indexes in the same migration (the `faces` migration's main + partial index).

Touches all three existing HNSW migrations:
- `20260620030000_add_media_embeddings`
- `20260702000000_add_visual_embeddings_and_duplicate_groups`
- `20260715000000_add_face_embedding_vector`

Editing already-applied migrations is safe: `prisma migrate deploy` does **not** re-validate checksums of applied migrations (verified against the live prod DB — reports "No pending migrations to apply"). Existing deployments are unaffected; fresh installs and any re-applies build serially.

## Relationship to the infra fix

Complementary to raising the postgres container's `shm_size` (done separately in the infra repo, `shm_size: 1g`). **Either change alone** prevents the failure; together they're belt-and-suspenders — this PR also protects any deployment whose Postgres still has the 64 MB default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkP3poUx1XXLnR2xzKEyR5