### PR TITLE
fix(api): resolve failing CI test in ai-settings.service.spec.ts

### DIFF
--- a/apps/api/src/ai/ai-settings.service.spec.ts
+++ b/apps/api/src/ai/ai-settings.service.spec.ts
@@ -208,6 +208,7 @@ describe('AiSettingsService', () => {
         search: { provider: null, model: null },
         tagging: { provider: null, model: null },
         embedding: { provider: null, model: null },
+        enhance: null,
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes the failing GitHub Actions CI run on `main` caused by a stale unit test expectation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Updated `apps/api/src/ai/ai-settings.service.spec.ts`'s "returns default feature settings when ai system settings are null" test to expect `enhance: null` in the default `features` object.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

### Test Instructions

1. `cd apps/api && npm run test:ci` — all 185 suites / 4394 tests pass.
2. `npm run typecheck --workspace=api` — clean.

## Additional Notes

Root cause: `AiSettingsService.getSettings()` correctly returns `enhance: null` in its default `features` object (added for the AI Picture Enhancer feature, `ai.features.enhance`). The corresponding unit test was never updated to expect this field, causing a spurious CI failure on `main`. This is a test-only fix — no production code was changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_012YEiqSG2BZEmHPKhXNAkcY)_