### PR TITLE
Fix bulk-import DB load: indexed auto-archive KNN, SQL-side centroids, admin-query indexes

### DIFF
--- a/apps/api/prisma/migrations/20260718000000_enrichment_jobs_admin_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20260718000000_enrichment_jobs_admin_indexes/migration.sql
@@ -1,0 +1,29 @@
+-- Two indexes on enrichment_jobs serving the admin dashboard's polling
+-- queries, which currently seq-scan the table and contributed to API
+-- brownouts during bulk imports (when the table is at its largest):
+--
+--   1. claimed_by_node_id — the admin WorkersPage polls
+--      groupBy(['claimedByNodeId','status']) every 5s
+--      (nodes.service.ts getJobCountsForNodes). Without an index on the
+--      grouping/filter column every poll is a full seq scan.
+--
+--   2. created_at DESC — the admin JobsPage default listing orders by
+--      createdAt desc with NO status filter
+--      (enrichment-admin.service.ts listJobs). None of the existing indexes
+--      lead with created_at, so the default page is a seq scan + sort.
+--
+-- Plain CREATE INDEX (not CONCURRENTLY): the table is bounded by the nightly
+-- job_history_purge (terminal rows older than jobs.history.retentionDays are
+-- deleted), so it stays small enough that the brief write lock at deploy time
+-- is fine — and Prisma migrations run inside a transaction, where
+-- CONCURRENTLY is not allowed anyway.
+--
+-- DOWN DIRECTION:
+--   DROP INDEX "enrichment_jobs_claimed_by_node_id_idx";
+--   DROP INDEX "enrichment_jobs_created_at_idx";
+
+-- CreateIndex
+CREATE INDEX "enrichment_jobs_claimed_by_node_id_idx" ON "enrichment_jobs"("claimed_by_node_id");
+
+-- CreateIndex
+CREATE INDEX "enrichment_jobs_created_at_idx" ON "enrichment_jobs"("created_at" DESC);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -848,6 +848,14 @@ model EnrichmentJob {
   @@index([mediaItemId])
   @@index([type, status])
   @@index([status, leaseExpiresAt])
+  // Admin surfaces (migration 20260718000000_enrichment_jobs_admin_indexes):
+  // - claimedByNodeId: WorkersPage polls groupBy(['claimedByNodeId','status'])
+  //   every 5s (nodes.service getJobCountsForNodes) — seq scan without it.
+  // - createdAt DESC: JobsPage default list orders by createdAt desc with no
+  //   status filter (enrichment-admin.service listJobs) — seq scan + sort
+  //   without it.
+  @@index([claimedByNodeId])
+  @@index([createdAt(sort: Desc)])
   @@map("enrichment_jobs")
 }
 

--- a/apps/api/src/face/face-detection-core.service.spec.ts
+++ b/apps/api/src/face/face-detection-core.service.spec.ts
@@ -14,6 +14,10 @@
  *    also match the archived pool.
  *  - A face with an empty embedding and no externalFaceId is skipped
  *    entirely: no matching calls, no archive attempt, no crash.
+ *  - pgvector routing (usesPgvectorFor=true): NO archived-candidates preload
+ *    query and matchFaceToArchived is called WITHOUT candidates; the app
+ *    backend keeps the preload+candidates in-loop reuse.
+ *  - A person match invalidates that person's cached centroid.
  *
  * FaceProviderRegistry, FaceSettingsService, FaceMatchingService, and
  * SystemSettingsService are all replaced with mocks — no transitive
@@ -73,6 +77,8 @@ describe('FaceDetectionCore — persistAndMatchFaces (auto-archive)', () => {
     matchFaceByExternalId: jest.Mock;
     matchFaceToPerson: jest.Mock;
     matchFaceToArchived: jest.Mock;
+    usesPgvectorFor: jest.Mock;
+    invalidateCentroid: jest.Mock;
     archiveMaxCandidates: number;
   };
   let mockSystemSettings: { getSettings: jest.Mock };
@@ -107,6 +113,10 @@ describe('FaceDetectionCore — persistAndMatchFaces (auto-archive)', () => {
       matchFaceByExternalId: jest.fn().mockResolvedValue(null),
       matchFaceToPerson: jest.fn().mockResolvedValue(null),
       matchFaceToArchived: jest.fn().mockResolvedValue(null),
+      // Default to the app-backend (preload+candidates) path; individual
+      // tests flip this to true to exercise the pgvector KNN path.
+      usesPgvectorFor: jest.fn().mockReturnValue(false),
+      invalidateCentroid: jest.fn(),
       archiveMaxCandidates: 5000,
     };
     mockSystemSettings = {
@@ -249,6 +259,158 @@ describe('FaceDetectionCore — persistAndMatchFaces (auto-archive)', () => {
 
     expect(mockMatchingService.matchFaceToArchived).not.toHaveBeenCalled();
     expect(mockPrisma.face.updateMany).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-archive: pgvector path (no candidate preload)
+  // -------------------------------------------------------------------------
+
+  it('skips the archived-candidates preload and calls matchFaceToArchived WITHOUT candidates on the pgvector path', async () => {
+    mockSystemSettings.getSettings.mockResolvedValue(makeSettings(true, 0.45));
+    mockMatchingService.matchFaceToPerson.mockResolvedValue(null);
+    mockMatchingService.usesPgvectorFor.mockReturnValue(true);
+    mockMatchingService.matchFaceToArchived.mockResolvedValue({
+      faceId: 'archived-ref-1',
+      similarity: 0.6,
+    });
+
+    const face = makeFace({ embedding: [1, 0] });
+
+    await service.persistAndMatchFaces({
+      mediaItemId: MEDIA_ID,
+      circleId: CIRCLE_ID,
+      providerKey: 'compreface',
+      modelVersion: 'v1',
+      faces: [face],
+      isVideo: false,
+    });
+
+    // No preload query for the archived reference set.
+    expect(mockPrisma.face.findMany).not.toHaveBeenCalled();
+    // KNN routing: called with threshold only — NO candidates key.
+    expect(mockMatchingService.matchFaceToArchived).toHaveBeenCalledWith(
+      CIRCLE_ID,
+      [1, 0],
+      { threshold: 0.45 },
+    );
+    // The match still lands in the batch archive.
+    expect(mockPrisma.face.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['face-0'] },
+        circleId: CIRCLE_ID,
+        personId: null,
+        hiddenAt: null,
+      },
+      data: { hiddenAt: expect.any(Date), hiddenReason: 'auto_archive_match' },
+    });
+  });
+
+  it('does not archive on the pgvector path when the KNN finds no archived match', async () => {
+    mockSystemSettings.getSettings.mockResolvedValue(makeSettings(true, 0.45));
+    mockMatchingService.matchFaceToPerson.mockResolvedValue(null);
+    mockMatchingService.usesPgvectorFor.mockReturnValue(true);
+    mockMatchingService.matchFaceToArchived.mockResolvedValue(null);
+
+    const face = makeFace({ embedding: [1, 0] });
+
+    await service.persistAndMatchFaces({
+      mediaItemId: MEDIA_ID,
+      circleId: CIRCLE_ID,
+      providerKey: 'compreface',
+      modelVersion: 'v1',
+      faces: [face],
+      isVideo: false,
+    });
+
+    expect(mockPrisma.face.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.face.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('preserves the preload+candidates behavior on the app backend (usesPgvectorFor=false)', async () => {
+    mockSystemSettings.getSettings.mockResolvedValue(makeSettings(true, 0.45));
+    mockMatchingService.matchFaceToPerson.mockResolvedValue(null);
+    mockMatchingService.usesPgvectorFor.mockReturnValue(false);
+
+    const archivedPool = [{ id: 'archived-ref-1', embedding: [0.9, 0.1] }];
+    (mockPrisma.face.findMany as jest.Mock).mockResolvedValue(archivedPool);
+    mockMatchingService.matchFaceToArchived.mockResolvedValue(null);
+
+    const faceA = makeFace({ embedding: [1, 0] });
+    const faceB = makeFace({ embedding: [0, 1] });
+
+    await service.persistAndMatchFaces({
+      mediaItemId: MEDIA_ID,
+      circleId: CIRCLE_ID,
+      providerKey: 'human',
+      modelVersion: 'v1',
+      faces: [faceA, faceB],
+      isVideo: false,
+    });
+
+    // Preloaded exactly once for the whole job (in-loop reuse) …
+    expect(mockPrisma.face.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.face.findMany).toHaveBeenCalledWith({
+      where: {
+        circleId: CIRCLE_ID,
+        personId: null,
+        hiddenAt: { not: null },
+        embedding: { isEmpty: false },
+      },
+      select: { id: true, embedding: true },
+      orderBy: { hiddenAt: 'desc' },
+      take: 5000,
+    });
+    // … and every probe passes the preloaded set as candidates.
+    expect(mockMatchingService.matchFaceToArchived).toHaveBeenCalledTimes(2);
+    expect(mockMatchingService.matchFaceToArchived).toHaveBeenCalledWith(
+      CIRCLE_ID,
+      [1, 0],
+      { threshold: 0.45, candidates: archivedPool },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Centroid cache invalidation on person assignment
+  // -------------------------------------------------------------------------
+
+  it('invalidates the matched person\'s cached centroid after assigning a face', async () => {
+    mockSystemSettings.getSettings.mockResolvedValue(makeSettings(false));
+    mockMatchingService.matchFaceToPerson.mockResolvedValue({ personId: 'person-1' });
+
+    const face = makeFace({ embedding: [1, 0] });
+
+    await service.persistAndMatchFaces({
+      mediaItemId: MEDIA_ID,
+      circleId: CIRCLE_ID,
+      providerKey: 'human',
+      modelVersion: 'v1',
+      faces: [face],
+      isVideo: false,
+    });
+
+    expect(mockPrisma.face.update).toHaveBeenCalledWith({
+      where: { id: 'face-0' },
+      data: { personId: 'person-1' },
+    });
+    expect(mockMatchingService.invalidateCentroid).toHaveBeenCalledWith('person-1');
+  });
+
+  it('does not invalidate any centroid when no person match occurs', async () => {
+    mockSystemSettings.getSettings.mockResolvedValue(makeSettings(false));
+    mockMatchingService.matchFaceToPerson.mockResolvedValue(null);
+
+    const face = makeFace({ embedding: [1, 0] });
+
+    await service.persistAndMatchFaces({
+      mediaItemId: MEDIA_ID,
+      circleId: CIRCLE_ID,
+      providerKey: 'human',
+      modelVersion: 'v1',
+      faces: [face],
+      isVideo: false,
+    });
+
+    expect(mockMatchingService.invalidateCentroid).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/face/face-detection-core.service.ts
+++ b/apps/api/src/face/face-detection-core.service.ts
@@ -277,9 +277,11 @@ export class FaceDetectionCore {
       createdFaces.push(created);
     }
 
-    // Lazily-loaded archived-face candidate pool (populated at most once per
-    // job, only when the first unmatched face needs it) and the batch of newly
-    // created faces to auto-archive after the loop completes.
+    // Lazily-loaded archived-face candidate pool — FALLBACK path only (app
+    // backend / non-128-d probes; populated at most once per job, only when
+    // the first unmatched face needs it). On the pgvector backend each probe
+    // is a single indexed KNN and this pool is never loaded. Also the batch of
+    // newly created faces to auto-archive after the loop completes.
     let archivedCandidates: Array<{ id: string; embedding: number[] }> | null =
       null;
     const toArchive: string[] = [];
@@ -306,37 +308,63 @@ export class FaceDetectionCore {
             where: { id: face.id },
             data: { personId: matchResult.personId },
           });
+          // The person just gained a face — drop its cached centroid so the
+          // next probe in this run recomputes against the fresh face set.
+          this.matchingService.invalidateCentroid(matchResult.personId);
           this.logger.debug(
             `Face ${face.id} matched to person ${matchResult.personId}`,
           );
         } else if (autoArchiveOn && face.embedding.length > 0) {
           // No person match: check whether this face matches a previously
           // archived unassigned face and, if so, auto-archive it.
-          if (archivedCandidates === null) {
-            archivedCandidates = await this.prisma.face.findMany({
-              where: {
-                circleId,
-                personId: null,
-                hiddenAt: { not: null },
-                embedding: { isEmpty: false },
-              },
-              select: { id: true, embedding: true },
-              orderBy: { hiddenAt: 'desc' },
-              take: this.matchingService.archiveMaxCandidates,
-            });
-          }
-
-          if (archivedCandidates.length > 0) {
+          //
+          // Faces archived by this same job are batch-applied after the loop,
+          // so neither path below sees them mid-loop — unchanged behavior.
+          if (this.matchingService.usesPgvectorFor(face.embedding)) {
+            // pgvector backend + 128-d probe: one indexed KNN against the
+            // partial archive HNSW index per face. Skipping the preload avoids
+            // reading up to archiveMaxCandidates (5000) rows per job.
             const archMatch = await this.matchingService.matchFaceToArchived(
               circleId,
               face.embedding,
-              { threshold: archiveThreshold, candidates: archivedCandidates },
+              { threshold: archiveThreshold },
             );
             if (archMatch) {
               toArchive.push(face.id);
               this.logger.debug(
                 `Face ${face.id} auto-archived (matched archived ${archMatch.faceId}, sim=${archMatch.similarity})`,
               );
+            }
+          } else {
+            // App backend / non-128-d probe: preload the archived reference
+            // set once per job and reuse it for every probe (in-loop reuse —
+            // candidates short-circuit matchFaceToArchived to the in-JS scan).
+            if (archivedCandidates === null) {
+              archivedCandidates = await this.prisma.face.findMany({
+                where: {
+                  circleId,
+                  personId: null,
+                  hiddenAt: { not: null },
+                  embedding: { isEmpty: false },
+                },
+                select: { id: true, embedding: true },
+                orderBy: { hiddenAt: 'desc' },
+                take: this.matchingService.archiveMaxCandidates,
+              });
+            }
+
+            if (archivedCandidates.length > 0) {
+              const archMatch = await this.matchingService.matchFaceToArchived(
+                circleId,
+                face.embedding,
+                { threshold: archiveThreshold, candidates: archivedCandidates },
+              );
+              if (archMatch) {
+                toArchive.push(face.id);
+                this.logger.debug(
+                  `Face ${face.id} auto-archived (matched archived ${archMatch.faceId}, sim=${archMatch.similarity})`,
+                );
+              }
             }
           }
         }

--- a/apps/api/src/face/face-matching.service.spec.ts
+++ b/apps/api/src/face/face-matching.service.spec.ts
@@ -147,6 +147,198 @@ describe('FaceMatchingService', () => {
   });
 
   // -------------------------------------------------------------------------
+  // usesPgvectorFor
+  // -------------------------------------------------------------------------
+
+  describe('usesPgvectorFor', () => {
+    function vec(dim: number): number[] {
+      return new Array(dim).fill(0).map((_, i) => (i === 0 ? 1 : 0));
+    }
+
+    async function makeService(backend?: string): Promise<FaceMatchingService> {
+      const config = makeConfigService(
+        backend ? { FACE_VECTOR_BACKEND: backend } : {},
+      );
+      const module = await Test.createTestingModule({
+        providers: [
+          FaceMatchingService,
+          { provide: PrismaService, useValue: mockPrisma },
+          { provide: ConfigService, useValue: config },
+        ],
+      }).compile();
+      return module.get<FaceMatchingService>(FaceMatchingService);
+    }
+
+    it('returns true for a 128-d embedding on the default (pgvector) backend', () => {
+      // beforeEach service has no FACE_VECTOR_BACKEND override → default 'pgvector'
+      expect(service.usesPgvectorFor(vec(128))).toBe(true);
+    });
+
+    it('returns true for a 128-d embedding with FACE_VECTOR_BACKEND=pgvector', async () => {
+      const s = await makeService('pgvector');
+      expect(s.usesPgvectorFor(vec(128))).toBe(true);
+    });
+
+    it('returns false for a 128-d embedding with FACE_VECTOR_BACKEND=app', async () => {
+      const s = await makeService('app');
+      expect(s.usesPgvectorFor(vec(128))).toBe(false);
+    });
+
+    it('returns false for a 1024-d ("human") embedding even on the pgvector backend', async () => {
+      const s = await makeService('pgvector');
+      expect(s.usesPgvectorFor(vec(1024))).toBe(false);
+    });
+
+    it('returns false for an empty embedding on the pgvector backend', async () => {
+      const s = await makeService('pgvector');
+      expect(s.usesPgvectorFor([])).toBe(false);
+    });
+
+    it('returns false for a small (2-d) test embedding on the default backend', () => {
+      expect(service.usesPgvectorFor([1, 0])).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // computePersonCentroidPgvector + centroid cache
+  // -------------------------------------------------------------------------
+
+  describe('computePersonCentroidPgvector', () => {
+    it('parses the avg(embedding_vec) text result and L2-normalizes it', async () => {
+      (mockPrisma.$queryRaw as unknown as jest.Mock).mockResolvedValue([
+        { centroid: '[3,4]', n: 2 },
+      ]);
+
+      const centroid = await service.computePersonCentroidPgvector('person-1');
+
+      expect(centroid).toHaveLength(2);
+      expect(centroid[0]).toBeCloseTo(0.6, 10);
+      expect(centroid[1]).toBeCloseTo(0.8, 10);
+      // No float8 fallback query
+      expect(mockPrisma.face.findMany).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the float8 computePersonCentroid path when avg() returns NULL', async () => {
+      // Person has only non-128-d / empty embeddings → no embedding_vec rows
+      (mockPrisma.$queryRaw as unknown as jest.Mock).mockResolvedValue([
+        { centroid: null, n: 0 },
+      ]);
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([
+        { embedding: [1, 0] },
+        { embedding: [0, 1] },
+      ]);
+
+      const centroid = await service.computePersonCentroidPgvector('person-legacy');
+      const expected = 1 / Math.sqrt(2);
+
+      expect(mockPrisma.face.findMany).toHaveBeenCalledWith({
+        where: { personId: 'person-legacy' },
+        select: { embedding: true },
+      });
+      expect(centroid[0]).toBeCloseTo(expected, 5);
+      expect(centroid[1]).toBeCloseTo(expected, 5);
+    });
+
+    it('falls back to the float8 path when the aggregate query returns no rows', async () => {
+      (mockPrisma.$queryRaw as unknown as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([
+        { embedding: [1, 0] },
+      ]);
+
+      const centroid = await service.computePersonCentroidPgvector('person-x');
+
+      expect(mockPrisma.face.findMany).toHaveBeenCalled();
+      expect(centroid[0]).toBeCloseTo(1, 5);
+    });
+
+    it('falls back to the float8 path when the centroid text is unparseable', async () => {
+      (mockPrisma.$queryRaw as unknown as jest.Mock).mockResolvedValue([
+        { centroid: '[1,not-a-number]', n: 1 },
+      ]);
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([
+        { embedding: [0, 1] },
+      ]);
+
+      const centroid = await service.computePersonCentroidPgvector('person-y');
+
+      expect(mockPrisma.face.findMany).toHaveBeenCalled();
+      expect(centroid[1]).toBeCloseTo(1, 5);
+    });
+  });
+
+  describe('centroid TTL cache (pgvector match path)', () => {
+    // Drives the cache through matchFaceToPerson on the default (pgvector)
+    // backend: the KNN returns one candidate person, and the SQL centroid is
+    // spied on to observe cache hits/misses.
+    function oneHot128(i: number): number[] {
+      return new Array(128).fill(0).map((_, idx) => (idx === i ? 1 : 0));
+    }
+
+    let nowSpy: jest.SpyInstance<number, []>;
+    let currentNow: number;
+
+    beforeEach(() => {
+      currentNow = 1_000_000;
+      nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentNow);
+
+      (mockPrisma.$transaction as unknown as jest.Mock).mockResolvedValue([
+        undefined,
+        [{ person_id: 'p1' }],
+      ]);
+      // Centroid aggregate: identical to the oneHot128(0) probe → similarity 1
+      (mockPrisma.$queryRaw as unknown as jest.Mock).mockResolvedValue([
+        { centroid: `[${oneHot128(0).join(',')}]`, n: 3 },
+      ]);
+    });
+
+    afterEach(() => {
+      nowSpy.mockRestore();
+    });
+
+    it('computes the centroid once and serves the second probe from cache within the TTL', async () => {
+      const centroidSpy = jest.spyOn(service, 'computePersonCentroidPgvector');
+
+      const r1 = await service.matchFaceToPerson('circle-1', oneHot128(0));
+      currentNow += 30_000; // still inside the 60s TTL
+      const r2 = await service.matchFaceToPerson('circle-1', oneHot128(0));
+
+      expect(r1!.personId).toBe('p1');
+      expect(r2!.personId).toBe('p1');
+      expect(centroidSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('recomputes the centroid after the TTL expires', async () => {
+      const centroidSpy = jest.spyOn(service, 'computePersonCentroidPgvector');
+
+      await service.matchFaceToPerson('circle-1', oneHot128(0));
+      currentNow += 60_001; // past the 60s TTL
+      await service.matchFaceToPerson('circle-1', oneHot128(0));
+
+      expect(centroidSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('recomputes the centroid after invalidateCentroid(personId)', async () => {
+      const centroidSpy = jest.spyOn(service, 'computePersonCentroidPgvector');
+
+      await service.matchFaceToPerson('circle-1', oneHot128(0));
+      service.invalidateCentroid('p1');
+      await service.matchFaceToPerson('circle-1', oneHot128(0));
+
+      expect(centroidSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateCentroid for a different person does not evict the cached entry', async () => {
+      const centroidSpy = jest.spyOn(service, 'computePersonCentroidPgvector');
+
+      await service.matchFaceToPerson('circle-1', oneHot128(0));
+      service.invalidateCentroid('someone-else');
+      await service.matchFaceToPerson('circle-1', oneHot128(0));
+
+      expect(centroidSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // matchFaceToPerson
   // -------------------------------------------------------------------------
 

--- a/apps/api/src/face/face-matching.service.ts
+++ b/apps/api/src/face/face-matching.service.ts
@@ -21,14 +21,18 @@
 //   - 'app': the original path — load candidates into the process and compute
 //     cosine similarity in JS.
 //
-// KNN-candidate → centroid parity design (matchFaceToPerson): the pgvector KNN
-// only SELECTS which persons are worth scoring (nearest float4 vectors); the
-// final accept/reject decision is still made by recomputing each candidate
-// person's float8 centroid via computePersonCentroid() and comparing against
-// matchThreshold with the exact same cosineSimilarity() used by the in-app
-// path. This keeps the pgvector path's accept/reject decision numerically
-// identical to the in-app path — the float4 mirror column only accelerates
-// candidate selection, it never decides a match on its own.
+// KNN-candidate → centroid design (matchFaceToPerson): the pgvector KNN only
+// SELECTS which persons are worth scoring (nearest float4 vectors); each
+// candidate person's centroid is then computed SQL-side via
+// `avg(embedding_vec)` (computePersonCentroidPgvector) — one aggregate row per
+// person instead of loading every face row of the person into the process —
+// and cached per-process for a short TTL. The accept/reject decision compares
+// that centroid against matchThreshold with the exact same cosineSimilarity()
+// used by the in-app path. Precision note: avg() over the float4 vector column
+// differs from the float8 mean at ~1e-7/element — negligible vs
+// FACE_MATCH_THRESHOLD 0.38; decision parity is preserved for practical
+// purposes. Persons with no vector-eligible faces (legacy 'human'-only 1024-d
+// embeddings) fall back to the float8 computePersonCentroid() path unchanged.
 //
 // Threshold conventions (ArcFace on LFW benchmark):
 //   - Same-person pairs typically score > 0.40 cosine similarity.
@@ -112,6 +116,17 @@ const HNSW_EF_SEARCH_FLOOR = 100;
 /** The one embedding dimensionality mirrored into the vector(128) column. */
 const PGVECTOR_EMBEDDING_DIM = 128;
 
+/**
+ * TTL for the per-process person-centroid cache used by the pgvector match
+ * path. Cache invalidation: a 60s-stale centroid only marginally shifts a
+ * fuzzy threshold decision; new-face assignments during a bulk run make
+ * centroids MORE representative over time, not less — acceptable staleness.
+ */
+const CENTROID_CACHE_TTL_MS = 60_000;
+
+/** Max centroid-cache entries before a wholesale clear (simple overflow guard). */
+const CENTROID_CACHE_MAX_ENTRIES = 5000;
+
 @Injectable()
 export class FaceMatchingService {
   private readonly logger = new Logger(FaceMatchingService.name);
@@ -133,6 +148,17 @@ export class FaceMatchingService {
 
   /** KNN candidate count fetched from the pgvector index before centroid recompute. */
   readonly matchKnnCandidates: number;
+
+  /**
+   * Per-process TTL cache of person centroids, used ONLY by the pgvector match
+   * path (matchFaceToPersonPgvector). See CENTROID_CACHE_TTL_MS for the
+   * staleness rationale. Other computePersonCentroid callers (people merge,
+   * clustering) keep the uncached method's exact semantics.
+   */
+  private readonly centroidCache = new Map<
+    string,
+    { centroid: number[]; expiresAt: number }
+  >();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -163,6 +189,31 @@ export class FaceMatchingService {
       this.config.get<string>('FACE_MATCH_KNN_CANDIDATES') ??
         String(DEFAULT_FACE_MATCH_KNN_CANDIDATES),
       10,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // usesPgvectorFor
+  // ---------------------------------------------------------------------------
+
+  /**
+   * True when a probe embedding would be routed through the pgvector KNN path:
+   * the resolved backend is 'pgvector' AND the embedding is exactly 128-d
+   * (the dimensionality mirrored into the vector(128) column). Exposed so
+   * callers (face-detection-core's auto-archive branch) can decide whether a
+   * per-probe indexed KNN beats preloading an in-app candidate set.
+   */
+  usesPgvectorFor(embedding: number[]): boolean {
+    return (
+      this.resolveVectorBackend() === 'pgvector' &&
+      embedding.length === PGVECTOR_EMBEDDING_DIM
+    );
+  }
+
+  /** Single source of truth for the FACE_VECTOR_BACKEND resolution. */
+  private resolveVectorBackend(): string {
+    return (
+      this.config.get<string>('FACE_VECTOR_BACKEND') ?? DEFAULT_FACE_VECTOR_BACKEND
     );
   }
 
@@ -232,6 +283,89 @@ export class FaceMatchingService {
   }
 
   // ---------------------------------------------------------------------------
+  // computePersonCentroidPgvector / centroid cache
+  // ---------------------------------------------------------------------------
+
+  /**
+   * SQL-side centroid: `avg(embedding_vec)` over the person's vector-eligible
+   * faces — one aggregate row instead of loading every embedding into the
+   * process (computePersonCentroid is O(faces) rows per call and was the
+   * dominant DB load of the pgvector match path during bulk imports).
+   *
+   * Precision note: avg() over the float4 vector column differs from the
+   * float8 mean at ~1e-7/element — negligible vs FACE_MATCH_THRESHOLD 0.38;
+   * decision parity is preserved for practical purposes.
+   *
+   * Falls back to the float8 computePersonCentroid() path when avg() returns
+   * NULL (person has only non-128-d 'human' or empty embeddings, so no
+   * embedding_vec rows exist) — behavior for legacy Human-only persons is
+   * unchanged.
+   */
+  async computePersonCentroidPgvector(personId: string): Promise<number[]> {
+    const rows = await this.prisma.$queryRaw<
+      { centroid: string | null; n: number }[]
+    >`
+      SELECT avg(embedding_vec)::text AS centroid, count(*)::int AS n
+      FROM faces
+      WHERE person_id = ${personId}::uuid
+        AND embedding_vec IS NOT NULL
+    `;
+
+    const centroidText = rows?.[0]?.centroid;
+    if (!centroidText) {
+      // No vector-eligible faces: legacy float8 path.
+      return this.computePersonCentroid(personId);
+    }
+
+    // pgvector text format: '[x,y,...]'
+    const parsed = centroidText
+      .replace(/^\[/, '')
+      .replace(/\]$/, '')
+      .split(',')
+      .map(Number);
+
+    if (parsed.length === 0 || parsed.some((v) => !Number.isFinite(v))) {
+      return this.computePersonCentroid(personId);
+    }
+
+    return l2NormalizeVec(parsed);
+  }
+
+  /**
+   * TTL-cached centroid retrieval, used ONLY inside the pgvector match loop.
+   * See CENTROID_CACHE_TTL_MS for the staleness rationale.
+   */
+  private async getPersonCentroidCached(personId: string): Promise<number[]> {
+    const now = Date.now();
+    const hit = this.centroidCache.get(personId);
+    if (hit && hit.expiresAt > now) {
+      return hit.centroid;
+    }
+
+    const centroid = await this.computePersonCentroidPgvector(personId);
+
+    // Simple overflow guard: wholesale clear rather than LRU bookkeeping.
+    if (this.centroidCache.size >= CENTROID_CACHE_MAX_ENTRIES) {
+      this.centroidCache.clear();
+    }
+    this.centroidCache.set(personId, {
+      centroid,
+      expiresAt: now + CENTROID_CACHE_TTL_MS,
+    });
+
+    return centroid;
+  }
+
+  /**
+   * Drop a person's cached centroid. Called by face-detection-core right after
+   * it assigns a newly detected face to the person, so the next probe in the
+   * same bulk run recomputes against the fresh face set.
+   */
+  invalidateCentroid(personId: string): void {
+    this.centroidCache.delete(personId);
+  }
+
+  // ---------------------------------------------------------------------------
   // matchFaceToPerson
   // ---------------------------------------------------------------------------
 
@@ -262,10 +396,7 @@ export class FaceMatchingService {
     circleId: string,
     embedding: number[],
   ): Promise<{ personId: string; similarity: number } | null> {
-    const vectorBackend =
-      this.config.get<string>('FACE_VECTOR_BACKEND') ?? DEFAULT_FACE_VECTOR_BACKEND;
-
-    if (vectorBackend === 'pgvector' && embedding.length === PGVECTOR_EMBEDDING_DIM) {
+    if (this.usesPgvectorFor(embedding)) {
       return this.matchFaceToPersonPgvector(circleId, embedding);
     }
 
@@ -303,15 +434,17 @@ export class FaceMatchingService {
   }
 
   /**
-   * pgvector implementation of matchFaceToPerson (option (b): KNN candidate
-   * selection → bounded centroid recompute for exact in-app parity).
+   * pgvector implementation of matchFaceToPerson (KNN candidate selection →
+   * bounded centroid recompute).
    *
    * Only invoked for 128-d probes (guarded by the caller). The KNN JOINs to
    * `people` so only active persons' faces are considered, and returns the
    * nearest candidate faces ordered by cosine distance; we collect the distinct
-   * person ids in nearest-first order, recompute each candidate's float8
-   * centroid, and keep the accept/reject decision on that centroid — identical
-   * to the in-app path.
+   * person ids in nearest-first order, then score each candidate against its
+   * SQL-side avg(embedding_vec) centroid (TTL-cached — see
+   * getPersonCentroidCached; precision/staleness rationale in the class
+   * header) and keep the accept/reject decision on cosineSimilarity() vs.
+   * matchThreshold, same comparison as the in-app path.
    *
    * `SET LOCAL hnsw.ef_search` only takes effect inside an explicit transaction,
    * so the SET and the SELECT are issued together via `$transaction([...])`
@@ -359,7 +492,7 @@ export class FaceMatchingService {
     let bestSimilarity = -Infinity;
 
     for (const personId of candidatePersonIds) {
-      const centroid = await this.computePersonCentroid(personId);
+      const centroid = await this.getPersonCentroidCached(personId);
       if (centroid.length === 0) continue;
 
       const similarity = this.cosineSimilarity(embedding, centroid);
@@ -429,9 +562,11 @@ export class FaceMatchingService {
    *
    * Backend selection (FACE_VECTOR_BACKEND, default DEFAULT_FACE_VECTOR_BACKEND):
    *   - opts.candidates supplied: ALWAYS the in-app path, regardless of backend.
-   *     This is the in-loop reuse case (face-detection-core loads the archived
-   *     reference set once and probes many faces against it), so a per-probe KNN
-   *     round-trip would be strictly worse.
+   *     This is the in-loop reuse case (face-detection-core, on the app backend
+   *     or for non-128-d probes, loads the archived reference set once and
+   *     probes many faces against it), so a per-probe KNN round-trip would be
+   *     strictly worse there. On the pgvector backend face-detection-core calls
+   *     this method WITHOUT candidates so each probe is one indexed KNN.
    *   - 'pgvector' (128-d probes only): a KNN query on the PARTIAL archive HNSW
    *     index (`faces_embedding_vec_archive_hnsw_idx`, scoped to
    *     person_id IS NULL AND hidden_at IS NOT NULL) returns the nearest archived
@@ -466,10 +601,7 @@ export class FaceMatchingService {
         : null;
     }
 
-    const vectorBackend =
-      this.config.get<string>('FACE_VECTOR_BACKEND') ?? DEFAULT_FACE_VECTOR_BACKEND;
-
-    if (vectorBackend === 'pgvector' && embedding.length === PGVECTOR_EMBEDDING_DIM) {
+    if (this.usesPgvectorFor(embedding)) {
       return this.matchFaceToArchivedPgvector(circleId, embedding, threshold);
     }
 


### PR DESCRIPTION
## Summary

Closes the remaining faces/enrichment_jobs load hotspots found while assessing readiness for a large (~30GB) bulk import. The #112 pgvector fix removed the O(N) candidate scan, but three read-amplification paths remained; this PR removes them while keeping face auto-archive fully enabled (it's what protects the review queue from already-archived faces after imports).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Follow-up to #112 (face-matching pgvector KNN) and #102 (pool hardening). Complements the still-open #125 (post-import bulk review-queue actions).

## Changes Made

- **Auto-archive matching uses the indexed KNN** (`face-detection-core.service.ts`): when the pgvector backend applies (new `FaceMatchingService.usesPgvectorFor`), detection-time archive matching calls straight into the existing partial-archive-HNSW KNN — one indexed lookup per face — instead of preloading up to 5,000 archived-face embeddings (~5MB) per media item and scanning in JS. The preload path remains as the fallback for the `app` backend / non-128-d probes.
- **Person centroids computed in Postgres** (`face-matching.service.ts`): the pgvector match path now gets each KNN-candidate person's centroid via `avg(embedding_vec)` (single row back) instead of loading every face row of the person, plus a 60s per-process TTL cache (5,000-entry overflow guard) and invalidation on face assignment. `computePersonCentroid` (float8) keeps exact semantics for its other callers and remains the fallback for legacy non-128-d persons. Float4-mean drift is ~1e-7/element — negligible vs the 0.38 threshold; rationale documented in-code.
- **Two `enrichment_jobs` indexes** (migration `20260718000000_enrichment_jobs_admin_indexes`): `claimed_by_node_id` (Worker Nodes page polls a groupBy on it every 5s → was a full seq scan growing all import) and `created_at DESC` (Job Queue default listing → was seq scan + sort). Plain `CREATE INDEX` — the table is purge-bounded and Prisma migrations are transactional.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

`src/face`: 550 tests pass (19/20 suites — the one failing suite is the pre-existing `face-detection.controller.spec.ts` `PeopleService` DI issue, untouched here and already excluded from `test:ci`). `src/enrichment` + `src/nodes`: 513/513 pass. New coverage: `usesPgvectorFor` matrix, pgvector centroid parse/normalize/fallbacks, TTL cache hit/expiry/invalidation, and detection-core assertions that the pgvector path performs no candidate preload while the app path preserves preload+reuse. `prisma validate`/`generate` clean.

### Test Instructions

1. `cd apps/api && npx jest --config ./test/jest.config.js src/face src/enrichment src/nodes`
2. On a seeded DB with the pgvector backend active, process a face-detection batch and confirm no `SELECT ... embedding FROM faces WHERE person_id = ...` multi-thousand-row reads appear per detected face, and no 5,000-row archived-pool read per media item.
3. Open `/admin/settings/jobs` and `/admin/settings/nodes` during a running batch and confirm the polled queries use the new indexes (no seq scan in `EXPLAIN`).

## Additional Notes

Behavioral parity: auto-archive decisions still use the same thresholds; the KNN path evaluates the nearest archived face via the same cosine threshold as the JS scan. Same-job archived faces were never visible mid-loop in either path (batch-applied after the loop) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spti78XMuA494aAqZGYnrX)_