### PR TITLE
Workflows Phase 1: data model, definition schema, condition compiler, preview API (#139)

### DIFF
--- a/apps/api/prisma/migrations/20260719000000_add_workflow_tables/migration.sql
+++ b/apps/api/prisma/migrations/20260719000000_add_workflow_tables/migration.sql
@@ -1,0 +1,136 @@
+-- Media Workflow Automation migration (Phase 1, issue #139): add
+-- WorkflowSubject, WorkflowTrigger, WorkflowRunStatus, and
+-- WorkflowRunItemStatus enums plus the workflows / workflow_runs /
+-- workflow_run_items tables.
+--
+-- workflows is a circle-scoped, user-authored automation definition: a
+-- subject (v1 only supports 'media_item' — the enum is the extension point
+-- for future subjects), a match/filter + action document (`definition`
+-- JSONB, versioned and subject-tagged), and a trigger (manual run,
+-- on_media_enriched event, or a cron schedule via cron_expression).
+-- cron_expression is required only when trigger='scheduled' — enforced in
+-- the application layer, not the DB, same precedent as other
+-- conditionally-required text columns elsewhere in this schema (e.g.
+-- media_shares' XOR-by-CHECK-constraint is the exception, not the rule).
+-- next_run_at is maintained by the Phase 4 scheduler for scheduled
+-- workflows.
+--
+-- workflow_runs is one row per execution attempt of a Workflow.
+-- definition_snapshot freezes the parent Workflow's `definition` at run
+-- time so edits to the workflow after a run has started never change what
+-- that run evaluates/applies. circle_id is denormalized from the parent
+-- Workflow for direct circle-scoped queries without a join (mirrors the
+-- media_visual_embedding.circle_id / media_tag_status.circle_id precedent).
+-- status walks evaluating -> (awaiting_approval ->) running -> completed |
+-- completed_with_errors | failed | cancelled | expired.
+--
+-- workflow_run_items is one row per matched media item within a
+-- WorkflowRun, tracking the per-item outcome of applying the workflow's
+-- actions. @@unique([runId, mediaItemId]) is the idempotency anchor for
+-- batch retries, mirroring the storage_migration_items
+-- @@unique([runId, objectId]) precedent.
+
+-- -----------------------------------------------------------------------------
+-- Enums
+-- -----------------------------------------------------------------------------
+
+CREATE TYPE "WorkflowSubject" AS ENUM ('media_item');
+
+CREATE TYPE "WorkflowTrigger" AS ENUM ('manual', 'on_media_enriched', 'scheduled');
+
+CREATE TYPE "WorkflowRunStatus" AS ENUM ('evaluating', 'awaiting_approval', 'running', 'completed', 'completed_with_errors', 'failed', 'cancelled', 'expired');
+
+CREATE TYPE "WorkflowRunItemStatus" AS ENUM ('matched', 'excluded', 'applied', 'partially_applied', 'failed', 'skipped');
+
+-- -----------------------------------------------------------------------------
+-- Table: workflows
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "workflows" (
+    "id"              UUID               NOT NULL DEFAULT gen_random_uuid(),
+    "circle_id"       UUID               NOT NULL,
+    "name"            TEXT               NOT NULL,
+    "description"     TEXT,
+    "subject_type"    "WorkflowSubject"  NOT NULL,
+    "enabled"         BOOLEAN            NOT NULL DEFAULT true,
+    "trigger"         "WorkflowTrigger"  NOT NULL,
+    "cron_expression" TEXT,
+    "next_run_at"     TIMESTAMPTZ,
+    "definition"      JSONB              NOT NULL,
+    "created_by_id"   UUID,
+    "created_at"      TIMESTAMPTZ        NOT NULL DEFAULT now(),
+    "updated_at"      TIMESTAMPTZ        NOT NULL DEFAULT now(),
+
+    CONSTRAINT "workflows_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "workflows_circle_id_fkey"
+        FOREIGN KEY ("circle_id") REFERENCES "circles"("id") ON DELETE CASCADE,
+    CONSTRAINT "workflows_created_by_id_fkey"
+        FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX "workflows_circle_id_enabled_idx"           ON "workflows" ("circle_id", "enabled");
+CREATE INDEX "workflows_trigger_enabled_next_run_at_idx" ON "workflows" ("trigger", "enabled", "next_run_at");
+
+-- -----------------------------------------------------------------------------
+-- Table: workflow_runs
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "workflow_runs" (
+    "id"                   UUID                 NOT NULL DEFAULT gen_random_uuid(),
+    "workflow_id"          UUID                 NOT NULL,
+    "circle_id"            UUID                 NOT NULL,
+    "status"               "WorkflowRunStatus"  NOT NULL,
+    "trigger_type"         "WorkflowTrigger"    NOT NULL,
+    "definition_snapshot"  JSONB                NOT NULL,
+    "matched_count"        INTEGER              NOT NULL DEFAULT 0,
+    "truncated"            BOOLEAN              NOT NULL DEFAULT false,
+    "processed_count"      INTEGER              NOT NULL DEFAULT 0,
+    "succeeded_count"      INTEGER              NOT NULL DEFAULT 0,
+    "failed_count"         INTEGER              NOT NULL DEFAULT 0,
+    "skipped_count"        INTEGER              NOT NULL DEFAULT 0,
+    "started_by_id"        UUID,
+    "approved_by_id"       UUID,
+    "created_at"           TIMESTAMPTZ          NOT NULL DEFAULT now(),
+    "updated_at"           TIMESTAMPTZ          NOT NULL DEFAULT now(),
+    "approved_at"          TIMESTAMPTZ,
+    "started_at"           TIMESTAMPTZ,
+    "finished_at"          TIMESTAMPTZ,
+    "last_error"           TEXT,
+
+    CONSTRAINT "workflow_runs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "workflow_runs_workflow_id_fkey"
+        FOREIGN KEY ("workflow_id") REFERENCES "workflows"("id") ON DELETE CASCADE,
+    CONSTRAINT "workflow_runs_circle_id_fkey"
+        FOREIGN KEY ("circle_id") REFERENCES "circles"("id") ON DELETE CASCADE,
+    CONSTRAINT "workflow_runs_started_by_id_fkey"
+        FOREIGN KEY ("started_by_id") REFERENCES "users"("id") ON DELETE SET NULL,
+    CONSTRAINT "workflow_runs_approved_by_id_fkey"
+        FOREIGN KEY ("approved_by_id") REFERENCES "users"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX "workflow_runs_workflow_id_created_at_idx" ON "workflow_runs" ("workflow_id", "created_at");
+CREATE INDEX "workflow_runs_circle_id_status_idx"       ON "workflow_runs" ("circle_id", "status");
+CREATE INDEX "workflow_runs_status_updated_at_idx"      ON "workflow_runs" ("status", "updated_at");
+
+-- -----------------------------------------------------------------------------
+-- Table: workflow_run_items
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "workflow_run_items" (
+    "id"              UUID                       NOT NULL DEFAULT gen_random_uuid(),
+    "run_id"          UUID                       NOT NULL,
+    "media_item_id"   UUID                       NOT NULL,
+    "status"          "WorkflowRunItemStatus"    NOT NULL,
+    "action_results"  JSONB,
+    "error"           TEXT,
+    "updated_at"      TIMESTAMPTZ                NOT NULL DEFAULT now(),
+
+    CONSTRAINT "workflow_run_items_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "workflow_run_items_run_id_fkey"
+        FOREIGN KEY ("run_id") REFERENCES "workflow_runs"("id") ON DELETE CASCADE,
+    CONSTRAINT "workflow_run_items_media_item_id_fkey"
+        FOREIGN KEY ("media_item_id") REFERENCES "media_items"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "workflow_run_items_run_id_media_item_id_key" ON "workflow_run_items" ("run_id", "media_item_id");
+CREATE INDEX "workflow_run_items_run_id_status_idx"               ON "workflow_run_items" ("run_id", "status");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -66,6 +66,10 @@ model User {
   nodeCredentials             NodeCredential[]            @relation("UserNodeCredentials")
   // AI Picture Enhancer relations
   mediaEnhancementsCreated    MediaEnhancement[]          @relation("MediaEnhancementCreatedBy")
+  // Workflow Automation relations
+  workflowsCreated            Workflow[]                  @relation("WorkflowCreatedBy")
+  workflowRunsStarted         WorkflowRun[]               @relation("WorkflowRunStartedBy")
+  workflowRunsApproved        WorkflowRun[]               @relation("WorkflowRunApprovedBy")
 
   @@map("users")
 }
@@ -394,6 +398,9 @@ model Circle {
   locationSuggestions   LocationSuggestion[]
   // AI Picture Enhancer relations
   mediaEnhancements     MediaEnhancement[]
+  // Workflow Automation relations
+  workflows             Workflow[]
+  workflowRuns          WorkflowRun[]
 
   @@index([ownerId])
   @@map("circles")
@@ -559,6 +566,8 @@ model MediaItem {
   // AI Picture Enhancer relations
   enhancementsAsSource   MediaEnhancement[]   @relation("MediaEnhancementSource")
   enhancementsAsResult   MediaEnhancement[]   @relation("MediaEnhancementResult")
+  // Workflow Automation relations
+  workflowRunItems       WorkflowRunItem[]
 
   @@index([circleId])
   @@index([addedById])
@@ -1444,4 +1453,133 @@ model MediaEnhancement {
   @@index([circleId, status])
   @@index([status, updatedAt])
   @@map("media_enhancements")
+}
+
+// =============================================================================
+// Media Workflow Automation
+// =============================================================================
+
+// WorkflowSubject is the extension point for future subjects beyond media
+// items (e.g. people, albums); v1 only supports media_item.
+enum WorkflowSubject {
+  media_item
+}
+
+enum WorkflowTrigger {
+  manual
+  on_media_enriched
+  scheduled
+}
+
+enum WorkflowRunStatus {
+  evaluating
+  awaiting_approval
+  running
+  completed
+  completed_with_errors
+  failed
+  cancelled
+  expired
+}
+
+enum WorkflowRunItemStatus {
+  matched
+  excluded
+  applied
+  partially_applied
+  failed
+  skipped
+}
+
+// A circle-scoped, user-authored automation definition: a subject (currently
+// only media_item), a match/filter + action document (`definition`), and a
+// trigger (manual run, on_media_enriched event, or a cron schedule).
+// cronExpression is required only when trigger=scheduled — enforced in the
+// application layer, not the DB. nextRunAt is maintained by the Phase 4
+// scheduler for scheduled workflows.
+model Workflow {
+  id             String          @id @default(uuid()) @db.Uuid
+  circleId       String          @map("circle_id") @db.Uuid
+  name           String
+  description    String?
+  subjectType    WorkflowSubject @map("subject_type")
+  enabled        Boolean         @default(true)
+  trigger        WorkflowTrigger
+  cronExpression String?         @map("cron_expression")
+  nextRunAt      DateTime?       @map("next_run_at") @db.Timestamptz
+  definition     Json
+  createdById    String?         @map("created_by_id") @db.Uuid
+  createdAt      DateTime        @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime        @updatedAt @map("updated_at") @db.Timestamptz
+
+  // Relations
+  circle    Circle        @relation(fields: [circleId], references: [id], onDelete: Cascade)
+  createdBy User?         @relation("WorkflowCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  runs      WorkflowRun[]
+
+  @@index([circleId, enabled])
+  @@index([trigger, enabled, nextRunAt])
+  @@map("workflows")
+}
+
+// One row per execution attempt of a Workflow. definitionSnapshot freezes
+// the parent Workflow's `definition` at run time so edits to the workflow
+// after a run has started never change what that run evaluates/applies.
+// circleId is denormalized from the parent Workflow for direct circle-scoped
+// queries without a join, mirroring the media_visual_embedding.circleId /
+// media_tag_status.circleId precedent elsewhere in this schema.
+model WorkflowRun {
+  id                  String            @id @default(uuid()) @db.Uuid
+  workflowId          String            @map("workflow_id") @db.Uuid
+  circleId            String            @map("circle_id") @db.Uuid
+  status              WorkflowRunStatus
+  triggerType         WorkflowTrigger   @map("trigger_type")
+  definitionSnapshot  Json              @map("definition_snapshot")
+  matchedCount        Int               @default(0) @map("matched_count")
+  truncated           Boolean           @default(false)
+  processedCount      Int               @default(0) @map("processed_count")
+  succeededCount      Int               @default(0) @map("succeeded_count")
+  failedCount         Int               @default(0) @map("failed_count")
+  skippedCount        Int               @default(0) @map("skipped_count")
+  startedById         String?           @map("started_by_id") @db.Uuid
+  approvedById        String?           @map("approved_by_id") @db.Uuid
+  createdAt           DateTime          @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt           DateTime          @updatedAt @map("updated_at") @db.Timestamptz
+  approvedAt          DateTime?         @map("approved_at") @db.Timestamptz
+  startedAt           DateTime?         @map("started_at") @db.Timestamptz
+  finishedAt          DateTime?         @map("finished_at") @db.Timestamptz
+  lastError           String?           @map("last_error")
+
+  // Relations
+  workflow    Workflow          @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  circle      Circle            @relation(fields: [circleId], references: [id], onDelete: Cascade)
+  startedBy   User?             @relation("WorkflowRunStartedBy", fields: [startedById], references: [id], onDelete: SetNull)
+  approvedBy  User?             @relation("WorkflowRunApprovedBy", fields: [approvedById], references: [id], onDelete: SetNull)
+  items       WorkflowRunItem[]
+
+  @@index([workflowId, createdAt])
+  @@index([circleId, status])
+  @@index([status, updatedAt])
+  @@map("workflow_runs")
+}
+
+// Per-media-item outcome row within a WorkflowRun. @@unique([runId, mediaItemId])
+// is the idempotency anchor for batch retries, mirroring the
+// storage_migration_items @@unique([runId, objectId]) precedent.
+model WorkflowRunItem {
+  id            String                 @id @default(uuid()) @db.Uuid
+  runId         String                 @map("run_id") @db.Uuid
+  mediaItemId   String                 @map("media_item_id") @db.Uuid
+  status        WorkflowRunItemStatus
+  actionResults Json?                  @map("action_results")
+  error         String?
+  updatedAt     DateTime               @updatedAt @map("updated_at") @db.Timestamptz
+
+  // Relations
+  run       WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+  mediaItem MediaItem   @relation(fields: [mediaItemId], references: [id], onDelete: Cascade)
+
+  @@unique([runId, mediaItemId])
+  @@index([runId, status])
+  @@map("workflow_run_items")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -35,6 +35,7 @@ import { ShareModule } from './share/share.module';
 import { SocialMediaModule } from './social-media/social-media.module';
 import { EnhancementModule } from './enhancement/enhancement.module';
 import { NodesModule } from './nodes/nodes.module';
+import { WorkflowsModule } from './workflows/workflows.module';
 import { DoctorModule } from './doctor/doctor.module';
 import { LoggerModule } from './common/logger/logger.module';
 import { TestAuthModule } from './test-auth/test-auth.module';
@@ -97,6 +98,7 @@ import configuration from './config/configuration';
     SocialMediaModule,
     EnhancementModule,
     NodesModule,
+    WorkflowsModule,
 
     // Test modules (non-production only)
     ...(process.env.NODE_ENV !== 'production' ? [TestAuthModule] : []),

--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -191,6 +191,36 @@ export const systemSettingsSchema = z.object({
     maxInputMegapixels: 50,
     retentionHours: 72,
   }),
+  // Media Workflow Automation (issue #139 / epic #138). The full namespace ships
+  // here in Phase 1; later phases read these values via getSettings() without a
+  // further schema change. Phase 1 actively reads maxItemsPerRun,
+  // maxWorkflowsPerCircle, requirePreview, previewTtlHours (+ features.workflows).
+  workflows: z.object({
+    maxItemsPerRun: z.number().int().min(100).max(500000).default(10000),
+    batchSize: z.number().int().min(50).max(1000).default(200),
+    maxConcurrentRuns: z.number().int().min(1).max(10).default(2),
+    requirePreview: z.boolean().default(true),
+    allowHardDelete: z.boolean().default(false),
+    maxWorkflowsPerCircle: z.number().int().min(1).max(100).default(20),
+    previewTtlHours: z.number().int().min(1).max(168).default(24),
+    runHistoryRetentionDays: z.number().int().min(1).max(365).default(30),
+    triggers: z.object({
+      onEnrichment: z.boolean().default(true),
+      scheduled: z.boolean().default(true),
+    }).default({ onEnrichment: true, scheduled: true }),
+    scheduleMinIntervalMinutes: z.number().int().min(60).max(10080).default(60),
+  }).optional().default({
+    maxItemsPerRun: 10000,
+    batchSize: 200,
+    maxConcurrentRuns: 2,
+    requirePreview: true,
+    allowHardDelete: false,
+    maxWorkflowsPerCircle: 20,
+    previewTtlHours: 24,
+    runHistoryRetentionDays: 30,
+    triggers: { onEnrichment: true, scheduled: true },
+    scheduleMinIntervalMinutes: 60,
+  }),
 });
 
 export type SystemSettingsDto = z.infer<typeof systemSettingsSchema>;
@@ -306,5 +336,20 @@ export const systemSettingsPatchSchema = z.object({
     blockReplaceOnDownscale: z.boolean().optional(),
     maxInputMegapixels: z.number().min(1).max(100).optional(),
     retentionHours: z.number().int().min(1).max(720).optional(),
+  }).optional(),
+  workflows: z.object({
+    maxItemsPerRun: z.number().int().min(100).max(500000).optional(),
+    batchSize: z.number().int().min(50).max(1000).optional(),
+    maxConcurrentRuns: z.number().int().min(1).max(10).optional(),
+    requirePreview: z.boolean().optional(),
+    allowHardDelete: z.boolean().optional(),
+    maxWorkflowsPerCircle: z.number().int().min(1).max(100).optional(),
+    previewTtlHours: z.number().int().min(1).max(168).optional(),
+    runHistoryRetentionDays: z.number().int().min(1).max(365).optional(),
+    triggers: z.object({
+      onEnrichment: z.boolean().optional(),
+      scheduled: z.boolean().optional(),
+    }).optional(),
+    scheduleMinIntervalMinutes: z.number().int().min(60).max(10080).optional(),
   }).optional(),
 });

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -166,6 +166,51 @@ export interface SystemSettingsValue {
     /** How long unapplied staging previews live before the purge cron reaps them. */
     retentionHours: number;
   };
+  /**
+   * Media Workflow Automation (epic #138). Full namespace ships in Phase 1 so all
+   * later phases read through getSettings() with no further schema change. Phase 1
+   * actively reads maxItemsPerRun / maxWorkflowsPerCircle / requirePreview /
+   * previewTtlHours; the rest are consumed by Phases 2/4.
+   */
+  workflows?: {
+    /** Hard cap on media items materialized/evaluated per run. */
+    maxItemsPerRun: number;
+    /** Items per queue-backed execution batch (Phase 2). */
+    batchSize: number;
+    /** Simultaneous non-terminal runs allowed (Phase 2/4). */
+    maxConcurrentRuns: number;
+    /** When true, manual runs default to preview + approval (Phase 2). */
+    requirePreview: boolean;
+    /** When false, hard-delete actions are never permitted (Phase 2). */
+    allowHardDelete: boolean;
+    /** Max stored workflow definitions per circle. */
+    maxWorkflowsPerCircle: number;
+    /** How long a stateless preview result is considered fresh (Phase 3). */
+    previewTtlHours: number;
+    /** Run/item history retention before the purge sweep (Phase 5). */
+    runHistoryRetentionDays: number;
+    /** Per-trigger master switches (Phase 4). */
+    triggers: {
+      onEnrichment: boolean;
+      scheduled: boolean;
+    };
+    /** Minimum cron interval enforced for scheduled workflows (Phase 4). */
+    scheduleMinIntervalMinutes: number;
+  };
+}
+
+/**
+ * Resolve whether the Media Workflow Automation feature is active: the
+ * `features.workflows` system-setting toggle must be on AND the
+ * `WORKFLOWS_ENABLED` env kill-switch must not be explicitly set to 'false'.
+ */
+export function isWorkflowsEnabled(settings: {
+  features?: Record<string, boolean>;
+}): boolean {
+  return (
+    settings.features?.[FEATURE_KEYS.WORKFLOWS] === true &&
+    process.env['WORKFLOWS_ENABLED'] !== 'false'
+  );
 }
 
 /**
@@ -226,6 +271,7 @@ export const FEATURE_KEYS = {
   SOCIAL_MEDIA_DETECTION: 'socialMediaDetection',
   FACE_AUTO_ARCHIVE: 'faceAutoArchive',
   PICTURE_ENHANCEMENT: 'pictureEnhancement',
+  WORKFLOWS: 'workflows',
 } as const;
 
 /**
@@ -257,6 +303,7 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
     [FEATURE_KEYS.SOCIAL_MEDIA_DETECTION]: false,
     [FEATURE_KEYS.FACE_AUTO_ARCHIVE]: false,
     [FEATURE_KEYS.PICTURE_ENHANCEMENT]: false,
+    [FEATURE_KEYS.WORKFLOWS]: false,
   },
   ai: {
     features: {
@@ -331,5 +378,20 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
     blockReplaceOnDownscale: false,
     maxInputMegapixels: 50,
     retentionHours: 72,
+  },
+  workflows: {
+    maxItemsPerRun: 10000,
+    batchSize: 200,
+    maxConcurrentRuns: 2,
+    requirePreview: true,
+    allowHardDelete: false,
+    maxWorkflowsPerCircle: 20,
+    previewTtlHours: 24,
+    runHistoryRetentionDays: 30,
+    triggers: {
+      onEnrichment: true,
+      scheduled: true,
+    },
+    scheduleMinIntervalMinutes: 60,
   },
 };

--- a/apps/api/src/common/types/workflows-settings.spec.ts
+++ b/apps/api/src/common/types/workflows-settings.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the `workflows.*` system-settings namespace and the
+ * `isWorkflowsEnabled` feature-gate helper (issue #139). The full namespace
+ * ships in Phase 1 so later phases (#140-#144) read it via
+ * SystemSettingsService.getSettings() with no further schema change.
+ */
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  FEATURE_KEYS,
+  isWorkflowsEnabled,
+} from './settings.types';
+import { systemSettingsSchema } from '../schemas/settings.schema';
+
+describe('workflows system settings', () => {
+  describe('DEFAULT_SYSTEM_SETTINGS.workflows', () => {
+    it('matches the documented Phase-1 defaults', () => {
+      expect(DEFAULT_SYSTEM_SETTINGS.workflows).toEqual({
+        maxItemsPerRun: 10000,
+        batchSize: 200,
+        maxConcurrentRuns: 2,
+        requirePreview: true,
+        allowHardDelete: false,
+        maxWorkflowsPerCircle: 20,
+        previewTtlHours: 24,
+        runHistoryRetentionDays: 30,
+        triggers: {
+          onEnrichment: true,
+          scheduled: true,
+        },
+        scheduleMinIntervalMinutes: 60,
+      });
+    });
+
+    it('defaults features.workflows to false', () => {
+      expect(DEFAULT_SYSTEM_SETTINGS.features[FEATURE_KEYS.WORKFLOWS]).toBe(false);
+    });
+
+    it('FEATURE_KEYS.WORKFLOWS is the string "workflows"', () => {
+      expect(FEATURE_KEYS.WORKFLOWS).toBe('workflows');
+    });
+
+    it('parses cleanly against the Zod systemSettingsSchema (schema/defaults agree)', () => {
+      const parsed = systemSettingsSchema.parse(DEFAULT_SYSTEM_SETTINGS);
+      expect(parsed.workflows).toEqual(DEFAULT_SYSTEM_SETTINGS.workflows);
+    });
+  });
+
+  describe('workflows schema bounds (Zod)', () => {
+    it('accepts values at the documented min/max bounds', () => {
+      const parsed = systemSettingsSchema.parse({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        workflows: {
+          maxItemsPerRun: 100, // min
+          batchSize: 1000, // max
+          maxConcurrentRuns: 10, // max
+          requirePreview: false,
+          allowHardDelete: true,
+          maxWorkflowsPerCircle: 100, // max
+          previewTtlHours: 168, // max
+          runHistoryRetentionDays: 1, // min
+          triggers: { onEnrichment: false, scheduled: false },
+          scheduleMinIntervalMinutes: 10080, // max
+        },
+      });
+      expect(parsed.workflows.maxItemsPerRun).toBe(100);
+      expect(parsed.workflows.scheduleMinIntervalMinutes).toBe(10080);
+    });
+
+    it('rejects maxItemsPerRun below the min (100)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          workflows: { ...DEFAULT_SYSTEM_SETTINGS.workflows, maxItemsPerRun: 99 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects maxWorkflowsPerCircle above the max (100)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          workflows: { ...DEFAULT_SYSTEM_SETTINGS.workflows, maxWorkflowsPerCircle: 101 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects scheduleMinIntervalMinutes below the min (60)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          workflows: { ...DEFAULT_SYSTEM_SETTINGS.workflows, scheduleMinIntervalMinutes: 59 },
+        }),
+      ).toThrow();
+    });
+
+    it('applies the schema default when the workflows block is omitted entirely', () => {
+      const { workflows, ...rest } = DEFAULT_SYSTEM_SETTINGS as any;
+      const parsed = systemSettingsSchema.parse(rest);
+      expect(parsed.workflows).toEqual(DEFAULT_SYSTEM_SETTINGS.workflows);
+    });
+  });
+
+  describe('isWorkflowsEnabled', () => {
+    const originalEnv = process.env['WORKFLOWS_ENABLED'];
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env['WORKFLOWS_ENABLED'];
+      } else {
+        process.env['WORKFLOWS_ENABLED'] = originalEnv;
+      }
+    });
+
+    it('is false when features.workflows is false', () => {
+      delete process.env['WORKFLOWS_ENABLED'];
+      expect(isWorkflowsEnabled({ features: { workflows: false } })).toBe(false);
+    });
+
+    it('is false when features.workflows is absent', () => {
+      delete process.env['WORKFLOWS_ENABLED'];
+      expect(isWorkflowsEnabled({ features: {} })).toBe(false);
+    });
+
+    it('is false when features is entirely absent', () => {
+      delete process.env['WORKFLOWS_ENABLED'];
+      expect(isWorkflowsEnabled({})).toBe(false);
+    });
+
+    it('is true when features.workflows is true and no env override is set', () => {
+      delete process.env['WORKFLOWS_ENABLED'];
+      expect(isWorkflowsEnabled({ features: { workflows: true } })).toBe(true);
+    });
+
+    it('the WORKFLOWS_ENABLED=false env kill-switch overrides an enabled feature flag', () => {
+      process.env['WORKFLOWS_ENABLED'] = 'false';
+      expect(isWorkflowsEnabled({ features: { workflows: true } })).toBe(false);
+    });
+
+    it('any other WORKFLOWS_ENABLED value does not disable the feature', () => {
+      process.env['WORKFLOWS_ENABLED'] = 'true';
+      expect(isWorkflowsEnabled({ features: { workflows: true } })).toBe(true);
+
+      process.env['WORKFLOWS_ENABLED'] = 'garbage';
+      expect(isWorkflowsEnabled({ features: { workflows: true } })).toBe(true);
+    });
+
+    it('the env kill-switch has no effect when the feature flag is already false', () => {
+      process.env['WORKFLOWS_ENABLED'] = 'false';
+      expect(isWorkflowsEnabled({ features: { workflows: false } })).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -35,6 +35,7 @@ export interface ResolvedSettings {
   email: SystemSettingsValue['email'];
   jobs: SystemSettingsValue['jobs'];
   pictureEnhancement: SystemSettingsValue['pictureEnhancement'];
+  workflows: SystemSettingsValue['workflows'];
   updatedAt: Date;
   updatedBy: { id: string; email: string } | null;
   version: number;
@@ -115,6 +116,7 @@ export class SystemSettingsService {
       email: value.email,
       jobs: value.jobs,
       pictureEnhancement: value.pictureEnhancement,
+      workflows: value.workflows,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,
@@ -178,6 +180,7 @@ export class SystemSettingsService {
       email: value.email,
       jobs: value.jobs,
       pictureEnhancement: value.pictureEnhancement,
+      workflows: value.workflows,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,
@@ -460,6 +463,54 @@ export class SystemSettingsService {
           (current as any).pictureEnhancement?.retentionHours ??
           72,
       },
+      workflows: {
+        maxItemsPerRun:
+          (dto as any).workflows?.maxItemsPerRun ??
+          (current as any).workflows?.maxItemsPerRun ??
+          10000,
+        batchSize:
+          (dto as any).workflows?.batchSize ??
+          (current as any).workflows?.batchSize ??
+          200,
+        maxConcurrentRuns:
+          (dto as any).workflows?.maxConcurrentRuns ??
+          (current as any).workflows?.maxConcurrentRuns ??
+          2,
+        requirePreview:
+          (dto as any).workflows?.requirePreview ??
+          (current as any).workflows?.requirePreview ??
+          true,
+        allowHardDelete:
+          (dto as any).workflows?.allowHardDelete ??
+          (current as any).workflows?.allowHardDelete ??
+          false,
+        maxWorkflowsPerCircle:
+          (dto as any).workflows?.maxWorkflowsPerCircle ??
+          (current as any).workflows?.maxWorkflowsPerCircle ??
+          20,
+        previewTtlHours:
+          (dto as any).workflows?.previewTtlHours ??
+          (current as any).workflows?.previewTtlHours ??
+          24,
+        runHistoryRetentionDays:
+          (dto as any).workflows?.runHistoryRetentionDays ??
+          (current as any).workflows?.runHistoryRetentionDays ??
+          30,
+        triggers: {
+          onEnrichment:
+            (dto as any).workflows?.triggers?.onEnrichment ??
+            (current as any).workflows?.triggers?.onEnrichment ??
+            true,
+          scheduled:
+            (dto as any).workflows?.triggers?.scheduled ??
+            (current as any).workflows?.triggers?.scheduled ??
+            true,
+        },
+        scheduleMinIntervalMinutes:
+          (dto as any).workflows?.scheduleMinIntervalMinutes ??
+          (current as any).workflows?.scheduleMinIntervalMinutes ??
+          60,
+      },
     };
 
     // Validate merged result
@@ -506,6 +557,7 @@ export class SystemSettingsService {
       email: value.email,
       jobs: value.jobs,
       pictureEnhancement: value.pictureEnhancement,
+      workflows: value.workflows,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,

--- a/apps/api/src/workflows/compiler/workflow-condition.compiler.spec.ts
+++ b/apps/api/src/workflows/compiler/workflow-condition.compiler.spec.ts
@@ -1,0 +1,523 @@
+/**
+ * Unit tests for WorkflowConditionCompiler (issue #139).
+ *
+ * Pure function tests — no NestJS module or DB needed. The compiler resolves
+ * field descriptors from the media_item registry and composes Prisma `where`
+ * fragments following the shared-array AND/OR composition rule documented in
+ * docs/audits/search-audit.md.
+ */
+import { WorkflowConditionCompiler } from './workflow-condition.compiler';
+import { WorkflowDefinition } from '../definition/workflow-definition.schema';
+
+const CIRCLE_ID = 'circle-abc-123';
+
+function baseDef(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    version: 1,
+    subject: 'media_item',
+    match: 'all',
+    conditions: [],
+    actions: [],
+    ...overrides,
+  } as WorkflowDefinition;
+}
+
+describe('WorkflowConditionCompiler', () => {
+  let compiler: WorkflowConditionCompiler;
+
+  beforeEach(() => {
+    compiler = new WorkflowConditionCompiler();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Baseline + empty conditions
+  // ---------------------------------------------------------------------------
+
+  describe('baseline scoping', () => {
+    it('always includes circleId and deletedAt:null', () => {
+      const { where } = compiler.compile(CIRCLE_ID, baseDef());
+      expect(where).toEqual({ circleId: CIRCLE_ID, deletedAt: null });
+    });
+
+    it('adds no AND/OR key when conditions is empty (matches every non-deleted item)', () => {
+      const { where } = compiler.compile(CIRCLE_ID, baseDef({ conditions: [] }));
+      expect((where as any).AND).toBeUndefined();
+      expect((where as any).OR).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-field-type compilation
+  // ---------------------------------------------------------------------------
+
+  describe('filename', () => {
+    it('contains compiles to originalFilename.contains (case-insensitive)', () => {
+      const def = baseDef({
+        conditions: [{ field: 'filename', op: 'contains', value: 'screenshot' }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND).toEqual([
+        { originalFilename: { contains: 'screenshot', mode: 'insensitive' } },
+      ]);
+    });
+
+    it('starts_with compiles to originalFilename.startsWith', () => {
+      const def = baseDef({
+        conditions: [{ field: 'filename', op: 'starts_with', value: 'IMG_' }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        originalFilename: { startsWith: 'IMG_', mode: 'insensitive' },
+      });
+    });
+  });
+
+  describe('mimeType', () => {
+    it('equals compiles to storageObject.mimeType relation filter', () => {
+      const def = baseDef({
+        conditions: [{ field: 'mimeType', op: 'equals', value: 'image/png' }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ storageObject: { mimeType: 'image/png' } });
+    });
+  });
+
+  describe('capturedAt', () => {
+    it('between compiles to capturedAt gte/lte via whereDateRange', () => {
+      const from = '2024-01-01T00:00:00.000Z';
+      const to = '2024-12-31T00:00:00.000Z';
+      const def = baseDef({
+        conditions: [{ field: 'capturedAt', op: 'between', value: { from, to } }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        capturedAt: { gte: new Date(from), lte: new Date(to) },
+      });
+    });
+
+    it('older_than_days compiles to capturedAt.lt a cutoff Date', () => {
+      const def = baseDef({
+        conditions: [{ field: 'capturedAt', op: 'older_than_days', value: 30 }],
+      });
+      const before = Date.now() - 30 * 24 * 60 * 60 * 1000;
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      const clause = (where as any).AND[0].capturedAt.lt as Date;
+      // Cutoff computed at compile time — allow a small tolerance for test execution jitter.
+      expect(Math.abs(clause.getTime() - before)).toBeLessThan(5000);
+    });
+
+    it('within_last_days compiles to capturedAt.gte a cutoff Date', () => {
+      const def = baseDef({
+        conditions: [{ field: 'capturedAt', op: 'within_last_days', value: 7 }],
+      });
+      const after = Date.now() - 7 * 24 * 60 * 60 * 1000;
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      const clause = (where as any).AND[0].capturedAt.gte as Date;
+      expect(Math.abs(clause.getTime() - after)).toBeLessThan(5000);
+    });
+  });
+
+  describe('missingCamera', () => {
+    it('is:true compiles to {cameraMake:null, cameraModel:null}', () => {
+      const def = baseDef({
+        conditions: [{ field: 'missingCamera', op: 'is', value: true }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ cameraMake: null, cameraModel: null });
+    });
+  });
+
+  describe('tags', () => {
+    const tagMatch = (name: string) => ({ mediaTags: { some: { tag: { name: { equals: name, mode: 'insensitive' } } } } });
+
+    it('has_any compiles to an OR of tag-name matches', () => {
+      const def = baseDef({
+        conditions: [{ field: 'tags', op: 'has_any', value: ['beach', 'sunset'] }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ OR: [tagMatch('beach'), tagMatch('sunset')] });
+    });
+
+    it('has_all compiles to an AND of tag-name matches', () => {
+      const def = baseDef({
+        conditions: [{ field: 'tags', op: 'has_all', value: ['beach', 'sunset'] }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ AND: [tagMatch('beach'), tagMatch('sunset')] });
+    });
+
+    it('has_none compiles to an AND of NOT tag-name matches', () => {
+      const def = baseDef({
+        conditions: [{ field: 'tags', op: 'has_none', value: ['spam'] }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ AND: [{ NOT: tagMatch('spam') }] });
+    });
+  });
+
+  describe('people', () => {
+    const ID_A = '11111111-1111-1111-1111-111111111111';
+    const ID_B = '22222222-2222-2222-2222-222222222222';
+
+    it('has_person with mode:any compiles via wherePeople(any)', () => {
+      const def = baseDef({
+        conditions: [{ field: 'people', op: 'has_person', value: { ids: [ID_A, ID_B], mode: 'any' } }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ faces: { some: { personId: { in: [ID_A, ID_B] } } } });
+    });
+
+    it('has_person defaults to mode:any when mode is omitted', () => {
+      // media-item-fields.ts: `const mode = v.mode === 'all' ? 'all' : 'any'` —
+      // any value other than the literal 'all' (including omitted) resolves to 'any'.
+      const def = baseDef({
+        conditions: [{ field: 'people', op: 'has_person', value: { ids: [ID_A] } }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ faces: { some: { personId: { in: [ID_A] } } } });
+    });
+
+    it('has_person with mode:all compiles via wherePeople(all)', () => {
+      const def = baseDef({
+        conditions: [{ field: 'people', op: 'has_person', value: { ids: [ID_A, ID_B], mode: 'all' } }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        AND: [
+          { faces: { some: { personId: ID_A } } },
+          { faces: { some: { personId: ID_B } } },
+        ],
+      });
+    });
+
+    it('not_has_person compiles to a NOT wrapper around faces.some.personId.in', () => {
+      const def = baseDef({
+        conditions: [{ field: 'people', op: 'not_has_person', value: { ids: [ID_A] } }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        NOT: { faces: { some: { personId: { in: [ID_A] } } } },
+      });
+    });
+  });
+
+  describe('near', () => {
+    it('compiles to a takenLat/takenLng bounding box', () => {
+      const def = baseDef({
+        conditions: [{ field: 'near', op: 'near', value: { lat: 9.93, lng: -84.09, radiusKm: 50 } }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      const clause = (where as any).AND[0];
+      expect(clause).toHaveProperty('takenLat.gte');
+      expect(clause).toHaveProperty('takenLat.lte');
+      expect(clause).toHaveProperty('takenLng.gte');
+      expect(clause).toHaveProperty('takenLng.lte');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Review-state descriptors
+  // ---------------------------------------------------------------------------
+
+  describe('review-state descriptors', () => {
+    it('inPendingBurstGroup:true compiles to burstGroup.is.status=pending', () => {
+      const def = baseDef({
+        conditions: [{ field: 'inPendingBurstGroup', op: 'is', value: true }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ burstGroup: { is: { status: 'pending' } } });
+    });
+
+    it('inPendingBurstGroup:false compiles to burstGroup.isNot.status=pending', () => {
+      const def = baseDef({
+        conditions: [{ field: 'inPendingBurstGroup', op: 'is', value: false }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ burstGroup: { isNot: { status: 'pending' } } });
+    });
+
+    it('burstGroupConfidence gte compiles to a pure indexed relation predicate', () => {
+      const def = baseDef({
+        conditions: [{ field: 'burstGroupConfidence', op: 'gte', value: 0.8 }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        burstGroup: { is: { status: 'pending', confidence: { gte: 0.8 } } },
+      });
+    });
+
+    it('inPendingDuplicateGroup:true compiles to duplicateGroup.is.status=pending', () => {
+      const def = baseDef({
+        conditions: [{ field: 'inPendingDuplicateGroup', op: 'is', value: true }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ duplicateGroup: { is: { status: 'pending' } } });
+    });
+
+    it('duplicateGroupConfidence compiles to the bounding predicate ONLY (no threshold in where)', () => {
+      // Documented Phase-1 limitation: duplicate confidence is computed at read
+      // time (not persisted), so the where clause cannot express the threshold —
+      // it only narrows to "already in a pending duplicate group".
+      const def = baseDef({
+        conditions: [{ field: 'duplicateGroupConfidence', op: 'gte', value: 0.9 }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ duplicateGroup: { is: { status: 'pending' } } });
+    });
+
+    it('hasPendingLocationSuggestion:true compiles to locationSuggestion.is.status=pending', () => {
+      const def = baseDef({
+        conditions: [{ field: 'hasPendingLocationSuggestion', op: 'is', value: true }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({ locationSuggestion: { is: { status: 'pending' } } });
+    });
+
+    it('locationSuggestionConfidence gte compiles to a pure indexed relation predicate', () => {
+      const def = baseDef({
+        conditions: [{ field: 'locationSuggestionConfidence', op: 'gte', value: 0.75 }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        locationSuggestion: { is: { status: 'pending', confidence: { gte: 0.75 } } },
+      });
+    });
+
+    it('locationSuggestionMethod equals compiles to locationSuggestion.is.method', () => {
+      const def = baseDef({
+        conditions: [{ field: 'locationSuggestionMethod', op: 'equals', value: 'interpolated' }],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND[0]).toEqual({
+        locationSuggestion: { is: { status: 'pending', method: 'interpolated' } },
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // match: all/any composition + one nested group level
+  // ---------------------------------------------------------------------------
+
+  describe('match composition', () => {
+    it('match:all composes fragments into an AND array', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [
+          { field: 'missingCamera', op: 'is', value: true },
+          { field: 'missingCapturedAt', op: 'is', value: true },
+        ],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).AND).toHaveLength(2);
+      expect((where as any).OR).toBeUndefined();
+    });
+
+    it('match:any composes fragments into an OR array', () => {
+      const def = baseDef({
+        match: 'any',
+        conditions: [
+          { field: 'favorite', op: 'is', value: true },
+          { field: 'archived', op: 'is', value: true },
+        ],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      expect((where as any).OR).toEqual([{ favorite: true }, { archivedAt: { not: null } }]);
+      expect((where as any).AND).toBeUndefined();
+    });
+
+    it('a single nested group compiles into a nested array under the root array', () => {
+      // The screenshot heuristic: filename contains "screenshot" OR
+      // (mimeType=png AND missingCamera AND missingCapturedAt).
+      const def = baseDef({
+        match: 'any',
+        conditions: [
+          { field: 'filename', op: 'contains', value: 'screenshot' },
+          {
+            match: 'all',
+            conditions: [
+              { field: 'mimeType', op: 'equals', value: 'image/png' },
+              { field: 'missingCamera', op: 'is', value: true },
+              { field: 'missingCapturedAt', op: 'is', value: true },
+            ],
+          },
+        ],
+      });
+      const { where } = compiler.compile(CIRCLE_ID, def);
+      const or = (where as any).OR as any[];
+      expect(or).toHaveLength(2);
+      expect(or[0]).toEqual({ originalFilename: { contains: 'screenshot', mode: 'insensitive' } });
+      expect(or[1]).toEqual({
+        AND: [
+          { storageObject: { mimeType: 'image/png' } },
+          { cameraMake: null, cameraModel: null },
+          { capturedAt: null },
+        ],
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Read-time refinements: orientationShape / megapixels
+  // ---------------------------------------------------------------------------
+
+  describe('read-time refinements', () => {
+    it('orientationShape on a pure-AND root path is collected as a refinement', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [{ field: 'orientationShape', op: 'equals', value: 'portrait' }],
+      });
+      const { where, refinements } = compiler.compile(CIRCLE_ID, def);
+      // Bounding predicate only narrows to "both dimensions present".
+      expect((where as any).AND[0]).toEqual({ width: { not: null }, height: { not: null } });
+      expect(refinements).toHaveLength(1);
+      expect(refinements[0].field).toBe('orientationShape');
+      expect(refinements[0].select).toEqual({ width: true, height: true });
+      expect(refinements[0].predicate({ width: 100, height: 200 })).toBe(true); // portrait
+      expect(refinements[0].predicate({ width: 200, height: 100 })).toBe(false); // landscape
+      expect(refinements[0].predicate({ width: null, height: 200 })).toBe(false); // missing dims
+    });
+
+    it('megapixels on a pure-AND root path is collected as a refinement', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [{ field: 'megapixels', op: 'gt', value: 12 }],
+      });
+      const { refinements } = compiler.compile(CIRCLE_ID, def);
+      expect(refinements).toHaveLength(1);
+      expect(refinements[0].field).toBe('megapixels');
+      // 4000x3000 = 12MP exactly -> not > 12
+      expect(refinements[0].predicate({ width: 4000, height: 3000 })).toBe(false);
+      // 5000x4000 = 20MP -> > 12
+      expect(refinements[0].predicate({ width: 5000, height: 4000 })).toBe(true);
+    });
+
+    it('is NOT collected when the root match is "any" (OR-nested path)', () => {
+      const def = baseDef({
+        match: 'any',
+        conditions: [
+          { field: 'orientationShape', op: 'equals', value: 'portrait' },
+          { field: 'favorite', op: 'is', value: true },
+        ],
+      });
+      const { refinements } = compiler.compile(CIRCLE_ID, def);
+      expect(refinements).toHaveLength(0);
+    });
+
+    it('is NOT collected when nested inside a match:"any" group even under a match:"all" root', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [
+          {
+            match: 'any',
+            conditions: [{ field: 'orientationShape', op: 'equals', value: 'square' }],
+          },
+        ],
+      });
+      const { refinements } = compiler.compile(CIRCLE_ID, def);
+      expect(refinements).toHaveLength(0);
+    });
+
+    it('IS collected when nested inside a match:"all" group under a match:"all" root', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [
+          {
+            match: 'all',
+            conditions: [{ field: 'orientationShape', op: 'equals', value: 'square' }],
+          },
+        ],
+      });
+      const { refinements } = compiler.compile(CIRCLE_ID, def);
+      expect(refinements).toHaveLength(1);
+      expect(refinements[0].field).toBe('orientationShape');
+    });
+
+    it('duplicateGroupConfidence is readTimeRefinement but has no refinementPredicate — never collected', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [{ field: 'duplicateGroupConfidence', op: 'gte', value: 0.9 }],
+      });
+      const { refinements } = compiler.compile(CIRCLE_ID, def);
+      expect(refinements).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dependency-set derivation
+  // ---------------------------------------------------------------------------
+
+  describe('dependency-set derivation', () => {
+    it('a metadata-only field yields {metadata}', () => {
+      const def = baseDef({
+        conditions: [{ field: 'filename', op: 'contains', value: 'x' }],
+      });
+      expect(compiler.deriveDependencies(def)).toEqual(['metadata']);
+    });
+
+    it('a tags condition yields {tags}', () => {
+      const def = baseDef({
+        conditions: [{ field: 'tags', op: 'has_any', value: ['a'] }],
+      });
+      expect(compiler.deriveDependencies(def)).toEqual(['tags']);
+    });
+
+    it('a people condition yields {faces}', () => {
+      const def = baseDef({
+        conditions: [
+          { field: 'people', op: 'has_person', value: { ids: ['11111111-1111-1111-1111-111111111111'] } },
+        ],
+      });
+      expect(compiler.deriveDependencies(def)).toEqual(['faces']);
+    });
+
+    it('mixing metadata + tags + faces + bursts + duplicates + locationSuggestions yields all six, deduped', () => {
+      const def = baseDef({
+        match: 'all',
+        conditions: [
+          { field: 'filename', op: 'contains', value: 'x' },
+          { field: 'uploadedAt', op: 'before', value: '2024-01-01T00:00:00.000Z' }, // metadata again (dedup)
+          { field: 'tags', op: 'has_any', value: ['a'] },
+          { field: 'noFaces', op: 'is', value: true }, // faces
+          { field: 'inPendingBurstGroup', op: 'is', value: true }, // bursts
+          { field: 'inPendingDuplicateGroup', op: 'is', value: true }, // duplicates
+          { field: 'hasPendingLocationSuggestion', op: 'is', value: true }, // locationSuggestions
+        ],
+      });
+      const deps = compiler.deriveDependencies(def);
+      expect(new Set(deps)).toEqual(
+        new Set(['metadata', 'tags', 'faces', 'bursts', 'duplicates', 'locationSuggestions']),
+      );
+      expect(deps).toHaveLength(6); // deduped, no repeats
+    });
+
+    it('derives dependencies from leaves nested inside a group', () => {
+      const def = baseDef({
+        match: 'any',
+        conditions: [
+          { field: 'favorite', op: 'is', value: true },
+          {
+            match: 'all',
+            conditions: [{ field: 'tags', op: 'has_any', value: ['a'] }],
+          },
+        ],
+      });
+      expect(new Set(compiler.deriveDependencies(def))).toEqual(new Set(['metadata', 'tags']));
+    });
+
+    it('returns an empty array for an empty conditions list', () => {
+      const def = baseDef({ conditions: [] });
+      expect(compiler.deriveDependencies(def)).toEqual([]);
+    });
+
+    it('also unions dependencies while compiling a full where (compile() populates the same set)', () => {
+      const def = baseDef({
+        conditions: [
+          { field: 'tags', op: 'has_any', value: ['a'] },
+          { field: 'inPendingBurstGroup', op: 'is', value: true },
+        ],
+      });
+      const { dependencies } = compiler.compile(CIRCLE_ID, def);
+      expect(dependencies).toEqual(new Set(['tags', 'bursts']));
+    });
+  });
+});

--- a/apps/api/src/workflows/compiler/workflow-condition.compiler.ts
+++ b/apps/api/src/workflows/compiler/workflow-condition.compiler.ts
@@ -1,0 +1,134 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  WorkflowDependency,
+  WorkflowOperator,
+} from '../registry/field-descriptor.interface';
+import { getField } from '../registry/subject-registry';
+import {
+  LeafCondition,
+  WorkflowDefinition,
+  isGroupCondition,
+} from '../definition/workflow-definition.schema';
+
+/**
+ * A read-time refinement: an exact predicate that cannot be expressed as a pure
+ * Prisma index predicate (see `media-item-fields.ts`). Collected by the compiler
+ * ONLY when the refinement field sits on an all-AND path from the definition
+ * root, which makes it sound to apply as a top-level AND post-filter. On any
+ * OR-nested path the field contributes only its bounding predicate (an upper
+ * bound), and no refinement is emitted.
+ */
+export interface CompiledRefinement {
+  field: string;
+  /** Extra columns the predicate needs selected on the fetched row. */
+  select: Prisma.MediaItemSelect;
+  predicate: (row: any) => boolean;
+}
+
+export interface CompiledWorkflow {
+  /** Prisma where, scoped `{ circleId, deletedAt: null }` + compiled conditions. */
+  where: Prisma.MediaItemWhereInput;
+  /** Enrichment outputs the conditions read (Phase 4 evaluability gating). */
+  dependencies: Set<WorkflowDependency>;
+  /** Read-time refinements to apply after the where (see CompiledRefinement). */
+  refinements: CompiledRefinement[];
+}
+
+/**
+ * Compiles a validated workflow definition into a Prisma `where` (plus a
+ * dependency set and read-time refinements), resolved per Subject through the
+ * registry.
+ *
+ * Composition follows the search engine's shared-array rule: every condition is
+ * pushed as its own element of an `AND` (match:'all') or `OR` (match:'any')
+ * array — fragments are never merged into one object — so two descriptors that
+ * each emit a top-level `OR`/`AND` key never collide (see
+ * `docs/audits/search-audit.md`).
+ */
+@Injectable()
+export class WorkflowConditionCompiler {
+  /**
+   * Compile a definition against a circle. Assumes the definition has already
+   * passed `WorkflowDefinitionValidator` (fields/ops/values are valid).
+   */
+  compile(circleId: string, def: WorkflowDefinition): CompiledWorkflow {
+    const dependencies = new Set<WorkflowDependency>();
+    const refinements: CompiledRefinement[] = [];
+    const rootPureAnd = def.match === 'all';
+
+    const fragments: Prisma.MediaItemWhereInput[] = def.conditions.map((cond) => {
+      if (isGroupCondition(cond)) {
+        // A group is one nesting level; its leaves compile with the group's own
+        // match. The group's leaves are on a pure-AND path only when BOTH the
+        // root and the group use match:'all'.
+        const groupPureAnd = rootPureAnd && cond.match === 'all';
+        const groupFragments = cond.conditions.map((leaf) =>
+          this.compileLeaf(def.subject, leaf, dependencies, refinements, groupPureAnd),
+        );
+        return cond.match === 'all' ? { AND: groupFragments } : { OR: groupFragments };
+      }
+      return this.compileLeaf(def.subject, cond, dependencies, refinements, rootPureAnd);
+    });
+
+    const where: Prisma.MediaItemWhereInput = { circleId, deletedAt: null };
+    if (fragments.length > 0) {
+      if (def.match === 'all') where.AND = fragments;
+      else where.OR = fragments;
+    }
+
+    return { where, dependencies, refinements };
+  }
+
+  /**
+   * Derive ONLY the dependency set for a definition without building a where —
+   * cheaper and value-agnostic (never throws on operand issues). Exposed so the
+   * service can surface `dependencies` per workflow. Silently skips unknown
+   * fields (a validated definition has none).
+   */
+  deriveDependencies(def: WorkflowDefinition): WorkflowDependency[] {
+    const deps = new Set<WorkflowDependency>();
+    const addLeaf = (subject: string, leaf: LeafCondition) => {
+      const descriptor = getField(subject, leaf.field);
+      if (descriptor) deps.add(descriptor.dependency);
+    };
+    for (const cond of def.conditions) {
+      if (isGroupCondition(cond)) {
+        for (const leaf of cond.conditions) addLeaf(def.subject, leaf);
+      } else {
+        addLeaf(def.subject, cond);
+      }
+    }
+    return [...deps];
+  }
+
+  private compileLeaf(
+    subject: string,
+    leaf: LeafCondition,
+    dependencies: Set<WorkflowDependency>,
+    refinements: CompiledRefinement[],
+    pureAndPath: boolean,
+  ): Prisma.MediaItemWhereInput {
+    const descriptor = getField(subject, leaf.field);
+    if (!descriptor) {
+      // Should be unreachable post-validation; guard defensively.
+      throw new BadRequestException(`Unknown field "${leaf.field}" for subject "${subject}"`);
+    }
+    dependencies.add(descriptor.dependency);
+
+    const op = leaf.op as WorkflowOperator;
+
+    // Collect a read-time refinement only when it is (a) evaluable in-process
+    // and (b) on a pure-AND path (sound to AND post-filter). Otherwise the
+    // bounding predicate from buildWhere is the only narrowing applied.
+    if (descriptor.readTimeRefinement && descriptor.refinementPredicate && pureAndPath) {
+      refinements.push({
+        field: descriptor.key,
+        select: descriptor.refinementSelect ?? {},
+        predicate: descriptor.refinementPredicate(op, leaf.value),
+      });
+    }
+
+    return descriptor.buildWhere(op, leaf.value);
+  }
+}

--- a/apps/api/src/workflows/definition/workflow-definition.schema.ts
+++ b/apps/api/src/workflows/definition/workflow-definition.schema.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+
+/**
+ * Structural Zod schema for a versioned, Subject-tagged workflow definition
+ * document (epic #138 / issue #139).
+ *
+ * This schema enforces SHAPE only:
+ *   - `version` and `subject` are mandatory.
+ *   - `conditions` are leaves `{ field, op, value }` OR exactly ONE nesting level
+ *     of groups `{ match, conditions: leaf[] }` — a group may not contain another
+ *     group, so deeper nesting is rejected here.
+ *   - `actions` are structurally validated (each has a `type`); per-action
+ *     parameter schemas live with the action library in Phase 2 (#140).
+ *
+ * Registry-aware validation (subject registered, field/op/action registered for
+ * the subject, operator/value-type match) is layered on top by
+ * `WorkflowDefinitionValidator` — a Zod schema cannot know the per-Subject
+ * catalog.
+ */
+
+/** A single leaf condition: `{ field, op, value? }`. */
+export const leafConditionSchema = z
+  .object({
+    field: z.string().min(1),
+    op: z.string().min(1),
+    // Value shape is operator-dependent; validated by the registry validator.
+    value: z.unknown().optional(),
+  })
+  .strict();
+
+export type LeafCondition = z.infer<typeof leafConditionSchema>;
+
+/**
+ * A group condition: `{ match, conditions: leaf[] }`. Its `conditions` accept
+ * ONLY leaves — this is what caps nesting at exactly one level.
+ */
+export const groupConditionSchema = z
+  .object({
+    match: z.enum(['all', 'any']),
+    conditions: z.array(leafConditionSchema).min(1),
+  })
+  .strict();
+
+export type GroupCondition = z.infer<typeof groupConditionSchema>;
+
+/** A top-level condition is either a leaf or a (single-level) group. */
+export const topConditionSchema = z.union([groupConditionSchema, leafConditionSchema]);
+
+export type TopCondition = z.infer<typeof topConditionSchema>;
+
+/**
+ * An action: structurally `{ type, ...params }`. Extra params pass through
+ * untouched in Phase 1 (Phase 2 validates them per action type).
+ */
+export const actionSchema = z
+  .object({
+    type: z.string().min(1),
+  })
+  .passthrough();
+
+export type WorkflowAction = z.infer<typeof actionSchema>;
+
+/** The full versioned, Subject-tagged definition document. */
+export const workflowDefinitionSchema = z
+  .object({
+    version: z.literal(1),
+    subject: z.string().min(1),
+    match: z.enum(['all', 'any']),
+    // An empty conditions array is allowed: it matches every (non-deleted) item
+    // in the circle — a legitimate "apply to all" workflow.
+    conditions: z.array(topConditionSchema).default([]),
+    // Actions optional in Phase 1 (no execution); Phase 2 will require ≥1 to run.
+    actions: z.array(actionSchema).default([]),
+    options: z
+      .object({
+        maxItems: z.number().int().positive().optional(),
+        requirePreview: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema>;
+
+/** Type guard: is this top-level condition a group (vs a leaf)? */
+export function isGroupCondition(c: TopCondition): c is GroupCondition {
+  return typeof c === 'object' && c !== null && 'match' in c && 'conditions' in c;
+}

--- a/apps/api/src/workflows/definition/workflow-definition.validator.spec.ts
+++ b/apps/api/src/workflows/definition/workflow-definition.validator.spec.ts
@@ -1,0 +1,481 @@
+/**
+ * Unit tests for WorkflowDefinitionValidator (issue #139).
+ *
+ * Pure — no NestJS module or DB dependency (constructed directly). Layers
+ * registry-aware validation on top of the structural Zod schema.
+ */
+import { BadRequestException } from '@nestjs/common';
+import { WorkflowDefinitionValidator } from './workflow-definition.validator';
+
+describe('WorkflowDefinitionValidator', () => {
+  let validator: WorkflowDefinitionValidator;
+
+  beforeEach(() => {
+    validator = new WorkflowDefinitionValidator();
+  });
+
+  // ---------------------------------------------------------------------------
+  // The documented screenshot-cleanup example (epic #138 / issue #139)
+  // ---------------------------------------------------------------------------
+
+  it('accepts a valid screenshot-cleanup definition', () => {
+    const definition = {
+      version: 1,
+      subject: 'media_item',
+      match: 'any',
+      conditions: [
+        { field: 'filename', op: 'contains', value: 'screenshot' },
+        {
+          match: 'all',
+          conditions: [
+            { field: 'mimeType', op: 'equals', value: 'image/png' },
+            { field: 'missingCamera', op: 'is', value: true },
+            { field: 'missingCapturedAt', op: 'is', value: true },
+          ],
+        },
+      ],
+      actions: [{ type: 'move_to_trash' }],
+      options: { maxItems: 5000, requirePreview: true },
+    };
+
+    const result = validator.validate(definition);
+    expect(result.subject).toBe('media_item');
+    expect(result.match).toBe('any');
+    expect(result.conditions).toHaveLength(2);
+    expect(result.actions).toEqual([{ type: 'move_to_trash' }]);
+  });
+
+  it('accepts a definition with empty conditions (matches every item in the circle)', () => {
+    const definition = {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [],
+      actions: [],
+    };
+    const result = validator.validate(definition);
+    expect(result.conditions).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // version / subject requirements
+  // ---------------------------------------------------------------------------
+
+  describe('version and subject requirements', () => {
+    it('rejects a definition missing version', () => {
+      expect(() =>
+        validator.validate({ subject: 'media_item', match: 'all', conditions: [], actions: [] }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects a definition with a version other than 1', () => {
+      expect(() =>
+        validator.validate({
+          version: 2,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [],
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects a definition missing subject', () => {
+      expect(() =>
+        validator.validate({ version: 1, match: 'all', conditions: [], actions: [] }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects an unregistered subject', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'duplicate_group',
+          match: 'all',
+          conditions: [],
+          actions: [],
+        }),
+      ).toThrow(/Unknown workflow subject/);
+    });
+
+    it('rejects a missing match', () => {
+      expect(() =>
+        validator.validate({ version: 1, subject: 'media_item', conditions: [], actions: [] }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects an invalid match value', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'xor',
+          conditions: [],
+          actions: [],
+        }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unknown field rejected
+  // ---------------------------------------------------------------------------
+
+  describe('unknown field rejection', () => {
+    it('rejects an unregistered field for media_item', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'doesNotExist', op: 'equals', value: 'x' }],
+          actions: [],
+        }),
+      ).toThrow(/Unknown field "doesNotExist"/);
+    });
+
+    it('rejects an unregistered field nested inside a group', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [
+            {
+              match: 'all',
+              conditions: [{ field: 'bogusNestedField', op: 'is', value: true }],
+            },
+          ],
+          actions: [],
+        }),
+      ).toThrow(/Unknown field "bogusNestedField"/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cross-Subject / unregistered action rejected
+  // ---------------------------------------------------------------------------
+
+  describe('unregistered action rejection', () => {
+    it('rejects an action type not in the media_item action catalog', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'launch_rocket' }],
+        }),
+      ).toThrow(/Unknown action "launch_rocket"/);
+    });
+
+    it('accepts every action type actually registered for media_item', () => {
+      const actionTypes = [
+        'move_to_trash',
+        'hard_delete',
+        'archive',
+        'unarchive',
+        'add_to_album',
+        'remove_from_album',
+        'add_tags',
+        'remove_tags',
+        'set_favorite',
+        'set_capture_date',
+        'shift_capture_date',
+        'move_to_circle',
+        'assign_person',
+        'remove_person',
+        'set_location',
+        'clear_location',
+        'resolve_burst_group',
+        'dismiss_burst_group',
+        'resolve_duplicate_group',
+        'dismiss_duplicate_group',
+        'accept_location_suggestion',
+        'reject_location_suggestion',
+        'rerun_enrichment',
+      ];
+      for (const type of actionTypes) {
+        expect(() =>
+          validator.validate({
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [],
+            actions: [{ type }],
+          }),
+        ).not.toThrow();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Nesting depth > 1 rejected (structural — enforced by the Zod schema)
+  // ---------------------------------------------------------------------------
+
+  describe('nesting depth', () => {
+    it('rejects a group nested inside another group (depth 2)', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [
+            {
+              match: 'all',
+              conditions: [
+                {
+                  match: 'any',
+                  conditions: [{ field: 'filename', op: 'contains', value: 'x' }],
+                },
+              ],
+            },
+          ],
+          actions: [],
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('accepts exactly one level of nesting', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [
+            {
+              match: 'all',
+              conditions: [{ field: 'filename', op: 'contains', value: 'x' }],
+            },
+          ],
+          actions: [],
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Operator/value type mismatches
+  // ---------------------------------------------------------------------------
+
+  describe('operator not valid for field', () => {
+    it('rejects an operator the field does not declare', () => {
+      // filename only supports contains/starts_with/ends_with/equals — not gt.
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'filename', op: 'gt', value: 'x' }],
+          actions: [],
+        }),
+      ).toThrow(/Operator "gt" is not valid for field "filename"/);
+    });
+  });
+
+  describe('operand type mismatches', () => {
+    it('rejects a non-boolean value for a boolean "is" field', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'missingCamera', op: 'is', value: 'yes' }],
+          actions: [],
+        }),
+      ).toThrow(/value must be a boolean/);
+    });
+
+    it('rejects a non-enum value for an enum "is" field (coordSource)', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'coordSource', op: 'is', value: 'gps_satellite' }],
+          actions: [],
+        }),
+      ).toThrow(/value must be one of/);
+    });
+
+    it('accepts a valid enum value for coordSource', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'coordSource', op: 'is', value: 'exif' }],
+          actions: [],
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects a non-numeric value for a gt/lt/gte operator', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'fileSize', op: 'gt', value: 'huge' }],
+          actions: [],
+        }),
+      ).toThrow(/value must be a number/);
+    });
+
+    it('rejects an empty string for a contains operator', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'filename', op: 'contains', value: '' }],
+          actions: [],
+        }),
+      ).toThrow(/non-empty string/);
+    });
+
+    it('rejects a non-ISO-date value for before/after', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'capturedAt', op: 'before', value: 'not-a-date' }],
+          actions: [],
+        }),
+      ).toThrow(/ISO 8601 date string/);
+    });
+
+    it('rejects a non-positive-integer value for older_than_days', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'capturedAt', op: 'older_than_days', value: -5 }],
+          actions: [],
+        }),
+      ).toThrow(/positive integer/);
+    });
+
+    it('rejects a between value with neither from nor to', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'capturedAt', op: 'between', value: {} }],
+          actions: [],
+        }),
+      ).toThrow(/from\?, to\?/);
+    });
+
+    it('accepts a between value with only "from"', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [
+            { field: 'capturedAt', op: 'between', value: { from: '2024-01-01T00:00:00.000Z' } },
+          ],
+          actions: [],
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects an empty array for has_any', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'tags', op: 'has_any', value: [] }],
+          actions: [],
+        }),
+      ).toThrow(/non-empty array of strings/);
+    });
+
+    it('rejects a has_person value missing ids', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'people', op: 'has_person', value: { mode: 'all' } }],
+          actions: [],
+        }),
+      ).toThrow(/non-empty ids array/);
+    });
+
+    it('rejects an invalid mode on a has_person value', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [
+            {
+              field: 'people',
+              op: 'has_person',
+              value: { ids: ['11111111-1111-1111-1111-111111111111'], mode: 'majority' },
+            },
+          ],
+          actions: [],
+        }),
+      ).toThrow(/mode must be 'any' or 'all'/);
+    });
+
+    it('rejects a near value missing radiusKm', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'near', op: 'near', value: { lat: 1, lng: 2 } }],
+          actions: [],
+        }),
+      ).toThrow(/lat, lng, radiusKm/);
+    });
+
+    it('accepts a valid near value', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'near', op: 'near', value: { lat: 9.9, lng: -84.0, radiusKm: 10 } }],
+          actions: [],
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects a non-uuid string for in_album', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [{ field: 'album', op: 'in_album', value: '' }],
+          actions: [],
+        }),
+      ).toThrow(/album UUID string/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Extra/unknown keys on a leaf are rejected by the strict Zod schema
+  // ---------------------------------------------------------------------------
+
+  it('rejects a leaf with unexpected extra keys (strict schema)', () => {
+    expect(() =>
+      validator.validate({
+        version: 1,
+        subject: 'media_item',
+        match: 'all',
+        conditions: [{ field: 'filename', op: 'contains', value: 'x', extra: 'nope' }],
+        actions: [],
+      }),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/workflows/definition/workflow-definition.validator.ts
+++ b/apps/api/src/workflows/definition/workflow-definition.validator.ts
@@ -1,0 +1,228 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  WorkflowDefinition,
+  isGroupCondition,
+  workflowDefinitionSchema,
+} from './workflow-definition.schema';
+import {
+  WorkflowFieldDescriptor,
+  WorkflowOperator,
+} from '../registry/field-descriptor.interface';
+import {
+  getField,
+  getSubjectRegistry,
+  isRegisteredAction,
+  isRegisteredSubject,
+  registeredSubjects,
+} from '../registry/subject-registry';
+
+/**
+ * Validates a workflow definition document against the per-Subject registry.
+ *
+ * Layered on top of the structural Zod schema: it rejects a `subject` not in the
+ * registry, any `field`/`op`/action `type` not registered for that Subject, and
+ * operator/value-type mismatches — so an unknown or cross-Subject combination
+ * can never be persisted.
+ *
+ * Stateless and pure (no I/O) — trivially unit-testable.
+ */
+@Injectable()
+export class WorkflowDefinitionValidator {
+  /**
+   * Parse + validate. Returns the normalized definition on success; throws
+   * `BadRequestException` with actionable messages on any failure.
+   */
+  validate(input: unknown): WorkflowDefinition {
+    // 1. Structural validation (version, subject present, nesting depth, shapes).
+    const parsed = workflowDefinitionSchema.safeParse(input);
+    if (!parsed.success) {
+      const issues = parsed.error.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ');
+      throw new BadRequestException(`Invalid workflow definition: ${issues}`);
+    }
+    const def = parsed.data;
+
+    // 2. Subject must be registered.
+    if (!isRegisteredSubject(def.subject)) {
+      throw new BadRequestException(
+        `Unknown workflow subject "${def.subject}". Registered subjects: ${registeredSubjects().join(', ')}`,
+      );
+    }
+
+    // 3. Conditions: every field/op/value must be valid for the Subject.
+    for (const cond of def.conditions) {
+      if (isGroupCondition(cond)) {
+        for (const leaf of cond.conditions) {
+          this.validateLeaf(def.subject, leaf.field, leaf.op, leaf.value);
+        }
+      } else {
+        this.validateLeaf(def.subject, cond.field, cond.op, cond.value);
+      }
+    }
+
+    // 4. Actions: each type must be registered for the Subject (params: Phase 2).
+    for (const action of def.actions) {
+      if (!isRegisteredAction(def.subject, action.type)) {
+        const registry = getSubjectRegistry(def.subject);
+        const known = registry?.actions.map((a) => a.type).join(', ') ?? '';
+        throw new BadRequestException(
+          `Unknown action "${action.type}" for subject "${def.subject}". Registered actions: ${known}`,
+        );
+      }
+    }
+
+    return def;
+  }
+
+  /** Validate one leaf `{ field, op, value }` against its descriptor. */
+  private validateLeaf(subject: string, field: string, op: string, value: unknown): void {
+    const descriptor = getField(subject, field);
+    if (!descriptor) {
+      throw new BadRequestException(
+        `Unknown field "${field}" for subject "${subject}"`,
+      );
+    }
+    if (!descriptor.operators.includes(op as WorkflowOperator)) {
+      throw new BadRequestException(
+        `Operator "${op}" is not valid for field "${field}". Allowed: ${descriptor.operators.join(', ')}`,
+      );
+    }
+    this.validateOperand(descriptor, op as WorkflowOperator, value);
+  }
+
+  /**
+   * Validate that `value` matches the shape the (field, operator) pair expects.
+   * The operator is the primary discriminator; enum membership is checked when
+   * the descriptor declares `enumValues`.
+   */
+  private validateOperand(
+    descriptor: WorkflowFieldDescriptor,
+    op: WorkflowOperator,
+    value: unknown,
+  ): void {
+    const fail = (msg: string): never => {
+      throw new BadRequestException(`Field "${descriptor.key}" (op "${op}"): ${msg}`);
+    };
+    const isNonEmptyString = (v: unknown): v is string =>
+      typeof v === 'string' && v.trim().length > 0;
+    const inEnum = (v: unknown): boolean =>
+      !!descriptor.enumValues && typeof v === 'string' && descriptor.enumValues.includes(v);
+
+    switch (op) {
+      case 'is':
+        // Overloaded: enum fields (e.g. coordSource) take an enum member; all
+        // other fields take a boolean.
+        if (descriptor.enumValues) {
+          if (!inEnum(value)) fail(`value must be one of: ${descriptor.enumValues.join(', ')}`);
+        } else if (typeof value !== 'boolean') {
+          fail('value must be a boolean');
+        }
+        return;
+
+      case 'is_set':
+        // No operand required.
+        return;
+
+      case 'equals':
+        if (descriptor.enumValues) {
+          if (!inEnum(value)) fail(`value must be one of: ${descriptor.enumValues.join(', ')}`);
+        } else if (!isNonEmptyString(value)) {
+          fail('value must be a non-empty string');
+        }
+        return;
+
+      case 'contains':
+      case 'starts_with':
+      case 'ends_with':
+        if (!isNonEmptyString(value)) fail('value must be a non-empty string');
+        return;
+
+      case 'gt':
+      case 'lt':
+      case 'gte':
+        if (typeof value !== 'number' || !Number.isFinite(value)) fail('value must be a number');
+        return;
+
+      case 'before':
+      case 'after':
+        if (!isNonEmptyString(value) || isNaN(new Date(value).getTime())) {
+          fail('value must be an ISO 8601 date string');
+        }
+        return;
+
+      case 'older_than_days':
+      case 'within_last_days':
+        if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+          fail('value must be a positive integer number of days');
+        }
+        return;
+
+      case 'between': {
+        const v = value as { from?: unknown; to?: unknown } | undefined;
+        if (!v || typeof v !== 'object' || (v.from === undefined && v.to === undefined)) {
+          fail('value must be an object { from?, to? } with at least one ISO date');
+        }
+        for (const bound of [v!.from, v!.to]) {
+          if (bound !== undefined && (!isNonEmptyString(bound) || isNaN(new Date(bound).getTime()))) {
+            fail('from/to must be ISO 8601 date strings');
+          }
+        }
+        return;
+      }
+
+      case 'has_any':
+      case 'has_all':
+      case 'has_none': {
+        if (
+          !Array.isArray(value) ||
+          value.length === 0 ||
+          !value.every((x) => isNonEmptyString(x))
+        ) {
+          fail('value must be a non-empty array of strings');
+        }
+        return;
+      }
+
+      case 'has_person':
+      case 'not_has_person': {
+        const v = value as { ids?: unknown; mode?: unknown } | undefined;
+        if (
+          !v ||
+          typeof v !== 'object' ||
+          !Array.isArray(v.ids) ||
+          v.ids.length === 0 ||
+          !v.ids.every((x) => isNonEmptyString(x))
+        ) {
+          fail('value must be an object { ids: string[] } with a non-empty ids array');
+        }
+        if (v!.mode !== undefined && v!.mode !== 'any' && v!.mode !== 'all') {
+          fail("mode must be 'any' or 'all' when provided");
+        }
+        return;
+      }
+
+      case 'in_album':
+      case 'not_in_album':
+        if (!isNonEmptyString(value)) fail('value must be an album UUID string');
+        return;
+
+      case 'near': {
+        const v = value as { lat?: unknown; lng?: unknown; radiusKm?: unknown } | undefined;
+        if (
+          !v ||
+          typeof v.lat !== 'number' ||
+          typeof v.lng !== 'number' ||
+          typeof v.radiusKm !== 'number' ||
+          v.radiusKm <= 0
+        ) {
+          fail('value must be { lat, lng, radiusKm } numbers with radiusKm > 0');
+        }
+        return;
+      }
+
+      default:
+        fail('unsupported operator');
+    }
+  }
+}

--- a/apps/api/src/workflows/dto/create-workflow.dto.ts
+++ b/apps/api/src/workflows/dto/create-workflow.dto.ts
@@ -1,0 +1,21 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { workflowDefinitionSchema } from '../definition/workflow-definition.schema';
+
+/**
+ * POST /api/workflows body. `subjectType` is NOT accepted here — it is derived
+ * from `definition.subject` so the two can never disagree. Cron validity for a
+ * `scheduled` trigger is enforced in the service (kept out of the DTO so
+ * createZodDto stays a plain ZodObject).
+ */
+export const createWorkflowSchema = z.object({
+  circleId: z.string().uuid(),
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).nullable().optional(),
+  enabled: z.boolean().optional().default(true),
+  trigger: z.enum(['manual', 'on_media_enriched', 'scheduled']).optional().default('manual'),
+  cronExpression: z.string().max(200).nullable().optional(),
+  definition: workflowDefinitionSchema,
+});
+
+export class CreateWorkflowDto extends createZodDto(createWorkflowSchema) {}

--- a/apps/api/src/workflows/dto/list-workflows-query.dto.ts
+++ b/apps/api/src/workflows/dto/list-workflows-query.dto.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+/** GET /api/workflows query params. */
+export const listWorkflowsQuerySchema = z.object({
+  circleId: z.string().uuid(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export class ListWorkflowsQueryDto extends createZodDto(listWorkflowsQuerySchema) {}

--- a/apps/api/src/workflows/dto/preview-workflow.dto.ts
+++ b/apps/api/src/workflows/dto/preview-workflow.dto.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { workflowDefinitionSchema } from '../definition/workflow-definition.schema';
+
+/** POST /api/workflows/preview body — stateless builder feedback. */
+export const previewWorkflowSchema = z.object({
+  circleId: z.string().uuid(),
+  definition: workflowDefinitionSchema,
+});
+
+export class PreviewWorkflowDto extends createZodDto(previewWorkflowSchema) {}

--- a/apps/api/src/workflows/dto/update-workflow.dto.ts
+++ b/apps/api/src/workflows/dto/update-workflow.dto.ts
@@ -1,0 +1,21 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { workflowDefinitionSchema } from '../definition/workflow-definition.schema';
+
+/**
+ * PATCH /api/workflows/:id body. All fields optional; `circleId` and
+ * `subjectType` are immutable (subjectType follows `definition.subject` when a
+ * new definition is supplied). Cron validity is enforced in the service.
+ */
+export const updateWorkflowSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).nullable().optional(),
+    enabled: z.boolean().optional(),
+    trigger: z.enum(['manual', 'on_media_enriched', 'scheduled']).optional(),
+    cronExpression: z.string().max(200).nullable().optional(),
+    definition: workflowDefinitionSchema.optional(),
+  })
+  .strict();
+
+export class UpdateWorkflowDto extends createZodDto(updateWorkflowSchema) {}

--- a/apps/api/src/workflows/registry/field-descriptor.interface.ts
+++ b/apps/api/src/workflows/registry/field-descriptor.interface.ts
@@ -1,0 +1,168 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Media Workflow Automation — condition (field) descriptor model.
+ *
+ * A workflow's Subject (v1: `media_item`) exposes a catalog of typed FIELDS.
+ * Each field declares the operators it supports, the JSON value shape those
+ * operators expect, the enrichment output it depends on (used by Phase 4 to
+ * decide when an item is evaluable), and a pure `buildWhere` that compiles one
+ * `{ field, op, value }` leaf into a `Prisma.MediaItemWhereInput` fragment.
+ *
+ * Every field MUST compile to an INDEXED or RELATION-based Prisma where-clause —
+ * no full scans, no user-supplied regex (glob / "contains" → `ILIKE` only).
+ *
+ * A small number of fields cannot be expressed as a pure index predicate
+ * (Postgres cannot compare two columns or do column arithmetic inside Prisma's
+ * typed `where`, and duplicate-group confidence is computed at read time, not
+ * persisted — see CLAUDE.md). Those fields set `readTimeRefinement: true`: their
+ * `buildWhere` returns the tightest *bounding* predicate they can, and the exact
+ * comparison is applied as a bounded read-time refinement by the compiler /
+ * preview. See `media-item-fields.ts` for the specifics.
+ */
+
+export type WorkflowFieldGroup =
+  | 'File'
+  | 'Dates'
+  | 'Location'
+  | 'Tags'
+  | 'People'
+  | 'Media'
+  | 'Organization'
+  | 'Review';
+
+/**
+ * High-level control type — a hint for the builder UI on how to render the
+ * value input for this field.
+ */
+export type WorkflowFieldType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'date'
+  | 'geo-radius'
+  | 'tag-set'
+  | 'person-set'
+  | 'uuid';
+
+/**
+ * The JSON shape an operator's `value` is expected to take. Used by the
+ * validator to reject operator/value-type mismatches.
+ */
+export type WorkflowValueType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'iso-date'
+  | 'date-range'
+  | 'positive-int'
+  | 'string-list'
+  | 'person-set'
+  | 'geo-radius'
+  | 'uuid'
+  | 'none';
+
+/**
+ * The full operator vocabulary across all fields. Each descriptor advertises the
+ * subset it accepts; the validator rejects any op not in that subset.
+ */
+export type WorkflowOperator =
+  | 'contains'
+  | 'starts_with'
+  | 'ends_with'
+  | 'equals'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'between'
+  | 'before'
+  | 'after'
+  | 'older_than_days'
+  | 'within_last_days'
+  | 'is'
+  | 'is_set'
+  | 'has_any'
+  | 'has_all'
+  | 'has_none'
+  | 'has_person'
+  | 'not_has_person'
+  | 'in_album'
+  | 'not_in_album'
+  | 'near';
+
+/**
+ * Which enrichment output a condition reads. Unioned by the compiler into the
+ * workflow's dependency set (Phase 4 uses it to gate on-media-enriched runs).
+ */
+export type WorkflowDependency =
+  | 'metadata'
+  | 'tags'
+  | 'faces'
+  | 'bursts'
+  | 'duplicates'
+  | 'locationSuggestions';
+
+export interface WorkflowFieldDescriptor {
+  /** Stable field key referenced by a definition's `{ field }`. */
+  key: string;
+  /** Human-readable label for the builder form. */
+  label: string;
+  /** Grouping bucket for the builder form. */
+  group: WorkflowFieldGroup;
+  /** Control-type hint for the builder UI. */
+  type: WorkflowFieldType;
+  /** Operators this field accepts. */
+  operators: WorkflowOperator[];
+  /** Shape the operand value must take. */
+  valueType: WorkflowValueType;
+  /** Enum members (only meaningful when `type: 'enum'`). */
+  enumValues?: string[];
+  /** Enrichment output this condition reads. */
+  dependency: WorkflowDependency;
+  /**
+   * When true, `buildWhere` returns only a BOUNDING predicate; the exact
+   * comparison is applied as a read-time refinement (see interface docblock).
+   */
+  readTimeRefinement?: boolean;
+  /**
+   * For a `readTimeRefinement` field that is evaluable in-process (needs only
+   * columns available on the row), a factory that returns a predicate over a
+   * fetched row. `undefined` for refinement fields whose exact evaluation is a
+   * heavier compute pass (e.g. `duplicateGroupConfidence`) and is deferred to
+   * the Phase-2 executor — the bounding predicate is used in the meantime.
+   */
+  refinementSelect?: Prisma.MediaItemSelect;
+  refinementPredicate?: (op: WorkflowOperator, value: unknown) => (row: any) => boolean;
+  /**
+   * Compile a single leaf condition into a Prisma where fragment. Pure — no I/O.
+   * MUST NOT mutate shared state. Throws for an unsupported operator/value.
+   */
+  buildWhere(op: WorkflowOperator, value: unknown): Prisma.MediaItemWhereInput;
+}
+
+/**
+ * Phase-1 action descriptor stub. The action LIBRARY (per-action parameter
+ * schemas + execution) is Phase 2 (#140); Phase 1 only needs the registered
+ * TYPE set so the validator can reject an unregistered action and
+ * `GET /api/workflows/subjects` can advertise the catalog shape.
+ */
+export interface WorkflowActionDescriptor {
+  type: string;
+  label: string;
+  /** Whether this action destroys data irreversibly (hard delete). Phase 2 gates it. */
+  destructive?: boolean;
+}
+
+/**
+ * One Subject's complete registry entry: its field catalog, action catalog, and
+ * the trigger options valid for it. v1 registers only `media_item`.
+ */
+export interface SubjectRegistryEntry {
+  subject: string;
+  label: string;
+  triggers: string[];
+  fields: WorkflowFieldDescriptor[];
+  actions: WorkflowActionDescriptor[];
+}

--- a/apps/api/src/workflows/registry/media-item-fields.ts
+++ b/apps/api/src/workflows/registry/media-item-fields.ts
@@ -1,0 +1,677 @@
+import { BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  WorkflowActionDescriptor,
+  WorkflowFieldDescriptor,
+  WorkflowOperator,
+} from './field-descriptor.interface';
+import {
+  whereType,
+  whereFavorite,
+  whereDateRange,
+  whereCreatedAtRange,
+  whereAlbum,
+  whereCountry,
+  whereRegion,
+  whereLocality,
+  whereNear,
+  whereMissingCapturedAt,
+  whereMissingCamera,
+  whereNoFaces,
+  whereMissingGeo,
+  wherePeople,
+} from '../../search/media-where.builder';
+
+// ---------------------------------------------------------------------------
+// Small local helpers (case-insensitive string, relative dates, string lists)
+// ---------------------------------------------------------------------------
+
+const ci = (s: unknown) => ({ equals: String(s), mode: 'insensitive' as const });
+
+function relativeDate(days: unknown, dir: 'older' | 'within'): Prisma.MediaItemWhereInput['capturedAt'] {
+  const n = Number(days);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new BadRequestException('Relative-day value must be a positive number');
+  }
+  const cutoff = new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+  // older_than_days: captured strictly before the cutoff.
+  // within_last_days: captured at or after the cutoff.
+  return dir === 'older' ? { lt: cutoff } : { gte: cutoff };
+}
+
+function asDate(v: unknown): Date {
+  const d = new Date(String(v));
+  if (isNaN(d.getTime())) throw new BadRequestException('Expected an ISO 8601 date value');
+  return d;
+}
+
+function asStringList(v: unknown): string[] {
+  if (!Array.isArray(v)) throw new BadRequestException('Expected an array of strings');
+  const list = v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+  if (list.length === 0) throw new BadRequestException('Expected a non-empty array of strings');
+  return list;
+}
+
+function tagNameMatch(name: string): Prisma.MediaItemWhereInput {
+  return { mediaTags: { some: { tag: { name: ci(name) } } } };
+}
+
+// ---------------------------------------------------------------------------
+// Date-family builder shared by capturedAt (captured_at) and uploadedAt (created_at)
+// ---------------------------------------------------------------------------
+
+function buildDateWhere(
+  column: 'capturedAt' | 'createdAt',
+  op: WorkflowOperator,
+  value: unknown,
+): Prisma.MediaItemWhereInput {
+  switch (op) {
+    case 'between': {
+      const range = (value ?? {}) as { from?: string; to?: string };
+      if (!range.from && !range.to) {
+        throw new BadRequestException('between requires { from, to } (at least one)');
+      }
+      const from = range.from ? asDate(range.from) : undefined;
+      const to = range.to ? asDate(range.to) : undefined;
+      return column === 'capturedAt' ? whereDateRange(from, to) : whereCreatedAtRange(from, to);
+    }
+    case 'before':
+      return { [column]: { lt: asDate(value) } };
+    case 'after':
+      return { [column]: { gt: asDate(value) } };
+    case 'older_than_days':
+      return { [column]: relativeDate(value, 'older') };
+    case 'within_last_days':
+      return { [column]: relativeDate(value, 'within') };
+    default:
+      throw new BadRequestException(`Unsupported operator "${op}" for date field`);
+  }
+}
+
+const DATE_OPERATORS: WorkflowOperator[] = [
+  'between',
+  'before',
+  'after',
+  'older_than_days',
+  'within_last_days',
+];
+
+// ---------------------------------------------------------------------------
+// Media Item field catalog
+// ---------------------------------------------------------------------------
+
+export const MEDIA_ITEM_FIELDS: WorkflowFieldDescriptor[] = [
+  // ------------------------------- File -----------------------------------
+  {
+    key: 'filename',
+    label: 'Filename',
+    group: 'File',
+    type: 'string',
+    operators: ['contains', 'starts_with', 'ends_with', 'equals'],
+    valueType: 'string',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const v = String(value ?? '');
+      if (!v) throw new BadRequestException('filename value must be a non-empty string');
+      // Case-insensitive ILIKE via Prisma mode:'insensitive' — never a raw regex.
+      switch (op) {
+        case 'contains':
+          return { originalFilename: { contains: v, mode: 'insensitive' } };
+        case 'starts_with':
+          return { originalFilename: { startsWith: v, mode: 'insensitive' } };
+        case 'ends_with':
+          return { originalFilename: { endsWith: v, mode: 'insensitive' } };
+        case 'equals':
+          return { originalFilename: { equals: v, mode: 'insensitive' } };
+        default:
+          throw new BadRequestException(`Unsupported operator "${op}" for filename`);
+      }
+    },
+  },
+  {
+    key: 'mimeType',
+    label: 'MIME type',
+    group: 'File',
+    type: 'string',
+    operators: ['equals'],
+    valueType: 'string',
+    dependency: 'metadata',
+    // mimeType lives on the required StorageObject relation.
+    buildWhere: (_op, value) => ({ storageObject: { mimeType: String(value ?? '') } }),
+  },
+  {
+    key: 'fileSize',
+    label: 'File size (bytes)',
+    group: 'File',
+    type: 'number',
+    operators: ['gt', 'lt'],
+    valueType: 'number',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new BadRequestException('fileSize value must be a non-negative number of bytes');
+      }
+      // StorageObject.size is a BigInt column.
+      const bytes = BigInt(Math.trunc(n));
+      return { storageObject: { size: op === 'gt' ? { gt: bytes } : { lt: bytes } } };
+    },
+  },
+
+  // ------------------------------- Media ----------------------------------
+  {
+    key: 'mediaType',
+    label: 'Media type',
+    group: 'Media',
+    type: 'enum',
+    operators: ['equals'],
+    valueType: 'enum',
+    enumValues: ['photo', 'video'],
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereType(String(value)),
+  },
+  {
+    key: 'width',
+    label: 'Width (px)',
+    group: 'Media',
+    type: 'number',
+    operators: ['gt', 'lt'],
+    valueType: 'number',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n)) throw new BadRequestException('width value must be a number');
+      return { width: op === 'gt' ? { gt: Math.trunc(n) } : { lt: Math.trunc(n) } };
+    },
+  },
+  {
+    key: 'height',
+    label: 'Height (px)',
+    group: 'Media',
+    type: 'number',
+    operators: ['gt', 'lt'],
+    valueType: 'number',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n)) throw new BadRequestException('height value must be a number');
+      return { height: op === 'gt' ? { gt: Math.trunc(n) } : { lt: Math.trunc(n) } };
+    },
+  },
+  {
+    key: 'megapixels',
+    label: 'Megapixels',
+    group: 'Media',
+    type: 'number',
+    operators: ['gt', 'lt'],
+    valueType: 'number',
+    dependency: 'metadata',
+    // Megapixels = width*height/1e6. Prisma's typed `where` cannot express a
+    // column-arithmetic comparison, so this is a read-time-refined field: the
+    // bounding predicate only requires both dimensions to be present; the exact
+    // comparison runs in `refinementPredicate`.
+    readTimeRefinement: true,
+    refinementSelect: { width: true, height: true },
+    refinementPredicate: (op, value) => {
+      const threshold = Number(value);
+      return (row: { width: number | null; height: number | null }) => {
+        if (row.width == null || row.height == null) return false;
+        const mp = (row.width * row.height) / 1_000_000;
+        return op === 'gt' ? mp > threshold : mp < threshold;
+      };
+    },
+    buildWhere: () => ({ width: { not: null }, height: { not: null } }),
+  },
+  {
+    key: 'orientationShape',
+    label: 'Orientation shape',
+    group: 'Media',
+    type: 'enum',
+    operators: ['equals'],
+    valueType: 'enum',
+    enumValues: ['portrait', 'landscape', 'square'],
+    dependency: 'metadata',
+    // Shape derives from a width-vs-height comparison, which Prisma's typed
+    // `where` cannot express (no column-to-column comparison), so it is
+    // read-time refined: bound to rows that have both dimensions, then compare.
+    readTimeRefinement: true,
+    refinementSelect: { width: true, height: true },
+    refinementPredicate: (_op, value) => {
+      const shape = String(value);
+      return (row: { width: number | null; height: number | null }) => {
+        if (row.width == null || row.height == null) return false;
+        if (shape === 'portrait') return row.height > row.width;
+        if (shape === 'landscape') return row.width > row.height;
+        return row.width === row.height; // square
+      };
+    },
+    buildWhere: () => ({ width: { not: null }, height: { not: null } }),
+  },
+  {
+    key: 'socialMediaSource',
+    label: 'Social-media source',
+    group: 'Media',
+    type: 'enum',
+    operators: ['is_set', 'equals'],
+    valueType: 'enum',
+    enumValues: ['tiktok', 'instagram', 'facebook', 'other'],
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      if (op === 'is_set') return { socialMediaSource: { not: null } };
+      return { socialMediaSource: String(value) };
+    },
+  },
+
+  // ------------------------------- Dates ----------------------------------
+  {
+    key: 'capturedAt',
+    label: 'Capture date',
+    group: 'Dates',
+    type: 'date',
+    operators: DATE_OPERATORS,
+    valueType: 'date-range',
+    dependency: 'metadata',
+    buildWhere: (op, value) => buildDateWhere('capturedAt', op, value),
+  },
+  {
+    key: 'missingCapturedAt',
+    label: 'Missing capture date',
+    group: 'Dates',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereMissingCapturedAt(value === true),
+  },
+  {
+    key: 'uploadedAt',
+    label: 'Upload date',
+    group: 'Dates',
+    type: 'date',
+    operators: DATE_OPERATORS,
+    valueType: 'date-range',
+    dependency: 'metadata',
+    buildWhere: (op, value) => buildDateWhere('createdAt', op, value),
+  },
+
+  // ----------------------------- Location ---------------------------------
+  {
+    key: 'hasGps',
+    label: 'Has GPS coordinates',
+    group: 'Location',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'metadata',
+    // is:true → coords present; is:false → coords absent.
+    buildWhere: (_op, value) => whereMissingGeo(value !== true),
+  },
+  {
+    key: 'noGps',
+    label: 'No GPS coordinates',
+    group: 'Location',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereMissingGeo(value === true),
+  },
+  {
+    key: 'country',
+    label: 'Country',
+    group: 'Location',
+    type: 'string',
+    operators: ['equals'],
+    valueType: 'string',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereCountry(String(value)),
+  },
+  {
+    key: 'region',
+    label: 'Region / State',
+    group: 'Location',
+    type: 'string',
+    operators: ['equals'],
+    valueType: 'string',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereRegion(String(value)),
+  },
+  {
+    key: 'locality',
+    label: 'Locality / City',
+    group: 'Location',
+    type: 'string',
+    operators: ['equals'],
+    valueType: 'string',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereLocality(String(value)),
+  },
+  {
+    key: 'near',
+    label: 'Near location (map radius)',
+    group: 'Location',
+    type: 'geo-radius',
+    operators: ['near'],
+    valueType: 'geo-radius',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => {
+      const v = (value ?? {}) as { lat?: unknown; lng?: unknown; radiusKm?: unknown };
+      if (
+        typeof v.lat !== 'number' ||
+        typeof v.lng !== 'number' ||
+        typeof v.radiusKm !== 'number' ||
+        v.radiusKm <= 0
+      ) {
+        throw new BadRequestException('near requires { lat, lng, radiusKm } numbers with radiusKm > 0');
+      }
+      return whereNear(v.lat, v.lng, v.radiusKm);
+    },
+  },
+  {
+    key: 'coordSource',
+    label: 'Coordinate source',
+    group: 'Location',
+    type: 'enum',
+    operators: ['is'],
+    valueType: 'enum',
+    enumValues: ['exif', 'manual', 'inferred'],
+    dependency: 'metadata',
+    buildWhere: (_op, value) => ({ coordSource: String(value) }),
+  },
+
+  // --------------------------- Organization -------------------------------
+  {
+    key: 'cameraMake',
+    label: 'Camera make',
+    group: 'Organization',
+    type: 'string',
+    operators: ['equals', 'contains'],
+    valueType: 'string',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const v = String(value ?? '');
+      return {
+        cameraMake:
+          op === 'equals' ? { equals: v, mode: 'insensitive' } : { contains: v, mode: 'insensitive' },
+      };
+    },
+  },
+  {
+    key: 'cameraModel',
+    label: 'Camera model',
+    group: 'Organization',
+    type: 'string',
+    operators: ['equals', 'contains'],
+    valueType: 'string',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const v = String(value ?? '');
+      return {
+        cameraModel:
+          op === 'equals' ? { equals: v, mode: 'insensitive' } : { contains: v, mode: 'insensitive' },
+      };
+    },
+  },
+  {
+    key: 'missingCamera',
+    label: 'Missing camera info',
+    group: 'Organization',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereMissingCamera(value === true),
+  },
+  {
+    key: 'favorite',
+    label: 'Favorite',
+    group: 'Organization',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'metadata',
+    buildWhere: (_op, value) => whereFavorite(value === true),
+  },
+  {
+    key: 'archived',
+    label: 'Archived',
+    group: 'Organization',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'metadata',
+    buildWhere: (_op, value) =>
+      value === true ? { archivedAt: { not: null } } : { archivedAt: null },
+  },
+  {
+    key: 'album',
+    label: 'Album membership',
+    group: 'Organization',
+    type: 'uuid',
+    operators: ['in_album', 'not_in_album'],
+    valueType: 'uuid',
+    dependency: 'metadata',
+    buildWhere: (op, value) => {
+      const albumId = String(value ?? '');
+      if (!albumId) throw new BadRequestException('album value must be an album UUID');
+      return op === 'in_album'
+        ? whereAlbum(albumId)
+        : { NOT: { albumItems: { some: { albumId } } } };
+    },
+  },
+
+  // ------------------------------- Tags -----------------------------------
+  {
+    key: 'tags',
+    label: 'Tags',
+    group: 'Tags',
+    type: 'tag-set',
+    operators: ['has_any', 'has_all', 'has_none'],
+    valueType: 'string-list',
+    dependency: 'tags',
+    buildWhere: (op, value) => {
+      const names = asStringList(value);
+      if (op === 'has_any') return { OR: names.map(tagNameMatch) };
+      if (op === 'has_all') return { AND: names.map(tagNameMatch) };
+      // has_none
+      return { AND: names.map((n) => ({ NOT: tagNameMatch(n) })) };
+    },
+  },
+  {
+    key: 'untagged',
+    label: 'Untagged',
+    group: 'Tags',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'tags',
+    buildWhere: (_op, value) =>
+      value === true ? { mediaTags: { none: {} } } : { mediaTags: { some: {} } },
+  },
+
+  // ------------------------------ People ----------------------------------
+  {
+    key: 'people',
+    label: 'People',
+    group: 'People',
+    type: 'person-set',
+    operators: ['has_person', 'not_has_person'],
+    valueType: 'person-set',
+    dependency: 'faces',
+    buildWhere: (op, value) => {
+      const v = (value ?? {}) as { ids?: unknown; mode?: unknown };
+      const ids = Array.isArray(v.ids)
+        ? (v.ids as unknown[]).filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+        : [];
+      if (ids.length === 0) throw new BadRequestException('people requires { ids: string[] }');
+      if (op === 'not_has_person') {
+        return { NOT: { faces: { some: { personId: { in: ids } } } } };
+      }
+      const mode = v.mode === 'all' ? 'all' : 'any';
+      return wherePeople(ids, mode);
+    },
+  },
+  {
+    key: 'noFaces',
+    label: 'No faces detected',
+    group: 'People',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'faces',
+    buildWhere: (_op, value) => whereNoFaces(value === true),
+  },
+  {
+    key: 'hasUnassignedFaces',
+    label: 'Has unassigned faces',
+    group: 'People',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'faces',
+    buildWhere: (_op, value) =>
+      value === true
+        ? { faces: { some: { personId: null } } }
+        : { faces: { none: { personId: null } } },
+  },
+
+  // ------------------------------ Review ----------------------------------
+  // Workflow-only descriptors targeting the burst/duplicate/location review
+  // queues so a Media-Item workflow can drive their resolve/dismiss/accept
+  // actions in Phase 2.
+  {
+    key: 'inPendingBurstGroup',
+    label: 'In a pending burst group',
+    group: 'Review',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'bursts',
+    buildWhere: (_op, value) =>
+      value === true
+        ? { burstGroup: { is: { status: 'pending' } } }
+        : { burstGroup: { isNot: { status: 'pending' } } },
+  },
+  {
+    key: 'burstGroupConfidence',
+    label: 'Burst-group confidence ≥',
+    group: 'Review',
+    type: 'number',
+    operators: ['gte'],
+    valueType: 'number',
+    dependency: 'bursts',
+    // Burst confidence IS persisted on burst_groups, so this is a pure indexed
+    // relation predicate (unlike duplicateGroupConfidence below).
+    buildWhere: (_op, value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n)) throw new BadRequestException('burstGroupConfidence value must be a number');
+      return { burstGroup: { is: { status: 'pending', confidence: { gte: n } } } };
+    },
+  },
+  {
+    key: 'inPendingDuplicateGroup',
+    label: 'In a pending duplicate group',
+    group: 'Review',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'duplicates',
+    buildWhere: (_op, value) =>
+      value === true
+        ? { duplicateGroup: { is: { status: 'pending' } } }
+        : { duplicateGroup: { isNot: { status: 'pending' } } },
+  },
+  {
+    key: 'duplicateGroupConfidence',
+    label: 'Duplicate-group confidence ≥',
+    group: 'Review',
+    type: 'number',
+    operators: ['gte'],
+    valueType: 'number',
+    dependency: 'duplicates',
+    // IMPORTANT: duplicate-group confidence (tightest-pair CLIP cosine
+    // similarity) is computed at READ time, NOT persisted (see CLAUDE.md), so
+    // this CANNOT be a pure index predicate the way burstGroupConfidence is.
+    // The bounding predicate restricts to items already in a pending duplicate
+    // group (a small set); the exact confidence comparison is a bounded
+    // per-candidate compute pass. In Phase 1 the compute pass is deferred to the
+    // Phase-2 executor (no `refinementPredicate` here), so preview counts items
+    // in a pending duplicate group without applying the threshold — documented
+    // behavior. Marked readTimeRefinement so the compiler surfaces it.
+    readTimeRefinement: true,
+    buildWhere: (_op, _value) => ({ duplicateGroup: { is: { status: 'pending' } } }),
+  },
+  {
+    key: 'hasPendingLocationSuggestion',
+    label: 'Has a pending location suggestion',
+    group: 'Review',
+    type: 'boolean',
+    operators: ['is'],
+    valueType: 'boolean',
+    dependency: 'locationSuggestions',
+    buildWhere: (_op, value) =>
+      value === true
+        ? { locationSuggestion: { is: { status: 'pending' } } }
+        : { locationSuggestion: { isNot: { status: 'pending' } } },
+  },
+  {
+    key: 'locationSuggestionConfidence',
+    label: 'Location-suggestion confidence ≥',
+    group: 'Review',
+    type: 'number',
+    operators: ['gte'],
+    valueType: 'number',
+    dependency: 'locationSuggestions',
+    buildWhere: (_op, value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n)) {
+        throw new BadRequestException('locationSuggestionConfidence value must be a number');
+      }
+      return { locationSuggestion: { is: { status: 'pending', confidence: { gte: n } } } };
+    },
+  },
+  {
+    key: 'locationSuggestionMethod',
+    label: 'Location-suggestion method',
+    group: 'Review',
+    type: 'enum',
+    operators: ['equals'],
+    valueType: 'enum',
+    enumValues: ['interpolated', 'nearest'],
+    dependency: 'locationSuggestions',
+    buildWhere: (_op, value) => ({
+      locationSuggestion: { is: { status: 'pending', method: String(value) } },
+    }),
+  },
+];
+
+/**
+ * Phase-1 action catalog stub for the Media Item Subject. Only the registered
+ * TYPE set matters this phase — per-action parameter schemas and execution are
+ * Phase 2 (#140). Types mirror the epic's Media-Item action list.
+ */
+export const MEDIA_ITEM_ACTIONS: WorkflowActionDescriptor[] = [
+  { type: 'move_to_trash', label: 'Move to Trash' },
+  { type: 'hard_delete', label: 'Delete permanently', destructive: true },
+  { type: 'archive', label: 'Archive' },
+  { type: 'unarchive', label: 'Unarchive' },
+  { type: 'add_to_album', label: 'Add to album' },
+  { type: 'remove_from_album', label: 'Remove from album' },
+  { type: 'add_tags', label: 'Add tags' },
+  { type: 'remove_tags', label: 'Remove tags' },
+  { type: 'set_favorite', label: 'Set favorite' },
+  { type: 'set_capture_date', label: 'Set capture date' },
+  { type: 'shift_capture_date', label: 'Shift capture date' },
+  { type: 'move_to_circle', label: 'Move to circle' },
+  { type: 'assign_person', label: 'Assign person' },
+  { type: 'remove_person', label: 'Remove person' },
+  { type: 'set_location', label: 'Set location' },
+  { type: 'clear_location', label: 'Clear location' },
+  { type: 'resolve_burst_group', label: 'Resolve burst group' },
+  { type: 'dismiss_burst_group', label: 'Dismiss burst group' },
+  { type: 'resolve_duplicate_group', label: 'Resolve duplicate group' },
+  { type: 'dismiss_duplicate_group', label: 'Dismiss duplicate group' },
+  { type: 'accept_location_suggestion', label: 'Accept location suggestion' },
+  { type: 'reject_location_suggestion', label: 'Reject location suggestion' },
+  { type: 'rerun_enrichment', label: 'Re-run enrichment' },
+];

--- a/apps/api/src/workflows/registry/subject-registry.spec.ts
+++ b/apps/api/src/workflows/registry/subject-registry.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the per-Subject workflow registry (issue #139). Pure lookups
+ * over the static MEDIA_ITEM_FIELDS / MEDIA_ITEM_ACTIONS catalogs — no I/O.
+ */
+import {
+  getField,
+  getFullRegistry,
+  getSubjectRegistry,
+  isRegisteredAction,
+  isRegisteredSubject,
+  registeredSubjects,
+} from './subject-registry';
+import { MEDIA_ITEM_ACTIONS, MEDIA_ITEM_FIELDS } from './media-item-fields';
+
+describe('subject-registry', () => {
+  describe('registeredSubjects / isRegisteredSubject', () => {
+    it('registers exactly one Subject in v1: media_item', () => {
+      expect(registeredSubjects()).toEqual(['media_item']);
+    });
+
+    it('isRegisteredSubject resolves media_item', () => {
+      expect(isRegisteredSubject('media_item')).toBe(true);
+    });
+
+    it('isRegisteredSubject returns false for an unknown subject', () => {
+      expect(isRegisteredSubject('duplicate_group')).toBe(false);
+      expect(isRegisteredSubject('burst_group')).toBe(false);
+      expect(isRegisteredSubject('')).toBe(false);
+    });
+  });
+
+  describe('getSubjectRegistry', () => {
+    it('resolves the media_item registry entry with its full field/action catalogs', () => {
+      const entry = getSubjectRegistry('media_item');
+      expect(entry).toBeDefined();
+      expect(entry!.subject).toBe('media_item');
+      expect(entry!.label).toBe('Media Item');
+      expect(entry!.triggers).toEqual(['manual', 'on_media_enriched', 'scheduled']);
+      expect(entry!.fields).toBe(MEDIA_ITEM_FIELDS);
+      expect(entry!.actions).toBe(MEDIA_ITEM_ACTIONS);
+    });
+
+    it('returns undefined for an unregistered subject (no throw)', () => {
+      expect(getSubjectRegistry('unassigned_face')).toBeUndefined();
+      expect(getSubjectRegistry('person')).toBeUndefined();
+    });
+  });
+
+  describe('getFullRegistry', () => {
+    it('returns an array with exactly one Subject entry', () => {
+      const registry = getFullRegistry();
+      expect(registry).toHaveLength(1);
+      expect(registry[0].subject).toBe('media_item');
+    });
+  });
+
+  describe('getField', () => {
+    it('resolves a known field for media_item', () => {
+      const field = getField('media_item', 'filename');
+      expect(field).toBeDefined();
+      expect(field!.key).toBe('filename');
+      expect(field!.group).toBe('File');
+    });
+
+    it('returns undefined for an unknown field key on a known subject', () => {
+      expect(getField('media_item', 'nonexistent_field')).toBeUndefined();
+    });
+
+    it('returns undefined for any field key on an unregistered subject', () => {
+      expect(getField('duplicate_group', 'filename')).toBeUndefined();
+    });
+  });
+
+  describe('isRegisteredAction', () => {
+    it('resolves a known action for media_item', () => {
+      expect(isRegisteredAction('media_item', 'move_to_trash')).toBe(true);
+      expect(isRegisteredAction('media_item', 'archive')).toBe(true);
+    });
+
+    it('returns false for an unknown action on a known subject', () => {
+      expect(isRegisteredAction('media_item', 'teleport')).toBe(false);
+    });
+
+    it('returns false for any action on an unregistered subject (cross-Subject rejection)', () => {
+      expect(isRegisteredAction('burst_group', 'move_to_trash')).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Catalog integrity — every field/action is well-formed
+  // ---------------------------------------------------------------------------
+
+  describe('MEDIA_ITEM_FIELDS catalog integrity', () => {
+    it('every field has a unique key', () => {
+      const keys = MEDIA_ITEM_FIELDS.map((f) => f.key);
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('every field declares key, label, group, type, operators, valueType, dependency, buildWhere', () => {
+      for (const field of MEDIA_ITEM_FIELDS) {
+        expect(typeof field.key).toBe('string');
+        expect(typeof field.label).toBe('string');
+        expect(typeof field.group).toBe('string');
+        expect(typeof field.type).toBe('string');
+        expect(Array.isArray(field.operators)).toBe(true);
+        expect(field.operators.length).toBeGreaterThan(0);
+        expect(typeof field.valueType).toBe('string');
+        expect(typeof field.dependency).toBe('string');
+        expect(typeof field.buildWhere).toBe('function');
+      }
+    });
+
+    it('includes the documented review-state descriptors', () => {
+      const keys = MEDIA_ITEM_FIELDS.map((f) => f.key);
+      expect(keys).toEqual(
+        expect.arrayContaining([
+          'inPendingBurstGroup',
+          'burstGroupConfidence',
+          'inPendingDuplicateGroup',
+          'duplicateGroupConfidence',
+          'hasPendingLocationSuggestion',
+          'locationSuggestionConfidence',
+          'locationSuggestionMethod',
+        ]),
+      );
+    });
+
+    it('every field with enumValues has a non-empty array', () => {
+      for (const field of MEDIA_ITEM_FIELDS) {
+        if (field.enumValues) {
+          expect(field.enumValues.length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('every readTimeRefinement field is documented as such and buildWhere still returns a bounding predicate', () => {
+      const refinementFields = MEDIA_ITEM_FIELDS.filter((f) => f.readTimeRefinement);
+      expect(refinementFields.map((f) => f.key).sort()).toEqual(
+        ['duplicateGroupConfidence', 'megapixels', 'orientationShape'].sort(),
+      );
+      for (const field of refinementFields) {
+        expect(field.buildWhere('gt' as any, 1)).toBeDefined();
+      }
+    });
+  });
+
+  describe('MEDIA_ITEM_ACTIONS catalog integrity', () => {
+    it('every action has a unique type', () => {
+      const types = MEDIA_ITEM_ACTIONS.map((a) => a.type);
+      expect(new Set(types).size).toBe(types.length);
+    });
+
+    it('every action declares type and label', () => {
+      for (const action of MEDIA_ITEM_ACTIONS) {
+        expect(typeof action.type).toBe('string');
+        expect(typeof action.label).toBe('string');
+      }
+    });
+
+    it('hard_delete is flagged destructive', () => {
+      const hardDelete = MEDIA_ITEM_ACTIONS.find((a) => a.type === 'hard_delete');
+      expect(hardDelete?.destructive).toBe(true);
+    });
+
+    it('move_to_trash is not flagged destructive', () => {
+      const moveToTrash = MEDIA_ITEM_ACTIONS.find((a) => a.type === 'move_to_trash');
+      expect(moveToTrash?.destructive).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/workflows/registry/subject-registry.ts
+++ b/apps/api/src/workflows/registry/subject-registry.ts
@@ -1,0 +1,61 @@
+import { WorkflowSubject } from '@prisma/client';
+import {
+  SubjectRegistryEntry,
+  WorkflowFieldDescriptor,
+} from './field-descriptor.interface';
+import { MEDIA_ITEM_ACTIONS, MEDIA_ITEM_FIELDS } from './media-item-fields';
+
+/**
+ * Per-Subject registry — the extension point for future Subjects (duplicate
+ * group, burst group, location suggestion, unassigned face, person). v1
+ * registers exactly `media_item`; the compiler, validator, and subjects API all
+ * resolve their catalogs through this map so a new Subject slots in by adding an
+ * entry here (plus its own field/action catalog) with no engine change.
+ */
+const REGISTRY: Record<string, SubjectRegistryEntry> = {
+  [WorkflowSubject.media_item]: {
+    subject: WorkflowSubject.media_item,
+    label: 'Media Item',
+    // Phase 1 registers the trigger vocabulary; execution/scheduling is Phase 2/4.
+    triggers: ['manual', 'on_media_enriched', 'scheduled'],
+    fields: MEDIA_ITEM_FIELDS,
+    actions: MEDIA_ITEM_ACTIONS,
+  },
+};
+
+/** All registered Subject keys. */
+export function registeredSubjects(): string[] {
+  return Object.keys(REGISTRY);
+}
+
+/** True when `subject` is a registered Subject. */
+export function isRegisteredSubject(subject: string): boolean {
+  return Object.prototype.hasOwnProperty.call(REGISTRY, subject);
+}
+
+/** Get a Subject's registry entry, or undefined if unknown. */
+export function getSubjectRegistry(subject: string): SubjectRegistryEntry | undefined {
+  return REGISTRY[subject];
+}
+
+/** Get the full registry (all Subjects). Used by GET /api/workflows/subjects. */
+export function getFullRegistry(): SubjectRegistryEntry[] {
+  return Object.values(REGISTRY);
+}
+
+/** O(1) field lookup within a Subject. Returns undefined for an unknown field. */
+export function getField(
+  subject: string,
+  fieldKey: string,
+): WorkflowFieldDescriptor | undefined {
+  const entry = REGISTRY[subject];
+  if (!entry) return undefined;
+  return entry.fields.find((f) => f.key === fieldKey);
+}
+
+/** True when `actionType` is registered for the Subject. */
+export function isRegisteredAction(subject: string, actionType: string): boolean {
+  const entry = REGISTRY[subject];
+  if (!entry) return false;
+  return entry.actions.some((a) => a.type === actionType);
+}

--- a/apps/api/src/workflows/util/cron.util.spec.ts
+++ b/apps/api/src/workflows/util/cron.util.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the 5-field cron validator used to gate `trigger='scheduled'`
+ * workflows (issue #139). Pure function, no I/O.
+ */
+import { isValidCron } from './cron.util';
+
+describe('isValidCron', () => {
+  describe('valid expressions', () => {
+    it('accepts every-field wildcard "* * * * *"', () => {
+      expect(isValidCron('* * * * *')).toBe(true);
+    });
+
+    it('accepts midnight daily "0 0 * * *"', () => {
+      expect(isValidCron('0 0 * * *')).toBe(true);
+    });
+
+    it('accepts a step expression "*/5 * * * *"', () => {
+      expect(isValidCron('*/5 * * * *')).toBe(true);
+    });
+
+    it('accepts a range expression "0 9-17 * * *"', () => {
+      expect(isValidCron('0 9-17 * * *')).toBe(true);
+    });
+
+    it('accepts a comma list "0,30 8-17 * * 1-5"', () => {
+      expect(isValidCron('0,30 8-17 * * 1-5')).toBe(true);
+    });
+
+    it('accepts a stepped range "0 0 1-30/5 * *"', () => {
+      expect(isValidCron('0 0 1-30/5 * *')).toBe(true);
+    });
+
+    it('accepts day-of-week 0 and 7 (both mean Sunday)', () => {
+      expect(isValidCron('0 0 * * 0')).toBe(true);
+      expect(isValidCron('0 0 * * 7')).toBe(true);
+    });
+
+    it('accepts boundary values for every field', () => {
+      // minute 0-59, hour 0-23, day-of-month 1-31, month 1-12, day-of-week 0-7
+      expect(isValidCron('59 23 31 12 7')).toBe(true);
+      expect(isValidCron('0 0 1 1 0')).toBe(true);
+    });
+
+    it('tolerates extra internal whitespace between fields', () => {
+      expect(isValidCron('0   0  *  *   *')).toBe(true);
+    });
+
+    it('tolerates leading/trailing whitespace', () => {
+      expect(isValidCron('  0 0 * * *  ')).toBe(true);
+    });
+  });
+
+  describe('malformed expressions', () => {
+    it('rejects too few fields', () => {
+      expect(isValidCron('0 0 * *')).toBe(false);
+    });
+
+    it('rejects too many fields', () => {
+      expect(isValidCron('0 0 * * * *')).toBe(false);
+    });
+
+    it('rejects an empty string', () => {
+      expect(isValidCron('')).toBe(false);
+    });
+
+    it('rejects a non-string input', () => {
+      expect(isValidCron(null as unknown as string)).toBe(false);
+      expect(isValidCron(undefined as unknown as string)).toBe(false);
+      expect(isValidCron(42 as unknown as string)).toBe(false);
+    });
+
+    it('rejects an out-of-range minute (60)', () => {
+      expect(isValidCron('60 0 * * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range hour (24)', () => {
+      expect(isValidCron('0 24 * * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range day-of-month (0)', () => {
+      expect(isValidCron('0 0 0 * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range day-of-month (32)', () => {
+      expect(isValidCron('0 0 32 * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range month (0)', () => {
+      expect(isValidCron('0 0 * 0 *')).toBe(false);
+    });
+
+    it('rejects an out-of-range month (13)', () => {
+      expect(isValidCron('0 0 * 13 *')).toBe(false);
+    });
+
+    it('rejects an out-of-range day-of-week (8)', () => {
+      expect(isValidCron('0 0 * * 8')).toBe(false);
+    });
+
+    it('rejects a non-numeric token', () => {
+      expect(isValidCron('a 0 * * *')).toBe(false);
+    });
+
+    it('rejects a malformed range (inverted lo > hi)', () => {
+      expect(isValidCron('0 17-9 * * *')).toBe(false);
+    });
+
+    it('rejects a step of zero', () => {
+      expect(isValidCron('*/0 * * * *')).toBe(false);
+    });
+
+    it('rejects a negative step', () => {
+      expect(isValidCron('*/-5 * * * *')).toBe(false);
+    });
+
+    it('rejects an empty comma-list segment', () => {
+      expect(isValidCron('0,,30 * * * *')).toBe(false);
+    });
+
+    it('rejects a non-numeric step', () => {
+      expect(isValidCron('*/x * * * *')).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/workflows/util/cron.util.ts
+++ b/apps/api/src/workflows/util/cron.util.ts
@@ -1,0 +1,49 @@
+/**
+ * Lightweight 5-field cron validator for `trigger='scheduled'` workflows.
+ *
+ * Phase 1 only needs to reject a malformed cron at save time; the actual
+ * scheduling engine (and minimum-interval enforcement via
+ * `workflows.scheduleMinIntervalMinutes`) is Phase 4. This validates the classic
+ * 5-field form: `minute hour day-of-month month day-of-week`, each field being a
+ * `*`, a number, a range, a step, or a comma list of those, within field bounds.
+ */
+
+const FIELD_BOUNDS: Array<[number, number]> = [
+  [0, 59], // minute
+  [0, 23], // hour
+  [1, 31], // day of month
+  [1, 12], // month
+  [0, 7], // day of week (0 and 7 both = Sunday)
+];
+
+function isValidNumber(token: string, min: number, max: number): boolean {
+  if (!/^\d+$/.test(token)) return false;
+  const n = Number(token);
+  return n >= min && n <= max;
+}
+
+function isValidFieldPart(part: string, min: number, max: number): boolean {
+  // step, e.g. "*/5" or "1-30/5"
+  let base = part;
+  if (part.includes('/')) {
+    const [range, step] = part.split('/');
+    if (!/^\d+$/.test(step) || Number(step) <= 0) return false;
+    base = range;
+  }
+  if (base === '*') return true;
+  if (base.includes('-')) {
+    const [lo, hi] = base.split('-');
+    return isValidNumber(lo, min, max) && isValidNumber(hi, min, max) && Number(lo) <= Number(hi);
+  }
+  return isValidNumber(base, min, max);
+}
+
+export function isValidCron(expr: string): boolean {
+  if (typeof expr !== 'string') return false;
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  return fields.every((field, i) => {
+    const [min, max] = FIELD_BOUNDS[i];
+    return field.split(',').every((part) => part.length > 0 && isValidFieldPart(part, min, max));
+  });
+}

--- a/apps/api/src/workflows/workflows.controller.ts
+++ b/apps/api/src/workflows/workflows.controller.ts
@@ -1,0 +1,124 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PERMISSIONS } from '../common/constants/roles.constants';
+import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+import { WorkflowsService } from './workflows.service';
+import { CreateWorkflowDto } from './dto/create-workflow.dto';
+import { UpdateWorkflowDto } from './dto/update-workflow.dto';
+import { ListWorkflowsQueryDto } from './dto/list-workflows-query.dto';
+import { PreviewWorkflowDto } from './dto/preview-workflow.dto';
+
+/**
+ * Media Workflow Automation — Phase 1 API (definition, validation, preview).
+ * All routes are circle-scoped and feature-gated by `features.workflows` +
+ * `WORKFLOWS_ENABLED`. Writes require the system `media:write` permission plus
+ * the per-circle `collaborator` role; reads require `media:read` plus `viewer`
+ * (per-circle roles are enforced in the service, mirroring bulk-media ops).
+ */
+@ApiTags('Workflows')
+@ApiBearerAuth()
+@Controller('workflows')
+export class WorkflowsController {
+  constructor(private readonly workflowsService: WorkflowsService) {}
+
+  @Post()
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @ApiOperation({ summary: 'Create a workflow (circle collaborator)' })
+  @ApiResponse({ status: 201, description: 'Workflow created' })
+  @ApiResponse({ status: 400, description: 'Invalid definition or per-circle cap reached' })
+  @ApiResponse({ status: 404, description: 'Feature disabled or circle not found' })
+  async create(@Body() dto: CreateWorkflowDto, @CurrentUser() user: RequestUser) {
+    return this.workflowsService.createWorkflow(dto, user);
+  }
+
+  @Get()
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({ summary: 'List workflows in a circle (paginated)' })
+  @ApiQuery({ name: 'circleId', type: String, required: true, format: 'uuid' })
+  @ApiQuery({ name: 'page', type: Number, required: false })
+  @ApiQuery({ name: 'pageSize', type: Number, required: false })
+  @ApiResponse({ status: 200, description: 'Workflows listed' })
+  async list(@Query() query: ListWorkflowsQueryDto, @CurrentUser() user: RequestUser) {
+    return this.workflowsService.listWorkflows(query, user);
+  }
+
+  // Static routes declared before ':id' so they are not captured as a workflow id.
+  @Get('subjects')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({
+    summary: 'Get the Subject registry (fields + operators + action catalog)',
+  })
+  @ApiResponse({ status: 200, description: 'Registry returned' })
+  async subjects(@CurrentUser() _user: RequestUser) {
+    return this.workflowsService.getSubjects();
+  }
+
+  @Post('preview')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Preview matched count + sample for a definition (stateless)',
+  })
+  @ApiResponse({ status: 200, description: 'Preview computed' })
+  @ApiResponse({ status: 400, description: 'Invalid definition' })
+  async preview(@Body() dto: PreviewWorkflowDto, @CurrentUser() user: RequestUser) {
+    return this.workflowsService.preview(dto, user);
+  }
+
+  @Get(':id')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({ summary: 'Get a workflow by id' })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Workflow returned' })
+  @ApiResponse({ status: 404, description: 'Workflow not found or feature disabled' })
+  async get(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: RequestUser) {
+    return this.workflowsService.getWorkflow(id, user);
+  }
+
+  @Patch(':id')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @ApiOperation({ summary: 'Update a workflow (circle collaborator)' })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Workflow updated' })
+  @ApiResponse({ status: 400, description: 'Invalid definition or trigger/cron' })
+  @ApiResponse({ status: 404, description: 'Workflow not found or feature disabled' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateWorkflowDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.workflowsService.updateWorkflow(id, dto, user);
+  }
+
+  @Delete(':id')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a workflow (circle collaborator); cascades runs' })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Workflow deleted' })
+  @ApiResponse({ status: 404, description: 'Workflow not found or feature disabled' })
+  async remove(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: RequestUser): Promise<void> {
+    await this.workflowsService.deleteWorkflow(id, user);
+  }
+}

--- a/apps/api/src/workflows/workflows.module.ts
+++ b/apps/api/src/workflows/workflows.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SettingsModule } from '../settings/settings.module';
+import { CirclesModule } from '../circles/circles.module';
+import { MediaModule } from '../media/media.module';
+import { WorkflowsController } from './workflows.controller';
+import { WorkflowsService } from './workflows.service';
+import { WorkflowDefinitionValidator } from './definition/workflow-definition.validator';
+import { WorkflowConditionCompiler } from './compiler/workflow-condition.compiler';
+
+/**
+ * Media Workflow Automation — Phase 1 (issue #139). Definition, validation,
+ * compilation, and preview only — no run/execution logic (Phase 2 #140).
+ */
+@Module({
+  imports: [PrismaModule, SettingsModule, CirclesModule, MediaModule],
+  controllers: [WorkflowsController],
+  providers: [WorkflowsService, WorkflowDefinitionValidator, WorkflowConditionCompiler],
+  exports: [WorkflowDefinitionValidator, WorkflowConditionCompiler],
+})
+export class WorkflowsModule {}

--- a/apps/api/src/workflows/workflows.service.ts
+++ b/apps/api/src/workflows/workflows.service.ts
@@ -1,0 +1,383 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, Workflow, WorkflowSubject, WorkflowTrigger } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { CircleMembershipService } from '../circles/circle-membership.service';
+import { MediaThumbnailService } from '../media/media-thumbnail.service';
+import { isWorkflowsEnabled } from '../common/types/settings.types';
+import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+import { WorkflowDefinitionValidator } from './definition/workflow-definition.validator';
+import { WorkflowDefinition } from './definition/workflow-definition.schema';
+import { WorkflowConditionCompiler } from './compiler/workflow-condition.compiler';
+import { getFullRegistry } from './registry/subject-registry';
+import { CreateWorkflowDto } from './dto/create-workflow.dto';
+import { UpdateWorkflowDto } from './dto/update-workflow.dto';
+import { ListWorkflowsQueryDto } from './dto/list-workflows-query.dto';
+import { PreviewWorkflowDto } from './dto/preview-workflow.dto';
+import { isValidCron } from './util/cron.util';
+
+/** Max sample items returned by the preview. */
+const PREVIEW_SAMPLE_SIZE = 12;
+
+@Injectable()
+export class WorkflowsService {
+  private readonly logger = new Logger(WorkflowsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly systemSettings: SystemSettingsService,
+    private readonly circleMembership: CircleMembershipService,
+    private readonly thumbnails: MediaThumbnailService,
+    private readonly validator: WorkflowDefinitionValidator,
+    private readonly compiler: WorkflowConditionCompiler,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  async createWorkflow(dto: CreateWorkflowDto, user: RequestUser) {
+    const settings = await this.assertFeatureEnabled();
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      dto.circleId,
+      user.permissions,
+      'collaborator',
+    );
+
+    // Registry-aware validation (subject + fields/ops/values + action types).
+    const definition = this.validator.validate(dto.definition);
+    const trigger = (dto.trigger ?? 'manual') as WorkflowTrigger;
+    const cronExpression = this.resolveCron(trigger, dto.cronExpression ?? null);
+
+    // Enforce the per-circle workflow cap.
+    const max = settings.workflows?.maxWorkflowsPerCircle ?? 20;
+    const existingCount = await this.prisma.workflow.count({
+      where: { circleId: dto.circleId },
+    });
+    if (existingCount >= max) {
+      throw new BadRequestException(
+        `Circle has reached the maximum of ${max} workflows`,
+      );
+    }
+
+    const workflow = await this.prisma.workflow.create({
+      data: {
+        circleId: dto.circleId,
+        name: dto.name,
+        description: dto.description ?? null,
+        subjectType: definition.subject as WorkflowSubject,
+        enabled: dto.enabled ?? true,
+        trigger,
+        cronExpression,
+        definition: definition as unknown as Prisma.InputJsonValue,
+        createdById: user.id,
+      },
+    });
+
+    await this.audit(user.id, 'workflow:created', workflow.id, {
+      circleId: workflow.circleId,
+      name: workflow.name,
+    });
+
+    return this.serialize(workflow);
+  }
+
+  async listWorkflows(query: ListWorkflowsQueryDto, user: RequestUser) {
+    await this.assertFeatureEnabled();
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      query.circleId,
+      user.permissions,
+      'viewer',
+    );
+
+    const { page, pageSize } = query;
+    const [items, totalItems] = await this.prisma.$transaction([
+      this.prisma.workflow.findMany({
+        where: { circleId: query.circleId },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      this.prisma.workflow.count({ where: { circleId: query.circleId } }),
+    ]);
+
+    return {
+      items: items.map((w) => this.serialize(w)),
+      meta: {
+        page,
+        pageSize,
+        totalItems,
+        totalPages: Math.ceil(totalItems / pageSize),
+      },
+    };
+  }
+
+  async getWorkflow(id: string, user: RequestUser) {
+    await this.assertFeatureEnabled();
+    const workflow = await this.findWorkflowOrThrow(id);
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      workflow.circleId,
+      user.permissions,
+      'viewer',
+    );
+    return this.serialize(workflow);
+  }
+
+  async updateWorkflow(id: string, dto: UpdateWorkflowDto, user: RequestUser) {
+    await this.assertFeatureEnabled();
+    const existing = await this.findWorkflowOrThrow(id);
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      existing.circleId,
+      user.permissions,
+      'collaborator',
+    );
+
+    const data: Prisma.WorkflowUpdateInput = {};
+
+    if (dto.name !== undefined) data.name = dto.name;
+    if (dto.description !== undefined) data.description = dto.description;
+    if (dto.enabled !== undefined) data.enabled = dto.enabled;
+
+    if (dto.definition !== undefined) {
+      const definition = this.validator.validate(dto.definition);
+      data.definition = definition as unknown as Prisma.InputJsonValue;
+      data.subjectType = definition.subject as WorkflowSubject;
+    }
+
+    // Resolve the trigger/cron pair after applying any partial change, then
+    // validate it as a whole (cron required iff scheduled).
+    const resultingTrigger = (dto.trigger ?? existing.trigger) as WorkflowTrigger;
+    const resultingCronInput =
+      dto.cronExpression !== undefined ? dto.cronExpression : existing.cronExpression;
+    const cronExpression = this.resolveCron(resultingTrigger, resultingCronInput);
+    if (dto.trigger !== undefined) data.trigger = resultingTrigger;
+    if (dto.trigger !== undefined || dto.cronExpression !== undefined) {
+      data.cronExpression = cronExpression;
+    }
+
+    const workflow = await this.prisma.workflow.update({ where: { id }, data });
+
+    await this.audit(user.id, 'workflow:updated', workflow.id, {
+      circleId: workflow.circleId,
+    });
+
+    return this.serialize(workflow);
+  }
+
+  async deleteWorkflow(id: string, user: RequestUser): Promise<void> {
+    await this.assertFeatureEnabled();
+    const existing = await this.findWorkflowOrThrow(id);
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      existing.circleId,
+      user.permissions,
+      'collaborator',
+    );
+
+    // DB cascade removes runs + run items.
+    await this.prisma.workflow.delete({ where: { id } });
+    await this.audit(user.id, 'workflow:deleted', id, {
+      circleId: existing.circleId,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Preview (stateless)
+  // ---------------------------------------------------------------------------
+
+  async preview(dto: PreviewWorkflowDto, user: RequestUser) {
+    const settings = await this.assertFeatureEnabled();
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      dto.circleId,
+      user.permissions,
+      'viewer',
+    );
+
+    const definition = this.validator.validate(dto.definition);
+    const compiled = this.compiler.compile(dto.circleId, definition);
+
+    // Cap the count probe: LIMIT (min(definition.options.maxItems, maxItemsPerRun) + 1).
+    const maxItemsPerRun = settings.workflows?.maxItemsPerRun ?? 10000;
+    const defMax = definition.options?.maxItems;
+    const cap = defMax !== undefined ? Math.min(defMax, maxItemsPerRun) : maxItemsPerRun;
+
+    const orderBy: Prisma.MediaItemOrderByWithRelationInput[] = [
+      { capturedAt: 'desc' },
+      { id: 'desc' },
+    ];
+
+    // Count probe — id (+ any refinement columns) only, hard-capped at cap+1.
+    const needRefine = compiled.refinements.length > 0;
+    const countSelect: Prisma.MediaItemSelect = { id: true };
+    if (needRefine) {
+      for (const r of compiled.refinements) Object.assign(countSelect, r.select);
+    }
+    const probe = await this.prisma.mediaItem.findMany({
+      where: compiled.where,
+      orderBy,
+      take: cap + 1,
+      select: countSelect,
+    });
+    const matchedRows = needRefine
+      ? probe.filter((row) => compiled.refinements.every((r) => r.predicate(row)))
+      : probe;
+    const capped = probe.length > cap;
+    const matchedCount = Math.min(matchedRows.length, cap);
+
+    // Sample — top N by the gallery keyset ordering, with signed thumbnails.
+    const sampleRows = await this.prisma.mediaItem.findMany({
+      where: compiled.where,
+      orderBy,
+      take: needRefine ? cap + 1 : PREVIEW_SAMPLE_SIZE,
+      select: {
+        id: true,
+        type: true,
+        capturedAt: true,
+        originalFilename: true,
+        width: true,
+        height: true,
+        metadata: true,
+      },
+    });
+    const filteredSample = (
+      needRefine
+        ? sampleRows.filter((row) => compiled.refinements.every((r) => r.predicate(row)))
+        : sampleRows
+    ).slice(0, PREVIEW_SAMPLE_SIZE);
+
+    const signed = await this.thumbnails.attachThumbnailUrls(filteredSample);
+    const sample = signed.map((item) => ({
+      id: item.id,
+      type: item.type,
+      capturedAt: item.capturedAt,
+      filename: item.originalFilename,
+      width: item.width,
+      height: item.height,
+      thumbnailUrl: item.thumbnailUrl,
+    }));
+
+    return { matchedCount, capped, sample };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Subjects registry
+  // ---------------------------------------------------------------------------
+
+  async getSubjects() {
+    await this.assertFeatureEnabled();
+    return {
+      subjects: getFullRegistry().map((entry) => ({
+        subject: entry.subject,
+        label: entry.label,
+        triggers: entry.triggers,
+        fields: entry.fields.map((f) => ({
+          key: f.key,
+          label: f.label,
+          group: f.group,
+          type: f.type,
+          operators: f.operators,
+          valueType: f.valueType,
+          ...(f.enumValues ? { enumValues: f.enumValues } : {}),
+          dependency: f.dependency,
+          ...(f.readTimeRefinement ? { readTimeRefinement: true } : {}),
+        })),
+        actions: entry.actions.map((a) => ({
+          type: a.type,
+          label: a.label,
+          ...(a.destructive ? { destructive: true } : {}),
+        })),
+      })),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Feature gate: 404 when the Workflows feature is disabled. */
+  private async assertFeatureEnabled() {
+    const settings = await this.systemSettings.getSettings();
+    if (!isWorkflowsEnabled(settings)) {
+      throw new NotFoundException('Workflows feature is not enabled');
+    }
+    return settings;
+  }
+
+  private async findWorkflowOrThrow(id: string): Promise<Workflow> {
+    const workflow = await this.prisma.workflow.findUnique({ where: { id } });
+    if (!workflow) {
+      throw new NotFoundException(`Workflow ${id} not found`);
+    }
+    return workflow;
+  }
+
+  /**
+   * Resolve the cron column for a trigger: required + valid for `scheduled`,
+   * forced null otherwise.
+   */
+  private resolveCron(trigger: WorkflowTrigger, cron: string | null): string | null {
+    if (trigger === 'scheduled') {
+      if (!cron || !isValidCron(cron)) {
+        throw new BadRequestException(
+          'cronExpression is required and must be a valid 5-field cron when trigger is scheduled',
+        );
+      }
+      return cron;
+    }
+    return null;
+  }
+
+  /** Attach the derived dependency set to a workflow row for the API response. */
+  private serialize(workflow: Workflow) {
+    let dependencies: string[] = [];
+    try {
+      const def = workflow.definition as unknown as WorkflowDefinition;
+      dependencies = this.compiler.deriveDependencies(def);
+    } catch {
+      dependencies = [];
+    }
+    return {
+      id: workflow.id,
+      circleId: workflow.circleId,
+      name: workflow.name,
+      description: workflow.description,
+      subjectType: workflow.subjectType,
+      enabled: workflow.enabled,
+      trigger: workflow.trigger,
+      cronExpression: workflow.cronExpression,
+      nextRunAt: workflow.nextRunAt,
+      definition: workflow.definition,
+      dependencies,
+      createdById: workflow.createdById,
+      createdAt: workflow.createdAt,
+      updatedAt: workflow.updatedAt,
+    };
+  }
+
+  private async audit(
+    actorUserId: string,
+    action: string,
+    targetId: string,
+    meta: Record<string, unknown>,
+  ): Promise<void> {
+    await this.prisma.auditEvent.create({
+      data: {
+        actorUserId,
+        action,
+        targetType: 'workflow',
+        targetId,
+        meta: meta as Prisma.InputJsonValue,
+      },
+    });
+  }
+}

--- a/apps/api/test/workflows/workflows.integration.spec.ts
+++ b/apps/api/test/workflows/workflows.integration.spec.ts
@@ -1,0 +1,822 @@
+/**
+ * Media Workflow Automation — Phase 1 Integration (DB-gated, issue #139)
+ *
+ * NOTE: These tests use useMockDatabase: true (mocked Prisma via jest-mock-extended),
+ * the same pattern as test/media/media-bulk-dashboard.integration.spec.ts. No live
+ * PostgreSQL connection is required — they run in CI.
+ *
+ * Because Prisma is fully mocked, `mediaItem.findMany` does NOT apply the `where`
+ * clause the way a real Postgres would — it returns whatever this file configures.
+ * "Preview correctness" here therefore verifies two things a mocked DB CAN prove:
+ *   1. WorkflowsService compiles the definition into the correct Prisma `where`
+ *      shape and passes it to mediaItem.findMany (asserted directly on the mock's
+ *      call args) — this is what the compiler unit tests exhaustively cover in
+ *      isolation, exercised here end-to-end through the real HTTP + service stack.
+ *   2. The service's own post-query logic (cap math, read-time refinement
+ *      filtering, sample building, thumbnail attachment) is correct given a set
+ *      of rows "as if" they already passed the where clause.
+ * Real Postgres-level filtering correctness is out of scope without a live DB.
+ */
+
+import request from 'supertest';
+import { randomUUID } from 'crypto';
+import {
+  TestContext,
+  createTestApp,
+  closeTestApp,
+} from '../helpers/test-app.helper';
+import { resetPrismaMock } from '../mocks/prisma.mock';
+import { setupBaseMocks } from '../fixtures/mock-setup.helper';
+import {
+  createMockAdminUser,
+  createMockContributorUser,
+  createMockViewerUser,
+  authHeader,
+} from '../helpers/auth-mock.helper';
+import { DEFAULT_SYSTEM_SETTINGS } from '../../src/common/types/settings.types';
+import { SystemSettingsService } from '../../src/settings/system-settings/system-settings.service';
+import { MEDIA_ITEM_ACTIONS, MEDIA_ITEM_FIELDS } from '../../src/workflows/registry/media-item-fields';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CIRCLE_ID = '550e8400-e29b-41d4-a716-446655440099';
+const OTHER_CIRCLE_ID = '550e8400-e29b-41d4-a716-446655440199';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Mirrors the setupCircleMocks helper in media-bulk-dashboard.integration.spec.ts. */
+function setupCircleMocks(
+  context: TestContext,
+  userId: string,
+  circleId: string,
+  role: string,
+): void {
+  context.prismaMock.circle.findUnique.mockResolvedValue({ id: circleId });
+  context.prismaMock.circleMember.findUnique.mockResolvedValue({
+    circleId,
+    userId,
+    role,
+    joinedAt: new Date(),
+  });
+}
+
+/**
+ * Enable features.workflows and populate the workflows.* settings block, busting
+ * the SystemSettingsService's 5s in-process cache so the change is visible
+ * immediately (same pattern as test/settings/system-settings.integration.spec.ts).
+ */
+function setupWorkflowsSettings(
+  context: TestContext,
+  workflowsOverrides: Record<string, unknown> = {},
+): void {
+  context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+    id: 'settings-1',
+    key: 'global',
+    value: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      features: { ...DEFAULT_SYSTEM_SETTINGS.features, workflows: true },
+      workflows: { ...DEFAULT_SYSTEM_SETTINGS.workflows, ...workflowsOverrides },
+    },
+    version: 1,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    updatedByUser: null,
+  } as any);
+
+  const settingsService = context.module.get(SystemSettingsService);
+  (settingsService as any).settingsCache = null;
+}
+
+/** Disable the feature (default state) — used to assert the 404 feature gate. */
+function setupWorkflowsFeatureDisabled(context: TestContext): void {
+  context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+    id: 'settings-1',
+    key: 'global',
+    value: { ...DEFAULT_SYSTEM_SETTINGS },
+    version: 1,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    updatedByUser: null,
+  } as any);
+  const settingsService = context.module.get(SystemSettingsService);
+  (settingsService as any).settingsCache = null;
+}
+
+function makeWorkflowRow(overrides: Record<string, unknown> = {}) {
+  const now = new Date();
+  return {
+    id: randomUUID(),
+    circleId: CIRCLE_ID,
+    name: 'Screenshot cleanup',
+    description: null,
+    subjectType: 'media_item',
+    enabled: true,
+    trigger: 'manual',
+    cronExpression: null,
+    nextRunAt: null,
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [{ field: 'filename', op: 'contains', value: 'screenshot' }],
+      actions: [{ type: 'move_to_trash' }],
+    },
+    createdById: 'user-1',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+/** Fixture media item shaped like the preview select projection. metadata:null
+ * avoids any storageObject lookup in MediaThumbnailService.attachThumbnailUrls. */
+function makePreviewRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: randomUUID(),
+    type: 'photo',
+    capturedAt: new Date('2024-06-01T12:00:00.000Z'),
+    originalFilename: 'IMG_0001.jpg',
+    width: 4000,
+    height: 3000,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+const screenshotHeuristicDefinition = {
+  version: 1,
+  subject: 'media_item',
+  match: 'any',
+  conditions: [
+    { field: 'filename', op: 'contains', value: 'screenshot' },
+    {
+      match: 'all',
+      conditions: [
+        { field: 'mimeType', op: 'equals', value: 'image/png' },
+        { field: 'missingCamera', op: 'is', value: true },
+        { field: 'missingCapturedAt', op: 'is', value: true },
+      ],
+    },
+  ],
+  actions: [{ type: 'move_to_trash' }],
+};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('Workflows Integration (DB-gated)', () => {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    context = await createTestApp({ useMockDatabase: true });
+  });
+
+  afterAll(async () => {
+    await closeTestApp(context);
+  });
+
+  beforeEach(() => {
+    resetPrismaMock();
+    setupBaseMocks();
+    jest.clearAllMocks();
+    // Default: feature enabled with stock settings. Individual tests override.
+    setupWorkflowsSettings(context);
+  });
+
+  // =========================================================================
+  // Feature gate
+  // =========================================================================
+
+  describe('feature gate', () => {
+    it('returns 404 for POST /api/workflows when features.workflows is disabled', async () => {
+      setupWorkflowsFeatureDisabled(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'Test workflow',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(404);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/workflows — CRUD + RBAC
+  // =========================================================================
+
+  describe('POST /api/workflows — RBAC', () => {
+    it('returns 401 without a token', async () => {
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .send({ circleId: CIRCLE_ID, name: 'x', definition: screenshotHeuristicDefinition })
+        .expect(401);
+    });
+
+    it('returns 403 for a viewer (lacks media:write)', async () => {
+      const viewer = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(viewer.accessToken))
+        .send({ circleId: CIRCLE_ID, name: 'x', definition: screenshotHeuristicDefinition })
+        .expect(403);
+    });
+
+    it('returns 201 for a contributor with collaborator role in the circle', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      context.prismaMock.workflow.count.mockResolvedValue(0);
+      context.prismaMock.workflow.create.mockImplementation(async ({ data }: any) =>
+        makeWorkflowRow({ ...data, id: randomUUID() }),
+      );
+
+      const response = await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'Screenshot cleanup',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(201);
+
+      expect(response.body.data).toMatchObject({
+        circleId: CIRCLE_ID,
+        name: 'Screenshot cleanup',
+        subjectType: 'media_item',
+        trigger: 'manual',
+      });
+      // dependencies derived from the definition: filename/mimeType/missingCamera/
+      // missingCapturedAt are all `metadata` dependency fields.
+      expect(response.body.data.dependencies).toEqual(['metadata']);
+    });
+
+    it('returns 403 when the contributor is not a member of the circle (cross-circle denied)', async () => {
+      const contributor = await createMockContributorUser(context);
+      context.prismaMock.circle.findUnique.mockResolvedValue({ id: CIRCLE_ID });
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null); // not a member
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'x',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(403);
+    });
+
+    it('returns 404 when the circle does not exist', async () => {
+      const contributor = await createMockContributorUser(context);
+      context.prismaMock.circle.findUnique.mockResolvedValue(null);
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: OTHER_CIRCLE_ID,
+          name: 'x',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(404);
+    });
+
+    it('allows a super-admin (media:write_any) to bypass the per-circle membership check', async () => {
+      const admin = await createMockAdminUser(context);
+      // Deliberately leave circle/circleMember mocks unconfigured (no membership) —
+      // the super-admin bypass must succeed without them.
+      context.prismaMock.workflow.count.mockResolvedValue(0);
+      context.prismaMock.workflow.create.mockImplementation(async ({ data }: any) =>
+        makeWorkflowRow({ ...data, id: randomUUID() }),
+      );
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(admin.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'Admin-created workflow',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(201);
+    });
+
+    it('returns 400 when the per-circle workflow cap is reached', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      // maxWorkflowsPerCircle default is 20.
+      context.prismaMock.workflow.count.mockResolvedValue(20);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'One too many',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(400);
+    });
+
+    it('returns 400 for an invalid definition (unknown field)', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'Bad def',
+          definition: {
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [{ field: 'doesNotExist', op: 'equals', value: 'x' }],
+            actions: [],
+          },
+        })
+        .expect(400);
+    });
+
+    it('returns 400 when trigger is scheduled without a valid cronExpression', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      context.prismaMock.workflow.count.mockResolvedValue(0);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows')
+        .set(authHeader(contributor.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          name: 'Scheduled without cron',
+          trigger: 'scheduled',
+          definition: screenshotHeuristicDefinition,
+        })
+        .expect(400);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/workflows — list, RBAC
+  // =========================================================================
+
+  describe('GET /api/workflows — RBAC', () => {
+    it('returns 401 without a token', async () => {
+      await request(context.app.getHttpServer())
+        .get(`/api/workflows?circleId=${CIRCLE_ID}`)
+        .expect(401);
+    });
+
+    it('returns 200 for a viewer with viewer role in the circle', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.workflow.findMany.mockResolvedValue([makeWorkflowRow()]);
+      context.prismaMock.workflow.count.mockResolvedValue(1);
+
+      const response = await request(context.app.getHttpServer())
+        .get(`/api/workflows?circleId=${CIRCLE_ID}`)
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.items).toHaveLength(1);
+      expect(response.body.data.meta).toMatchObject({ page: 1, pageSize: 20, totalItems: 1 });
+    });
+
+    it('returns 403 when the viewer is not a member of the circle', async () => {
+      const viewer = await createMockViewerUser(context);
+      context.prismaMock.circle.findUnique.mockResolvedValue({ id: CIRCLE_ID });
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/workflows?circleId=${CIRCLE_ID}`)
+        .set(authHeader(viewer.accessToken))
+        .expect(403);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/workflows/:id
+  // =========================================================================
+
+  describe('GET /api/workflows/:id', () => {
+    it('returns 200 for a viewer with circle access', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      const row = makeWorkflowRow();
+      context.prismaMock.workflow.findUnique.mockResolvedValue(row);
+
+      const response = await request(context.app.getHttpServer())
+        .get(`/api/workflows/${row.id}`)
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.id).toBe(row.id);
+    });
+
+    it('returns 404 when the workflow does not exist', async () => {
+      const viewer = await createMockViewerUser(context);
+      context.prismaMock.workflow.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/workflows/${randomUUID()}`)
+        .set(authHeader(viewer.accessToken))
+        .expect(404);
+    });
+  });
+
+  // =========================================================================
+  // PATCH /api/workflows/:id — RBAC
+  // =========================================================================
+
+  describe('PATCH /api/workflows/:id — RBAC', () => {
+    it('returns 403 for a viewer (lacks media:write)', async () => {
+      const viewer = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch(`/api/workflows/${randomUUID()}`)
+        .set(authHeader(viewer.accessToken))
+        .send({ name: 'Renamed' })
+        .expect(403);
+    });
+
+    it('returns 200 for a contributor with collaborator role', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      const row = makeWorkflowRow();
+      context.prismaMock.workflow.findUnique.mockResolvedValue(row);
+      context.prismaMock.workflow.update.mockImplementation(async ({ data }: any) => ({
+        ...row,
+        ...data,
+        updatedAt: new Date(),
+      }));
+
+      const response = await request(context.app.getHttpServer())
+        .patch(`/api/workflows/${row.id}`)
+        .set(authHeader(contributor.accessToken))
+        .send({ name: 'Renamed workflow' })
+        .expect(200);
+
+      expect(response.body.data.name).toBe('Renamed workflow');
+    });
+
+    it('returns 403 for a contributor who is not a circle member (cross-circle denied)', async () => {
+      const contributor = await createMockContributorUser(context);
+      const row = makeWorkflowRow();
+      context.prismaMock.workflow.findUnique.mockResolvedValue(row);
+      context.prismaMock.circle.findUnique.mockResolvedValue({ id: row.circleId });
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .patch(`/api/workflows/${row.id}`)
+        .set(authHeader(contributor.accessToken))
+        .send({ name: 'Renamed' })
+        .expect(403);
+    });
+
+    it('allows a super-admin to bypass the per-circle membership check', async () => {
+      const admin = await createMockAdminUser(context);
+      const row = makeWorkflowRow();
+      context.prismaMock.workflow.findUnique.mockResolvedValue(row);
+      context.prismaMock.workflow.update.mockImplementation(async ({ data }: any) => ({
+        ...row,
+        ...data,
+        updatedAt: new Date(),
+      }));
+
+      await request(context.app.getHttpServer())
+        .patch(`/api/workflows/${row.id}`)
+        .set(authHeader(admin.accessToken))
+        .send({ enabled: false })
+        .expect(200);
+    });
+  });
+
+  // =========================================================================
+  // DELETE /api/workflows/:id — RBAC
+  // =========================================================================
+
+  describe('DELETE /api/workflows/:id — RBAC', () => {
+    it('returns 403 for a viewer (lacks media:write)', async () => {
+      const viewer = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/workflows/${randomUUID()}`)
+        .set(authHeader(viewer.accessToken))
+        .expect(403);
+    });
+
+    it('returns 204 for a contributor with collaborator role', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      const row = makeWorkflowRow();
+      context.prismaMock.workflow.findUnique.mockResolvedValue(row);
+      context.prismaMock.workflow.delete.mockResolvedValue(row);
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/workflows/${row.id}`)
+        .set(authHeader(contributor.accessToken))
+        .expect(204);
+    });
+
+    it('returns 403 for a contributor who is only a viewer in the circle (rank too low)', async () => {
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'viewer');
+      const row = makeWorkflowRow();
+      context.prismaMock.workflow.findUnique.mockResolvedValue(row);
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/workflows/${row.id}`)
+        .set(authHeader(contributor.accessToken))
+        .expect(403);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/workflows/preview
+  // =========================================================================
+
+  describe('POST /api/workflows/preview', () => {
+    it('returns 200 for a viewer (preview only requires viewer role)', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([makePreviewRow()]);
+
+      const response = await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({ circleId: CIRCLE_ID, definition: screenshotHeuristicDefinition })
+        .expect(200);
+
+      expect(response.body.data).toHaveProperty('matchedCount');
+      expect(response.body.data).toHaveProperty('capped');
+      expect(response.body.data).toHaveProperty('sample');
+    });
+
+    it('compiles the screenshot heuristic into the expected OR/AND where shape', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([
+        makePreviewRow(),
+        makePreviewRow(),
+      ]);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({ circleId: CIRCLE_ID, definition: screenshotHeuristicDefinition })
+        .expect(200);
+
+      const calls = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const where = calls[0][0].where;
+      expect(where).toMatchObject({ circleId: CIRCLE_ID, deletedAt: null });
+      expect(where.OR).toHaveLength(2);
+      expect(where.OR[0]).toEqual({
+        originalFilename: { contains: 'screenshot', mode: 'insensitive' },
+      });
+      expect(where.OR[1]).toEqual({
+        AND: [
+          { storageObject: { mimeType: 'image/png' } },
+          { cameraMake: null, cameraModel: null },
+          { capturedAt: null },
+        ],
+      });
+    });
+
+    it('compiles a pending-burst-group condition into the expected relation filter', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([makePreviewRow()]);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          definition: {
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [{ field: 'inPendingBurstGroup', op: 'is', value: true }],
+            actions: [],
+          },
+        })
+        .expect(200);
+
+      const where = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls[0][0].where;
+      expect(where.AND).toEqual([{ burstGroup: { is: { status: 'pending' } } }]);
+    });
+
+    it('compiles a pending-duplicate-group condition into the expected relation filter', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([makePreviewRow()]);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          definition: {
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [{ field: 'inPendingDuplicateGroup', op: 'is', value: true }],
+            actions: [],
+          },
+        })
+        .expect(200);
+
+      const where = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls[0][0].where;
+      expect(where.AND).toEqual([{ duplicateGroup: { is: { status: 'pending' } } }]);
+    });
+
+    it('compiles a pending-location-suggestion condition into the expected relation filter', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([makePreviewRow()]);
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          definition: {
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [{ field: 'hasPendingLocationSuggestion', op: 'is', value: true }],
+            actions: [],
+          },
+        })
+        .expect(200);
+
+      const where = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls[0][0].where;
+      expect(where.AND).toEqual([{ locationSuggestion: { is: { status: 'pending' } } }]);
+    });
+
+    it('reports matchedCount equal to the number of returned rows when under the cap', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([
+        makePreviewRow(),
+        makePreviewRow(),
+        makePreviewRow(),
+      ]);
+
+      const response = await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({ circleId: CIRCLE_ID, definition: screenshotHeuristicDefinition })
+        .expect(200);
+
+      expect(response.body.data.matchedCount).toBe(3);
+      expect(response.body.data.capped).toBe(false);
+    });
+
+    it('caps matchedCount and sets capped:true when rows exceed workflows.maxItemsPerRun', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      // Lower the cap so the test doesn't need to fabricate 10001 rows.
+      setupWorkflowsSettings(context, { maxItemsPerRun: 5 });
+
+      // cap + 1 rows returned by the probe query.
+      const rows = Array.from({ length: 6 }, () => makePreviewRow());
+      context.prismaMock.mediaItem.findMany.mockResolvedValue(rows);
+
+      const response = await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({ circleId: CIRCLE_ID, definition: screenshotHeuristicDefinition })
+        .expect(200);
+
+      expect(response.body.data.matchedCount).toBe(5);
+      expect(response.body.data.capped).toBe(true);
+
+      // LIMIT (cap + 1) — the probe query's `take` argument.
+      const probeCall = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(probeCall.take).toBe(6);
+
+      // Never a full COUNT(*) — the service uses only findMany, never .count(), for preview.
+      expect(context.prismaMock.mediaItem.count).not.toHaveBeenCalled();
+    });
+
+    it('applies the orientationShape read-time refinement to the preview sample', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      // One portrait (600x800) and one landscape (800x600) row; only the
+      // portrait one should survive the orientationShape:portrait refinement.
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([
+        makePreviewRow({ id: 'portrait-1', width: 600, height: 800 }),
+        makePreviewRow({ id: 'landscape-1', width: 800, height: 600 }),
+      ]);
+
+      const response = await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          definition: {
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [{ field: 'orientationShape', op: 'equals', value: 'portrait' }],
+            actions: [],
+          },
+        })
+        .expect(200);
+
+      expect(response.body.data.matchedCount).toBe(1);
+      expect(response.body.data.sample).toHaveLength(1);
+      expect(response.body.data.sample[0].id).toBe('portrait-1');
+    });
+
+    it('returns 400 for an invalid definition (unknown field)', async () => {
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+
+      await request(context.app.getHttpServer())
+        .post('/api/workflows/preview')
+        .set(authHeader(viewer.accessToken))
+        .send({
+          circleId: CIRCLE_ID,
+          definition: {
+            version: 1,
+            subject: 'media_item',
+            match: 'all',
+            conditions: [{ field: 'doesNotExist', op: 'equals', value: 'x' }],
+            actions: [],
+          },
+        })
+        .expect(400);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/workflows/subjects
+  // =========================================================================
+
+  describe('GET /api/workflows/subjects', () => {
+    it('returns 401 without a token', async () => {
+      await request(context.app.getHttpServer()).get('/api/workflows/subjects').expect(401);
+    });
+
+    it('returns a single media_item Subject with the full field + action catalogs', async () => {
+      const viewer = await createMockViewerUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/workflows/subjects')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      const { subjects } = response.body.data;
+      expect(subjects).toHaveLength(1);
+      expect(subjects[0].subject).toBe('media_item');
+      expect(subjects[0].label).toBe('Media Item');
+      expect(subjects[0].triggers).toEqual(['manual', 'on_media_enriched', 'scheduled']);
+      expect(subjects[0].fields).toHaveLength(MEDIA_ITEM_FIELDS.length);
+      expect(subjects[0].actions).toHaveLength(MEDIA_ITEM_ACTIONS.length);
+
+      const filenameField = subjects[0].fields.find((f: any) => f.key === 'filename');
+      expect(filenameField).toMatchObject({
+        key: 'filename',
+        label: 'Filename',
+        group: 'File',
+        type: 'string',
+        operators: expect.arrayContaining(['contains', 'starts_with', 'ends_with', 'equals']),
+      });
+
+      const moveToTrash = subjects[0].actions.find((a: any) => a.type === 'move_to_trash');
+      expect(moveToTrash).toEqual({ type: 'move_to_trash', label: 'Move to Trash' });
+
+      const hardDelete = subjects[0].actions.find((a: any) => a.type === 'hard_delete');
+      expect(hardDelete).toEqual({
+        type: 'hard_delete',
+        label: 'Delete permanently',
+        destructive: true,
+      });
+    });
+
+    it('does not require a circle context (no membership check)', async () => {
+      const viewer = await createMockViewerUser(context);
+      // Deliberately leave circle/circleMember mocks unconfigured.
+      await request(context.app.getHttpServer())
+        .get('/api/workflows/subjects')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+    });
+  });
+});


### PR DESCRIPTION
Part of #138 (Media Workflow Automation epic). **Closes #139.**

Phase 1 establishes the **Subject · Trigger · If · Then** rule model with **Media Item** as the sole v1 Subject, behind a per-Subject registry so future Subjects slot in without touching the engine. No execution yet — this phase is definition, validation, compilation, and preview only.

## What's in this PR

**Database** (`database-dev`)
- Three tables + four enums, all shipped now so Phases 2–6 are pure logic: `workflows`, `workflow_runs`, `workflow_run_items`; enums `WorkflowSubject`, `WorkflowTrigger`, `WorkflowRunStatus`, `WorkflowRunItemStatus`.
- Indexes per spec incl. `(trigger, enabled, next_run_at)` (Phase 4 scheduler) and `@@unique([runId, mediaItemId])` (batch idempotency anchor).
- Migration `20260719000000_add_workflow_tables`; `prisma validate` + `prisma:generate` pass (no live DB in this env — see repo testing constraints).

**Settings foundation** (`backend-dev`)
- Entire `workflows.*` namespace + defaults added now (read by all later phases): `maxItemsPerRun` (10000), `batchSize` (200), `maxConcurrentRuns` (2), `requirePreview` (true), `allowHardDelete` (false), `maxWorkflowsPerCircle` (20), `previewTtlHours` (24), `runHistoryRetentionDays` (30), `triggers.onEnrichment`/`scheduled` (true), `scheduleMinIntervalMinutes` (60).
- `features.workflows` (default off) + `WORKFLOWS_ENABLED` env kill-switch via `isWorkflowsEnabled()`.

**Registry + compiler** (`backend-dev`)
- Per-Subject registry (v1: `media_item`) with a 36-field Media Item condition catalog grouped File/Dates/Location/Tags/People/Media/Organization/Review, **reusing the deterministic-search `whereX` fragments** and the shared `AND: []` composition rule.
- `WorkflowConditionCompiler`: definition JSON → Prisma `where` (`all`/`any`, one nesting level), plus the **dependency-set** emitter (`metadata|tags|faces|bursts|duplicates|locationSuggestions`) that Phase 4 needs.
- Versioned + subject-tagged Zod definition schema; validator rejects unknown/cross-Subject fields & actions and >1 nesting level.
- Review-queue descriptors (burst/duplicate/location-suggestion) incl. the documented read-time `duplicateGroupConfidence` caveat.

**API** (`backend-dev`) — all circle-scoped, feature-gated
- `POST/GET/PATCH/DELETE /api/workflows`, `POST /api/workflows/preview` (bounded `LIMIT N+1` count → `capped`, **no `COUNT(*)`**, ≤12 signed-thumbnail sample via `signThumbsBatched`), `GET /api/workflows/subjects` (drives the Phase 3 builder). `media:write`+collaborator for writes, viewer read. Audit `workflow:created/updated/deleted`. Swagger annotated.

**Tests** (`testing-dev`)
- **136 unit tests passing** (compiler, validator, registry, settings defaults, cron util).
- Integration specs written (CRUD/RBAC/preview/subjects) but not executed locally — the worktree lacks its own `node_modules` and resolves against the root install built on `main`, so DB-backed HTTP specs can't compile here (pre-existing environmental gap, verified against an existing untouched integration spec; not caused by this code).

## Notes
- No runtime behavior is exposed until `features.workflows` is turned on.
- BigInt gotcha honored (byte sizes returned as strings).

Subagents used per project convention: `database-dev`, `backend-dev`, `testing-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7pn41YVW5ixYGyT29ntkU