### PR TITLE
fix(web): resolve issue #123 — large map cluster pins now show photos

### DIFF
--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -1984,6 +1984,19 @@ describe('MediaService', () => {
       expect(call[0].where).toMatchObject({ deletedAt: null });
     });
 
+    it('always excludes exact (0,0) Null Island coordinates via a NOT clause', async () => {
+      await service.listLocations(emptyLocQuery, 'user-1', ownPerms);
+      const [call] = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls;
+      expect(call[0].where).toMatchObject({ NOT: { takenLat: 0, takenLng: 0 } });
+    });
+
+    it('still excludes exact (0,0) Null Island coordinates when bbox is supplied', async () => {
+      const bbox = { minLat: 9, minLng: -85, maxLat: 10, maxLng: -84 };
+      await service.listLocations({ circleId: CIRCLE_ID, bbox } as any, 'user-1', ownPerms);
+      const [call] = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls;
+      expect(call[0].where).toMatchObject({ NOT: { takenLat: 0, takenLng: 0 } });
+    });
+
     // ----- Where-clause: ownership branch -----
 
     it('filters by circleId from query', async () => {
@@ -2204,6 +2217,13 @@ describe('MediaService', () => {
       expect(sqlObj.values).toEqual([CIRCLE_ID]);
     });
 
+    it('always excludes exact (0,0) Null Island coordinates, even with no optional filters supplied', async () => {
+      await service.aggregateLocations(baseQuery, 'user-1', ownPerms);
+      const sqlObj = (mockPrisma.$queryRaw as jest.Mock).mock.calls[0][0] as Prisma.Sql;
+
+      expect(sqlObj.text).toContain('NOT (taken_lat = 0 AND taken_lng = 0)');
+    });
+
     it('interpolates capturedAtFrom into the query when supplied', async () => {
       const from = new Date('2024-01-01');
       await service.aggregateLocations({ ...baseQuery, capturedAtFrom: from }, 'user-1', ownPerms);
@@ -2303,6 +2323,7 @@ describe('MediaService', () => {
         takenLng: { not: null },
         deletedAt: null,
         archivedAt: null,
+        NOT: { takenLat: 0, takenLng: 0 },
       });
       expect(arg._min).toEqual({ takenLat: true, takenLng: true });
       expect(arg._max).toEqual({ takenLat: true, takenLng: true });
@@ -2363,6 +2384,12 @@ describe('MediaService', () => {
       await service.getLocationsExtent(baseQuery, 'user-1', ownPerms);
       const arg = (mockPrisma.mediaItem.aggregate as jest.Mock).mock.calls[0][0];
       expect(arg.where.type).toBeUndefined();
+    });
+
+    it('always excludes exact (0,0) Null Island coordinates via a NOT clause', async () => {
+      await service.getLocationsExtent(baseQuery, 'user-1', ownPerms);
+      const arg = (mockPrisma.mediaItem.aggregate as jest.Mock).mock.calls[0][0];
+      expect(arg.where).toMatchObject({ NOT: { takenLat: 0, takenLng: 0 } });
     });
 
     it('returns { minLat, minLng, maxLat, maxLng, count } mapped from a non-null aggregate result', async () => {

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -482,6 +482,10 @@ export class MediaService {
       takenLng: bbox
         ? { not: null, gte: bbox.minLng, lte: bbox.maxLng }
         : { not: null },
+      // Exclude implausible (0,0) "Null Island" coordinates written by devices
+      // that failed to acquire a GPS fix — only when BOTH are exactly zero, so a
+      // legitimate photo on the equator or prime meridian is kept.
+      NOT: { takenLat: 0, takenLng: 0 },
       // Exclude soft-deleted and archived items
       deletedAt: null,
       archivedAt: null,
@@ -633,6 +637,7 @@ export class MediaService {
       WHERE circle_id = ${circleId}::uuid
         AND deleted_at IS NULL AND archived_at IS NULL
         AND taken_lat IS NOT NULL AND taken_lng IS NOT NULL
+        AND NOT (taken_lat = 0 AND taken_lng = 0)
         ${Prisma.join(fragments, ' ')}
       GROUP BY gy, gx
     `);
@@ -679,6 +684,10 @@ export class MediaService {
       circleId,
       takenLat: { not: null },
       takenLng: { not: null },
+      // Exclude implausible (0,0) "Null Island" coordinates written by devices
+      // that failed to acquire a GPS fix — only when BOTH are exactly zero, so a
+      // legitimate photo on the equator or prime meridian is kept.
+      NOT: { takenLat: 0, takenLng: 0 },
       deletedAt: null,
       archivedAt: null,
       ...(type && { type }),

--- a/apps/web/src/__tests__/pages/MediaMapPage.test.tsx
+++ b/apps/web/src/__tests__/pages/MediaMapPage.test.tsx
@@ -42,13 +42,14 @@
  * MapTimeFilter is also left unmocked (pure MUI, no leaflet dependency).
  *
  * Tests cover the fetch lifecycle (no-circle guard, loading, empty, error,
- * data), the two cluster-click flows (single-item → detail drawer,
- * small multi-item → "Photos here" drawer data fetch), and the
- * extent-driven initial framing (fitBounds/setView call, null-extent and
- * rejected-fetch handling, and the GPS-fallback regression check above).
- * The large-cluster drill-down (`map.flyTo`) is not asserted — it requires
- * no additional network calls and is the lowest-value path to cover
- * through the mocked leaflet layer.
+ * data), the cluster-click flows (single-item → detail drawer, multi-item →
+ * "Photos here" drawer data fetch — both small clusters and large clusters,
+ * since the old `count > 60` fly-drill branch was removed and every
+ * multi-item cluster now opens the drawer), the drawer's "Show all N
+ * photos" jump into deterministic search (via `useSearch()`), the drawer's
+ * error state, and the extent-driven initial framing (fitBounds/setView
+ * call, null-extent and rejected-fetch handling, and the GPS-fallback
+ * regression check above).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -142,6 +143,17 @@ vi.mock('../../components/media/MediaDetailDrawer', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock SearchContext — the component calls useSearch() to get
+// runDeterministicSearch for the "Show all N photos" button. Following the
+// exact pattern used in SearchPage.test.tsx.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../contexts/SearchContext', () => ({
+  useSearch: vi.fn(),
+  SearchProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// ---------------------------------------------------------------------------
 // Mock services/media
 // ---------------------------------------------------------------------------
 
@@ -166,6 +178,11 @@ const mockListMediaLocations = vi.mocked(listMediaLocations);
 const mockGetThumbnails = vi.mocked(getThumbnails);
 const mockGetMedia = vi.mocked(getMedia);
 const mockGetLocationExtent = vi.mocked(getLocationExtent);
+
+import { useSearch } from '../../contexts/SearchContext';
+
+const mockUseSearch = vi.mocked(useSearch);
+const mockRunDeterministicSearch = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Now import the component under test (after all mocks are registered)
@@ -277,6 +294,18 @@ describe('MediaMapPage', () => {
     Object.defineProperty(window.navigator, 'geolocation', {
       value: { getCurrentPosition: mockGetCurrentPosition, watchPosition: vi.fn() },
       configurable: true,
+    });
+
+    mockRunDeterministicSearch.mockReset();
+    mockUseSearch.mockReturnValue({
+      messages: [],
+      results: null,
+      searchRequest: null,
+      isSearching: false,
+      error: null,
+      runAgentSearch: vi.fn(),
+      runDeterministicSearch: mockRunDeterministicSearch,
+      clearSearch: vi.fn(),
     });
   });
 
@@ -458,6 +487,120 @@ describe('MediaMapPage', () => {
       await waitFor(() => {
         expect(screen.getByText(/photos here \(2\)/i)).toBeInTheDocument();
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Large cluster click → "Photos here" drawer with capped thumbnail fetch
+  // and a "Show all N photos" jump into deterministic search.
+  // -------------------------------------------------------------------------
+
+  describe('large cluster — Show all photos', () => {
+    function makeManyLocations(count: number): MediaLocation[] {
+      return Array.from({ length: count }, (_, i) =>
+        makeLocation({ id: `p${i + 1}` }),
+      );
+    }
+
+    it('opens the drawer showing the full total and caps the thumbnail fetch at CLUSTER_THUMB_LIMIT (24)', async () => {
+      mockAggregateLocations.mockResolvedValue([
+        makeCluster({ count: 50, sampleId: 'cluster-big', lat: 10, lng: -85 }),
+      ]);
+      mockListMediaLocations.mockResolvedValue(makeManyLocations(50));
+      mockGetThumbnails.mockResolvedValue(
+        Array.from({ length: 24 }, (_, i) => ({
+          id: `p${i + 1}`,
+          thumbnailUrl: `https://cdn.example.com/p${i + 1}.jpg`,
+        })),
+      );
+
+      render(<MediaMapPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('marker')).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId('marker'));
+
+      await waitFor(() => {
+        expect(mockGetThumbnails).toHaveBeenCalled();
+      });
+      const [, requestedIds] = mockGetThumbnails.mock.calls[0];
+      expect(requestedIds).toHaveLength(24);
+
+      await waitFor(() => {
+        expect(screen.getByText(/photos here \(50\)/i)).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole('button', { name: /show all 50 photos/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('clicking "Show all N photos" calls runDeterministicSearch with a near filter and closes the drawer', async () => {
+      mockAggregateLocations.mockResolvedValue([
+        makeCluster({ count: 50, sampleId: 'cluster-big', lat: 10, lng: -85 }),
+      ]);
+      mockListMediaLocations.mockResolvedValue(makeManyLocations(50));
+      mockGetThumbnails.mockResolvedValue(
+        Array.from({ length: 24 }, (_, i) => ({
+          id: `p${i + 1}`,
+          thumbnailUrl: `https://cdn.example.com/p${i + 1}.jpg`,
+        })),
+      );
+
+      render(<MediaMapPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('marker')).toBeInTheDocument();
+      });
+      await userEvent.click(screen.getByTestId('marker'));
+
+      const showAllButton = await screen.findByRole('button', {
+        name: /show all 50 photos/i,
+      });
+      await userEvent.click(showAllButton);
+
+      await waitFor(() => {
+        expect(mockRunDeterministicSearch).toHaveBeenCalledWith({
+          circleId: 'circle-1',
+          filters: {
+            near: expect.objectContaining({
+              lat: expect.any(Number),
+              lng: expect.any(Number),
+              radiusKm: expect.any(Number),
+            }),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText(/show all/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it('renders the error Alert (not a silent empty grid) when the drawer fetch rejects', async () => {
+      mockAggregateLocations.mockResolvedValue([
+        makeCluster({ count: 50, sampleId: 'cluster-big', lat: 10, lng: -85 }),
+      ]);
+      mockListMediaLocations.mockRejectedValue(new Error('network error'));
+
+      render(<MediaMapPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('marker')).toBeInTheDocument();
+      });
+      await userEvent.click(screen.getByTestId('marker'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/couldn.t load photos for this location\./i),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: /show all/i })).not.toBeInTheDocument();
+      // No photo tiles rendered in the error state — AlbumTile gives each
+      // tile role="button" with an aria-label derived from geoLocality/coords.
+      expect(screen.queryByText('La Fortuna')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/^photo taken at/i)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/MediaMapPage/MediaMapPage.tsx
+++ b/apps/web/src/pages/MediaMapPage/MediaMapPage.tsx
@@ -6,8 +6,8 @@
  *   pan/zoom. This keeps payloads bounded regardless of library size.
  * - Renders each cluster as a Leaflet marker: a count badge for multi-item
  *   cells, a normal pin for single-item cells.
- * - Clicking a multi-item cluster flies in one drill-down level; the moveend
- *   handler refetches at finer precision.
+ * - Clicking a multi-item cluster opens the "Photos here" drawer (a preview of
+ *   the cluster's photos plus a "Show all" jump into search).
  * - Clicking a single-item marker opens MediaDetailDrawer for that item.
  */
 
@@ -16,6 +16,7 @@ import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from 'react-lea
 import L from 'leaflet';
 import {
   Box,
+  Button,
   CircularProgress,
   Alert,
   Typography,
@@ -38,6 +39,7 @@ import {
 } from '../../services/media';
 import { useCircle } from '../../hooks/useCircle';
 import { useAuth } from '../../contexts/AuthContext';
+import { useSearch } from '../../contexts/SearchContext';
 import { MediaDetailDrawer } from '../../components/media/MediaDetailDrawer';
 import { MapTimeFilter, type MapTimeRange } from '../../components/map/MapTimeFilter';
 import { MapControls } from '../../components/map/MapControls';
@@ -65,14 +67,13 @@ const DEFAULT_ZOOM = 2;
 /** Debounce (ms) applied to viewport change events before refetching. */
 const VIEWPORT_DEBOUNCE_MS = 250;
 
-/** How many zoom levels a cluster drill-down flies in. */
-const DRILL_ZOOM_STEP = 3;
-
 /**
- * Clusters at or below this member count open the "Photos here" drawer
- * (fetch + show thumbnails) instead of flying in to drill down further.
+ * Maximum number of thumbnails fetched for the "Photos here" drawer preview.
+ * Kept well under the server-side `GET /api/media/thumbnails` cap of 200 ids so
+ * a large cluster never overruns it; the full count is still shown in the title
+ * and the "Show all" button drills into search for the complete set.
  */
-const CLUSTER_DRAWER_MAX = 60;
+const CLUSTER_THUMB_LIMIT = 24;
 
 // ---------------------------------------------------------------------------
 // Zoom → grid precision. Coarser cells at low zoom keep bucket counts bounded.
@@ -274,8 +275,8 @@ function AlbumTile({ point, onClick }: AlbumTileProps) {
 
 // ---------------------------------------------------------------------------
 // ClusterLayer — renders one Leaflet marker per aggregate cluster and handles
-// clicks: single-item cells open the media drawer, small clusters open the
-// "Photos here" drawer, larger clusters fly in one drill-down level.
+// clicks: single-item cells open the media drawer, and any multi-item cluster
+// opens the "Photos here" drawer.
 // ---------------------------------------------------------------------------
 
 interface ClusterLayerProps {
@@ -293,12 +294,12 @@ function ClusterLayer({ clusters, onOpenItem, onOpenCluster }: ClusterLayerProps
         onOpenItem(cluster.sampleId);
         return;
       }
-      if (cluster.count <= CLUSTER_DRAWER_MAX) {
-        onOpenCluster(cluster, precisionForZoom(map.getZoom()));
-        return;
-      }
-      const target = Math.min(map.getZoom() + DRILL_ZOOM_STEP, map.getMaxZoom());
-      map.flyTo([cluster.lat, cluster.lng], target);
+      // Any multi-item cluster opens the "Photos here" drawer. A cluster that
+      // cannot split further (e.g. every item at the same point) previously
+      // dead-ended on a programmatic fly-in that did nothing; the drawer always
+      // gives the user a way in. Native Leaflet scroll/double-click zoom is
+      // unaffected.
+      onOpenCluster(cluster, precisionForZoom(map.getZoom()));
     },
     [map, onOpenItem, onOpenCluster],
   );
@@ -325,6 +326,7 @@ export default function MediaMapPage() {
   const theme = useTheme();
   const { activeCircle } = useCircle();
   const { isLoading: authIsLoading } = useAuth();
+  const { runDeterministicSearch } = useSearch();
 
   // Leaflet map instance, captured from inside <MapContainer> so page-level
   // overlays (MapControls) can drive it imperatively.
@@ -410,8 +412,17 @@ export default function MediaMapPage() {
   }, [activeCircle, authIsLoading, timeRange]);
 
   // ----- "Photos here" cluster drawer (lazy points + thumbnails) -----
-  // null = closed; [] = open + loading; populated array = loaded.
-  const [albumPoints, setAlbumPoints] = useState<MediaLocation[] | null>(null);
+  // `clusterDrawer === null` means closed; otherwise the drawer is open and
+  // `status` reflects the fetch lifecycle. `points` holds only the first
+  // CLUSTER_THUMB_LIMIT items (with thumbnails merged in); `total` is the full
+  // cluster size so the title and "Show all" button reflect every photo.
+  type ClusterDrawerState = {
+    status: 'loading' | 'loaded' | 'error';
+    points: MediaLocation[];
+    total: number;
+    near: { lat: number; lng: number; radiusKm: number };
+  };
+  const [clusterDrawer, setClusterDrawer] = useState<ClusterDrawerState | null>(null);
   const albumReqRef = useRef(0);
 
   const handleOpenCluster = useCallback(
@@ -419,11 +430,19 @@ export default function MediaMapPage() {
       if (!activeCircle) return;
       const reqId = ++albumReqRef.current;
       const circleId = activeCircle.id;
-      setAlbumPoints([]); // open in loading state
 
       // Cell bounds: half a grid cell each way around the cluster centroid.
       const half = 0.5 * Math.pow(10, -precision);
       const bbox = `${cluster.lng - half},${cluster.lat - half},${cluster.lng + half},${cluster.lat + half}`;
+
+      // Derive a "near" radius from the grid cell so "Show all" searches the
+      // same area the drawer previews. Half a cell in degrees → km (~111.32
+      // km/deg of latitude), widened 1.5× for margin, floored at 0.5 km.
+      const radiusKm = Math.max(0.5, half * 111.32 * 1.5);
+      const near = { lat: cluster.lat, lng: cluster.lng, radiusKm };
+
+      // Open immediately in the loading state.
+      setClusterDrawer({ status: 'loading', points: [], total: 0, near });
 
       void (async () => {
         try {
@@ -434,19 +453,27 @@ export default function MediaMapPage() {
             capturedAtTo: timeRange.to ?? undefined,
           });
           if (albumReqRef.current !== reqId) return;
-          setAlbumPoints(pts);
+          const total = pts.length;
 
+          // Only request thumbnails for the first N points — the server caps
+          // GET /api/media/thumbnails at 200 ids, and a large cluster would
+          // blow past it.
+          const head = pts.slice(0, CLUSTER_THUMB_LIMIT);
           const thumbs = await getThumbnails(
             circleId,
-            pts.map((p) => p.id),
+            head.map((p) => p.id),
           );
           if (albumReqRef.current !== reqId) return;
           const byId = new Map(thumbs.map((t) => [t.id, t.thumbnailUrl]));
-          setAlbumPoints(
-            pts.map((p) => ({ ...p, thumbnailUrl: byId.get(p.id) ?? null })),
-          );
+          const headWithThumbs = head.map((p) => ({
+            ...p,
+            thumbnailUrl: byId.get(p.id) ?? null,
+          }));
+          setClusterDrawer({ status: 'loaded', points: headWithThumbs, total, near });
         } catch {
-          if (albumReqRef.current === reqId) setAlbumPoints([]);
+          if (albumReqRef.current === reqId) {
+            setClusterDrawer({ status: 'error', points: [], total: 0, near });
+          }
         }
       })();
     },
@@ -455,7 +482,7 @@ export default function MediaMapPage() {
 
   const handleCloseCluster = useCallback(() => {
     albumReqRef.current++; // invalidate any in-flight request
-    setAlbumPoints(null);
+    setClusterDrawer(null);
   }, []);
 
   // ----- MediaDetailDrawer (single item) -----
@@ -607,7 +634,7 @@ export default function MediaMapPage() {
         // Default zoom control replaced by the custom MapControls stack.
         zoomControl={false}
         // Disable scroll-wheel zoom while the cluster drawer is open.
-        scrollWheelZoom={albumPoints === null}
+        scrollWheelZoom={clusterDrawer === null}
       >
         {/* Theme-aware basemap: CARTO dark tiles in dark mode, light otherwise.
             The `key` forces react-leaflet to swap the layer cleanly on theme
@@ -662,7 +689,7 @@ export default function MediaMapPage() {
       {/* "Photos here" cluster drawer — lazy points + batched thumbnails */}
       <Drawer
         anchor="right"
-        open={albumPoints !== null}
+        open={clusterDrawer !== null}
         onClose={handleCloseCluster}
         variant="temporary"
         ModalProps={{ keepMounted: false }}
@@ -686,17 +713,47 @@ export default function MediaMapPage() {
           <IconButton onClick={handleCloseCluster} size="small" aria-label="Close photos panel">
             <CloseIcon />
           </IconButton>
-          <Typography variant="h6">Photos here ({albumPoints?.length ?? 0})</Typography>
+          <Typography variant="h6">Photos here ({clusterDrawer?.total ?? 0})</Typography>
         </Box>
 
         <Box sx={{ p: 2, overflowY: 'auto', flex: 1 }}>
-          <Grid container spacing={1}>
-            {(albumPoints ?? []).map((point) => (
-              <Grid key={point.id} size={{ xs: 4 }}>
-                <AlbumTile point={point} onClick={() => handleMarkerOpen(point.id)} />
+          {clusterDrawer?.status === 'error' ? (
+            <Alert severity="error">Couldn&apos;t load photos for this location.</Alert>
+          ) : clusterDrawer?.status === 'loading' ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress aria-label="Loading photos" />
+            </Box>
+          ) : (
+            <>
+              <Grid container spacing={1}>
+                {(clusterDrawer?.points ?? []).map((point) => (
+                  <Grid key={point.id} size={{ xs: 4 }}>
+                    <AlbumTile point={point} onClick={() => handleMarkerOpen(point.id)} />
+                  </Grid>
+                ))}
               </Grid>
-            ))}
-          </Grid>
+
+              {clusterDrawer &&
+                clusterDrawer.status === 'loaded' &&
+                clusterDrawer.total > clusterDrawer.points.length &&
+                activeCircle && (
+                  <Button
+                    variant="contained"
+                    fullWidth
+                    sx={{ mt: 2 }}
+                    onClick={() => {
+                      runDeterministicSearch({
+                        circleId: activeCircle.id,
+                        filters: { near: clusterDrawer.near },
+                      });
+                      handleCloseCluster();
+                    }}
+                  >
+                    Show all {clusterDrawer.total} photos
+                  </Button>
+                )}
+            </>
+          )}
         </Box>
       </Drawer>
 


### PR DESCRIPTION
## Summary

On the Map page (`/map`), clicking a location cluster pin with a large count (e.g. the reported `460` pin plotted at `(0, 0)` / "Null Island" off West Africa) did nothing — no drawer, no photos, no error. This PR makes every cluster pin openable and stops implausible `(0,0)` coordinates from being plotted as a fake place.

Two root causes:
1. **Frontend dead-end:** `ClusterLayer.handleClick` only fly-drilled the map for clusters larger than 60 — no fetch, no fallback UI. A cluster that can't split further (all items at one point) never opened anything.
2. **Backend:** map-clustering queries excluded only `NULL` coordinates, so the spurious `(0,0)` cluster was plotted, and since `round(0, N) === 0` at every precision it could never be split by zooming.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #123

## Changes Made

- **`fix(api)`** — `aggregateLocations`, `listLocations`, and `getLocationsExtent` in `apps/api/src/media/media.service.ts` now exclude the exact `(0,0)` point (only when **both** lat and lng are zero, so real equator / prime-meridian photos are kept). The Null-Island pin no longer appears on the map.
- **`fix(web)`** — `apps/web/src/pages/MediaMapPage/MediaMapPage.tsx`: removed the drill-only branch so **every** multi-item cluster opens the "Photos here" drawer. It previews the first 24 thumbnails (under the 200-id `GET /api/media/thumbnails` cap), shows the true total in the title, and adds a **"Show all N photos"** button that jumps to `/search` pre-scoped with the existing `near` radius filter (reusing `runDeterministicSearch`). The fetch `catch` now surfaces an error Alert instead of a silent empty "Photos here (0)" drawer.
- **`test(api)`** — new cases covering the `(0,0)` exclusion across the three map queries.
- **`test(web)`** — new suite covering the cluster drawer, the "Show all" `near`-filter navigation, and the error state.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

Backend `media.service.spec.ts`: 214 passed. Frontend `MediaMapPage.test.tsx`: 21 passed. `tsc --noEmit` clean for both `apps/api` and `apps/web`. (Full-suite DB-backed integration specs excluded per the project's own `test:ci` are unaffected.)

### Test Instructions

1. On `/map` with the `ALL` time range on a circle containing photos with `(0,0)` GPS — confirm the Null-Island pin near West Africa no longer appears.
2. Click a genuinely large real cluster — the "Photos here" drawer opens with the first ~24 thumbnails, the total count in the title, and a "Show all N photos" button; clicking it lands on `/search` scoped to that location.
3. Simulate a thumbnail-fetch failure — the drawer shows an error Alert, not a silent "Photos here (0)".

## Additional Notes

The `near` map-radius search filter reused by "Show all" was already wired end-to-end (`searchable-fields.registry.ts` → `whereNear`), so no backend search change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017JDpXToHyWGGvLnPTSYmjH)_