### PR TITLE
Workflows Phase 3: web UI — list, IFTTT-style builder, live preview, approval & run progress (#141)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -59,6 +59,9 @@ const ArchivePage = lazy(() => import('./pages/Archive/ArchivePage'));
 const TrashPage = lazy(() => import('./pages/Trash/TrashPage'));
 const PublicSharePage = lazy(() => import('./pages/Public/PublicSharePage'));
 const PublicSharesPage = lazy(() => import('./pages/Admin/PublicSharesPage'));
+const WorkflowListPage = lazy(() => import('./pages/Workflows/WorkflowListPage'));
+const WorkflowBuilderPage = lazy(() => import('./pages/Workflows/WorkflowBuilderPage'));
+const WorkflowRunPage = lazy(() => import('./pages/Workflows/WorkflowRunPage'));
 
 // Test login page (development only)
 const TestLoginPage = import.meta.env.PROD
@@ -136,6 +139,10 @@ function AppRoutes() {
                 <Route path="/places/cities" element={<LevelBrowsePage level="cities" />} />
                 <Route path="/albums" element={<AlbumsPage />} />
                 <Route path="/albums/:albumId" element={<AlbumPage />} />
+                <Route path="/workflows" element={<WorkflowListPage />} />
+                <Route path="/workflows/new" element={<WorkflowBuilderPage />} />
+                <Route path="/workflows/:id" element={<WorkflowBuilderPage />} />
+                <Route path="/workflows/:id/runs/:runId" element={<WorkflowRunPage />} />
                 <Route path="/bursts" element={<BurstsPage />} />
                 <Route path="/bursts/:id" element={<BurstGroupPage />} />
                 <Route path="/duplicates" element={<DuplicatesPage />} />

--- a/apps/web/src/__tests__/components/workflows/builder/ActionsBlock.test.tsx
+++ b/apps/web/src/__tests__/components/workflows/builder/ActionsBlock.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * RTL tests for ActionsBlock (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers the "action options reflect the registry" half of the "Subject-
+ * driven form population" bullet, plus add/remove of an action row through
+ * the real `builderReducer`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useReducer } from 'react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../utils/test-utils';
+import { ActionsBlock } from '../../../../components/workflows/builder/ActionsBlock';
+import {
+  builderReducer,
+  blankState,
+} from '../../../../pages/Workflows/builderState';
+import type { WorkflowActionDescriptor } from '../../../../types/workflows';
+
+// ActionParamEditor's 'tags' kind reads the circle's tag vocabulary.
+vi.mock('../../../../services/media', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../services/media')>();
+  return {
+    ...actual,
+    getExploreTags: vi.fn().mockResolvedValue([]),
+    listAlbums: vi.fn().mockResolvedValue({ items: [], meta: { page: 1, pageSize: 200, totalItems: 0, totalPages: 0 } }),
+  };
+});
+
+// Every type here maps to ActionParamKind 'none' or 'tags' (ACTION_PARAM_KIND
+// in workflowActionMeta.ts), so no person-picker / circle-picker network
+// calls are triggered.
+const ACTIONS: WorkflowActionDescriptor[] = [
+  { type: 'move_to_trash', label: 'Move to Trash' },
+  { type: 'archive', label: 'Archive' },
+  { type: 'unarchive', label: 'Unarchive' },
+  { type: 'add_tags', label: 'Add tags' },
+  { type: 'hard_delete', label: 'Permanently delete', destructive: true },
+];
+
+function ActionsHarness({ actionCatalog = ACTIONS }: { actionCatalog?: WorkflowActionDescriptor[] }) {
+  const [state, dispatch] = useReducer(builderReducer, undefined, blankState);
+  return (
+    <ActionsBlock
+      circleId="circle-1"
+      actionCatalog={actionCatalog}
+      actions={state.definition.actions}
+      dispatch={dispatch}
+      hardDeleteAllowed={null}
+    />
+  );
+}
+
+describe('ActionsBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('subject-driven action population', () => {
+    it('defaults a newly-added action to the first non-destructive registry action', async () => {
+      const user = userEvent.setup();
+      render(<ActionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+
+      // The Action Select's current value is the first non-destructive type
+      // (move_to_trash comes before the destructive hard_delete entry).
+      expect(screen.getByText('Move to Trash')).toBeInTheDocument();
+    });
+
+    it('offers exactly the registry actions, in order, in the Action picker', async () => {
+      const user = userEvent.setup();
+      render(<ActionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+      await user.click(screen.getAllByRole('combobox')[0]);
+
+      const listbox = await screen.findByRole('listbox');
+      const optionLabels = within(listbox)
+        .getAllByRole('option')
+        .map((o) => o.textContent);
+
+      expect(optionLabels).toEqual([
+        'Move to Trash',
+        'Archive',
+        'Unarchive',
+        'Add tags',
+        'Permanently delete',
+      ]);
+    });
+  });
+
+  describe('action rows', () => {
+    it('shows an empty-state hint and no rows before any action is added', async () => {
+      render(<ActionsHarness />);
+      // `findBy` flushes the block's tag/album fetch effect inside act(),
+      // avoiding a spurious "not wrapped in act" warning from that unrelated
+      // in-flight promise resolving after this test's synchronous assertions.
+      expect(
+        await screen.findByText(/add at least one action for this workflow to do anything/i),
+      ).toBeInTheDocument();
+      expect(screen.queryAllByRole('combobox')).toHaveLength(0);
+    });
+
+    it('adds an action row on "Add action"', async () => {
+      const user = userEvent.setup();
+      render(<ActionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+      expect(screen.getAllByRole('combobox')).toHaveLength(1);
+      expect(
+        screen.queryByText(/add at least one action for this workflow/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('adds a second action row appended after the first', async () => {
+      const user = userEvent.setup();
+      render(<ActionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+      expect(screen.getAllByRole('combobox')).toHaveLength(2);
+    });
+
+    it('removes an action row on its remove button', async () => {
+      const user = userEvent.setup();
+      render(<ActionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+      expect(screen.getAllByRole('combobox')).toHaveLength(1);
+
+      await user.click(screen.getByRole('button', { name: 'Remove action' }));
+      expect(screen.queryAllByRole('combobox')).toHaveLength(0);
+      expect(
+        screen.getByText(/add at least one action for this workflow to do anything/i),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the manual-trigger-only warning for hard_delete but not for a normal action', async () => {
+      const user = userEvent.setup();
+      render(<ActionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add action' }));
+      expect(screen.queryByText(/permanent delete — use with care/i)).not.toBeInTheDocument();
+
+      await user.click(screen.getAllByRole('combobox')[0]);
+      await user.click(await screen.findByRole('option', { name: 'Permanently delete' }));
+
+      expect(screen.getByText(/permanent delete — use with care/i)).toBeInTheDocument();
+      expect(screen.getByText(/manual trigger only/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/workflows/builder/ConditionsBlock.test.tsx
+++ b/apps/web/src/__tests__/components/workflows/builder/ConditionsBlock.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * RTL tests for ConditionsBlock (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers the issue's "Builder condition rows" and "Subject-driven form
+ * population" bullets: the field picker reflects exactly the Subject
+ * registry's fields (grouped), and add/remove of a top-level condition row,
+ * adding a nested condition group (one level), and toggling ALL/ANY all work
+ * through the real `builderReducer` (via a small harness component — no
+ * network, no router needed for this block in isolation).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useReducer } from 'react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../utils/test-utils';
+import { ConditionsBlock } from '../../../../components/workflows/builder/ConditionsBlock';
+import {
+  builderReducer,
+  blankState,
+} from '../../../../pages/Workflows/builderState';
+import type { WorkflowFieldDescriptor } from '../../../../types/workflows';
+
+// ---------------------------------------------------------------------------
+// The value editor (via ConditionRow) fetches the circle's tag vocabulary and
+// albums once per block mount. Mock the network-backed service so the block
+// never hits real fetch — deterministic, empty lists are enough since none of
+// these tests select a tag-set/album field.
+// ---------------------------------------------------------------------------
+vi.mock('../../../../services/media', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../services/media')>();
+  return {
+    ...actual,
+    getExploreTags: vi.fn().mockResolvedValue([]),
+    listAlbums: vi.fn().mockResolvedValue({ items: [], meta: { page: 1, pageSize: 200, totalItems: 0, totalPages: 0 } }),
+  };
+});
+
+// A field registry spanning every WorkflowFieldGroup, mirroring the shape
+// `GET /api/workflows/subjects` would return for the media_item subject.
+const FIELDS: WorkflowFieldDescriptor[] = [
+  { key: 'filename', label: 'Filename', group: 'File', type: 'string', operators: ['contains', 'starts_with', 'equals'], valueType: 'string', dependency: 'metadata' },
+  { key: 'capturedAt', label: 'Capture date', group: 'Dates', type: 'date', operators: ['before', 'after'], valueType: 'iso-date', dependency: 'metadata' },
+  { key: 'country', label: 'Country', group: 'Location', type: 'string', operators: ['equals'], valueType: 'string', dependency: 'metadata' },
+  { key: 'hasTag', label: 'Has tag', group: 'Tags', type: 'string', operators: ['contains'], valueType: 'string', dependency: 'tags' },
+  { key: 'personName', label: 'Person name', group: 'People', type: 'string', operators: ['contains'], valueType: 'string', dependency: 'faces' },
+  { key: 'mimeType', label: 'File type', group: 'Media', type: 'string', operators: ['equals'], valueType: 'string', dependency: 'metadata' },
+  { key: 'albumName', label: 'Album name', group: 'Organization', type: 'string', operators: ['equals'], valueType: 'string', dependency: 'metadata' },
+  { key: 'inPendingDuplicateGroup', label: 'In pending duplicate group', group: 'Review', type: 'boolean', operators: ['is'], valueType: 'boolean', dependency: 'duplicates' },
+];
+
+// Harness — a real reducer + dispatch, so every interaction exercises the
+// production `builderReducer`, not a mock.
+function ConditionsHarness({ fields = FIELDS }: { fields?: WorkflowFieldDescriptor[] }) {
+  const [state, dispatch] = useReducer(builderReducer, undefined, blankState);
+  return (
+    <ConditionsBlock
+      circleId="circle-1"
+      fields={fields}
+      match={state.definition.match}
+      conditions={state.definition.conditions}
+      dispatch={dispatch}
+    />
+  );
+}
+
+describe('ConditionsBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('subject-driven field population', () => {
+    it('offers exactly the registry fields, grouped, in the field picker', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add condition' }));
+
+      const fieldInput = screen.getByRole('combobox', { name: /field/i });
+      await user.click(fieldInput);
+
+      const listbox = await screen.findByRole('listbox');
+      const optionLabels = within(listbox)
+        .getAllByRole('option')
+        .map((o) => o.textContent);
+
+      expect(optionLabels).toEqual([
+        'Filename',
+        'Capture date',
+        'Country',
+        'Has tag',
+        'Person name',
+        'File type',
+        'Album name',
+        'In pending duplicate group',
+      ]);
+    });
+
+    it('filters the operator choices to the selected field\'s registry operators', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add condition' }));
+      await user.click(screen.getByRole('combobox', { name: /field/i }));
+      await user.click(await screen.findByRole('option', { name: 'Filename' }));
+
+      // MUI's Select trigger doesn't compute an accessible name reliably in
+      // jsdom even though it is visually labeled "Condition" — select it
+      // positionally: the Field Autocomplete is combobox[0], the operator
+      // Select is combobox[1] once a field has been chosen.
+      await user.click(screen.getAllByRole('combobox')[1]);
+      const opListbox = await screen.findByRole('listbox');
+      const opLabels = within(opListbox)
+        .getAllByRole('option')
+        .map((o) => o.textContent);
+      // Filename's registry operators are contains / starts_with / equals.
+      expect(opLabels).toEqual(['contains', 'starts with', 'is']);
+    });
+  });
+
+  describe('condition rows', () => {
+    it('adds a top-level condition row on "Add condition"', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      expect(screen.queryByRole('combobox', { name: /field/i })).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Add condition' }));
+      expect(screen.getAllByRole('combobox', { name: /field/i })).toHaveLength(1);
+    });
+
+    it('removes a top-level condition row on the row\'s remove button', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add condition' }));
+      expect(screen.getAllByRole('combobox', { name: /field/i })).toHaveLength(1);
+
+      await user.click(screen.getByRole('button', { name: /remove condition/i }));
+      expect(screen.queryByRole('combobox', { name: /field/i })).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/this workflow will match every item/i),
+      ).toBeInTheDocument();
+    });
+
+    it('adds a nested condition group (one level) with its own match toggle and an inner leaf', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add condition group' }));
+
+      expect(screen.getByText('Condition group')).toBeInTheDocument();
+      // The group starts with exactly one empty leaf row.
+      expect(screen.getAllByRole('combobox', { name: /field/i })).toHaveLength(1);
+      // Add a second leaf inside the group.
+      await user.click(screen.getByRole('button', { name: 'Add condition to group' }));
+      expect(screen.getAllByRole('combobox', { name: /field/i })).toHaveLength(2);
+    });
+
+    it('removing the group removes all of its nested leaves at once', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add condition group' }));
+      await user.click(screen.getByRole('button', { name: 'Add condition to group' }));
+      expect(screen.getAllByRole('combobox', { name: /field/i })).toHaveLength(2);
+
+      await user.click(screen.getByRole('button', { name: /remove group/i }));
+      expect(screen.queryByRole('combobox', { name: /field/i })).not.toBeInTheDocument();
+      expect(screen.queryByText('Condition group')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ALL / ANY toggle', () => {
+    it('toggles the top-level match mode between ALL and ANY', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      const allButtons = screen.getAllByRole('button', { name: 'Match ALL' });
+      const anyButtons = screen.getAllByRole('button', { name: 'Match ANY' });
+      // Only the top-level toggle exists before any group is added.
+      expect(allButtons).toHaveLength(1);
+      expect(anyButtons).toHaveLength(1);
+
+      expect(allButtons[0]).toHaveAttribute('aria-pressed', 'true');
+      expect(anyButtons[0]).toHaveAttribute('aria-pressed', 'false');
+
+      await user.click(anyButtons[0]);
+
+      expect(screen.getAllByRole('button', { name: 'Match ANY' })[0]).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(screen.getAllByRole('button', { name: 'Match ALL' })[0]).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('toggles a group\'s own match mode independently of the top-level toggle', async () => {
+      const user = userEvent.setup();
+      render(<ConditionsHarness />);
+
+      await user.click(screen.getByRole('button', { name: 'Add condition group' }));
+
+      // Now two ALL/ANY toggles exist: top-level and the group's own.
+      const anyButtons = screen.getAllByRole('button', { name: 'Match ANY' });
+      expect(anyButtons).toHaveLength(2);
+      const groupAnyButton = anyButtons[1];
+
+      await user.click(groupAnyButton);
+
+      // The top-level toggle is unaffected; only the group's toggle flips.
+      expect(screen.getAllByRole('button', { name: 'Match ALL' })[0]).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(screen.getAllByRole('button', { name: 'Match ANY' })[1]).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/workflows/builder/WorkflowPreviewPanel.test.tsx
+++ b/apps/web/src/__tests__/components/workflows/builder/WorkflowPreviewPanel.test.tsx
@@ -1,0 +1,349 @@
+/**
+ * RTL tests for WorkflowPreviewPanel (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers two issue bullets:
+ *   - "Live plain-language summary" updates as the draft changes.
+ *   - "Preview debounce + capped rendering": a definition change triggers a
+ *     debounced (600ms) preview call (fake timers); `capped` renders as
+ *     "10,000+"; only the first 12 sample thumbnails render.
+ *
+ * `useWorkflowPreview` is mocked directly (the panel's only network-adjacent
+ * dependency) so these tests exercise real component logic — the debounce
+ * timer, the sanitize-then-preview wiring, and the render branches — without
+ * a real fetch or MSW handler.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { render } from '../../../utils/test-utils';
+import { WorkflowPreviewPanel } from '../../../../components/workflows/builder/WorkflowPreviewPanel';
+import type {
+  WorkflowDefinition,
+  SubjectRegistryEntry,
+  WorkflowPreviewResponse,
+} from '../../../../types/workflows';
+
+vi.mock('../../../../hooks/useWorkflowPreview', () => ({
+  useWorkflowPreview: vi.fn(),
+}));
+
+import { useWorkflowPreview } from '../../../../hooks/useWorkflowPreview';
+
+const mockUseWorkflowPreview = vi.mocked(useWorkflowPreview);
+
+type HookReturn = ReturnType<typeof useWorkflowPreview>;
+
+function makeHook(overrides: Partial<HookReturn> = {}): HookReturn {
+  return {
+    preview: vi.fn().mockResolvedValue(null),
+    data: null,
+    isLoading: false,
+    error: null,
+    reset: vi.fn(),
+    ...overrides,
+  } as HookReturn;
+}
+
+const SUBJECT: SubjectRegistryEntry = {
+  subject: 'media_item',
+  label: 'Media Items',
+  triggers: ['manual', 'on_media_enriched', 'scheduled'],
+  fields: [
+    {
+      key: 'country',
+      label: 'Country',
+      group: 'Location',
+      type: 'string',
+      operators: ['equals'],
+      valueType: 'string',
+      dependency: 'metadata',
+    },
+  ],
+  actions: [{ type: 'archive', label: 'Archive' }],
+};
+
+function baseDefinition(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    version: 1,
+    subject: 'media_item',
+    match: 'all',
+    conditions: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function sampleItem(id: string) {
+  return {
+    id,
+    type: 'photo',
+    capturedAt: null,
+    filename: `${id}.jpg`,
+    width: 100,
+    height: 100,
+    thumbnailUrl: `https://cdn.example.com/${id}.jpg`,
+  };
+}
+
+describe('WorkflowPreviewPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('plain-language summary', () => {
+    it('renders the sentence for the current draft and updates it as the draft changes', () => {
+      mockUseWorkflowPreview.mockReturnValue(makeHook());
+
+      const { rerender } = render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getByText('In plain language')).toBeInTheDocument();
+      expect(screen.getByText(/for every item, do nothing yet\./i)).toBeInTheDocument();
+
+      rerender(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition({
+            conditions: [{ field: 'country', op: 'equals', value: 'Italy' }],
+            actions: [{ type: 'archive' }],
+          })}
+          subjectEntry={SUBJECT}
+          trigger="on_media_enriched"
+          cronExpression=""
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'When new media is enriched, if the country is “Italy”, archive it.',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('debounced preview', () => {
+    it('does not call preview() before the 600ms debounce elapses, then calls it once with the sanitized definition', () => {
+      vi.useFakeTimers();
+      const previewMock = vi.fn().mockResolvedValue(null);
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ preview: previewMock }));
+
+      const definition = baseDefinition({
+        conditions: [{ field: 'country', op: 'equals', value: 'Italy' }],
+      });
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={definition}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(previewMock).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(599);
+      });
+      expect(previewMock).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(previewMock).toHaveBeenCalledTimes(1);
+      // The single complete leaf survives sanitizeDefinitionForPreview
+      // unchanged, so the sanitized definition is deep-equal to the input.
+      expect(previewMock).toHaveBeenCalledWith({ circleId: 'circle-1', definition });
+    });
+
+    it('collapses rapid successive definition changes into a single debounced call', () => {
+      vi.useFakeTimers();
+      const previewMock = vi.fn().mockResolvedValue(null);
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ preview: previewMock }));
+
+      const defA = baseDefinition({
+        conditions: [{ field: 'country', op: 'equals', value: 'Italy' }],
+      });
+      const defB = baseDefinition({
+        conditions: [{ field: 'country', op: 'equals', value: 'France' }],
+      });
+
+      const { rerender } = render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={defA}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(previewMock).not.toHaveBeenCalled();
+
+      // A second edit arrives before the first debounce window closes — the
+      // timer restarts rather than firing twice.
+      rerender(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={defB}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(previewMock).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(previewMock).toHaveBeenCalledTimes(1);
+      expect(previewMock).toHaveBeenCalledWith({ circleId: 'circle-1', definition: defB });
+    });
+
+    it('does not schedule a preview call when circleId is empty', () => {
+      vi.useFakeTimers();
+      const previewMock = vi.fn().mockResolvedValue(null);
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ preview: previewMock }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId=""
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(previewMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('match count rendering', () => {
+    it('renders a plain count when not capped', () => {
+      const data: WorkflowPreviewResponse = { matchedCount: 42, capped: false, sample: [] };
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ data }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getByText('42')).toBeInTheDocument();
+      expect(screen.queryByText(/42\+/)).not.toBeInTheDocument();
+    });
+
+    it('renders "N+" when the preview response is capped', () => {
+      const data: WorkflowPreviewResponse = { matchedCount: 10000, capped: true, sample: [] };
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ data }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getByText('10,000+')).toBeInTheDocument();
+    });
+
+    it('shows a loading indicator while the preview is in flight', () => {
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ isLoading: true }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getByText(/counting matches/i)).toBeInTheDocument();
+    });
+
+    it('surfaces a preview error', () => {
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ error: 'Preview failed' }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getByText('Preview failed')).toBeInTheDocument();
+    });
+  });
+
+  describe('sample grid', () => {
+    it('renders only the first 12 sample thumbnails even when more are returned', () => {
+      const sample = Array.from({ length: 20 }, (_, i) => sampleItem(`item-${i}`));
+      const data: WorkflowPreviewResponse = { matchedCount: 20, capped: false, sample };
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ data }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getAllByRole('img')).toHaveLength(12);
+    });
+
+    it('shows a "no items match yet" notice for a zero-match, non-loading result', () => {
+      const data: WorkflowPreviewResponse = { matchedCount: 0, capped: false, sample: [] };
+      mockUseWorkflowPreview.mockReturnValue(makeHook({ data }));
+
+      render(
+        <WorkflowPreviewPanel
+          circleId="circle-1"
+          definition={baseDefinition()}
+          subjectEntry={SUBJECT}
+          trigger="manual"
+          cronExpression=""
+        />,
+      );
+
+      expect(screen.getByText(/no items match yet/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/__tests__/pages/Workflows/WorkflowBuilderPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Workflows/WorkflowBuilderPage.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * RTL tests for WorkflowBuilderPage (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers the "Template hydration" bullet: navigating to the builder with a
+ * template pre-fills the form, via BOTH hydration paths documented in the
+ * component's own header comment —
+ *   1. router state:      navigate('/workflows/new', { state: { template } })
+ *   2. query param:       navigate('/workflows/new?template=<id>')
+ *
+ * A real MemoryRouter (not a mocked useParams/useLocation) drives this test,
+ * since the hydration effect reads `useLocation().state` and
+ * `useSearchParams()` directly — the very thing under test. Every data hook
+ * is mocked so the page never touches the network.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../hooks/useCircle', () => ({ useCircle: vi.fn() }));
+vi.mock('../../../hooks/usePermissions', () => ({ usePermissions: vi.fn() }));
+vi.mock('../../../hooks/useWorkflowSubjects', () => ({ useWorkflowSubjects: vi.fn() }));
+vi.mock('../../../hooks/useWorkflow', () => ({ useWorkflow: vi.fn() }));
+vi.mock('../../../hooks/useWorkflowMutations', () => ({ useWorkflowMutations: vi.fn() }));
+// The preview panel's own hook is mocked so this page-level test never fires
+// a real (debounced) network call or leaves a dangling timer — preview
+// behavior itself is covered by WorkflowPreviewPanel.test.tsx.
+vi.mock('../../../hooks/useWorkflowPreview', () => ({ useWorkflowPreview: vi.fn() }));
+vi.mock('../../../services/media', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../services/media')>();
+  return {
+    ...actual,
+    getExploreTags: vi.fn().mockResolvedValue([]),
+    listAlbums: vi.fn().mockResolvedValue({ items: [], meta: { page: 1, pageSize: 200, totalItems: 0, totalPages: 0 } }),
+  };
+});
+
+import WorkflowBuilderPage from '../../../pages/Workflows/WorkflowBuilderPage';
+import { useCircle } from '../../../hooks/useCircle';
+import { usePermissions } from '../../../hooks/usePermissions';
+import { useWorkflowSubjects } from '../../../hooks/useWorkflowSubjects';
+import { useWorkflow } from '../../../hooks/useWorkflow';
+import { useWorkflowMutations } from '../../../hooks/useWorkflowMutations';
+import { useWorkflowPreview } from '../../../hooks/useWorkflowPreview';
+import { WORKFLOW_TEMPLATES } from '../../../constants/workflowTemplates';
+import type { SubjectRegistryEntry } from '../../../types/workflows';
+
+const mockUseCircle = vi.mocked(useCircle);
+const mockUsePermissions = vi.mocked(usePermissions);
+const mockUseWorkflowSubjects = vi.mocked(useWorkflowSubjects);
+const mockUseWorkflow = vi.mocked(useWorkflow);
+const mockUseWorkflowMutations = vi.mocked(useWorkflowMutations);
+const mockUseWorkflowPreview = vi.mocked(useWorkflowPreview);
+
+// A registry entry covering exactly the fields/action the "Clean up
+// screenshots" template's definition references.
+const SUBJECT: SubjectRegistryEntry = {
+  subject: 'media_item',
+  label: 'Media Items',
+  triggers: ['manual', 'on_media_enriched', 'scheduled'],
+  fields: [
+    { key: 'filename', label: 'Filename', group: 'File', type: 'string', operators: ['contains', 'starts_with', 'equals'], valueType: 'string', dependency: 'metadata' },
+    { key: 'mimeType', label: 'Mime type', group: 'Media', type: 'enum', operators: ['equals'], valueType: 'enum', enumValues: ['image/png'], dependency: 'metadata' },
+    { key: 'missingCamera', label: 'Missing camera', group: 'Media', type: 'boolean', operators: ['is'], valueType: 'boolean', dependency: 'metadata' },
+    { key: 'missingCapturedAt', label: 'Missing capture date', group: 'Dates', type: 'boolean', operators: ['is'], valueType: 'boolean', dependency: 'metadata' },
+  ],
+  actions: [{ type: 'move_to_trash', label: 'Move to Trash' }],
+};
+
+const EXPECTED_SENTENCE =
+  'When new media is enriched, if the filename contains “screenshot” or ' +
+  '(the mime type is image/png, missing camera and missing capture date), move it to Trash.';
+
+function renderBuilder(initialEntries: Parameters<typeof MemoryRouter>[0]['initialEntries']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <WorkflowBuilderPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('WorkflowBuilderPage — template hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCircle.mockReturnValue({
+      activeCircle: { id: 'circle-1', name: 'Test Circle', description: null, ownerId: 'user-1', isPersonal: false, createdAt: '', updatedAt: '' },
+      activeCircleId: 'circle-1',
+      activeCircleRole: 'collaborator',
+      circles: [],
+      loading: false,
+      setActiveCircle: vi.fn().mockResolvedValue(undefined),
+      refreshCircles: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof useCircle>);
+    mockUsePermissions.mockReturnValue({
+      permissions: new Set(['media:write']),
+      roles: new Set<string>(),
+      hasPermission: (p: string) => p === 'media:write',
+      hasAnyPermission: () => true,
+      hasAllPermissions: () => true,
+      hasRole: () => false,
+      hasAnyRole: () => false,
+      isAdmin: false,
+    } as unknown as ReturnType<typeof usePermissions>);
+    mockUseWorkflowSubjects.mockReturnValue({
+      subjects: [SUBJECT],
+      enabled: true,
+      isLoading: false,
+      error: null,
+    });
+    mockUseWorkflow.mockReturnValue({
+      workflow: null,
+      isLoading: false,
+      error: null,
+      fetchWorkflow: vi.fn().mockResolvedValue(undefined),
+    });
+    mockUseWorkflowMutations.mockReturnValue({
+      createWorkflow: vi.fn(),
+      updateWorkflow: vi.fn(),
+      deleteWorkflow: vi.fn(),
+      runWorkflow: vi.fn(),
+      approveRun: vi.fn(),
+      cancelRun: vi.fn(),
+      duplicateWorkflow: vi.fn(),
+      setEnabled: vi.fn(),
+      isSaving: false,
+      error: null,
+    } as unknown as ReturnType<typeof useWorkflowMutations>);
+    mockUseWorkflowPreview.mockReturnValue({
+      preview: vi.fn().mockResolvedValue(null),
+      data: null,
+      isLoading: false,
+      error: null,
+      reset: vi.fn(),
+    });
+  });
+
+  it('pre-fills the form from a template passed via router state (from the templates gallery)', async () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+
+    renderBuilder([{ pathname: '/workflows/new', state: { template } }]);
+
+    expect(screen.getByRole('heading', { name: 'New workflow' })).toBeInTheDocument();
+    // `findBy` flushes ConditionsBlock/ActionsBlock's tag+album fetch effect
+    // inside act(), avoiding a spurious "not wrapped in act" warning from
+    // that unrelated in-flight promise resolving after this test returns.
+    expect(await screen.findByLabelText('Name', { exact: false })).toHaveValue(template.name);
+    expect(screen.getByLabelText('Description')).toHaveValue(template.description);
+    expect(
+      screen.getByRole('radio', { name: 'When new media is enriched' }),
+    ).toBeChecked();
+    expect(screen.getByText(EXPECTED_SENTENCE)).toBeInTheDocument();
+  });
+
+  it('pre-fills the form from a template referenced by the ?template= query param', async () => {
+    renderBuilder(['/workflows/new?template=clean-up-screenshots']);
+
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+    expect(await screen.findByLabelText('Name', { exact: false })).toHaveValue(template.name);
+    expect(screen.getByLabelText('Description')).toHaveValue(template.description);
+    expect(
+      screen.getByRole('radio', { name: 'When new media is enriched' }),
+    ).toBeChecked();
+    expect(screen.getByText(EXPECTED_SENTENCE)).toBeInTheDocument();
+  });
+
+  it('prefers router state over the query param when both are present', async () => {
+    const stateTemplate = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+    renderBuilder([
+      { pathname: '/workflows/new', search: '?template=trip-album', state: { template: stateTemplate } },
+    ]);
+
+    // Router-state template ("Clean up screenshots") wins over the
+    // query-param template ("Album from a trip").
+    expect(await screen.findByLabelText('Name', { exact: false })).toHaveValue('Clean up screenshots');
+  });
+
+  it('starts from a blank draft when no template is referenced', async () => {
+    renderBuilder(['/workflows/new']);
+
+    expect(await screen.findByLabelText('Name', { exact: false })).toHaveValue('');
+    expect(screen.getByLabelText('Description')).toHaveValue('');
+    expect(screen.getByRole('radio', { name: 'Manual — I run it myself' })).toBeChecked();
+  });
+});

--- a/apps/web/src/__tests__/pages/Workflows/WorkflowRunPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Workflows/WorkflowRunPage.test.tsx
@@ -1,0 +1,405 @@
+/**
+ * RTL tests for WorkflowRunPage (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers three issue bullets:
+ *   - "Approval typed-confirmation gate": on a hard_delete run, the Approve
+ *     button stays disabled until the user types `DELETE {matchedCount}`.
+ *   - "Exclusion checkboxes": checking items accumulates excluded ids, and
+ *     the ≤500 exclusion cap disables further checkboxes once reached.
+ *   - "Progress polling": while a run is non-terminal, the run detail is
+ *     re-fetched on the 2s interval (fake timers); polling stops once the
+ *     run reaches a terminal status.
+ *
+ * All data hooks are mocked directly (mirroring the DuplicateGroupPage.test
+ * precedent), so these tests exercise WorkflowRunPage's own render/effect
+ * logic without a real network or MSW handler.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useWorkflowRun', () => ({
+  useWorkflowRun: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useWorkflowRunItems', () => ({
+  useWorkflowRunItems: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useWorkflowMutations', () => ({
+  useWorkflowMutations: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: 'wf-1', runId: 'run-1' }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import WorkflowRunPage from '../../../pages/Workflows/WorkflowRunPage';
+import { usePermissions } from '../../../hooks/usePermissions';
+import { useCircle } from '../../../hooks/useCircle';
+import { useWorkflowRun } from '../../../hooks/useWorkflowRun';
+import { useWorkflowRunItems } from '../../../hooks/useWorkflowRunItems';
+import { useWorkflowMutations } from '../../../hooks/useWorkflowMutations';
+import type { WorkflowRunDetail, WorkflowRunItem } from '../../../types/workflows';
+
+const mockUsePermissions = vi.mocked(usePermissions);
+const mockUseCircle = vi.mocked(useCircle);
+const mockUseWorkflowRun = vi.mocked(useWorkflowRun);
+const mockUseWorkflowRunItems = vi.mocked(useWorkflowRunItems);
+const mockUseWorkflowMutations = vi.mocked(useWorkflowMutations);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCircleContext(overrides: Partial<ReturnType<typeof useCircle>> = {}) {
+  return {
+    activeCircle: { id: 'circle-1', name: 'Test Circle', description: null, ownerId: 'user-1', isPersonal: false, createdAt: '', updatedAt: '' },
+    activeCircleId: 'circle-1',
+    activeCircleRole: 'collaborator',
+    circles: [],
+    loading: false,
+    setActiveCircle: vi.fn().mockResolvedValue(undefined),
+    refreshCircles: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ReturnType<typeof useCircle>;
+}
+
+function makePermissions(perms: string[] = ['media:write', 'media:delete']) {
+  return {
+    permissions: new Set(perms),
+    roles: new Set<string>(),
+    hasPermission: (p: string) => perms.includes(p),
+    hasAnyPermission: () => true,
+    hasAllPermissions: () => true,
+    hasRole: () => false,
+    hasAnyRole: () => false,
+    isAdmin: false,
+  } as unknown as ReturnType<typeof usePermissions>;
+}
+
+function makeRun(overrides: Partial<WorkflowRunDetail> = {}): WorkflowRunDetail {
+  return {
+    id: 'run-1',
+    workflowId: 'wf-1',
+    circleId: 'circle-1',
+    status: 'awaiting_approval',
+    triggerType: 'manual',
+    matchedCount: 5,
+    truncated: false,
+    processedCount: 0,
+    succeededCount: 0,
+    failedCount: 0,
+    skippedCount: 0,
+    startedById: null,
+    approvedById: null,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    approvedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    lastError: null,
+    definitionSnapshot: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [],
+      actions: [{ type: 'move_to_trash' }],
+    },
+    itemStatusCounts: {},
+    actionSummary: { scanned: 0, partial: false, byActionType: {} },
+    ...overrides,
+  };
+}
+
+function makeItem(id: string, overrides: Partial<WorkflowRunItem> = {}): WorkflowRunItem {
+  return {
+    id,
+    mediaItemId: id,
+    status: 'matched',
+    actionResults: null,
+    error: null,
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    media: { type: 'photo', capturedAt: null, filename: `${id}.jpg`, width: 100, height: 100 },
+    thumbnailUrl: null,
+    ...overrides,
+  };
+}
+
+type RunHookReturn = ReturnType<typeof useWorkflowRun>;
+function makeRunHook(overrides: Partial<RunHookReturn> = {}): RunHookReturn {
+  return {
+    run: makeRun(),
+    isLoading: false,
+    error: null,
+    fetchRun: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as RunHookReturn;
+}
+
+type ItemsHookReturn = ReturnType<typeof useWorkflowRunItems>;
+function makeItemsHook(overrides: Partial<ItemsHookReturn> = {}): ItemsHookReturn {
+  return {
+    items: [],
+    meta: null,
+    isLoading: false,
+    error: null,
+    fetchItems: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as ItemsHookReturn;
+}
+
+type MutationsHookReturn = ReturnType<typeof useWorkflowMutations>;
+function makeMutationsHook(overrides: Partial<MutationsHookReturn> = {}): MutationsHookReturn {
+  return {
+    createWorkflow: vi.fn(),
+    updateWorkflow: vi.fn(),
+    deleteWorkflow: vi.fn(),
+    runWorkflow: vi.fn(),
+    approveRun: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'running' }),
+    cancelRun: vi.fn().mockResolvedValue({ runId: 'run-1', status: 'cancelled' }),
+    duplicateWorkflow: vi.fn(),
+    setEnabled: vi.fn(),
+    isSaving: false,
+    error: null,
+    ...overrides,
+  } as MutationsHookReturn;
+}
+
+describe('WorkflowRunPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCircle.mockReturnValue(makeCircleContext());
+    mockUsePermissions.mockReturnValue(makePermissions());
+    mockUseWorkflowRunItems.mockReturnValue(makeItemsHook());
+    mockUseWorkflowMutations.mockReturnValue(makeMutationsHook());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Approval typed-confirmation gate
+  // -------------------------------------------------------------------------
+  describe('hard-delete typed confirmation gate', () => {
+    it('keeps Approve disabled until the exact "DELETE {matchedCount}" text is typed', async () => {
+      const user = userEvent.setup();
+      const run = makeRun({
+        matchedCount: 5,
+        definitionSnapshot: {
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'hard_delete' }],
+        },
+      });
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run }));
+
+      render(<WorkflowRunPage />);
+
+      const approveButton = screen.getByRole('button', { name: /approve & run/i });
+      expect(approveButton).toBeDisabled();
+
+      const confirmField = screen.getByPlaceholderText('DELETE 5');
+      await user.type(confirmField, 'DELETE 3');
+      expect(approveButton).toBeDisabled();
+      expect(screen.getByText('Confirmation text does not match.')).toBeInTheDocument();
+
+      await user.clear(confirmField);
+      await user.type(confirmField, 'DELETE 5');
+      expect(approveButton).toBeEnabled();
+    });
+
+    it('submits the exact confirmation string on approve', async () => {
+      const user = userEvent.setup();
+      const run = makeRun({
+        matchedCount: 5,
+        definitionSnapshot: {
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'hard_delete' }],
+        },
+      });
+      const approveRun = vi.fn().mockResolvedValue({ runId: 'run-1', status: 'running' });
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run }));
+      mockUseWorkflowMutations.mockReturnValue(makeMutationsHook({ approveRun }));
+
+      render(<WorkflowRunPage />);
+
+      await user.type(screen.getByPlaceholderText('DELETE 5'), 'DELETE 5');
+      await user.click(screen.getByRole('button', { name: /approve & run/i }));
+
+      expect(approveRun).toHaveBeenCalledWith('run-1', {
+        excludedItemIds: undefined,
+        confirmation: 'DELETE 5',
+      });
+    });
+
+    it('does not gate the Approve button when the run has no hard_delete action', () => {
+      const run = makeRun({ matchedCount: 5 }); // default action: move_to_trash
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run }));
+
+      render(<WorkflowRunPage />);
+
+      expect(screen.getByRole('button', { name: /approve & run/i })).toBeEnabled();
+      expect(screen.queryByText(/permanent deletion/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Exclusion checkboxes
+  // -------------------------------------------------------------------------
+  describe('exclusion checkboxes', () => {
+    it('accumulates excluded item ids and shows the effective-matched count', async () => {
+      const user = userEvent.setup();
+      const run = makeRun({ matchedCount: 5 });
+      const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run }));
+      mockUseWorkflowRunItems.mockReturnValue(makeItemsHook({ items }));
+
+      render(<WorkflowRunPage />);
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(3);
+
+      await user.click(checkboxes[0]);
+      await user.click(checkboxes[1]);
+
+      expect(screen.getByText(/2 excluded/)).toBeInTheDocument();
+      expect(screen.getByText(/3 will be affected/)).toBeInTheDocument();
+
+      // Unchecking restores it.
+      await user.click(checkboxes[0]);
+      expect(screen.getByText(/1 excluded/)).toBeInTheDocument();
+      expect(screen.getByText(/4 will be affected/)).toBeInTheDocument();
+    });
+
+    it('caps exclusions at 500 and disables further checkboxes once the cap is reached', () => {
+      // The item grid is unpaginated/unmemoized in the component, so
+      // rendering 500+ real Cards at once and clicking each one is
+      // computationally infeasible in jsdom (each click re-renders every
+      // sibling). Instead, this drives the SAME mounted page instance
+      // through 100 "pages" of 5 freshly-mocked items each — exactly how a
+      // real user would reach 500 exclusions by paging through the review
+      // grid — so `excluded` genuinely accumulates to 500 real ids via 500
+      // real checkbox clicks, without ever rendering more than 5 Cards at
+      // a time.
+      const PAGE_SIZE = 5;
+      const PAGES = 100; // 100 * 5 = exactly 500 distinct excluded ids
+      const run = makeRun({ matchedCount: 600 });
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run }));
+
+      let utils: ReturnType<typeof render> | undefined;
+      for (let page = 0; page < PAGES; page++) {
+        const items = Array.from({ length: PAGE_SIZE }, (_, i) => makeItem(`p${page}-${i}`));
+        mockUseWorkflowRunItems.mockReturnValue(makeItemsHook({ items }));
+        if (!utils) {
+          utils = render(<WorkflowRunPage />);
+        } else {
+          utils.rerender(<WorkflowRunPage />);
+        }
+        for (const cb of screen.getAllByRole('checkbox')) {
+          fireEvent.click(cb);
+        }
+      }
+
+      expect(screen.getByText(/exclusion limit reached \(500\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/500 excluded/)).toBeInTheDocument();
+
+      // A brand-new, never-before-seen item on the "next page": its
+      // checkbox is disabled on arrival because the cap is already hit, and
+      // clicking it has no effect.
+      const freshItem = makeItem('fresh-item');
+      mockUseWorkflowRunItems.mockReturnValue(makeItemsHook({ items: [freshItem] }));
+      utils!.rerender(<WorkflowRunPage />);
+
+      const [freshCheckbox] = screen.getAllByRole('checkbox');
+      expect(freshCheckbox).toBeDisabled();
+      fireEvent.click(freshCheckbox);
+      expect(freshCheckbox).not.toBeChecked();
+      expect(screen.getByText(/500 excluded/)).toBeInTheDocument();
+    }, 60000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Progress polling
+  // -------------------------------------------------------------------------
+  describe('progress polling', () => {
+    it('re-fetches the run every 2s while non-terminal, and stops once terminal', () => {
+      vi.useFakeTimers();
+      const fetchRun = vi.fn().mockResolvedValue(undefined);
+      const runningRun = makeRun({ status: 'running', matchedCount: 100, processedCount: 10 });
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: runningRun, fetchRun }));
+
+      const { rerender } = render(<WorkflowRunPage />);
+
+      // Initial mount fetch.
+      expect(fetchRun).toHaveBeenCalledTimes(1);
+      expect(fetchRun).toHaveBeenCalledWith('run-1');
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(fetchRun).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(fetchRun).toHaveBeenCalledTimes(3);
+
+      // The run reaches a terminal status — polling must stop.
+      const completedRun = makeRun({ status: 'completed', matchedCount: 100, processedCount: 100, succeededCount: 100 });
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: completedRun, fetchRun }));
+      rerender(<WorkflowRunPage />);
+
+      const callsAtTerminal = fetchRun.mock.calls.length;
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      expect(fetchRun).toHaveBeenCalledTimes(callsAtTerminal);
+    });
+
+    it('does not poll at all when the run starts already terminal', () => {
+      vi.useFakeTimers();
+      const fetchRun = vi.fn().mockResolvedValue(undefined);
+      const completedRun = makeRun({ status: 'completed', matchedCount: 10, processedCount: 10, succeededCount: 10 });
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: completedRun, fetchRun }));
+
+      render(<WorkflowRunPage />);
+      const callsAfterMount = fetchRun.mock.calls.length;
+
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      expect(fetchRun).toHaveBeenCalledTimes(callsAfterMount);
+    });
+  });
+});

--- a/apps/web/src/__tests__/pages/Workflows/builderState.test.ts
+++ b/apps/web/src/__tests__/pages/Workflows/builderState.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Unit tests for the workflow builder's draft state + reducer
+ * (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers: blank/template/workflow hydration (incl. deep-clone independence),
+ * `sanitizeDefinitionForPreview`, and every reducer branch (top-level and
+ * group-level condition edits, action list edits, safety options, and the
+ * wholesale `replace` used by hydration).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  builderReducer,
+  blankState,
+  stateFromTemplate,
+  stateFromWorkflow,
+  cloneDefinition,
+  sanitizeDefinitionForPreview,
+  type BuilderState,
+} from '../../../pages/Workflows/builderState';
+import { WORKFLOW_TEMPLATES } from '../../../constants/workflowTemplates';
+import type { Workflow, WorkflowDefinition } from '../../../types/workflows';
+
+function baseDefinition(): WorkflowDefinition {
+  return {
+    version: 1,
+    subject: 'media_item',
+    match: 'all',
+    conditions: [],
+    actions: [],
+    options: { requirePreview: true },
+  };
+}
+
+describe('blankState', () => {
+  it('produces an empty, manual-trigger draft with requirePreview on', () => {
+    const state = blankState();
+    expect(state).toEqual({
+      name: '',
+      description: '',
+      enabled: false,
+      trigger: 'manual',
+      cronExpression: '',
+      definition: {
+        version: 1,
+        subject: 'media_item',
+        match: 'all',
+        conditions: [],
+        actions: [],
+        options: { requirePreview: true },
+      },
+    });
+  });
+
+  it('returns a fresh object each call (no shared mutable state)', () => {
+    const a = blankState();
+    const b = blankState();
+    expect(a).not.toBe(b);
+    expect(a.definition).not.toBe(b.definition);
+  });
+});
+
+describe('stateFromTemplate', () => {
+  it('hydrates name/description/trigger/cron and deep-clones the definition', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+    const state = stateFromTemplate(template);
+
+    expect(state.name).toBe(template.name);
+    expect(state.description).toBe(template.description);
+    expect(state.enabled).toBe(false);
+    expect(state.trigger).toBe(template.suggestedTrigger);
+    expect(state.cronExpression).toBe('');
+    expect(state.definition).toEqual(template.definition);
+    expect(state.definition).not.toBe(template.definition);
+  });
+
+  it('falls back to an empty cron string when the template has no suggestedCron', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'trip-album')!;
+    expect(template.suggestedCron).toBeUndefined();
+    const state = stateFromTemplate(template);
+    expect(state.cronExpression).toBe('');
+  });
+
+  it('carries the suggestedCron through for a scheduled template', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'archive-social-videos')!;
+    const state = stateFromTemplate(template);
+    expect(state.cronExpression).toBe(template.suggestedCron);
+  });
+
+  it('never lets edits to the hydrated draft mutate the shared template constant', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+    const originalConditionCount = template.definition.conditions.length;
+
+    const state = stateFromTemplate(template);
+    state.definition.conditions.push({ field: 'extra', op: 'contains', value: 'x' });
+    state.definition.actions.push({ type: 'archive' });
+
+    expect(template.definition.conditions).toHaveLength(originalConditionCount);
+    expect(template.definition.actions).toEqual([{ type: 'move_to_trash' }]);
+  });
+});
+
+describe('stateFromWorkflow', () => {
+  function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+    return {
+      id: 'wf-1',
+      circleId: 'circle-1',
+      name: 'My workflow',
+      description: null,
+      subjectType: 'media_item',
+      enabled: true,
+      trigger: 'scheduled',
+      cronExpression: '0 3 * * *',
+      nextRunAt: null,
+      definition: baseDefinition(),
+      dependencies: [],
+      createdById: 'user-1',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('maps a null description to an empty string and a null cron to an empty string', () => {
+    const workflow = makeWorkflow({ description: null, trigger: 'manual', cronExpression: null });
+    const state = stateFromWorkflow(workflow);
+    expect(state.description).toBe('');
+    expect(state.cronExpression).toBe('');
+  });
+
+  it('preserves a real description/cron and deep-clones the definition', () => {
+    const workflow = makeWorkflow({ description: 'Nightly cleanup' });
+    const state = stateFromWorkflow(workflow);
+    expect(state.description).toBe('Nightly cleanup');
+    expect(state.enabled).toBe(true);
+    expect(state.trigger).toBe('scheduled');
+    expect(state.cronExpression).toBe('0 3 * * *');
+    expect(state.definition).toEqual(workflow.definition);
+    expect(state.definition).not.toBe(workflow.definition);
+  });
+});
+
+describe('cloneDefinition', () => {
+  it('produces a deep, independent copy', () => {
+    const def = baseDefinition();
+    def.conditions.push({ field: 'x', op: 'contains', value: 'y' });
+    const clone = cloneDefinition(def);
+    expect(clone).toEqual(def);
+    clone.conditions.push({ field: 'z', op: 'contains', value: 'w' });
+    expect(def.conditions).toHaveLength(1);
+    expect(clone.conditions).toHaveLength(2);
+  });
+});
+
+describe('sanitizeDefinitionForPreview', () => {
+  it('drops a half-built top-level leaf (no field/op)', () => {
+    const def: WorkflowDefinition = {
+      ...baseDefinition(),
+      conditions: [
+        { field: '', op: '' },
+        { field: 'country', op: 'equals', value: 'Italy' },
+      ],
+    };
+    const result = sanitizeDefinitionForPreview(def);
+    expect(result.conditions).toEqual([{ field: 'country', op: 'equals', value: 'Italy' }]);
+  });
+
+  it('drops a group that becomes empty after filtering incomplete leaves', () => {
+    const def: WorkflowDefinition = {
+      ...baseDefinition(),
+      conditions: [
+        {
+          match: 'all',
+          conditions: [{ field: '', op: '' }],
+        },
+      ],
+    };
+    const result = sanitizeDefinitionForPreview(def);
+    expect(result.conditions).toEqual([]);
+  });
+
+  it('keeps a group but drops only its incomplete member leaves', () => {
+    const def: WorkflowDefinition = {
+      ...baseDefinition(),
+      conditions: [
+        {
+          match: 'all',
+          conditions: [
+            { field: 'country', op: 'equals', value: 'Italy' },
+            { field: '', op: '' },
+          ],
+        },
+      ],
+    };
+    const result = sanitizeDefinitionForPreview(def);
+    expect(result.conditions).toEqual([
+      { match: 'all', conditions: [{ field: 'country', op: 'equals', value: 'Italy' }] },
+    ]);
+  });
+
+  it('does not mutate the input definition', () => {
+    const def: WorkflowDefinition = {
+      ...baseDefinition(),
+      conditions: [{ field: '', op: '' }],
+    };
+    const before = JSON.stringify(def);
+    sanitizeDefinitionForPreview(def);
+    expect(JSON.stringify(def)).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+describe('builderReducer', () => {
+  it('handles setName/setDescription/setEnabled/setTrigger/setCron', () => {
+    let state = blankState();
+    state = builderReducer(state, { kind: 'setName', value: 'My workflow' });
+    expect(state.name).toBe('My workflow');
+    state = builderReducer(state, { kind: 'setDescription', value: 'desc' });
+    expect(state.description).toBe('desc');
+    state = builderReducer(state, { kind: 'setEnabled', value: true });
+    expect(state.enabled).toBe(true);
+    state = builderReducer(state, { kind: 'setTrigger', value: 'scheduled' });
+    expect(state.trigger).toBe('scheduled');
+    state = builderReducer(state, { kind: 'setCron', value: '0 3 * * *' });
+    expect(state.cronExpression).toBe('0 3 * * *');
+  });
+
+  it('handles setMatch at the top level', () => {
+    let state = blankState();
+    state = builderReducer(state, { kind: 'setMatch', value: 'any' });
+    expect(state.definition.match).toBe('any');
+  });
+
+  describe('top-level conditions', () => {
+    it('addLeaf appends an empty leaf', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addLeaf' });
+      expect(state.definition.conditions).toEqual([{ field: '', op: '' }]);
+    });
+
+    it('addGroup appends a group with one empty leaf and match "all"', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addGroup' });
+      expect(state.definition.conditions).toEqual([
+        { match: 'all', conditions: [{ field: '', op: '' }] },
+      ]);
+    });
+
+    it('updateLeaf patches only the targeted top-level leaf', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addLeaf' });
+      state = builderReducer(state, { kind: 'addLeaf' });
+      state = builderReducer(state, {
+        kind: 'updateLeaf',
+        index: 1,
+        patch: { field: 'country', op: 'equals', value: 'Italy' },
+      });
+      expect(state.definition.conditions).toEqual([
+        { field: '', op: '' },
+        { field: 'country', op: 'equals', value: 'Italy' },
+      ]);
+    });
+
+    it('updateLeaf is a no-op when the target index is a group', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addGroup' });
+      const before = state.definition.conditions[0];
+      state = builderReducer(state, {
+        kind: 'updateLeaf',
+        index: 0,
+        patch: { field: 'country' },
+      });
+      expect(state.definition.conditions[0]).toEqual(before);
+    });
+
+    it('removeTop removes the condition at the given index', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addLeaf' });
+      state = builderReducer(state, { kind: 'addGroup' });
+      state = builderReducer(state, { kind: 'removeTop', index: 0 });
+      expect(state.definition.conditions).toHaveLength(1);
+      expect(state.definition.conditions[0]).toEqual({ match: 'all', conditions: [{ field: '', op: '' }] });
+    });
+  });
+
+  describe('group-level conditions', () => {
+    function withOneGroup(): BuilderState {
+      return builderReducer(blankState(), { kind: 'addGroup' });
+    }
+
+    it('setGroupMatch updates only the targeted group', () => {
+      let state = withOneGroup();
+      state = builderReducer(state, { kind: 'setGroupMatch', groupIndex: 0, value: 'any' });
+      expect(state.definition.conditions).toEqual([
+        { match: 'any', conditions: [{ field: '', op: '' }] },
+      ]);
+    });
+
+    it('addGroupLeaf appends an empty leaf inside the group', () => {
+      let state = withOneGroup();
+      state = builderReducer(state, { kind: 'addGroupLeaf', groupIndex: 0 });
+      const group = state.definition.conditions[0] as { conditions: unknown[] };
+      expect(group.conditions).toHaveLength(2);
+    });
+
+    it('updateGroupLeaf patches only the targeted child leaf', () => {
+      let state = withOneGroup();
+      state = builderReducer(state, { kind: 'addGroupLeaf', groupIndex: 0 });
+      state = builderReducer(state, {
+        kind: 'updateGroupLeaf',
+        groupIndex: 0,
+        childIndex: 1,
+        patch: { field: 'country', op: 'equals', value: 'Italy' },
+      });
+      expect(state.definition.conditions).toEqual([
+        {
+          match: 'all',
+          conditions: [
+            { field: '', op: '' },
+            { field: 'country', op: 'equals', value: 'Italy' },
+          ],
+        },
+      ]);
+    });
+
+    it('removeGroupLeaf removes only the targeted child leaf', () => {
+      let state = withOneGroup();
+      state = builderReducer(state, { kind: 'addGroupLeaf', groupIndex: 0 });
+      state = builderReducer(state, { kind: 'removeGroupLeaf', groupIndex: 0, childIndex: 0 });
+      const group = state.definition.conditions[0] as { conditions: unknown[] };
+      expect(group.conditions).toHaveLength(1);
+    });
+
+    it('group-scoped actions never touch a top-level leaf at the same index', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addLeaf' }); // index 0: a plain leaf, not a group
+      state = builderReducer(state, {
+        kind: 'setGroupMatch',
+        groupIndex: 0,
+        value: 'any',
+      });
+      // No group exists at index 0, so the leaf is untouched.
+      expect(state.definition.conditions).toEqual([{ field: '', op: '' }]);
+    });
+  });
+
+  describe('actions', () => {
+    it('addAction appends to the end', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'move_to_trash' } });
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'archive' } });
+      expect(state.definition.actions).toEqual([{ type: 'move_to_trash' }, { type: 'archive' }]);
+    });
+
+    it('setAction replaces the action at the given index', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'move_to_trash' } });
+      state = builderReducer(state, {
+        kind: 'setAction',
+        index: 0,
+        action: { type: 'add_tags', names: ['x'] },
+      });
+      expect(state.definition.actions).toEqual([{ type: 'add_tags', names: ['x'] }]);
+    });
+
+    it('removeAction removes the action at the given index', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'move_to_trash' } });
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'archive' } });
+      state = builderReducer(state, { kind: 'removeAction', index: 0 });
+      expect(state.definition.actions).toEqual([{ type: 'archive' }]);
+    });
+
+    it('moveAction swaps adjacent actions', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'a' } });
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'b' } });
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'c' } });
+      state = builderReducer(state, { kind: 'moveAction', index: 0, direction: 1 });
+      expect(state.definition.actions.map((a) => a.type)).toEqual(['b', 'a', 'c']);
+    });
+
+    it('moveAction is a no-op moving the first action up', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'a' } });
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'b' } });
+      const before = state;
+      const after = builderReducer(state, { kind: 'moveAction', index: 0, direction: -1 });
+      expect(after).toBe(before);
+    });
+
+    it('moveAction is a no-op moving the last action down', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'a' } });
+      state = builderReducer(state, { kind: 'addAction', action: { type: 'b' } });
+      const before = state;
+      const after = builderReducer(state, { kind: 'moveAction', index: 1, direction: 1 });
+      expect(after).toBe(before);
+    });
+  });
+
+  describe('safety options', () => {
+    it('setMaxItems sets a value', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'setMaxItems', value: 500 });
+      expect(state.definition.options?.maxItems).toBe(500);
+    });
+
+    it('setMaxItems with undefined clears a previously-set value', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'setMaxItems', value: 500 });
+      state = builderReducer(state, { kind: 'setMaxItems', value: undefined });
+      expect(state.definition.options?.maxItems).toBeUndefined();
+      expect('maxItems' in (state.definition.options ?? {})).toBe(false);
+    });
+
+    it('setRequirePreview sets the flag without disturbing maxItems', () => {
+      let state = blankState();
+      state = builderReducer(state, { kind: 'setMaxItems', value: 100 });
+      state = builderReducer(state, { kind: 'setRequirePreview', value: false });
+      expect(state.definition.options).toEqual({ requirePreview: false, maxItems: 100 });
+    });
+  });
+
+  it('replace swaps in a wholesale new state (template/workflow hydration)', () => {
+    const state = blankState();
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+    const hydrated = stateFromTemplate(template);
+    const result = builderReducer(state, { kind: 'replace', state: hydrated });
+    expect(result).toBe(hydrated);
+  });
+
+  it('returns the same state reference for an unknown action kind (defensive default)', () => {
+    const state = blankState();
+    // @ts-expect-error — deliberately exercising the reducer's default branch.
+    const result = builderReducer(state, { kind: 'not_a_real_action' });
+    expect(result).toBe(state);
+  });
+});

--- a/apps/web/src/__tests__/utils/workflowCron.test.ts
+++ b/apps/web/src/__tests__/utils/workflowCron.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for workflowCron.ts (issue #141 — Workflows Phase 3 web UI).
+ *
+ * `isValidCron` enforces standard 5-field cron syntax PLUS an hourly floor:
+ * the minute field must be a single fixed integer (no wildcard, step, list,
+ * or range), so nothing runs more often than once an hour.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isValidCron,
+  CRON_PRESETS,
+  CRON_MIN_INTERVAL_HINT,
+} from '../../utils/workflowCron';
+
+describe('isValidCron', () => {
+  describe('valid expressions', () => {
+    it('accepts a plain daily expression', () => {
+      expect(isValidCron('0 3 * * *')).toBe(true);
+    });
+
+    it('accepts a weekly expression with a day-of-week', () => {
+      expect(isValidCron('0 4 * * 0')).toBe(true);
+    });
+
+    it('accepts a monthly expression with a day-of-month', () => {
+      expect(isValidCron('0 5 1 * *')).toBe(true);
+    });
+
+    it('accepts a range in the day-of-month field', () => {
+      expect(isValidCron('0 6 1-15 * *')).toBe(true);
+    });
+
+    it('accepts a list in the month field', () => {
+      expect(isValidCron('0 6 1 1,6,12 *')).toBe(true);
+    });
+
+    it('accepts a step in a non-minute field', () => {
+      expect(isValidCron('0 */2 * * *')).toBe(true);
+    });
+
+    it('accepts day-of-week 7 (alternate Sunday)', () => {
+      expect(isValidCron('0 4 * * 7')).toBe(true);
+    });
+
+    it('tolerates surrounding whitespace and multi-space separators', () => {
+      expect(isValidCron('  0   3  *  *  *  ')).toBe(true);
+    });
+  });
+
+  describe('invalid expressions — hourly floor', () => {
+    it('rejects a wildcard minute field (would run every minute)', () => {
+      expect(isValidCron('* * * * *')).toBe(false);
+    });
+
+    it('rejects a step minute field (sub-hourly)', () => {
+      expect(isValidCron('*/15 * * * *')).toBe(false);
+    });
+
+    it('rejects a list minute field', () => {
+      expect(isValidCron('0,30 * * * *')).toBe(false);
+    });
+
+    it('rejects a range minute field', () => {
+      expect(isValidCron('0-30 * * * *')).toBe(false);
+    });
+  });
+
+  describe('invalid expressions — malformed', () => {
+    it('rejects the wrong number of fields', () => {
+      expect(isValidCron('0 3 * *')).toBe(false);
+      expect(isValidCron('0 3 * * * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range hour', () => {
+      expect(isValidCron('0 24 * * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range day-of-month', () => {
+      expect(isValidCron('0 3 32 * *')).toBe(false);
+      expect(isValidCron('0 3 0 * *')).toBe(false);
+    });
+
+    it('rejects an out-of-range month', () => {
+      expect(isValidCron('0 3 1 13 *')).toBe(false);
+    });
+
+    it('rejects an out-of-range day-of-week', () => {
+      expect(isValidCron('0 3 * * 8')).toBe(false);
+    });
+
+    it('rejects a non-numeric field', () => {
+      expect(isValidCron('0 abc * * *')).toBe(false);
+    });
+
+    it('rejects an inverted range (a > b)', () => {
+      expect(isValidCron('0 3 20-10 * *')).toBe(false);
+    });
+
+    it('rejects a non-positive step value', () => {
+      expect(isValidCron('0 */0 * * *')).toBe(false);
+    });
+
+    it('rejects an empty string', () => {
+      expect(isValidCron('')).toBe(false);
+    });
+
+    it('rejects non-string input defensively', () => {
+      // @ts-expect-error — deliberately passing a non-string to verify the
+      // runtime guard, since callers may pass an untyped form value.
+      expect(isValidCron(null)).toBe(false);
+      // @ts-expect-error — same as above.
+      expect(isValidCron(undefined)).toBe(false);
+    });
+  });
+});
+
+describe('CRON_PRESETS', () => {
+  it('exposes exactly the nightly / weekly / monthly presets', () => {
+    expect(CRON_PRESETS).toHaveLength(3);
+    expect(CRON_PRESETS.map((p) => p.id)).toEqual(['nightly', 'weekly', 'monthly']);
+  });
+
+  it('every preset expression is itself valid under isValidCron', () => {
+    for (const preset of CRON_PRESETS) {
+      expect(isValidCron(preset.expression)).toBe(true);
+    }
+  });
+});
+
+describe('CRON_MIN_INTERVAL_HINT', () => {
+  it('is a non-empty explanatory string', () => {
+    expect(typeof CRON_MIN_INTERVAL_HINT).toBe('string');
+    expect(CRON_MIN_INTERVAL_HINT.length).toBeGreaterThan(0);
+    expect(CRON_MIN_INTERVAL_HINT.toLowerCase()).toContain('hour');
+  });
+});

--- a/apps/web/src/__tests__/utils/workflowFormat.test.ts
+++ b/apps/web/src/__tests__/utils/workflowFormat.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit tests for workflowFormat.ts (issue #141 — Workflows Phase 3 web UI).
+ *
+ * Covers the pure formatting helpers used by the run review/progress page and
+ * the builder: cronToText, runStatusColor/Label, deriveActionImpacts,
+ * hardDeleteConfirmationText, definitionHasHardDelete, describeWorkflowAction,
+ * and isTerminalRunStatus.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  cronToText,
+  runStatusColor,
+  runStatusLabel,
+  isTerminalRunStatus,
+  formatCount,
+  hardDeleteConfirmationText,
+  definitionHasHardDelete,
+  describeWorkflowAction,
+  deriveActionImpacts,
+} from '../../utils/workflowFormat';
+import type {
+  WorkflowRunStatus,
+  WorkflowDefinition,
+  WorkflowActionInstance,
+} from '../../types/workflows';
+
+// ---------------------------------------------------------------------------
+// cronToText
+// ---------------------------------------------------------------------------
+
+describe('cronToText', () => {
+  it('returns empty string for null', () => {
+    expect(cronToText(null)).toBe('');
+  });
+
+  it('renders a daily schedule', () => {
+    expect(cronToText('0 3 * * *')).toBe('Daily at 3:00 AM');
+  });
+
+  it('renders midnight and noon correctly (12-hour boundary)', () => {
+    expect(cronToText('0 0 * * *')).toBe('Daily at 12:00 AM');
+    expect(cronToText('0 12 * * *')).toBe('Daily at 12:00 PM');
+  });
+
+  it('renders a weekly schedule with the correct weekday name', () => {
+    expect(cronToText('0 4 * * 0')).toBe('Weekly on Sunday at 4:00 AM');
+    expect(cronToText('30 9 * * 3')).toBe('Weekly on Wednesday at 9:30 AM');
+  });
+
+  it('treats day-of-week 7 as Sunday', () => {
+    expect(cronToText('0 4 * * 7')).toBe('Weekly on Sunday at 4:00 AM');
+  });
+
+  it('renders a monthly schedule', () => {
+    expect(cronToText('0 5 1 * *')).toBe('Monthly on day 1 at 5:00 AM');
+    expect(cronToText('15 22 28 * *')).toBe('Monthly on day 28 at 10:15 PM');
+  });
+
+  it('falls back to the raw cron string for an unrecognized shape', () => {
+    // Both day-of-month and month set — not one of the three known shapes.
+    expect(cronToText('0 3 1 6 *')).toBe('Cron: 0 3 1 6 *');
+  });
+
+  it('falls back for the wrong field count', () => {
+    expect(cronToText('0 3 * *')).toBe('Cron: 0 3 * *');
+  });
+
+  it('falls back for a non-numeric minute/hour', () => {
+    expect(cronToText('a b * * *')).toBe('Cron: a b * * *');
+  });
+
+  it('falls back for an out-of-range hour', () => {
+    expect(cronToText('0 99 * * *')).toBe('Cron: 0 99 * * *');
+  });
+
+  it('never throws on garbage input', () => {
+    expect(() => cronToText('not a cron expression at all')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStatusColor / runStatusLabel
+// ---------------------------------------------------------------------------
+
+describe('runStatusColor', () => {
+  it.each<[WorkflowRunStatus, string]>([
+    ['evaluating', 'info'],
+    ['running', 'info'],
+    ['awaiting_approval', 'warning'],
+    ['completed', 'success'],
+    ['completed_with_errors', 'warning'],
+    ['failed', 'error'],
+    ['cancelled', 'default'],
+    ['expired', 'default'],
+  ])('maps %s to %s', (status, color) => {
+    expect(runStatusColor(status)).toBe(color);
+  });
+});
+
+describe('runStatusLabel', () => {
+  it('title-cases only the first word and keeps underscores as spaces', () => {
+    expect(runStatusLabel('awaiting_approval')).toBe('Awaiting approval');
+    expect(runStatusLabel('completed_with_errors')).toBe('Completed with errors');
+    expect(runStatusLabel('completed')).toBe('Completed');
+    expect(runStatusLabel('failed')).toBe('Failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTerminalRunStatus
+// ---------------------------------------------------------------------------
+
+describe('isTerminalRunStatus', () => {
+  it.each<WorkflowRunStatus>(['completed', 'completed_with_errors', 'failed', 'cancelled', 'expired'])(
+    'treats %s as terminal',
+    (status) => {
+      expect(isTerminalRunStatus(status)).toBe(true);
+    },
+  );
+
+  it.each<WorkflowRunStatus>(['evaluating', 'awaiting_approval', 'running'])(
+    'treats %s as non-terminal',
+    (status) => {
+      expect(isTerminalRunStatus(status)).toBe(false);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// formatCount
+// ---------------------------------------------------------------------------
+
+describe('formatCount', () => {
+  it('adds thousands separators', () => {
+    expect(formatCount(2481)).toBe('2,481');
+    expect(formatCount(10000)).toBe('10,000');
+  });
+
+  it('rounds fractional input', () => {
+    expect(formatCount(3.7)).toBe('4');
+  });
+
+  it('falls back to 0 for non-finite input', () => {
+    expect(formatCount(NaN)).toBe('0');
+    expect(formatCount(Infinity)).toBe('0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hardDeleteConfirmationText
+// ---------------------------------------------------------------------------
+
+describe('hardDeleteConfirmationText', () => {
+  it('formats the exact backend-required confirmation string', () => {
+    expect(hardDeleteConfirmationText(2481)).toBe('DELETE 2481');
+  });
+
+  it('does not use thousands separators (raw integer only)', () => {
+    expect(hardDeleteConfirmationText(10000)).toBe('DELETE 10000');
+  });
+
+  it('handles zero matches', () => {
+    expect(hardDeleteConfirmationText(0)).toBe('DELETE 0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// definitionHasHardDelete
+// ---------------------------------------------------------------------------
+
+describe('definitionHasHardDelete', () => {
+  const baseDef: WorkflowDefinition = {
+    version: 1,
+    subject: 'media_item',
+    match: 'all',
+    conditions: [],
+    actions: [],
+  };
+
+  it('returns true when a hard_delete action is present', () => {
+    const def: WorkflowDefinition = { ...baseDef, actions: [{ type: 'hard_delete' }] };
+    expect(definitionHasHardDelete(def)).toBe(true);
+  });
+
+  it('returns false when no hard_delete action is present', () => {
+    const def: WorkflowDefinition = { ...baseDef, actions: [{ type: 'move_to_trash' }] };
+    expect(definitionHasHardDelete(def)).toBe(false);
+  });
+
+  it('returns false for null/undefined definitions (defensive)', () => {
+    expect(definitionHasHardDelete(null)).toBe(false);
+    expect(definitionHasHardDelete(undefined)).toBe(false);
+  });
+
+  it('returns false when actions is not an array (defensive)', () => {
+    const malformed = { ...baseDef, actions: undefined } as unknown as WorkflowDefinition;
+    expect(definitionHasHardDelete(malformed)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeWorkflowAction
+// ---------------------------------------------------------------------------
+
+describe('describeWorkflowAction', () => {
+  it('describes simple no-param actions', () => {
+    expect(describeWorkflowAction({ type: 'move_to_trash' })).toBe('Move to Trash');
+    expect(describeWorkflowAction({ type: 'archive' })).toBe('Archive');
+    expect(describeWorkflowAction({ type: 'unarchive' })).toBe('Unarchive');
+    expect(describeWorkflowAction({ type: 'hard_delete' })).toBe('Permanently delete');
+  });
+
+  it('describes set_favorite based on the boolean value', () => {
+    expect(describeWorkflowAction({ type: 'set_favorite', favorite: true })).toBe('Mark favorite');
+    expect(describeWorkflowAction({ type: 'set_favorite', favorite: false })).toBe('Unmark favorite');
+  });
+
+  it('describes move_to_circle with the target name when present', () => {
+    expect(
+      describeWorkflowAction({ type: 'move_to_circle', targetCircleName: 'Family' }),
+    ).toBe("Move to circle 'Family'");
+    expect(describeWorkflowAction({ type: 'move_to_circle' })).toBe('Move to circle');
+  });
+
+  it('describes add_to_album, preferring createAlbumNamed over albumName/albumId', () => {
+    expect(
+      describeWorkflowAction({ type: 'add_to_album', createAlbumNamed: 'Italy 2025' }),
+    ).toBe("Add to album 'Italy 2025'");
+    expect(
+      describeWorkflowAction({ type: 'add_to_album', albumName: 'Existing Album' }),
+    ).toBe("Add to album 'Existing Album'");
+    expect(describeWorkflowAction({ type: 'add_to_album' })).toBe('Add to album');
+  });
+
+  it('describes add_tags/remove_tags with a comma-joined tag list (reads the real `names` param)', () => {
+    // `add_tags`/`remove_tags` (plural) with a `names` array is the actual
+    // shape used everywhere else (templates, ActionsBlock, the backend
+    // registry) — see ACTION_PARAM_KIND in workflowActionMeta.ts.
+    expect(describeWorkflowAction({ type: 'add_tags', names: ['screenshot'] })).toBe(
+      "Add tag 'screenshot'",
+    );
+    expect(
+      describeWorkflowAction({ type: 'add_tags', names: ['a', 'b'] }),
+    ).toBe("Add tag 'a', 'b'");
+    expect(describeWorkflowAction({ type: 'remove_tags', names: ['old'] })).toBe(
+      "Remove tag 'old'",
+    );
+    expect(describeWorkflowAction({ type: 'add_tags' })).toBe('Add tag');
+  });
+
+  it('describes resolve_duplicate_group / resolve_burst_group by action outcome', () => {
+    expect(
+      describeWorkflowAction({ type: 'resolve_duplicate_group', action: 'trash' }),
+    ).toBe('Resolve duplicate groups: keep best, trash the rest');
+    expect(
+      describeWorkflowAction({ type: 'resolve_duplicate_group', action: 'archive' }),
+    ).toBe('Resolve duplicate groups: keep best, archive the rest');
+    expect(
+      describeWorkflowAction({ type: 'resolve_burst_group', action: 'archive' }),
+    ).toBe('Resolve burst groups: keep best, archive the rest');
+  });
+
+  it('describes add_person with the person name when present', () => {
+    expect(describeWorkflowAction({ type: 'add_person', personName: 'Alice' })).toBe(
+      "Tag person 'Alice'",
+    );
+    expect(describeWorkflowAction({ type: 'add_person' })).toBe('Tag person');
+  });
+
+  it('falls back to a prettified type for unknown action types', () => {
+    expect(describeWorkflowAction({ type: 'some_future_action' })).toBe('Some Future Action');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveActionImpacts
+// ---------------------------------------------------------------------------
+
+describe('deriveActionImpacts', () => {
+  it('returns an empty array for non-array input (defensive)', () => {
+    expect(deriveActionImpacts(null, 10)).toEqual([]);
+    expect(deriveActionImpacts(undefined, 10)).toEqual([]);
+  });
+
+  it('uses the effective (matched-minus-excluded) count when no byActionType is given', () => {
+    const actions: WorkflowActionInstance[] = [{ type: 'move_to_trash' }];
+    const impacts = deriveActionImpacts(actions, 2481);
+    expect(impacts).toEqual([{ key: 'move_to_trash-0', label: 'Move to Trash', count: 2481 }]);
+  });
+
+  it('clamps a negative effective count to zero', () => {
+    const impacts = deriveActionImpacts([{ type: 'archive' }], -5);
+    expect(impacts[0].count).toBe(0);
+  });
+
+  it('prefers the applied count from byActionType once the run has begun applying', () => {
+    const actions: WorkflowActionInstance[] = [
+      { type: 'move_to_trash' },
+      { type: 'add_tags', names: ['screenshot'] },
+    ];
+    const impacts = deriveActionImpacts(actions, 2481, {
+      move_to_trash: { applied: 34, failed: 1, skipped: 0 },
+    });
+    expect(impacts[0]).toEqual({ key: 'move_to_trash-0', label: 'Move to Trash', count: 34 });
+    // No byActionType entry for add_tags yet — falls back to the effective count.
+    expect(impacts[1]).toEqual({
+      key: 'add_tags-1',
+      label: "Add tag 'screenshot'",
+      count: 2481,
+    });
+  });
+
+  it('produces a stable key per action ordinal even for duplicate types', () => {
+    const impacts = deriveActionImpacts(
+      [{ type: 'archive' }, { type: 'archive' }],
+      5,
+    );
+    expect(impacts.map((i) => i.key)).toEqual(['archive-0', 'archive-1']);
+  });
+});

--- a/apps/web/src/__tests__/utils/workflowSentence.test.ts
+++ b/apps/web/src/__tests__/utils/workflowSentence.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for workflowSentence.ts (issue #141 — Workflows Phase 3 web UI).
+ *
+ * `definitionToSentence` renders a WorkflowDefinition as one plain-English
+ * sentence for the live builder summary. It is pure, defensive, and never
+ * throws — unknown fields/operators/actions fall back gracefully.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { definitionToSentence } from '../../utils/workflowSentence';
+import { WORKFLOW_TEMPLATES } from '../../constants/workflowTemplates';
+import type {
+  WorkflowDefinition,
+  WorkflowFieldDescriptor,
+  SubjectRegistryEntry,
+} from '../../types/workflows';
+
+function field(
+  key: string,
+  label: string,
+  overrides: Partial<WorkflowFieldDescriptor> = {},
+): WorkflowFieldDescriptor {
+  return {
+    key,
+    label,
+    group: 'File',
+    type: 'string',
+    operators: ['contains', 'equals', 'is_set'],
+    valueType: 'string',
+    dependency: 'metadata',
+    ...overrides,
+  };
+}
+
+const SUBJECT: SubjectRegistryEntry = {
+  subject: 'media_item',
+  label: 'Media Items',
+  triggers: ['manual', 'on_media_enriched', 'scheduled'],
+  fields: [
+    field('filename', 'Filename'),
+    field('mimeType', 'Mime type', { type: 'enum', valueType: 'enum', enumValues: ['image/png'] }),
+    field('missingCamera', 'Missing camera', { type: 'boolean', valueType: 'boolean', operators: ['is'] }),
+    field('missingCapturedAt', 'Missing capture date', {
+      type: 'boolean',
+      valueType: 'boolean',
+      operators: ['is'],
+    }),
+    field('socialMediaSource', 'Social media source', { operators: ['is_set'] }),
+    field('capturedAt', 'Capture date', { group: 'Dates', type: 'date', valueType: 'date-range' }),
+    field('country', 'Country', { group: 'Location' }),
+    field('tags', 'Tags', { group: 'Tags', type: 'tag-set', valueType: 'string-list', operators: ['has_any', 'has_all', 'has_none'] }),
+    field('inPendingDuplicateGroup', 'In a pending duplicate group', {
+      group: 'Review',
+      type: 'boolean',
+      valueType: 'boolean',
+      operators: ['is'],
+    }),
+    field('duplicateGroupConfidence', 'Duplicate group confidence', {
+      group: 'Review',
+      type: 'number',
+      valueType: 'number',
+      operators: ['gte'],
+    }),
+    field('nearLocation', 'Near a location', {
+      group: 'Location',
+      type: 'geo-radius',
+      valueType: 'geo-radius',
+      operators: ['near'],
+    }),
+  ],
+  actions: [
+    { type: 'move_to_trash', label: 'Move to Trash' },
+    { type: 'archive', label: 'Archive' },
+    { type: 'add_to_album', label: 'Add to album' },
+    { type: 'add_tags', label: 'Add tags' },
+    { type: 'resolve_duplicate_group', label: 'Resolve duplicate group' },
+  ],
+};
+
+const BASE_DEF: WorkflowDefinition = {
+  version: 1,
+  subject: 'media_item',
+  match: 'all',
+  conditions: [],
+  actions: [],
+};
+
+describe('definitionToSentence', () => {
+  it('renders the "Clean up screenshots" template exactly (OR of a leaf and a nested AND group)', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-screenshots')!;
+    const sentence = definitionToSentence(
+      template.definition,
+      SUBJECT,
+      template.suggestedTrigger,
+      template.suggestedCron ?? undefined,
+    );
+
+    expect(sentence).toBe(
+      'When new media is enriched, if the filename contains “screenshot” or ' +
+        '(the mime type is image/png, missing camera and missing capture date), move it to Trash.',
+    );
+  });
+
+  it('renders a nested group with an internal OR, combined with a top-level AND', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      match: 'all',
+      conditions: [
+        { field: 'country', op: 'equals', value: 'Italy' },
+        {
+          match: 'any',
+          conditions: [
+            { field: 'missingCamera', op: 'is', value: true },
+            { field: 'missingCapturedAt', op: 'is', value: true },
+          ],
+        },
+      ],
+      actions: [{ type: 'archive' }],
+    };
+    const sentence = definitionToSentence(def, SUBJECT, 'manual');
+    expect(sentence).toBe(
+      'When you run this workflow, if the country is “Italy” and ' +
+        '(missing camera or missing capture date), archive it.',
+    );
+  });
+
+  it('renders the "Archive social-media videos" template with a scheduled trigger and is_set operator', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'archive-social-videos')!;
+    const sentence = definitionToSentence(
+      template.definition,
+      SUBJECT,
+      template.suggestedTrigger,
+      template.suggestedCron ?? undefined,
+    );
+    expect(sentence).toBe(
+      'Daily at 3:00 AM, if the social media source is set, archive it.',
+    );
+  });
+
+  it('renders a between date range condition with both bounds', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [
+        { field: 'capturedAt', op: 'between', value: { from: '2025-06-01', to: '2025-06-14' } },
+      ],
+      actions: [{ type: 'add_to_album', createAlbumNamed: 'Italy 2025' }],
+    };
+    const sentence = definitionToSentence(def, SUBJECT, 'manual');
+    expect(sentence).toBe(
+      'When you run this workflow, if the capture date is between 2025-06-01 and 2025-06-14, ' +
+        'add it to a new album “Italy 2025”.',
+    );
+  });
+
+  it('renders a from-only and a to-only date range distinctly', () => {
+    const fromOnly = definitionToSentence(
+      { ...BASE_DEF, conditions: [{ field: 'capturedAt', op: 'between', value: { from: '2025-01-01' } }] },
+      SUBJECT,
+      'manual',
+    );
+    expect(fromOnly).toContain('the capture date is on or after 2025-01-01');
+
+    const toOnly = definitionToSentence(
+      { ...BASE_DEF, conditions: [{ field: 'capturedAt', op: 'between', value: { to: '2025-01-01' } }] },
+      SUBJECT,
+      'manual',
+    );
+    expect(toOnly).toContain('the capture date is on or before 2025-01-01');
+  });
+
+  it('renders has_any tag-list phrasing', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [{ field: 'tags', op: 'has_any', value: ['WhatsApp', 'Screenshot'] }],
+      actions: [{ type: 'add_tags', names: ['WhatsApp'] }],
+    };
+    const sentence = definitionToSentence(def, SUBJECT, 'manual');
+    expect(sentence).toContain(
+      'it has any of the tags “WhatsApp”, “Screenshot”',
+    );
+    expect(sentence).toContain('tag it “WhatsApp”');
+  });
+
+  it('renders a "near" geo-radius condition', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [{ field: 'nearLocation', op: 'near', value: { lat: 1, lng: 2, radiusKm: 25 } }],
+      actions: [{ type: 'archive' }],
+    };
+    const sentence = definitionToSentence(def, SUBJECT, 'manual');
+    expect(sentence).toContain('it is within 25 km of the selected location');
+  });
+
+  it('renders the "Clean up duplicates" template with gte and boolean-true review conditions', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'clean-up-duplicates')!;
+    const sentence = definitionToSentence(
+      template.definition,
+      SUBJECT,
+      template.suggestedTrigger,
+      template.suggestedCron ?? undefined,
+    );
+    expect(sentence).toBe(
+      'Weekly on Sunday at 4:00 AM, if in a pending duplicate group and ' +
+        'the duplicate group confidence is at least 0.9, keep the best copy and trash the duplicates.',
+    );
+  });
+
+  it('renders "for every item" when there are no conditions', () => {
+    const sentence = definitionToSentence(
+      { ...BASE_DEF, conditions: [], actions: [{ type: 'archive' }] },
+      SUBJECT,
+      'manual',
+    );
+    expect(sentence).toContain('for every item');
+  });
+
+  it('renders "do nothing yet" when there are no actions', () => {
+    const sentence = definitionToSentence(
+      { ...BASE_DEF, conditions: [{ field: 'country', op: 'equals', value: 'Italy' }], actions: [] },
+      SUBJECT,
+      'manual',
+    );
+    expect(sentence).toContain('do nothing yet');
+  });
+
+  it('falls back to "When you run this workflow" for a manual/undefined trigger', () => {
+    const sentence = definitionToSentence(BASE_DEF, SUBJECT, undefined);
+    expect(sentence.startsWith('When you run this workflow,')).toBe(true);
+  });
+
+  it('is defensive against an incomplete condition (missing field descriptor)', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [{ field: 'unknownField', op: 'contains', value: 'x' }],
+      actions: [{ type: 'archive' }],
+    };
+    expect(() => definitionToSentence(def, SUBJECT, 'manual')).not.toThrow();
+    expect(definitionToSentence(def, SUBJECT, 'manual')).toContain('(incomplete condition)');
+  });
+
+  it('is defensive when subjectEntry is undefined (registry not yet loaded)', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [{ field: 'country', op: 'equals', value: 'Italy' }],
+      actions: [{ type: 'archive' }],
+    };
+    expect(() => definitionToSentence(def, undefined, 'manual')).not.toThrow();
+  });
+
+  it('negates a false boolean value ("not <label>")', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [{ field: 'missingCamera', op: 'is', value: false }],
+      actions: [{ type: 'archive' }],
+    };
+    const sentence = definitionToSentence(def, SUBJECT, 'manual');
+    expect(sentence).toContain('not missing camera');
+  });
+
+  it('falls back to a prettified label for an unknown action type', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [],
+      actions: [{ type: 'some_future_action' }],
+    };
+    // Exercise via the public entry with a subject entry whose action catalog
+    // includes the label, so the fallback path (labelByType lookup) is hit.
+    const subjectWithFutureAction: SubjectRegistryEntry = {
+      ...SUBJECT,
+      actions: [...SUBJECT.actions, { type: 'some_future_action', label: 'Some Future Action' }],
+    };
+    const sentence = definitionToSentence(def, subjectWithFutureAction, 'manual');
+    // `lc()` only lowercases the FIRST character of the fallback label, so
+    // "Some Future Action" becomes "some Future Action" (not fully lowercase).
+    expect(sentence).toContain('some Future Action');
+  });
+});

--- a/apps/web/src/components/navigation/Sidebar.tsx
+++ b/apps/web/src/components/navigation/Sidebar.tsx
@@ -31,9 +31,11 @@ import {
   Hub as HubIcon,
   Insights as InsightsIcon,
   Public as PublicIcon,
+  AccountTree as AccountTreeIcon,
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { usePermissions } from '../../hooks/usePermissions';
+import { useWorkflowsEnabled } from '../../hooks/useWorkflowSubjects';
 
 interface SidebarProps {
   open: boolean;
@@ -59,6 +61,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { isAdmin, hasPermission } = usePermissions();
+  const workflowsEnabled = useWorkflowsEnabled();
 
   const primaryItems: NavItemDef[] = [
     { label: 'Photos', icon: <HomeIcon />, path: '/' },
@@ -79,6 +82,9 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     { label: 'Review Duplicates', icon: <ContentCopyIcon />, path: '/duplicates' },
     { label: 'Review Insights', icon: <InsightsIcon />, path: '/review-insights' },
     { label: 'Location Suggestions', icon: <MyLocationIcon />, path: '/location-suggestions' },
+    ...(workflowsEnabled === true
+      ? [{ label: 'Workflows', icon: <AccountTreeIcon />, path: '/workflows' }]
+      : []),
   ];
 
   const adminItems: NavItemDef[] = [

--- a/apps/web/src/components/workflows/WorkflowCard.tsx
+++ b/apps/web/src/components/workflows/WorkflowCard.tsx
@@ -1,0 +1,223 @@
+import { useState, type MouseEvent } from 'react';
+import {
+  Card,
+  CardContent,
+  Box,
+  Typography,
+  Chip,
+  Switch,
+  FormControlLabel,
+  IconButton,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import {
+  MoreVert as MoreVertIcon,
+  PlayArrow as PlayArrowIcon,
+  ContentCopy as ContentCopyIcon,
+  Delete as DeleteIcon,
+  TouchApp as TouchAppIcon,
+  AutoAwesome as AutoAwesomeIcon,
+  Schedule as ScheduleIcon,
+} from '@mui/icons-material';
+import type { Workflow } from '../../types/workflows';
+import {
+  triggerLabel,
+  cronToText,
+  formatRelativeTime,
+  runStatusColor,
+  runStatusLabel,
+} from '../../utils/workflowFormat';
+
+interface WorkflowCardProps {
+  workflow: Workflow;
+  /** collaborator+ AND media:write */
+  canManage: boolean;
+  onToggleEnabled: (workflow: Workflow, enabled: boolean) => void;
+  onOpen: (workflow: Workflow) => void;
+  onRunNow: (workflow: Workflow) => void;
+  onDuplicate: (workflow: Workflow) => void;
+  onDelete: (workflow: Workflow) => void;
+}
+
+function triggerIcon(trigger: Workflow['trigger']) {
+  switch (trigger) {
+    case 'manual':
+      return <TouchAppIcon fontSize="small" />;
+    case 'on_media_enriched':
+      return <AutoAwesomeIcon fontSize="small" />;
+    case 'scheduled':
+      return <ScheduleIcon fontSize="small" />;
+    default:
+      return undefined;
+  }
+}
+
+export function WorkflowCard({
+  workflow,
+  canManage,
+  onToggleEnabled,
+  onOpen,
+  onRunNow,
+  onDuplicate,
+  onDelete,
+}: WorkflowCardProps) {
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const menuOpen = Boolean(menuAnchor);
+
+  const openMenu = (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+  };
+  const closeMenu = () => setMenuAnchor(null);
+
+  const handleMenuAction = (action: (w: Workflow) => void) => {
+    closeMenu();
+    action(workflow);
+  };
+
+  const scheduleLabel =
+    workflow.trigger === 'scheduled'
+      ? `${triggerLabel(workflow.trigger)} · ${cronToText(workflow.cronExpression)}`
+      : triggerLabel(workflow.trigger);
+
+  const lastRun = workflow.lastRun;
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+    >
+      <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {/* Header: clickable name + kebab */}
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+          <Typography
+            variant="subtitle1"
+            noWrap
+            title={workflow.name}
+            onClick={() => onOpen(workflow)}
+            sx={{
+              fontWeight: 600,
+              flexGrow: 1,
+              cursor: 'pointer',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            {workflow.name}
+          </Typography>
+          {canManage && (
+            <IconButton
+              size="small"
+              onClick={openMenu}
+              aria-label="Workflow actions"
+              sx={{ mt: -0.5, mr: -0.5 }}
+            >
+              <MoreVertIcon fontSize="small" />
+            </IconButton>
+          )}
+          <Menu anchorEl={menuAnchor} open={menuOpen} onClose={closeMenu}>
+            <MenuItem onClick={() => handleMenuAction(onRunNow)}>
+              <ListItemIcon>
+                <PlayArrowIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Run now</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={() => handleMenuAction(onDuplicate)}>
+              <ListItemIcon>
+                <ContentCopyIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Duplicate</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={() => handleMenuAction(onDelete)}>
+              <ListItemIcon>
+                <DeleteIcon fontSize="small" color="error" />
+              </ListItemIcon>
+              <ListItemText sx={{ color: 'error.main' }}>Delete</ListItemText>
+            </MenuItem>
+          </Menu>
+        </Box>
+
+        {/* Description (2-line clamp) or muted placeholder */}
+        {workflow.description ? (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {workflow.description}
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="text.disabled" sx={{ fontStyle: 'italic' }}>
+            No description
+          </Typography>
+        )}
+
+        {/* Chips: subject + trigger */}
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          <Chip size="small" label="Media Items" />
+          <Chip
+            size="small"
+            variant="outlined"
+            icon={triggerIcon(workflow.trigger)}
+            label={scheduleLabel}
+          />
+        </Box>
+
+        {/* Next run (scheduled only) */}
+        {workflow.trigger === 'scheduled' && workflow.nextRunAt && (
+          <Typography variant="caption" color="text.secondary">
+            Next run: {formatRelativeTime(workflow.nextRunAt)}
+          </Typography>
+        )}
+
+        {/* Last-run chip / never-run caption */}
+        <Box sx={{ mt: 'auto', pt: 1 }}>
+          {lastRun ? (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 0.5 }}>
+              <Chip
+                size="small"
+                color={runStatusColor(lastRun.status)}
+                label={`${runStatusLabel(lastRun.status)} · ${formatRelativeTime(
+                  lastRun.finishedAt ?? lastRun.createdAt,
+                )}`}
+              />
+              <Typography variant="caption" color="text.secondary">
+                ✓{lastRun.succeededCount} ✗{lastRun.failedCount}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="caption" color="text.disabled">
+              Never run
+            </Typography>
+          )}
+        </Box>
+
+        {/* Enabled switch (kept out of any card-wide action area) */}
+        <Box onClick={(e) => e.stopPropagation()}>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={workflow.enabled}
+                disabled={!canManage}
+                onChange={(e) => onToggleEnabled(workflow, e.target.checked)}
+              />
+            }
+            label={
+              <Typography variant="body2" color="text.secondary">
+                {workflow.enabled ? 'Enabled' : 'Disabled'}
+              </Typography>
+            }
+          />
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/workflows/WorkflowTemplatesGallery.tsx
+++ b/apps/web/src/components/workflows/WorkflowTemplatesGallery.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography, Grid, Card, CardActionArea, CardContent } from '@mui/material';
-import { AddCircleOutline as AddCircleOutlineIcon } from '@mui/icons-material';
+import { AddCircle as AddCircleIcon } from '@mui/icons-material';
 import { WORKFLOW_TEMPLATES, type WorkflowTemplate } from '../../constants/workflowTemplates';
 
 interface WorkflowTemplatesGalleryProps {
@@ -97,7 +97,7 @@ export function WorkflowTemplatesGallery({
                   p: 2,
                 }}
               >
-                <AddCircleOutlineIcon sx={{ fontSize: 40, color: 'text.secondary', mb: 1 }} />
+                <AddCircleIcon sx={{ fontSize: 40, color: 'text.secondary', mb: 1 }} />
                 <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                   Start from scratch
                 </Typography>

--- a/apps/web/src/components/workflows/WorkflowTemplatesGallery.tsx
+++ b/apps/web/src/components/workflows/WorkflowTemplatesGallery.tsx
@@ -1,0 +1,116 @@
+import { Box, Typography, Grid, Card, CardActionArea, CardContent } from '@mui/material';
+import { AddCircleOutline as AddCircleOutlineIcon } from '@mui/icons-material';
+import { WORKFLOW_TEMPLATES, type WorkflowTemplate } from '../../constants/workflowTemplates';
+
+interface WorkflowTemplatesGalleryProps {
+  onSelect: (template: WorkflowTemplate) => void;
+  /**
+   * When provided, prepends a "Start from scratch" card that invokes this
+   * callback (the parent navigates to a blank builder). Omitted → no card.
+   */
+  onStartFromScratch?: () => void;
+  heading?: string;
+}
+
+/**
+ * Props-driven gallery of ready-made workflow templates. Renders a responsive
+ * card grid; clicking a template card calls `onSelect(template)` and the
+ * optional "Start from scratch" card calls `onStartFromScratch()`. Navigation
+ * is the parent's responsibility — this component performs none, so it stays
+ * trivially testable.
+ */
+export function WorkflowTemplatesGallery({
+  onSelect,
+  onStartFromScratch,
+  heading = 'Start from a template',
+}: WorkflowTemplatesGalleryProps) {
+  return (
+    <Box>
+      {heading && (
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 2 }}>
+          {heading}
+        </Typography>
+      )}
+      <Grid container spacing={2}>
+        {WORKFLOW_TEMPLATES.map((template) => {
+          const Icon = template.icon;
+          return (
+            <Grid key={template.id} size={{ xs: 12, sm: 6, md: 4 }}>
+              <Card
+                variant="outlined"
+                sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+              >
+                <CardActionArea
+                  onClick={() => onSelect(template)}
+                  sx={{
+                    flexGrow: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                  }}
+                >
+                  <CardContent sx={{ flexGrow: 1 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                      <Icon color="primary" />
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                        {template.title}
+                      </Typography>
+                    </Box>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      {template.description}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', fontStyle: 'italic' }}
+                    >
+                      {template.plainLanguage}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          );
+        })}
+
+        {onStartFromScratch && (
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <Card
+              variant="outlined"
+              sx={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                borderStyle: 'dashed',
+              }}
+            >
+              <CardActionArea
+                onClick={onStartFromScratch}
+                sx={{
+                  flexGrow: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minHeight: 140,
+                  textAlign: 'center',
+                  p: 2,
+                }}
+              >
+                <AddCircleOutlineIcon sx={{ fontSize: 40, color: 'text.secondary', mb: 1 }} />
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                  Start from scratch
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Build a new workflow with a blank rule.
+                </Typography>
+              </CardActionArea>
+            </Card>
+          </Grid>
+        )}
+      </Grid>
+    </Box>
+  );
+}
+
+export default WorkflowTemplatesGallery;

--- a/apps/web/src/components/workflows/builder/ActionParamEditor.tsx
+++ b/apps/web/src/components/workflows/builder/ActionParamEditor.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useState } from 'react';
+import {
+  TextField,
+  Box,
+  Autocomplete,
+  Chip,
+  ToggleButtonGroup,
+  ToggleButton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Typography,
+  Stack,
+  Checkbox,
+  FormControlLabel,
+} from '@mui/material';
+import { LocationPickerMap } from '../../media/LocationPickerMap';
+import { usePeople } from '../../../hooks/usePeople';
+import { listCircles } from '../../../services/circles';
+import type { ExploreItem } from '../../../services/media';
+import type { Album } from '../../../types/media';
+import type { Circle } from '../../../types/circles';
+import type { WorkflowActionInstance } from '../../../types/workflows';
+import { paramKindFor, RERUN_KINDS } from '../../../constants/workflowActionMeta';
+
+interface ActionParamEditorProps {
+  circleId: string;
+  action: WorkflowActionInstance;
+  onChange: (action: WorkflowActionInstance) => void;
+  tags: ExploreItem[];
+  albums: Album[];
+}
+
+// ---------------------------------------------------------------------------
+// ActionParamEditor — the per-action parameter form. Params are top-level
+// siblings of `type` (never nested under a `params` key).
+// ---------------------------------------------------------------------------
+
+export function ActionParamEditor({
+  circleId,
+  action,
+  onChange,
+  tags,
+  albums,
+}: ActionParamEditorProps) {
+  const kind = paramKindFor(action.type);
+  const set = (patch: Record<string, unknown>) => onChange({ ...action, ...patch });
+  const replace = (next: WorkflowActionInstance) => onChange(next);
+
+  const { data: peopleData } = usePeople(
+    kind === 'person' ? circleId : null,
+  );
+  const [circles, setCircles] = useState<Circle[]>([]);
+
+  useEffect(() => {
+    if (kind !== 'circle') return;
+    let active = true;
+    void listCircles()
+      .then((resp) => active && setCircles(resp.items))
+      .catch(() => active && setCircles([]));
+    return () => {
+      active = false;
+    };
+  }, [kind]);
+
+  switch (kind) {
+    case 'none':
+      return null;
+
+    // --- add_to_album: pick existing OR create-new -------------------------
+    case 'album': {
+      const albumId = typeof action.albumId === 'string' ? action.albumId : '';
+      const createNamed =
+        typeof action.createAlbumNamed === 'string' ? action.createAlbumNamed : '';
+      const selectValue = createNamed ? '__new__' : albumId;
+      return (
+        <>
+          <FormControl size="small" sx={{ minWidth: 240 }}>
+            <InputLabel>Album</InputLabel>
+            <Select
+              label="Album"
+              value={selectValue}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === '__new__') {
+                  replace({ type: action.type, createAlbumNamed: '' });
+                } else {
+                  replace({ type: action.type, albumId: v });
+                }
+              }}
+            >
+              {albums.map((a) => (
+                <MenuItem key={a.id} value={a.id}>
+                  {a.name}
+                </MenuItem>
+              ))}
+              <MenuItem value="__new__">
+                <em>+ Create new album…</em>
+              </MenuItem>
+            </Select>
+          </FormControl>
+          {selectValue === '__new__' && (
+            <TextField
+              label="New album name"
+              size="small"
+              helperText="A new album with this name is created when the workflow runs"
+              value={createNamed}
+              onChange={(e) =>
+                replace({ type: action.type, createAlbumNamed: e.target.value })
+              }
+              sx={{ minWidth: 240 }}
+            />
+          )}
+        </>
+      );
+    }
+
+    // --- remove_from_album -------------------------------------------------
+    case 'albumId': {
+      const albumId = typeof action.albumId === 'string' ? action.albumId : '';
+      return (
+        <FormControl size="small" sx={{ minWidth: 240 }}>
+          <InputLabel>Album</InputLabel>
+          <Select
+            label="Album"
+            value={albumId}
+            onChange={(e) => set({ albumId: e.target.value })}
+          >
+            {albums.map((a) => (
+              <MenuItem key={a.id} value={a.id}>
+                {a.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      );
+    }
+
+    // --- add_tags / remove_tags -------------------------------------------
+    case 'tags': {
+      const names = Array.isArray(action.names) ? (action.names as string[]) : [];
+      return (
+        <Autocomplete<string, true, false, true>
+          multiple
+          freeSolo
+          options={tags.map((t) => t.name)}
+          value={names}
+          onChange={(_, v) => set({ names: v })}
+          renderValue={(vals, getItemProps) =>
+            (vals as string[]).map((option, index) => {
+              const { key, ...chipProps } = getItemProps({ index });
+              return <Chip key={key} {...chipProps} label={option} size="small" />;
+            })
+          }
+          renderInput={(params) => (
+            <TextField {...params} label="Tags" size="small" placeholder="Add tag" />
+          )}
+          sx={{ minWidth: 260, flex: 1 }}
+        />
+      );
+    }
+
+    // --- set_favorite ------------------------------------------------------
+    case 'favorite': {
+      const val = action.value === true;
+      return (
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={val ? 'true' : 'false'}
+          onChange={(_, v) => {
+            if (v !== null) set({ value: v === 'true' });
+          }}
+        >
+          <ToggleButton value="true">Favorite</ToggleButton>
+          <ToggleButton value="false">Not favorite</ToggleButton>
+        </ToggleButtonGroup>
+      );
+    }
+
+    // --- set_captured_at (set | shift | clear) -----------------------------
+    case 'capturedAt': {
+      const mode = (action.mode as string) || 'set';
+      return (
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ flex: 1 }}>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>Mode</InputLabel>
+            <Select
+              label="Mode"
+              value={mode}
+              onChange={(e) => replace({ type: action.type, mode: e.target.value })}
+            >
+              <MenuItem value="set">Set to date</MenuItem>
+              <MenuItem value="shift">Shift by minutes</MenuItem>
+              <MenuItem value="clear">Clear date</MenuItem>
+            </Select>
+          </FormControl>
+          {mode === 'set' && (
+            <TextField
+              label="Date &amp; time"
+              type="datetime-local"
+              size="small"
+              value={typeof action.value === 'string' ? isoToLocal(action.value) : ''}
+              onChange={(e) =>
+                set({ value: e.target.value ? localToIso(e.target.value) : undefined })
+              }
+              slotProps={{ inputLabel: { shrink: true } }}
+              sx={{ minWidth: 220 }}
+            />
+          )}
+          {mode === 'shift' && (
+            <TextField
+              label="Shift (minutes, may be negative)"
+              type="number"
+              size="small"
+              value={typeof action.shiftMinutes === 'number' ? action.shiftMinutes : ''}
+              onChange={(e) =>
+                set({
+                  shiftMinutes: e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+              sx={{ minWidth: 240 }}
+            />
+          )}
+        </Stack>
+      );
+    }
+
+    // --- assign_person / remove_person ------------------------------------
+    case 'person': {
+      const people = (peopleData?.items ?? []).filter((p) => p.name != null);
+      const selected = people.find((p) => p.id === action.personId) ?? null;
+      return (
+        <Autocomplete
+          options={people}
+          value={selected}
+          onChange={(_, v) => set({ personId: v?.id })}
+          getOptionLabel={(p) => p.name ?? p.id.slice(0, 8)}
+          isOptionEqualToValue={(a, b) => a.id === b.id}
+          size="small"
+          sx={{ minWidth: 240, flex: 1 }}
+          renderInput={(params) => <TextField {...params} label="Person" />}
+        />
+      );
+    }
+
+    // --- set_location ------------------------------------------------------
+    case 'location': {
+      const lat = typeof action.lat === 'number' ? action.lat : undefined;
+      const lng = typeof action.lng === 'number' ? action.lng : undefined;
+      const pin = lat !== undefined && lng !== undefined ? { lat, lng } : null;
+      return (
+        <Box sx={{ width: '100%' }}>
+          <LocationPickerMap
+            value={pin}
+            onChange={(latlng) => set({ lat: latlng.lat, lng: latlng.lng })}
+            height={220}
+          />
+          {pin && (
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+              {pin.lat.toFixed(5)}, {pin.lng.toFixed(5)}
+            </Typography>
+          )}
+        </Box>
+      );
+    }
+
+    // --- move_to_circle ----------------------------------------------------
+    case 'circle': {
+      const targetCircleId =
+        typeof action.targetCircleId === 'string' ? action.targetCircleId : '';
+      return (
+        <FormControl size="small" sx={{ minWidth: 240 }}>
+          <InputLabel>Destination circle</InputLabel>
+          <Select
+            label="Destination circle"
+            value={targetCircleId}
+            onChange={(e) => set({ targetCircleId: e.target.value })}
+          >
+            {circles
+              .filter((c) => c.id !== circleId)
+              .map((c) => (
+                <MenuItem key={c.id} value={c.id}>
+                  {c.name}
+                </MenuItem>
+              ))}
+          </Select>
+        </FormControl>
+      );
+    }
+
+    // --- rerun_enrichment --------------------------------------------------
+    case 'rerunKinds': {
+      const kinds = Array.isArray(action.kinds) ? (action.kinds as string[]) : [];
+      const toggle = (k: string) => {
+        const next = kinds.includes(k) ? kinds.filter((x) => x !== k) : [...kinds, k];
+        set({ kinds: next });
+      };
+      return (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {RERUN_KINDS.map((k) => (
+            <FormControlLabel
+              key={k}
+              control={
+                <Checkbox size="small" checked={kinds.includes(k)} onChange={() => toggle(k)} />
+              }
+              label={k}
+            />
+          ))}
+        </Box>
+      );
+    }
+
+    // --- resolve_(burst|duplicate)_group -----------------------------------
+    case 'resolveAction': {
+      const resolveAction = (action.action as string) || 'trash';
+      return (
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={resolveAction}
+          onChange={(_, v) => {
+            if (v !== null) set({ action: v });
+          }}
+        >
+          <ToggleButton value="archive">Keep best, archive rest</ToggleButton>
+          <ToggleButton value="trash">Keep best, trash rest</ToggleButton>
+        </ToggleButtonGroup>
+      );
+    }
+
+    default:
+      return null;
+  }
+}
+
+// datetime-local <-> ISO 8601 helpers -----------------------------------------
+function isoToLocal(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function localToIso(local: string): string {
+  const d = new Date(local);
+  return Number.isNaN(d.getTime()) ? local : d.toISOString();
+}

--- a/apps/web/src/components/workflows/builder/ActionRow.tsx
+++ b/apps/web/src/components/workflows/builder/ActionRow.tsx
@@ -1,0 +1,180 @@
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  IconButton,
+  Tooltip,
+  Alert,
+  Typography,
+} from '@mui/material';
+import {
+  DeleteOutlined,
+  ArrowUpward,
+  ArrowDownward,
+  WarningAmber,
+} from '@mui/icons-material';
+import { ActionParamEditor } from './ActionParamEditor';
+import type { ExploreItem } from '../../../services/media';
+import type { Album } from '../../../types/media';
+import type {
+  WorkflowActionInstance,
+  WorkflowActionDescriptor,
+} from '../../../types/workflows';
+import {
+  MANUAL_ONLY_ACTIONS,
+  HIGH_IMPACT_ACTIONS,
+  defaultActionInstance,
+} from '../../../constants/workflowActionMeta';
+
+interface ActionRowProps {
+  circleId: string;
+  index: number;
+  total: number;
+  action: WorkflowActionInstance;
+  actionCatalog: WorkflowActionDescriptor[];
+  onChange: (action: WorkflowActionInstance) => void;
+  onRemove: () => void;
+  onMove: (direction: -1 | 1) => void;
+  tags: ExploreItem[];
+  albums: Album[];
+  /** null = unknown (non-admin). false = admin setting disables hard_delete. */
+  hardDeleteAllowed: boolean | null;
+}
+
+// ---------------------------------------------------------------------------
+// ActionRow — one action: reorder controls, a type Select from the registry
+// action catalog, its parameter editor, and remove. hard_delete is
+// error-colored with its manual-only / admin-gated / typed-confirmation
+// constraints; move_to_circle carries a high-impact advisory.
+// ---------------------------------------------------------------------------
+
+export function ActionRow({
+  circleId,
+  index,
+  total,
+  action,
+  actionCatalog,
+  onChange,
+  onRemove,
+  onMove,
+  tags,
+  albums,
+  hardDeleteAllowed,
+}: ActionRowProps) {
+  const descriptor = actionCatalog.find((a) => a.type === action.type);
+  const isDestructive = Boolean(descriptor?.destructive);
+  const isHighImpact = HIGH_IMPACT_ACTIONS.has(action.type);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        alignItems: 'flex-start',
+        p: 1.5,
+        border: 1,
+        borderColor: isDestructive ? 'error.main' : 'divider',
+        borderRadius: 1,
+      }}
+    >
+      {/* Reorder */}
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        <Tooltip title="Move up">
+          <span>
+            <IconButton
+              size="small"
+              disabled={index === 0}
+              onClick={() => onMove(-1)}
+              aria-label="Move action up"
+            >
+              <ArrowUpward fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title="Move down">
+          <span>
+            <IconButton
+              size="small"
+              disabled={index === total - 1}
+              onClick={() => onMove(1)}
+              aria-label="Move action down"
+            >
+              <ArrowDownward fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+          <FormControl size="small" sx={{ minWidth: 220 }}>
+            <InputLabel>Action</InputLabel>
+            <Select
+              label="Action"
+              value={action.type}
+              onChange={(e) => onChange(defaultActionInstance(e.target.value))}
+            >
+              {actionCatalog.map((a) => (
+                <MenuItem
+                  key={a.type}
+                  value={a.type}
+                  sx={a.destructive ? { color: 'error.main' } : undefined}
+                >
+                  {a.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <ActionParamEditor
+            circleId={circleId}
+            action={action}
+            onChange={onChange}
+            tags={tags}
+            albums={albums}
+          />
+        </Box>
+
+        {MANUAL_ONLY_ACTIONS.has(action.type) && (
+          <Alert
+            severity="error"
+            icon={<WarningAmber fontSize="small" />}
+            sx={{ mt: 1.5 }}
+          >
+            <Typography variant="body2" component="div" sx={{ fontWeight: 600 }}>
+              Permanent delete — use with care
+            </Typography>
+            Manual trigger only · requires admin to enable and the media:delete
+            permission · a typed confirmation is required on the approval screen.
+            The deletion is unrecoverable.
+            {hardDeleteAllowed === false && (
+              <Box sx={{ mt: 0.5, fontWeight: 600 }}>
+                This action is currently disabled by the admin setting
+                (workflows.allowHardDelete). Saving will be rejected.
+              </Box>
+            )}
+          </Alert>
+        )}
+
+        {isHighImpact && !MANUAL_ONLY_ACTIONS.has(action.type) && (
+          <Alert
+            severity="warning"
+            icon={<WarningAmber fontSize="small" />}
+            sx={{ mt: 1.5 }}
+          >
+            High-impact action — moving items re-runs enrichment in the
+            destination circle and requires media:write on both circles.
+          </Alert>
+        )}
+      </Box>
+
+      <Tooltip title="Remove action">
+        <IconButton size="small" onClick={onRemove} aria-label="Remove action">
+          <DeleteOutlined fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/apps/web/src/components/workflows/builder/ActionsBlock.tsx
+++ b/apps/web/src/components/workflows/builder/ActionsBlock.tsx
@@ -1,0 +1,89 @@
+import { Box, Button, Stack, Typography, Alert } from '@mui/material';
+import { Add } from '@mui/icons-material';
+import { ActionRow } from './ActionRow';
+import { useConditionEditorData } from './ConditionValueEditor';
+import { BuilderBlock } from './BuilderBlock';
+import { defaultActionInstance } from '../../../constants/workflowActionMeta';
+import type { BuilderAction } from '../../../pages/Workflows/builderState';
+import type {
+  WorkflowActionInstance,
+  WorkflowActionDescriptor,
+} from '../../../types/workflows';
+
+interface ActionsBlockProps {
+  circleId: string;
+  actionCatalog: WorkflowActionDescriptor[];
+  actions: WorkflowActionInstance[];
+  dispatch: (action: BuilderAction) => void;
+  hardDeleteAllowed: boolean | null;
+}
+
+// ---------------------------------------------------------------------------
+// ActionsBlock — the "Then" block: an ordered, reorderable list of actions,
+// each with a type Select and a per-action parameter editor.
+// ---------------------------------------------------------------------------
+
+export function ActionsBlock({
+  circleId,
+  actionCatalog,
+  actions,
+  dispatch,
+  hardDeleteAllowed,
+}: ActionsBlockProps) {
+  const { tags, albums } = useConditionEditorData(circleId);
+
+  // First non-destructive action makes a sensible default for a new row.
+  const firstType =
+    actionCatalog.find((a) => !a.destructive)?.type ?? actionCatalog[0]?.type ?? 'move_to_trash';
+
+  return (
+    <BuilderBlock
+      keyword="THEN"
+      title="Actions"
+      subtitle="These actions run in order on every matching item."
+      color="success"
+    >
+      <Stack spacing={1.5}>
+        {actions.length === 0 && (
+          <Alert severity="info">
+            Add at least one action for this workflow to do anything.
+          </Alert>
+        )}
+
+        {actions.map((action, index) => (
+          <ActionRow
+            key={index}
+            circleId={circleId}
+            index={index}
+            total={actions.length}
+            action={action}
+            actionCatalog={actionCatalog}
+            tags={tags}
+            albums={albums}
+            hardDeleteAllowed={hardDeleteAllowed}
+            onChange={(next) => dispatch({ kind: 'setAction', index, action: next })}
+            onRemove={() => dispatch({ kind: 'removeAction', index })}
+            onMove={(direction) => dispatch({ kind: 'moveAction', index, direction })}
+          />
+        ))}
+
+        <Box sx={{ pt: 0.5 }}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Add />}
+            onClick={() =>
+              dispatch({ kind: 'addAction', action: defaultActionInstance(firstType) })
+            }
+          >
+            Add action
+          </Button>
+        </Box>
+
+        <Typography variant="caption" color="text.secondary">
+          Actions apply to every matching item in run order.
+        </Typography>
+      </Stack>
+    </BuilderBlock>
+  );
+}

--- a/apps/web/src/components/workflows/builder/BuilderBlock.tsx
+++ b/apps/web/src/components/workflows/builder/BuilderBlock.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+import { Paper, Box, Typography, Chip } from '@mui/material';
+
+// ---------------------------------------------------------------------------
+// BuilderBlock — the stacked, full-width IFTTT-style card used for every
+// builder section (Subject · Trigger · If · Then · Safety). A bold keyword
+// label ("ON", "WHEN", "IF", "THEN") anchors the top-to-bottom reading order.
+// ---------------------------------------------------------------------------
+
+export interface BuilderBlockProps {
+  /** Short uppercase keyword, e.g. "ON", "WHEN", "IF", "THEN". */
+  keyword: string;
+  title: string;
+  subtitle?: ReactNode;
+  /** Optional accent color for the keyword chip. */
+  color?: 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'default';
+  children: ReactNode;
+  /** Optional trailing element (e.g. a match toggle) rendered in the header row. */
+  action?: ReactNode;
+}
+
+export function BuilderBlock({
+  keyword,
+  title,
+  subtitle,
+  color = 'primary',
+  children,
+  action,
+}: BuilderBlockProps) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ p: { xs: 2, md: 3 }, borderRadius: 2, width: '100%' }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 2,
+          mb: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
+          <Chip
+            label={keyword}
+            color={color === 'default' ? undefined : color}
+            size="small"
+            sx={{ fontWeight: 700, letterSpacing: 0.5, borderRadius: 1 }}
+          />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+              {title}
+            </Typography>
+            {subtitle && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                {subtitle}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+        {action && <Box sx={{ flexShrink: 0 }}>{action}</Box>}
+      </Box>
+      {children}
+    </Paper>
+  );
+}

--- a/apps/web/src/components/workflows/builder/ConditionRow.tsx
+++ b/apps/web/src/components/workflows/builder/ConditionRow.tsx
@@ -1,0 +1,181 @@
+import {
+  Box,
+  Autocomplete,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import { DeleteOutlined } from '@mui/icons-material';
+import { ConditionValueEditor } from './ConditionValueEditor';
+import type { ExploreItem } from '../../../services/media';
+import type { Album } from '../../../types/media';
+import type {
+  WorkflowFieldDescriptor,
+  WorkflowLeafCondition,
+  WorkflowOperator,
+} from '../../../types/workflows';
+
+// Human-readable operator labels.
+const OPERATOR_LABELS: Record<WorkflowOperator, string> = {
+  contains: 'contains',
+  starts_with: 'starts with',
+  ends_with: 'ends with',
+  equals: 'is',
+  gt: 'greater than',
+  lt: 'less than',
+  gte: 'at least',
+  between: 'is between',
+  before: 'is before',
+  after: 'is after',
+  older_than_days: 'is older than (days)',
+  within_last_days: 'is within last (days)',
+  is: 'is',
+  is_set: 'is set',
+  has_any: 'has any of',
+  has_all: 'has all of',
+  has_none: 'has none of',
+  has_person: 'includes',
+  not_has_person: 'excludes',
+  in_album: 'is in album',
+  not_in_album: 'is not in album',
+  near: 'is near',
+};
+
+// Field-picker option shape (carries its group for Autocomplete grouping).
+interface FieldOption {
+  key: string;
+  label: string;
+  group: string;
+}
+
+// Stable group ordering for the field picker.
+const GROUP_ORDER = [
+  'File',
+  'Dates',
+  'Location',
+  'Tags',
+  'People',
+  'Media',
+  'Organization',
+  'Review',
+];
+
+interface ConditionRowProps {
+  circleId: string;
+  fields: WorkflowFieldDescriptor[];
+  condition: WorkflowLeafCondition;
+  onChange: (patch: Partial<WorkflowLeafCondition>) => void;
+  onRemove: () => void;
+  tags: ExploreItem[];
+  albums: Album[];
+}
+
+// ---------------------------------------------------------------------------
+// ConditionRow — one leaf condition: grouped field Select, an operator Select
+// filtered to that field, and a per-type value editor.
+// ---------------------------------------------------------------------------
+
+export function ConditionRow({
+  circleId,
+  fields,
+  condition,
+  onChange,
+  onRemove,
+  tags,
+  albums,
+}: ConditionRowProps) {
+  const options: FieldOption[] = [...fields]
+    .map((f) => ({ key: f.key, label: f.label, group: f.group }))
+    .sort((a, b) => {
+      const ga = GROUP_ORDER.indexOf(a.group);
+      const gb = GROUP_ORDER.indexOf(b.group);
+      if (ga !== gb) return ga - gb;
+      return a.label.localeCompare(b.label);
+    });
+
+  const field = fields.find((f) => f.key === condition.field);
+  const selectedOption = options.find((o) => o.key === condition.field) ?? null;
+  const op = condition.op as WorkflowOperator;
+
+  const handleFieldChange = (next: FieldOption | null) => {
+    if (!next) {
+      onChange({ field: '', op: '', value: undefined });
+      return;
+    }
+    const nextField = fields.find((f) => f.key === next.key);
+    // Default to the field's first operator; reset the value.
+    onChange({
+      field: next.key,
+      op: nextField?.operators[0] ?? '',
+      value: undefined,
+    });
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1.5,
+        alignItems: 'flex-start',
+        p: 1.5,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+      }}
+    >
+      <Autocomplete<FieldOption>
+        options={options}
+        groupBy={(o) => o.group}
+        value={selectedOption}
+        onChange={(_, v) => handleFieldChange(v)}
+        getOptionLabel={(o) => o.label}
+        isOptionEqualToValue={(a, b) => a.key === b.key}
+        size="small"
+        sx={{ minWidth: 220 }}
+        renderInput={(params) => <TextField {...params} label="Field" />}
+      />
+
+      <FormControl size="small" sx={{ minWidth: 170 }} disabled={!field}>
+        <InputLabel>Condition</InputLabel>
+        <Select
+          label="Condition"
+          value={field ? op : ''}
+          onChange={(e) =>
+            onChange({ op: e.target.value as WorkflowOperator, value: undefined })
+          }
+        >
+          {(field?.operators ?? []).map((o) => (
+            <MenuItem key={o} value={o}>
+              {OPERATOR_LABELS[o] ?? o}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {field && op && (
+        <Box sx={{ display: 'flex', flex: 1, minWidth: 200 }}>
+          <ConditionValueEditor
+            circleId={circleId}
+            field={field}
+            op={op}
+            value={condition.value}
+            onChange={(value) => onChange({ value })}
+            tags={tags}
+            albums={albums}
+          />
+        </Box>
+      )}
+
+      <Tooltip title="Remove condition">
+        <IconButton size="small" onClick={onRemove} aria-label="Remove condition">
+          <DeleteOutlined fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/apps/web/src/components/workflows/builder/ConditionValueEditor.tsx
+++ b/apps/web/src/components/workflows/builder/ConditionValueEditor.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useState } from 'react';
+import {
+  TextField,
+  Box,
+  Autocomplete,
+  Chip,
+  ToggleButtonGroup,
+  ToggleButton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Slider,
+  Typography,
+} from '@mui/material';
+import { PersonMultiSelect } from '../../search/PersonMultiSelect';
+import { LocationPickerMap } from '../../media/LocationPickerMap';
+import { getExploreTags, listAlbums } from '../../../services/media';
+import type { ExploreItem } from '../../../services/media';
+import type { Album } from '../../../types/media';
+import type {
+  WorkflowFieldDescriptor,
+  WorkflowOperator,
+} from '../../../types/workflows';
+
+interface ConditionValueEditorProps {
+  circleId: string;
+  field: WorkflowFieldDescriptor;
+  op: WorkflowOperator;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  /** Tag vocabulary + albums are loaded once by the parent block and passed down. */
+  tags: ExploreItem[];
+  albums: Album[];
+}
+
+interface DateRange {
+  from?: string;
+  to?: string;
+}
+
+interface GeoRadius {
+  lat: number;
+  lng: number;
+  radiusKm: number;
+}
+
+interface PersonSet {
+  ids: string[];
+  mode: 'all' | 'any';
+}
+
+// ---------------------------------------------------------------------------
+// ConditionValueEditor — renders the right value control for a field+operator,
+// reusing the deterministic-search editors (tag autocomplete, PersonMultiSelect
+// people picker, LocationPickerMap map-radius picker, date inputs).
+//
+// Operator matters, not just field.valueType: date fields switch between a
+// range (between), a single date (before/after), and a day-count (relative).
+// ---------------------------------------------------------------------------
+
+export function ConditionValueEditor({
+  circleId,
+  field,
+  op,
+  value,
+  onChange,
+  tags,
+  albums,
+}: ConditionValueEditorProps) {
+  // is_set (and any no-value operator) needs no editor.
+  if (op === 'is_set') return null;
+
+  // ---- Date family (operator-driven) --------------------------------------
+  if (field.valueType === 'date-range' || field.type === 'date') {
+    if (op === 'older_than_days' || op === 'within_last_days') {
+      return (
+        <TextField
+          label="Days"
+          type="number"
+          size="small"
+          value={typeof value === 'number' ? value : ''}
+          onChange={(e) => onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+          sx={{ minWidth: 140 }}
+          slotProps={{ htmlInput: { min: 1 } }}
+        />
+      );
+    }
+    if (op === 'before' || op === 'after') {
+      return (
+        <TextField
+          label="Date"
+          type="date"
+          size="small"
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value || undefined)}
+          slotProps={{ inputLabel: { shrink: true } }}
+          sx={{ minWidth: 180 }}
+        />
+      );
+    }
+    // between → { from, to }
+    const range = (value ?? {}) as DateRange;
+    return (
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        <TextField
+          label="From"
+          type="date"
+          size="small"
+          value={range.from ?? ''}
+          onChange={(e) =>
+            onChange({ ...range, from: e.target.value || undefined })
+          }
+          slotProps={{ inputLabel: { shrink: true } }}
+          sx={{ minWidth: 160 }}
+        />
+        <TextField
+          label="To"
+          type="date"
+          size="small"
+          value={range.to ?? ''}
+          onChange={(e) => onChange({ ...range, to: e.target.value || undefined })}
+          slotProps={{ inputLabel: { shrink: true } }}
+          sx={{ minWidth: 160 }}
+        />
+      </Box>
+    );
+  }
+
+  // ---- Boolean (op 'is') ---------------------------------------------------
+  if (field.valueType === 'boolean') {
+    const bool = value === true;
+    return (
+      <ToggleButtonGroup
+        exclusive
+        size="small"
+        value={bool ? 'true' : 'false'}
+        onChange={(_, v) => {
+          if (v !== null) onChange(v === 'true');
+        }}
+      >
+        <ToggleButton value="true">Yes</ToggleButton>
+        <ToggleButton value="false">No</ToggleButton>
+      </ToggleButtonGroup>
+    );
+  }
+
+  // ---- Enum ----------------------------------------------------------------
+  if (field.valueType === 'enum') {
+    return (
+      <FormControl size="small" sx={{ minWidth: 180 }}>
+        <InputLabel>Value</InputLabel>
+        <Select
+          label="Value"
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {(field.enumValues ?? []).map((ev) => (
+            <MenuItem key={ev} value={ev}>
+              {ev}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    );
+  }
+
+  // ---- Number / positive-int ----------------------------------------------
+  if (field.valueType === 'number' || field.valueType === 'positive-int') {
+    return (
+      <TextField
+        label="Value"
+        type="number"
+        size="small"
+        value={typeof value === 'number' ? value : ''}
+        onChange={(e) => onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+        sx={{ minWidth: 160 }}
+      />
+    );
+  }
+
+  // ---- Tag set (string-list) ----------------------------------------------
+  if (field.valueType === 'string-list') {
+    const list = Array.isArray(value) ? (value as string[]) : [];
+    return (
+      <Autocomplete<string, true, false, true>
+        multiple
+        freeSolo
+        options={tags.map((t) => t.name)}
+        value={list}
+        onChange={(_, v) => onChange(v)}
+        renderValue={(vals, getItemProps) =>
+          (vals as string[]).map((option, index) => {
+            const { key, ...chipProps } = getItemProps({ index });
+            return <Chip key={key} {...chipProps} label={option} size="small" />;
+          })
+        }
+        renderInput={(params) => (
+          <TextField {...params} label="Tags" size="small" placeholder="Add tag" />
+        )}
+        sx={{ minWidth: 240, flex: 1 }}
+      />
+    );
+  }
+
+  // ---- Person set ----------------------------------------------------------
+  if (field.valueType === 'person-set') {
+    const pv = (value ?? { ids: [], mode: 'any' }) as PersonSet;
+    return (
+      <Box sx={{ flex: 1, minWidth: 260 }}>
+        <PersonMultiSelect
+          circleId={circleId}
+          value={pv}
+          onChange={(next) => onChange(next)}
+          label="People"
+        />
+      </Box>
+    );
+  }
+
+  // ---- Geo radius ----------------------------------------------------------
+  if (field.valueType === 'geo-radius') {
+    const geo = (value ?? null) as GeoRadius | null;
+    const pin = geo ? { lat: geo.lat, lng: geo.lng } : null;
+    const radiusKm = geo?.radiusKm ?? 25;
+    return (
+      <Box sx={{ width: '100%' }}>
+        <LocationPickerMap
+          value={pin}
+          onChange={(latlng) => onChange({ ...latlng, radiusKm })}
+          height={220}
+        />
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          Radius: {radiusKm} km
+        </Typography>
+        <Slider
+          value={radiusKm}
+          onChange={(_, v) => {
+            const r = Array.isArray(v) ? v[0] : v;
+            onChange({ lat: pin?.lat ?? 0, lng: pin?.lng ?? 0, radiusKm: r });
+          }}
+          disabled={!pin}
+          min={1}
+          max={200}
+          step={5}
+          valueLabelDisplay="auto"
+        />
+      </Box>
+    );
+  }
+
+  // ---- Album (uuid) --------------------------------------------------------
+  if (field.valueType === 'uuid') {
+    return (
+      <FormControl size="small" sx={{ minWidth: 220 }}>
+        <InputLabel>Album</InputLabel>
+        <Select
+          label="Album"
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {albums.map((a) => (
+            <MenuItem key={a.id} value={a.id}>
+              {a.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    );
+  }
+
+  // ---- String (default) ----------------------------------------------------
+  return (
+    <TextField
+      label="Value"
+      size="small"
+      value={typeof value === 'string' ? value : ''}
+      onChange={(e) => onChange(e.target.value)}
+      sx={{ minWidth: 200, flex: 1 }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small hook: load the circle's tag vocabulary + albums once for the whole
+// Conditions block (and reused by the Actions block). Exported for reuse.
+// ---------------------------------------------------------------------------
+
+export function useConditionEditorData(circleId: string | null): {
+  tags: ExploreItem[];
+  albums: Album[];
+} {
+  const [tags, setTags] = useState<ExploreItem[]>([]);
+  const [albums, setAlbums] = useState<Album[]>([]);
+
+  useEffect(() => {
+    if (!circleId) return;
+    let active = true;
+    void getExploreTags(circleId)
+      .then((data) => active && setTags(data))
+      .catch(() => active && setTags([]));
+    void listAlbums({ circleId, pageSize: 200, sortBy: 'name', sortOrder: 'asc' })
+      .then((resp) => active && setAlbums(resp.items))
+      .catch(() => active && setAlbums([]));
+    return () => {
+      active = false;
+    };
+  }, [circleId]);
+
+  return { tags, albums };
+}

--- a/apps/web/src/components/workflows/builder/ConditionsBlock.tsx
+++ b/apps/web/src/components/workflows/builder/ConditionsBlock.tsx
@@ -1,0 +1,200 @@
+import {
+  Box,
+  Button,
+  Stack,
+  ToggleButtonGroup,
+  ToggleButton,
+  Typography,
+  IconButton,
+  Tooltip,
+  Paper,
+} from '@mui/material';
+import { Add, DeleteOutlined, AccountTree } from '@mui/icons-material';
+import { ConditionRow } from './ConditionRow';
+import { useConditionEditorData } from './ConditionValueEditor';
+import { BuilderBlock } from './BuilderBlock';
+import type { BuilderAction } from '../../../pages/Workflows/builderState';
+import { isWorkflowGroupCondition } from '../../../types/workflows';
+import type {
+  WorkflowFieldDescriptor,
+  WorkflowMatch,
+  WorkflowTopCondition,
+  WorkflowLeafCondition,
+} from '../../../types/workflows';
+
+interface ConditionsBlockProps {
+  circleId: string;
+  fields: WorkflowFieldDescriptor[];
+  match: WorkflowMatch;
+  conditions: WorkflowTopCondition[];
+  dispatch: (action: BuilderAction) => void;
+}
+
+function MatchToggle({
+  value,
+  onChange,
+  size = 'small',
+}: {
+  value: WorkflowMatch;
+  onChange: (m: WorkflowMatch) => void;
+  size?: 'small' | 'medium';
+}) {
+  return (
+    <ToggleButtonGroup
+      exclusive
+      size={size}
+      value={value}
+      onChange={(_, v: WorkflowMatch | null) => {
+        if (v !== null) onChange(v);
+      }}
+    >
+      <ToggleButton value="all">Match ALL</ToggleButton>
+      <ToggleButton value="any">Match ANY</ToggleButton>
+    </ToggleButtonGroup>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ConditionsBlock — the "If" block: an all/any match toggle plus a list of
+// leaf rows and (one level of) nested condition groups.
+// ---------------------------------------------------------------------------
+
+export function ConditionsBlock({
+  circleId,
+  fields,
+  match,
+  conditions,
+  dispatch,
+}: ConditionsBlockProps) {
+  const { tags, albums } = useConditionEditorData(circleId);
+
+  return (
+    <BuilderBlock
+      keyword="IF"
+      title="Conditions"
+      subtitle="Only items matching these conditions are acted on. Leave empty to match every item."
+      color="info"
+      action={<MatchToggle value={match} onChange={(m) => dispatch({ kind: 'setMatch', value: m })} />}
+    >
+      <Stack spacing={1.5}>
+        {conditions.length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            No conditions yet — this workflow will match every item in the circle.
+          </Typography>
+        )}
+
+        {conditions.map((c, index) => {
+          if (isWorkflowGroupCondition(c)) {
+            return (
+              <Paper
+                key={index}
+                variant="outlined"
+                sx={{ p: 1.5, borderRadius: 1, bgcolor: 'action.hover', ml: { sm: 2 } }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                    mb: 1.5,
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <AccountTree fontSize="small" color="action" />
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                      Condition group
+                    </Typography>
+                  </Box>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <MatchToggle
+                      value={c.match}
+                      onChange={(m) =>
+                        dispatch({ kind: 'setGroupMatch', groupIndex: index, value: m })
+                      }
+                    />
+                    <Tooltip title="Remove group">
+                      <IconButton
+                        size="small"
+                        onClick={() => dispatch({ kind: 'removeTop', index })}
+                        aria-label="Remove group"
+                      >
+                        <DeleteOutlined fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                </Box>
+
+                <Stack spacing={1.5}>
+                  {c.conditions.map((leaf: WorkflowLeafCondition, childIndex) => (
+                    <ConditionRow
+                      key={childIndex}
+                      circleId={circleId}
+                      fields={fields}
+                      condition={leaf}
+                      tags={tags}
+                      albums={albums}
+                      onChange={(patch) =>
+                        dispatch({
+                          kind: 'updateGroupLeaf',
+                          groupIndex: index,
+                          childIndex,
+                          patch,
+                        })
+                      }
+                      onRemove={() =>
+                        dispatch({ kind: 'removeGroupLeaf', groupIndex: index, childIndex })
+                      }
+                    />
+                  ))}
+                  <Box>
+                    <Button
+                      size="small"
+                      startIcon={<Add />}
+                      onClick={() => dispatch({ kind: 'addGroupLeaf', groupIndex: index })}
+                    >
+                      Add condition to group
+                    </Button>
+                  </Box>
+                </Stack>
+              </Paper>
+            );
+          }
+
+          return (
+            <ConditionRow
+              key={index}
+              circleId={circleId}
+              fields={fields}
+              condition={c}
+              tags={tags}
+              albums={albums}
+              onChange={(patch) => dispatch({ kind: 'updateLeaf', index, patch })}
+              onRemove={() => dispatch({ kind: 'removeTop', index })}
+            />
+          );
+        })}
+
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', pt: 0.5 }}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Add />}
+            onClick={() => dispatch({ kind: 'addLeaf' })}
+          >
+            Add condition
+          </Button>
+          <Button
+            variant="text"
+            size="small"
+            startIcon={<AccountTree />}
+            onClick={() => dispatch({ kind: 'addGroup' })}
+          >
+            Add condition group
+          </Button>
+        </Box>
+      </Stack>
+    </BuilderBlock>
+  );
+}

--- a/apps/web/src/components/workflows/builder/SafetyBlock.tsx
+++ b/apps/web/src/components/workflows/builder/SafetyBlock.tsx
@@ -1,0 +1,106 @@
+import { useEffect } from 'react';
+import {
+  Stack,
+  TextField,
+  FormControlLabel,
+  Switch,
+  Typography,
+  Box,
+} from '@mui/material';
+import { BuilderBlock } from './BuilderBlock';
+import type { BuilderAction } from '../../../pages/Workflows/builderState';
+
+interface SafetyBlockProps {
+  maxItems: number | undefined;
+  requirePreview: boolean | undefined;
+  /** System-wide per-run cap (workflows.maxItemsPerRun). */
+  systemCap: number;
+  /** True when the system requires preview+approval (workflows.requirePreview). */
+  systemRequiresPreview: boolean;
+  /** True when a gated action (hard_delete) is present — forces preview ON. */
+  hasGatedAction: boolean;
+  dispatch: (action: BuilderAction) => void;
+}
+
+// ---------------------------------------------------------------------------
+// SafetyBlock — a per-workflow max-items cap (bounded by, and showing, the
+// system cap) and a require-preview toggle (locked ON when the system requires
+// it or a gated action is present). Persisted into definition.options.
+// ---------------------------------------------------------------------------
+
+export function SafetyBlock({
+  maxItems,
+  requirePreview,
+  systemCap,
+  systemRequiresPreview,
+  hasGatedAction,
+  dispatch,
+}: SafetyBlockProps) {
+  const previewLocked = systemRequiresPreview || hasGatedAction;
+  const effectiveRequirePreview = previewLocked ? true : requirePreview ?? true;
+
+  // Keep the persisted flag consistent with the lock.
+  useEffect(() => {
+    if (previewLocked && requirePreview !== true) {
+      dispatch({ kind: 'setRequirePreview', value: true });
+    }
+  }, [previewLocked, requirePreview, dispatch]);
+
+  const overCap = maxItems !== undefined && maxItems > systemCap;
+
+  return (
+    <BuilderBlock
+      keyword="SAFETY"
+      title="Safety limits"
+      subtitle="Bound how much a single run can touch, and require a preview before it runs."
+      color="warning"
+    >
+      <Stack spacing={2.5}>
+        <Box>
+          <TextField
+            label="Max items per run (optional)"
+            type="number"
+            size="small"
+            value={maxItems ?? ''}
+            onChange={(e) =>
+              dispatch({
+                kind: 'setMaxItems',
+                value: e.target.value === '' ? undefined : Math.max(1, Number(e.target.value)),
+              })
+            }
+            error={overCap}
+            helperText={
+              overCap
+                ? `Exceeds the system cap of ${systemCap.toLocaleString()}; the run is limited to ${systemCap.toLocaleString()}.`
+                : `Leave blank to use the system cap of ${systemCap.toLocaleString()}.`
+            }
+            slotProps={{ htmlInput: { min: 1, max: systemCap } }}
+            sx={{ maxWidth: 340 }}
+          />
+        </Box>
+
+        <Box>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={effectiveRequirePreview}
+                disabled={previewLocked}
+                onChange={(e) =>
+                  dispatch({ kind: 'setRequirePreview', value: e.target.checked })
+                }
+              />
+            }
+            label="Require a preview + approval before this workflow runs"
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+            {hasGatedAction
+              ? 'Locked on — a permanent-delete action always requires a reviewed preview.'
+              : systemRequiresPreview
+                ? 'Locked on by the system settings for all workflows.'
+                : 'When on, manual runs pause for you to review the matched items before applying.'}
+          </Typography>
+        </Box>
+      </Stack>
+    </BuilderBlock>
+  );
+}

--- a/apps/web/src/components/workflows/builder/SubjectBlock.tsx
+++ b/apps/web/src/components/workflows/builder/SubjectBlock.tsx
@@ -1,0 +1,59 @@
+import {
+  FormControl,
+  Select,
+  MenuItem,
+  Box,
+  Typography,
+  Tooltip,
+} from '@mui/material';
+import { InfoOutlined } from '@mui/icons-material';
+import { BuilderBlock } from './BuilderBlock';
+import type { SubjectRegistryEntry, WorkflowSubjectType } from '../../../types/workflows';
+
+interface SubjectBlockProps {
+  subjects: SubjectRegistryEntry[];
+  value: WorkflowSubjectType;
+  onChange: (subject: WorkflowSubjectType) => void;
+}
+
+// ---------------------------------------------------------------------------
+// SubjectBlock — "This workflow applies to: [Media Items ▾]". v1 exposes the
+// single `media_item` Subject from the registry, with a subtle "more coming"
+// affordance so the concept is visible even though it can't yet be changed.
+// ---------------------------------------------------------------------------
+
+export function SubjectBlock({ subjects, value, onChange }: SubjectBlockProps) {
+  return (
+    <BuilderBlock keyword="ON" title="Subject" color="primary">
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+        <Typography variant="body1">This workflow applies to:</Typography>
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <Select
+            value={value}
+            onChange={(e) => onChange(e.target.value as WorkflowSubjectType)}
+            aria-label="Subject"
+          >
+            {subjects.map((s) => (
+              <MenuItem key={s.subject} value={s.subject}>
+                {s.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Tooltip title="More Subjects (duplicate groups, people, and more) are coming in a future release.">
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.5,
+              color: 'text.secondary',
+            }}
+          >
+            <InfoOutlined fontSize="small" />
+            <Typography variant="caption">More coming</Typography>
+          </Box>
+        </Tooltip>
+      </Box>
+    </BuilderBlock>
+  );
+}

--- a/apps/web/src/components/workflows/builder/TriggerBlock.tsx
+++ b/apps/web/src/components/workflows/builder/TriggerBlock.tsx
@@ -1,0 +1,185 @@
+import {
+  TextField,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Switch,
+  Box,
+  Stack,
+  Typography,
+  Button,
+  Alert,
+} from '@mui/material';
+import { BuilderBlock } from './BuilderBlock';
+import type {
+  WorkflowTriggerType,
+  SubjectRegistryEntry,
+} from '../../../types/workflows';
+import { cronToText } from '../../../utils/workflowFormat';
+import {
+  CRON_PRESETS,
+  CRON_MIN_INTERVAL_HINT,
+  isValidCron,
+} from '../../../utils/workflowCron';
+
+interface TriggerBlockProps {
+  subject: SubjectRegistryEntry | undefined;
+  name: string;
+  description: string;
+  enabled: boolean;
+  trigger: WorkflowTriggerType;
+  cronExpression: string;
+  onName: (v: string) => void;
+  onDescription: (v: string) => void;
+  onEnabled: (v: boolean) => void;
+  onTrigger: (v: WorkflowTriggerType) => void;
+  onCron: (v: string) => void;
+  /** True when a gated action (hard_delete) is present but the trigger is non-manual. */
+  gatedActionError?: string | null;
+  /** Minimum-interval note from settings, if available (else the static hint is shown). */
+  minIntervalNote?: string | null;
+  nameError?: boolean;
+}
+
+const TRIGGER_LABELS: Record<WorkflowTriggerType, string> = {
+  manual: 'Manual — I run it myself',
+  on_media_enriched: 'When new media is enriched',
+  scheduled: 'On a schedule',
+};
+
+// ---------------------------------------------------------------------------
+// TriggerBlock — name / description / enabled + the trigger radio and, for the
+// scheduled option, a cron helper (presets + validated raw field).
+// ---------------------------------------------------------------------------
+
+export function TriggerBlock({
+  subject,
+  name,
+  description,
+  enabled,
+  trigger,
+  cronExpression,
+  onName,
+  onDescription,
+  onEnabled,
+  onTrigger,
+  onCron,
+  gatedActionError,
+  minIntervalNote,
+  nameError,
+}: TriggerBlockProps) {
+  // v1 registers the same trigger vocabulary for every Subject; fall back to the
+  // full set if the registry entry has not loaded yet.
+  const triggers: WorkflowTriggerType[] =
+    subject?.triggers ?? ['manual', 'on_media_enriched', 'scheduled'];
+
+  const cronInvalid = trigger === 'scheduled' && cronExpression.trim() !== '' && !isValidCron(cronExpression);
+
+  return (
+    <BuilderBlock
+      keyword="WHEN"
+      title="Trigger"
+      subtitle="Name your workflow and choose how a run starts."
+      color="secondary"
+      action={
+        <FormControlLabel
+          control={
+            <Switch checked={enabled} onChange={(e) => onEnabled(e.target.checked)} />
+          }
+          label={enabled ? 'Enabled' : 'Disabled'}
+          labelPlacement="start"
+        />
+      }
+    >
+      <Stack spacing={2.5}>
+        <TextField
+          label="Name"
+          required
+          fullWidth
+          size="small"
+          value={name}
+          onChange={(e) => onName(e.target.value)}
+          error={nameError}
+          helperText={nameError ? 'A name is required' : undefined}
+        />
+        <TextField
+          label="Description"
+          fullWidth
+          size="small"
+          multiline
+          maxRows={3}
+          value={description}
+          onChange={(e) => onDescription(e.target.value)}
+        />
+
+        <Box>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+            Run this workflow…
+          </Typography>
+          <RadioGroup
+            value={trigger}
+            onChange={(e) => onTrigger(e.target.value as WorkflowTriggerType)}
+          >
+            {triggers.map((t) => (
+              <FormControlLabel
+                key={t}
+                value={t}
+                control={<Radio size="small" />}
+                label={TRIGGER_LABELS[t]}
+              />
+            ))}
+          </RadioGroup>
+        </Box>
+
+        {gatedActionError && (
+          <Alert severity="error">{gatedActionError}</Alert>
+        )}
+
+        {trigger === 'scheduled' && (
+          <Box
+            sx={{
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 1,
+              p: 2,
+            }}
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+              Schedule
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
+              {CRON_PRESETS.map((preset) => (
+                <Button
+                  key={preset.id}
+                  size="small"
+                  variant={cronExpression === preset.expression ? 'contained' : 'outlined'}
+                  onClick={() => onCron(preset.expression)}
+                >
+                  {preset.label}
+                </Button>
+              ))}
+            </Stack>
+            <TextField
+              label="Cron expression (min hour day month weekday)"
+              fullWidth
+              size="small"
+              value={cronExpression}
+              onChange={(e) => onCron(e.target.value)}
+              error={cronInvalid}
+              helperText={
+                cronInvalid
+                  ? 'Not a valid hourly-or-slower 5-field cron expression'
+                  : cronExpression.trim()
+                    ? cronToText(cronExpression)
+                    : 'e.g. 0 3 * * * (nightly at 3 AM)'
+              }
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+              {minIntervalNote || CRON_MIN_INTERVAL_HINT}
+            </Typography>
+          </Box>
+        )}
+      </Stack>
+    </BuilderBlock>
+  );
+}

--- a/apps/web/src/components/workflows/builder/WorkflowPreviewPanel.tsx
+++ b/apps/web/src/components/workflows/builder/WorkflowPreviewPanel.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  Paper,
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  useMediaQuery,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { ExpandMore, AutoAwesome } from '@mui/icons-material';
+import { useWorkflowPreview } from '../../../hooks/useWorkflowPreview';
+import { definitionToSentence } from '../../../utils/workflowSentence';
+import { sanitizeDefinitionForPreview } from '../../../pages/Workflows/builderState';
+import type {
+  WorkflowDefinition,
+  WorkflowTriggerType,
+  SubjectRegistryEntry,
+} from '../../../types/workflows';
+
+interface WorkflowPreviewPanelProps {
+  circleId: string;
+  definition: WorkflowDefinition;
+  subjectEntry: SubjectRegistryEntry | undefined;
+  trigger: WorkflowTriggerType;
+  cronExpression: string;
+}
+
+const DEBOUNCE_MS = 600;
+
+// ---------------------------------------------------------------------------
+// WorkflowPreviewPanel — the plain-language summary plus a debounced live match
+// preview ("N matching items" + a 12-thumbnail sample). Sticky on desktop,
+// collapsible on mobile.
+// ---------------------------------------------------------------------------
+
+export function WorkflowPreviewPanel({
+  circleId,
+  definition,
+  subjectEntry,
+  trigger,
+  cronExpression,
+}: WorkflowPreviewPanelProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const { preview, data, isLoading, error } = useWorkflowPreview();
+
+  const sentence = useMemo(
+    () => definitionToSentence(definition, subjectEntry, trigger, cronExpression),
+    [definition, subjectEntry, trigger, cronExpression],
+  );
+
+  // Debounced preview on any change to the (sanitized) definition.
+  const sanitized = useMemo(
+    () => sanitizeDefinitionForPreview(definition),
+    [definition],
+  );
+  const key = useMemo(
+    () => JSON.stringify({ circleId, conditions: sanitized.conditions, match: sanitized.match }),
+    [circleId, sanitized],
+  );
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!circleId) return;
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      void preview({ circleId, definition: sanitized });
+    }, DEBOUNCE_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // `key` captures every relevant field of `sanitized`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, circleId, preview]);
+
+  const countLabel =
+    data == null
+      ? null
+      : data.capped
+        ? `${data.matchedCount.toLocaleString()}+`
+        : data.matchedCount.toLocaleString();
+
+  const body = (
+    <>
+      {/* Plain-language summary */}
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          alignItems: 'flex-start',
+          p: 1.5,
+          mb: 2,
+          borderRadius: 1,
+          bgcolor: 'action.hover',
+        }}
+      >
+        <AutoAwesome fontSize="small" color="primary" sx={{ mt: 0.25 }} />
+        <Box>
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ lineHeight: 1.2, display: 'block' }}
+          >
+            In plain language
+          </Typography>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            {sentence}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Match count */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5, minHeight: 40 }}>
+        {isLoading ? (
+          <>
+            <CircularProgress size={18} />
+            <Typography variant="body2" color="text.secondary">
+              Counting matches…
+            </Typography>
+          </>
+        ) : error ? (
+          <Alert severity="error" sx={{ width: '100%' }}>
+            {error}
+          </Alert>
+        ) : countLabel != null ? (
+          <>
+            <Chip label={countLabel} color="primary" />
+            <Typography variant="body2" color="text.secondary">
+              matching item{data && data.matchedCount === 1 && !data.capped ? '' : 's'}
+            </Typography>
+          </>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            Adjust conditions to preview matches.
+          </Typography>
+        )}
+      </Box>
+
+      {/* Sample grid */}
+      {data && data.matchedCount === 0 && !isLoading && !error && (
+        <Alert severity="info">No items match yet.</Alert>
+      )}
+      {data && data.sample.length > 0 && (
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(4, 1fr)',
+            gap: 0.75,
+          }}
+        >
+          {data.sample.slice(0, 12).map((item) => (
+            <Box
+              key={item.id}
+              sx={{
+                position: 'relative',
+                aspectRatio: '1 / 1',
+                borderRadius: 1,
+                overflow: 'hidden',
+                bgcolor: 'action.selected',
+              }}
+            >
+              {item.thumbnailUrl ? (
+                <Box
+                  component="img"
+                  src={item.thumbnailUrl}
+                  alt={item.filename ?? 'sample'}
+                  loading="lazy"
+                  sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                />
+              ) : null}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Accordion defaultExpanded variant="outlined" sx={{ borderRadius: 2, width: '100%' }}>
+        <AccordionSummary expandIcon={<ExpandMore />}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            Preview{countLabel != null ? ` · ${countLabel} items` : ''}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>{body}</AccordionDetails>
+      </Accordion>
+    );
+  }
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        width: 340,
+        flexShrink: 0,
+        position: 'sticky',
+        top: 16,
+        alignSelf: 'flex-start',
+      }}
+    >
+      <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1.5 }}>
+        Live preview
+      </Typography>
+      {body}
+    </Paper>
+  );
+}

--- a/apps/web/src/constants/workflowActionMeta.ts
+++ b/apps/web/src/constants/workflowActionMeta.ts
@@ -1,0 +1,93 @@
+import type { WorkflowActionInstance } from '../types/workflows';
+
+// ---------------------------------------------------------------------------
+// Client-side action metadata.
+//
+// The `GET /api/workflows/subjects` response strips action descriptors to
+// `{ type, label, destructive? }`, so the advisory flags the builder UI needs
+// (manual-trigger-only, high-impact) and the correct param-editor kind live
+// here, keyed by action type. This mirrors the backend MEDIA_ITEM_ACTIONS
+// catalog (apps/api/src/workflows/registry/media-item-fields.ts).
+// ---------------------------------------------------------------------------
+
+/** Actions that may only run on a manual trigger (backend rejects otherwise). */
+export const MANUAL_ONLY_ACTIONS = new Set<string>(['hard_delete']);
+
+/** Actions flagged high-impact (extra warning surface in the builder). */
+export const HIGH_IMPACT_ACTIONS = new Set<string>([
+  'hard_delete',
+  'move_to_circle',
+]);
+
+/** Action type gated behind the admin `workflows.allowHardDelete` setting. */
+export const ADMIN_GATED_ACTIONS = new Set<string>(['hard_delete']);
+
+/** How to render an action's parameter editor. */
+export type ActionParamKind =
+  | 'none'
+  | 'album' // add_to_album  → { albumId } XOR { createAlbumNamed }
+  | 'albumId' // remove_from_album → { albumId }
+  | 'tags' // add_tags / remove_tags → { names: string[] }
+  | 'favorite' // set_favorite → { value: boolean }
+  | 'capturedAt' // set_captured_at → { mode, value?, shiftMinutes? }
+  | 'person' // assign_person / remove_person → { personId }
+  | 'location' // set_location → { lat, lng }
+  | 'circle' // move_to_circle → { targetCircleId }
+  | 'rerunKinds' // rerun_enrichment → { kinds: string[] }
+  | 'resolveAction'; // resolve_(burst|duplicate)_group → { action: 'archive'|'trash' }
+
+export const ACTION_PARAM_KIND: Record<string, ActionParamKind> = {
+  move_to_trash: 'none',
+  hard_delete: 'none',
+  archive: 'none',
+  unarchive: 'none',
+  add_to_album: 'album',
+  remove_from_album: 'albumId',
+  add_tags: 'tags',
+  remove_tags: 'tags',
+  set_favorite: 'favorite',
+  set_captured_at: 'capturedAt',
+  assign_person: 'person',
+  remove_person: 'person',
+  set_location: 'location',
+  clear_location: 'none',
+  move_to_circle: 'circle',
+  rerun_enrichment: 'rerunKinds',
+  resolve_burst_group: 'resolveAction',
+  dismiss_burst_group: 'none',
+  resolve_duplicate_group: 'resolveAction',
+  dismiss_duplicate_group: 'none',
+  accept_location_suggestion: 'none',
+  reject_location_suggestion: 'none',
+};
+
+/** Enrichment kinds offered by the `rerun_enrichment` action. */
+export const RERUN_KINDS = [
+  'tagging',
+  'faces',
+  'metadata',
+  'thumbnail',
+  'duplicates',
+] as const;
+
+/** A fresh, minimally-valid instance for a newly-added action of `type`. */
+export function defaultActionInstance(type: string): WorkflowActionInstance {
+  switch (ACTION_PARAM_KIND[type]) {
+    case 'tags':
+      return { type, names: [] };
+    case 'favorite':
+      return { type, value: true };
+    case 'capturedAt':
+      return { type, mode: 'set' };
+    case 'rerunKinds':
+      return { type, kinds: [] };
+    case 'resolveAction':
+      return { type, action: 'trash' };
+    default:
+      return { type };
+  }
+}
+
+export function paramKindFor(type: string): ActionParamKind {
+  return ACTION_PARAM_KIND[type] ?? 'none';
+}

--- a/apps/web/src/constants/workflowTemplates.ts
+++ b/apps/web/src/constants/workflowTemplates.ts
@@ -1,0 +1,152 @@
+import type { SvgIconComponent } from '@mui/icons-material';
+import {
+  DeleteSweep,
+  Movie,
+  PhotoAlbum,
+  Label,
+  ContentCopy,
+} from '@mui/icons-material';
+import type { WorkflowDefinition, WorkflowTriggerType } from '../types/workflows';
+
+// ---------------------------------------------------------------------------
+// Ready-made workflow templates surfaced in the templates gallery. These are
+// pure client-side constants; selecting one pre-fills the builder (see the
+// template hydration contract in WorkflowBuilderPage). Each `definition` is a
+// full, valid backend definition (version 1, subject 'media_item') with action
+// params as TOP-LEVEL siblings of `type`.
+// ---------------------------------------------------------------------------
+
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  title: string;
+  description: string;
+  plainLanguage: string;
+  icon: SvgIconComponent;
+  suggestedTrigger: WorkflowTriggerType;
+  suggestedCron?: string | null;
+  definition: WorkflowDefinition;
+}
+
+export const WORKFLOW_TEMPLATES: WorkflowTemplate[] = [
+  {
+    id: 'clean-up-screenshots',
+    name: 'Clean up screenshots',
+    title: 'Clean up screenshots',
+    description:
+      'Automatically move screenshots to Trash as new media arrives.',
+    plainLanguage:
+      "When new media is enriched, if the filename contains 'screenshot' or it's a PNG with no camera and no date, move it to Trash.",
+    icon: DeleteSweep,
+    suggestedTrigger: 'on_media_enriched',
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'any',
+      conditions: [
+        { field: 'filename', op: 'contains', value: 'screenshot' },
+        {
+          match: 'all',
+          conditions: [
+            { field: 'mimeType', op: 'equals', value: 'image/png' },
+            { field: 'missingCamera', op: 'is', value: true },
+            { field: 'missingCapturedAt', op: 'is', value: true },
+          ],
+        },
+      ],
+      actions: [{ type: 'move_to_trash' }],
+    },
+  },
+  {
+    id: 'archive-social-videos',
+    name: 'Archive social-media videos',
+    title: 'Archive social-media videos',
+    description:
+      'Keep social-media re-shares out of your main library by archiving them nightly.',
+    plainLanguage:
+      'Every night, if a video came from social media, archive it.',
+    icon: Movie,
+    suggestedTrigger: 'scheduled',
+    suggestedCron: '0 3 * * *',
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [{ field: 'socialMediaSource', op: 'is_set' }],
+      actions: [{ type: 'archive' }],
+    },
+  },
+  {
+    id: 'trip-album',
+    name: 'Album from a trip',
+    title: 'Album from a trip',
+    description:
+      'Gather photos from a date range and country into a named album.',
+    plainLanguage:
+      'If a photo was captured within a date range and in a chosen country, add it to an album.',
+    icon: PhotoAlbum,
+    suggestedTrigger: 'manual',
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [
+        {
+          field: 'capturedAt',
+          op: 'between',
+          value: { from: '2025-06-01', to: '2025-06-14' },
+        },
+        { field: 'country', op: 'equals', value: 'Italy' },
+      ],
+      actions: [{ type: 'add_to_album', createAlbumNamed: 'Italy 2025' }],
+    },
+  },
+  {
+    id: 'tag-whatsapp',
+    name: 'Tag WhatsApp images',
+    title: 'Tag WhatsApp images',
+    description:
+      'Label incoming WhatsApp-style images so you can find or filter them later.',
+    plainLanguage:
+      "If the filename starts with 'IMG-' and there's no camera info, add a WhatsApp tag.",
+    icon: Label,
+    suggestedTrigger: 'on_media_enriched',
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [
+        { field: 'filename', op: 'starts_with', value: 'IMG-' },
+        { field: 'missingCamera', op: 'is', value: true },
+      ],
+      actions: [{ type: 'add_tags', names: ['WhatsApp'] }],
+    },
+  },
+  {
+    id: 'clean-up-duplicates',
+    name: 'Clean up duplicates',
+    title: 'Clean up duplicates',
+    description:
+      'Weekly, keep the best copy in high-confidence duplicate groups and trash the rest.',
+    plainLanguage:
+      'Weekly, for photos in a pending duplicate group with confidence ≥ 0.9, keep the best copy and trash the rest.',
+    icon: ContentCopy,
+    suggestedTrigger: 'scheduled',
+    suggestedCron: '0 4 * * 0',
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [
+        { field: 'inPendingDuplicateGroup', op: 'is', value: true },
+        { field: 'duplicateGroupConfidence', op: 'gte', value: 0.9 },
+      ],
+      actions: [{ type: 'resolve_duplicate_group', action: 'trash' }],
+    },
+  },
+];
+
+/** Look up a template by its stable slug id. */
+export function getWorkflowTemplate(id: string): WorkflowTemplate | undefined {
+  return WORKFLOW_TEMPLATES.find((t) => t.id === id);
+}

--- a/apps/web/src/hooks/useWorkflow.ts
+++ b/apps/web/src/hooks/useWorkflow.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import type { Workflow } from '../types/workflows';
+import { getWorkflow as getWorkflowApi } from '../services/workflows';
+
+interface UseWorkflowResult {
+  workflow: Workflow | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchWorkflow: (id: string) => Promise<void>;
+}
+
+export function useWorkflow(): UseWorkflowResult {
+  const [workflow, setWorkflow] = useState<Workflow | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchWorkflow = useCallback(async (id: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await getWorkflowApi(id);
+      setWorkflow(response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch workflow';
+      setError(message);
+      setWorkflow(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { workflow, isLoading, error, fetchWorkflow };
+}

--- a/apps/web/src/hooks/useWorkflowMutations.ts
+++ b/apps/web/src/hooks/useWorkflowMutations.ts
@@ -1,0 +1,115 @@
+import { useState, useCallback } from 'react';
+import type {
+  Workflow,
+  CreateWorkflowDto,
+  UpdateWorkflowDto,
+  CreateRunDto,
+  ApproveRunDto,
+  WorkflowRunStatus,
+} from '../types/workflows';
+import {
+  createWorkflow as createWorkflowApi,
+  updateWorkflow as updateWorkflowApi,
+  deleteWorkflow as deleteWorkflowApi,
+  runWorkflow as runWorkflowApi,
+  approveWorkflowRun as approveWorkflowRunApi,
+  cancelWorkflowRun as cancelWorkflowRunApi,
+  duplicateWorkflow as duplicateWorkflowApi,
+} from '../services/workflows';
+
+type RunResult = { runId: string; status: WorkflowRunStatus };
+
+interface UseWorkflowMutationsResult {
+  createWorkflow: (dto: CreateWorkflowDto) => Promise<Workflow>;
+  updateWorkflow: (id: string, dto: UpdateWorkflowDto) => Promise<Workflow>;
+  deleteWorkflow: (id: string) => Promise<void>;
+  runWorkflow: (id: string, body?: CreateRunDto) => Promise<RunResult>;
+  approveRun: (runId: string, body: ApproveRunDto) => Promise<RunResult>;
+  cancelRun: (runId: string) => Promise<RunResult>;
+  duplicateWorkflow: (source: Workflow) => Promise<Workflow>;
+  setEnabled: (id: string, enabled: boolean) => Promise<Workflow>;
+  isSaving: boolean;
+  error: string | null;
+}
+
+export function useWorkflowMutations(): UseWorkflowMutationsResult {
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async <T>(fn: () => Promise<T>, fallback: string): Promise<T> => {
+      setIsSaving(true);
+      setError(null);
+      try {
+        return await fn();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : fallback;
+        setError(message);
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [],
+  );
+
+  const createWorkflow = useCallback(
+    (dto: CreateWorkflowDto) =>
+      run(() => createWorkflowApi(dto), 'Failed to create workflow'),
+    [run],
+  );
+
+  const updateWorkflow = useCallback(
+    (id: string, dto: UpdateWorkflowDto) =>
+      run(() => updateWorkflowApi(id, dto), 'Failed to update workflow'),
+    [run],
+  );
+
+  const deleteWorkflow = useCallback(
+    (id: string) => run(() => deleteWorkflowApi(id), 'Failed to delete workflow'),
+    [run],
+  );
+
+  const runWorkflow = useCallback(
+    (id: string, body?: CreateRunDto) =>
+      run(() => runWorkflowApi(id, body), 'Failed to run workflow'),
+    [run],
+  );
+
+  const approveRun = useCallback(
+    (runId: string, body: ApproveRunDto) =>
+      run(() => approveWorkflowRunApi(runId, body), 'Failed to approve run'),
+    [run],
+  );
+
+  const cancelRun = useCallback(
+    (runId: string) =>
+      run(() => cancelWorkflowRunApi(runId), 'Failed to cancel run'),
+    [run],
+  );
+
+  const duplicateWorkflow = useCallback(
+    (source: Workflow) =>
+      run(() => duplicateWorkflowApi(source), 'Failed to duplicate workflow'),
+    [run],
+  );
+
+  const setEnabled = useCallback(
+    (id: string, enabled: boolean) =>
+      run(() => updateWorkflowApi(id, { enabled }), 'Failed to update workflow'),
+    [run],
+  );
+
+  return {
+    createWorkflow,
+    updateWorkflow,
+    deleteWorkflow,
+    runWorkflow,
+    approveRun,
+    cancelRun,
+    duplicateWorkflow,
+    setEnabled,
+    isSaving,
+    error,
+  };
+}

--- a/apps/web/src/hooks/useWorkflowPreview.ts
+++ b/apps/web/src/hooks/useWorkflowPreview.ts
@@ -1,0 +1,62 @@
+import { useState, useRef, useCallback } from 'react';
+import type {
+  WorkflowPreviewRequest,
+  WorkflowPreviewResponse,
+} from '../types/workflows';
+import { previewWorkflow as previewWorkflowApi } from '../services/workflows';
+
+interface UseWorkflowPreviewResult {
+  preview: (body: WorkflowPreviewRequest) => Promise<WorkflowPreviewResponse | null>;
+  data: WorkflowPreviewResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  reset: () => void;
+}
+
+/**
+ * Mutation hook for the live workflow preview. The CALLER is responsible for
+ * debouncing — this hook does not debounce internally. Out-of-order responses
+ * are guarded via a monotonic request id so only the latest request's result
+ * is applied to state.
+ */
+export function useWorkflowPreview(): UseWorkflowPreviewResult {
+  const [data, setData] = useState<WorkflowPreviewResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const latestRequestId = useRef(0);
+
+  const preview = useCallback(
+    async (body: WorkflowPreviewRequest): Promise<WorkflowPreviewResponse | null> => {
+      const requestId = ++latestRequestId.current;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await previewWorkflowApi(body);
+        // Only apply if this is still the most recent request.
+        if (requestId === latestRequestId.current) {
+          setData(response);
+          setIsLoading(false);
+        }
+        return response;
+      } catch (err) {
+        if (requestId === latestRequestId.current) {
+          const message = err instanceof Error ? err.message : 'Failed to preview workflow';
+          setError(message);
+          setIsLoading(false);
+        }
+        return null;
+      }
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    // Invalidate any in-flight request so its late response is ignored.
+    latestRequestId.current++;
+    setData(null);
+    setError(null);
+    setIsLoading(false);
+  }, []);
+
+  return { preview, data, isLoading, error, reset };
+}

--- a/apps/web/src/hooks/useWorkflowRun.ts
+++ b/apps/web/src/hooks/useWorkflowRun.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+import type { WorkflowRunDetail } from '../types/workflows';
+import { getWorkflowRun as getWorkflowRunApi } from '../services/workflows';
+
+interface UseWorkflowRunResult {
+  run: WorkflowRunDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchRun: (runId: string) => Promise<void>;
+}
+
+/**
+ * Fetch a single run's detail. The caller can poll live progress by invoking
+ * `fetchRun` on an interval.
+ */
+export function useWorkflowRun(): UseWorkflowRunResult {
+  const [run, setRun] = useState<WorkflowRunDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRun = useCallback(async (runId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await getWorkflowRunApi(runId);
+      setRun(response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch workflow run';
+      setError(message);
+      setRun(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { run, isLoading, error, fetchRun };
+}

--- a/apps/web/src/hooks/useWorkflowRunItems.ts
+++ b/apps/web/src/hooks/useWorkflowRunItems.ts
@@ -1,0 +1,44 @@
+import { useState, useCallback } from 'react';
+import type {
+  WorkflowRunItem,
+  WorkflowListMeta,
+  RunItemsQueryParams,
+} from '../types/workflows';
+import { listWorkflowRunItems as listWorkflowRunItemsApi } from '../services/workflows';
+
+interface UseWorkflowRunItemsResult {
+  items: WorkflowRunItem[];
+  meta: WorkflowListMeta | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchItems: (runId: string, params?: RunItemsQueryParams) => Promise<void>;
+}
+
+export function useWorkflowRunItems(): UseWorkflowRunItemsResult {
+  const [items, setItems] = useState<WorkflowRunItem[]>([]);
+  const [meta, setMeta] = useState<WorkflowListMeta | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(
+    async (runId: string, params?: RunItemsQueryParams) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await listWorkflowRunItemsApi(runId, params);
+        setItems(response.items);
+        setMeta(response.meta);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to fetch workflow run items';
+        setError(message);
+        setItems([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [],
+  );
+
+  return { items, meta, isLoading, error, fetchItems };
+}

--- a/apps/web/src/hooks/useWorkflowRuns.ts
+++ b/apps/web/src/hooks/useWorkflowRuns.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from 'react';
+import type {
+  WorkflowRun,
+  WorkflowListMeta,
+  RunsQueryParams,
+} from '../types/workflows';
+import { listWorkflowRuns as listWorkflowRunsApi } from '../services/workflows';
+
+interface UseWorkflowRunsResult {
+  runs: WorkflowRun[];
+  meta: WorkflowListMeta | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchRuns: (id: string, params?: RunsQueryParams) => Promise<void>;
+}
+
+export function useWorkflowRuns(): UseWorkflowRunsResult {
+  const [runs, setRuns] = useState<WorkflowRun[]>([]);
+  const [meta, setMeta] = useState<WorkflowListMeta | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRuns = useCallback(async (id: string, params?: RunsQueryParams) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await listWorkflowRunsApi(id, params);
+      setRuns(response.items);
+      setMeta(response.meta);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch workflow runs';
+      setError(message);
+      setRuns([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { runs, meta, isLoading, error, fetchRuns };
+}

--- a/apps/web/src/hooks/useWorkflowSubjects.ts
+++ b/apps/web/src/hooks/useWorkflowSubjects.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react';
+import { ApiError } from '../services/api';
+import type { SubjectRegistryEntry } from '../types/workflows';
+import { getWorkflowSubjects } from '../services/workflows';
+
+// ---------------------------------------------------------------------------
+// Feature-gate probe
+//
+// `GET /workflows/subjects` doubles as the client feature-gate mechanism:
+//   - 200 → `features.workflows` is ON; response carries the subject registry
+//   - 404 → the feature is OFF (no error surfaced)
+//   - any other error → fail closed (enabled = false, error set)
+//
+// It requires only media:read (which every circle member holds), so it works
+// for non-admins where there is no dedicated feature-flag endpoint.
+// ---------------------------------------------------------------------------
+
+interface ProbeResult {
+  subjects: SubjectRegistryEntry[] | null;
+  enabled: boolean;
+  error: string | null;
+}
+
+// Module-level cache so multiple mounts (Sidebar + a page) share one request.
+let probePromise: Promise<ProbeResult> | null = null;
+
+function runProbe(): Promise<ProbeResult> {
+  if (!probePromise) {
+    probePromise = getWorkflowSubjects()
+      .then((response): ProbeResult => ({
+        subjects: response.subjects,
+        enabled: true,
+        error: null,
+      }))
+      .catch((err): ProbeResult => {
+        if (err instanceof ApiError && err.status === 404) {
+          // Feature is off — not an error condition.
+          return { subjects: null, enabled: false, error: null };
+        }
+        const message = err instanceof Error ? err.message : 'Failed to load workflows';
+        // Fail closed on any other error.
+        return { subjects: null, enabled: false, error: message };
+      });
+  }
+  return probePromise;
+}
+
+interface UseWorkflowSubjectsResult {
+  subjects: SubjectRegistryEntry[] | null;
+  enabled: boolean | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useWorkflowSubjects(): UseWorkflowSubjectsResult {
+  const [subjects, setSubjects] = useState<SubjectRegistryEntry[] | null>(null);
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    runProbe().then((result) => {
+      if (!active) return;
+      setSubjects(result.subjects);
+      setEnabled(result.enabled);
+      setError(result.error);
+      setIsLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { subjects, enabled, isLoading, error };
+}
+
+/**
+ * Lightweight feature-gate hook reusing the same cached probe.
+ * Returns `null` while the probe is still loading, then `true`/`false`.
+ */
+export function useWorkflowsEnabled(): boolean | null {
+  const { enabled, isLoading } = useWorkflowSubjects();
+  return isLoading ? null : enabled;
+}

--- a/apps/web/src/hooks/useWorkflows.ts
+++ b/apps/web/src/hooks/useWorkflows.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from 'react';
+import type {
+  Workflow,
+  WorkflowListMeta,
+  WorkflowsQueryParams,
+} from '../types/workflows';
+import { listWorkflows as listWorkflowsApi } from '../services/workflows';
+
+interface UseWorkflowsResult {
+  workflows: Workflow[];
+  meta: WorkflowListMeta | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchWorkflows: (params: WorkflowsQueryParams) => Promise<void>;
+}
+
+export function useWorkflows(): UseWorkflowsResult {
+  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [meta, setMeta] = useState<WorkflowListMeta | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchWorkflows = useCallback(async (params: WorkflowsQueryParams) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await listWorkflowsApi(params);
+      setWorkflows(response.items);
+      setMeta(response.meta);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch workflows';
+      setError(message);
+      setWorkflows([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { workflows, meta, isLoading, error, fetchWorkflows };
+}

--- a/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
@@ -41,7 +41,16 @@ import {
 import { SubjectBlock } from '../../components/workflows/builder/SubjectBlock';
 import { TriggerBlock } from '../../components/workflows/builder/TriggerBlock';
 import { ConditionsBlock } from '../../components/workflows/builder/ConditionsBlock';
+import { ActionsBlock } from '../../components/workflows/builder/ActionsBlock';
+import { api } from '../../services/api';
 import type { CreateWorkflowDto, UpdateWorkflowDto } from '../../types/workflows';
+
+/** Subset of `workflows.*` system settings the builder reads (admin-only). */
+interface WorkflowSystemSettings {
+  allowHardDelete?: boolean;
+  maxItemsPerRun?: number;
+  requirePreview?: boolean;
+}
 
 const GATED_ACTION_TYPES = new Set(['hard_delete']);
 
@@ -69,6 +78,27 @@ export default function WorkflowBuilderPage() {
 
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Admin-only `workflows.*` settings (cap, requirePreview, allowHardDelete).
+  // Non-admins get 403 here; we fall back to safe defaults.
+  const [sysWorkflows, setSysWorkflows] = useState<WorkflowSystemSettings | null>(null);
+  const canReadSettings = hasPermission('system_settings:read');
+  useEffect(() => {
+    if (!canReadSettings) return;
+    let active = true;
+    void api
+      .get<{ workflows?: WorkflowSystemSettings }>('/system-settings')
+      .then((res) => active && setSysWorkflows(res.workflows ?? {}))
+      .catch(() => active && setSysWorkflows(null));
+    return () => {
+      active = false;
+    };
+  }, [canReadSettings]);
+
+  // null when unknown (non-admin); the backend still enforces the gate.
+  const hardDeleteAllowed: boolean | null = sysWorkflows
+    ? sysWorkflows.allowHardDelete ?? false
+    : null;
 
   const canManage =
     (activeCircleRole === 'collaborator' || activeCircleRole === 'circle_admin') &&
@@ -276,8 +306,17 @@ export default function WorkflowBuilderPage() {
             />
           )}
 
-          {/* Actions (Then) and Safety blocks are added in the following
-              checkpoints. */}
+          {subjectEntry && (
+            <ActionsBlock
+              circleId={activeCircle.id}
+              actionCatalog={subjectEntry.actions}
+              actions={state.definition.actions}
+              dispatch={dispatch}
+              hardDeleteAllowed={hardDeleteAllowed}
+            />
+          )}
+
+          {/* Safety block is added in a following checkpoint. */}
         </Stack>
 
         {/* The live plain-language summary + preview panel is added in a later

--- a/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
@@ -1,0 +1,31 @@
+// TODO: Phase 3 turn B — form-based rule builder (Subject·Trigger·If·Then), plain-language summary, live preview.
+//
+// Template hydration contract (set by the templates gallery in checkpoint 3):
+//   navigate(`/workflows/new?template=<templateId>`, { state: { template: WorkflowTemplate } })
+//   Builder resolves the starting definition by: location.state?.template first,
+//   else look up WORKFLOW_TEMPLATES by the `?template=<id>` query param.
+//   A blank "New workflow" navigates to /workflows/new with no state and no query param.
+import { Box, Typography } from '@mui/material';
+import { useParams, useLocation, useSearchParams } from 'react-router-dom';
+
+export default function WorkflowBuilderPage() {
+  const { id } = useParams<{ id?: string }>();
+  // Read here so the next turn can wire up the template hydration contract above.
+  useLocation();
+  useSearchParams();
+
+  const isEdit = Boolean(id);
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 } }}>
+      <Typography variant="h5" gutterBottom>
+        Workflow builder
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {isEdit
+          ? `Editing workflow ${id} — builder coming in a later turn. (Placeholder stub.)`
+          : 'Creating a new workflow — builder coming in a later turn. (Placeholder stub.)'}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
@@ -1,31 +1,288 @@
-// TODO: Phase 3 turn B — form-based rule builder (Subject·Trigger·If·Then), plain-language summary, live preview.
+// ---------------------------------------------------------------------------
+// Workflow builder — form-based rule builder (Subject · Trigger · If · Then ·
+// Safety) with a live plain-language summary and match-preview panel.
 //
-// Template hydration contract (set by the templates gallery in checkpoint 3):
-//   navigate(`/workflows/new?template=<templateId>`, { state: { template: WorkflowTemplate } })
-//   Builder resolves the starting definition by: location.state?.template first,
-//   else look up WORKFLOW_TEMPLATES by the `?template=<id>` query param.
-//   A blank "New workflow" navigates to /workflows/new with no state and no query param.
-import { Box, Typography } from '@mui/material';
-import { useParams, useLocation, useSearchParams } from 'react-router-dom';
+// Template hydration contract (from the templates gallery):
+//   navigate(`/workflows/new?template=<id>`, { state: { template } })
+//   Resolution order: location.state.template → getWorkflowTemplate(?template) → blank.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+  Snackbar,
+  Stack,
+} from '@mui/material';
+import { Close as CloseIcon, Save as SaveIcon } from '@mui/icons-material';
+import {
+  useParams,
+  useLocation,
+  useSearchParams,
+  useNavigate,
+} from 'react-router-dom';
+import { useCircle } from '../../hooks/useCircle';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useWorkflowSubjects } from '../../hooks/useWorkflowSubjects';
+import { useWorkflow } from '../../hooks/useWorkflow';
+import { useWorkflowMutations } from '../../hooks/useWorkflowMutations';
+import { getWorkflowTemplate } from '../../constants/workflowTemplates';
+import type { WorkflowTemplate } from '../../constants/workflowTemplates';
+import { isValidCron } from '../../utils/workflowCron';
+import {
+  builderReducer,
+  blankState,
+  stateFromTemplate,
+  stateFromWorkflow,
+} from './builderState';
+import { SubjectBlock } from '../../components/workflows/builder/SubjectBlock';
+import { TriggerBlock } from '../../components/workflows/builder/TriggerBlock';
+import type { CreateWorkflowDto, UpdateWorkflowDto } from '../../types/workflows';
+
+const GATED_ACTION_TYPES = new Set(['hard_delete']);
 
 export default function WorkflowBuilderPage() {
   const { id } = useParams<{ id?: string }>();
-  // Read here so the next turn can wire up the template hydration contract above.
-  useLocation();
-  useSearchParams();
-
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const isEdit = Boolean(id);
 
+  const { activeCircle, activeCircleRole } = useCircle();
+  const { hasPermission } = usePermissions();
+  const {
+    subjects,
+    enabled: featureEnabled,
+    isLoading: subjectsLoading,
+    error: subjectsError,
+  } = useWorkflowSubjects();
+  const { workflow, isLoading: workflowLoading, error: workflowError, fetchWorkflow } =
+    useWorkflow();
+  const { createWorkflow, updateWorkflow, isSaving } = useWorkflowMutations();
+
+  const [state, dispatch] = useReducer(builderReducer, undefined, blankState);
+  const hydratedRef = useRef(false);
+
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const canManage =
+    (activeCircleRole === 'collaborator' || activeCircleRole === 'circle_admin') &&
+    hasPermission('media:write');
+
+  // Load the existing workflow when editing.
+  useEffect(() => {
+    if (isEdit && id) void fetchWorkflow(id);
+  }, [isEdit, id, fetchWorkflow]);
+
+  // Hydrate the draft exactly once, from the right source.
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    if (isEdit) {
+      if (workflow) {
+        dispatch({ kind: 'replace', state: stateFromWorkflow(workflow) });
+        hydratedRef.current = true;
+      }
+      return;
+    }
+    // Create mode: template via router state, else ?template=<id>, else blank.
+    const stateTemplate = (location.state as { template?: WorkflowTemplate } | null)?.template;
+    const paramTemplate = searchParams.get('template');
+    const template = stateTemplate ?? (paramTemplate ? getWorkflowTemplate(paramTemplate) : undefined);
+    if (template) {
+      dispatch({ kind: 'replace', state: stateFromTemplate(template) });
+    }
+    hydratedRef.current = true;
+  }, [isEdit, workflow, location.state, searchParams]);
+
+  const subjectEntry = useMemo(
+    () => subjects?.find((s) => s.subject === state.definition.subject),
+    [subjects, state.definition.subject],
+  );
+
+  // Validation --------------------------------------------------------------
+  const hasGatedAction = state.definition.actions.some((a) =>
+    GATED_ACTION_TYPES.has(a.type),
+  );
+  const gatedActionError =
+    hasGatedAction && state.trigger !== 'manual'
+      ? 'Permanent delete is only allowed on manual-trigger workflows. Switch the trigger to Manual or remove the action.'
+      : null;
+
+  const nameError = submitAttempted && state.name.trim() === '';
+  const cronError =
+    state.trigger === 'scheduled' && !isValidCron(state.cronExpression);
+
+  const canSave = !isSaving && canManage && Boolean(activeCircle);
+
+  const handleSave = async () => {
+    setSubmitAttempted(true);
+    setSaveError(null);
+    if (!activeCircle) return;
+    if (state.name.trim() === '') return;
+    if (state.trigger === 'scheduled' && cronError) return;
+    if (gatedActionError) return;
+
+    const cronExpression =
+      state.trigger === 'scheduled' ? state.cronExpression.trim() : null;
+
+    try {
+      if (isEdit && id) {
+        const dto: UpdateWorkflowDto = {
+          name: state.name.trim(),
+          description: state.description.trim() || null,
+          enabled: state.enabled,
+          trigger: state.trigger,
+          cronExpression,
+          definition: state.definition,
+        };
+        const updated = await updateWorkflow(id, dto);
+        navigate(`/workflows/${updated.id}`);
+      } else {
+        const dto: CreateWorkflowDto = {
+          circleId: activeCircle.id,
+          name: state.name.trim(),
+          description: state.description.trim() || null,
+          enabled: state.enabled,
+          trigger: state.trigger,
+          cronExpression,
+          definition: state.definition,
+        };
+        const created = await createWorkflow(dto);
+        navigate(`/workflows/${created.id}`);
+      }
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save workflow');
+    }
+  };
+
+  // --- Guard states --------------------------------------------------------
+  if (!activeCircle) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <Alert severity="info">Select a circle to build a workflow.</Alert>
+      </Box>
+    );
+  }
+
+  if (subjectsLoading || (isEdit && workflowLoading && !hydratedRef.current)) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (featureEnabled === false) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <Alert severity="info">The Workflows feature is not enabled.</Alert>
+      </Box>
+    );
+  }
+
+  if (subjectsError || workflowError) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <Alert severity="error">{subjectsError || workflowError}</Alert>
+      </Box>
+    );
+  }
+
   return (
-    <Box sx={{ p: { xs: 2, md: 3 } }}>
-      <Typography variant="h5" gutterBottom>
-        Workflow builder
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        {isEdit
-          ? `Editing workflow ${id} — builder coming in a later turn. (Placeholder stub.)`
-          : 'Creating a new workflow — builder coming in a later turn. (Placeholder stub.)'}
-      </Typography>
+    <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1400, mx: 'auto' }}>
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 3,
+          gap: 1,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          {isEdit ? 'Edit workflow' : 'New workflow'}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="text"
+            startIcon={<CloseIcon />}
+            onClick={() => navigate('/workflows')}
+            sx={{ minHeight: 44 }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={isSaving ? <CircularProgress size={16} color="inherit" /> : <SaveIcon />}
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            sx={{ minHeight: 44 }}
+          >
+            {isSaving ? 'Saving…' : isEdit ? 'Save changes' : 'Create workflow'}
+          </Button>
+        </Box>
+      </Box>
+
+      {!canManage && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          You have read-only access to this workflow. Collaborator role and
+          media:write are required to edit.
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', gap: 3, alignItems: 'flex-start' }}>
+        {/* Main column — stacked blocks */}
+        <Stack spacing={2.5} sx={{ flex: 1, minWidth: 0 }}>
+          {subjects && (
+            <SubjectBlock
+              subjects={subjects}
+              value={state.definition.subject}
+              onChange={() => {
+                /* v1: single Subject; selection is fixed to media_item */
+              }}
+            />
+          )}
+
+          <TriggerBlock
+            subject={subjectEntry}
+            name={state.name}
+            description={state.description}
+            enabled={state.enabled}
+            trigger={state.trigger}
+            cronExpression={state.cronExpression}
+            onName={(v) => dispatch({ kind: 'setName', value: v })}
+            onDescription={(v) => dispatch({ kind: 'setDescription', value: v })}
+            onEnabled={(v) => dispatch({ kind: 'setEnabled', value: v })}
+            onTrigger={(v) => dispatch({ kind: 'setTrigger', value: v })}
+            onCron={(v) => dispatch({ kind: 'setCron', value: v })}
+            gatedActionError={gatedActionError}
+            nameError={nameError}
+          />
+
+          {/* Conditions (If), Actions (Then), and Safety blocks are added in
+              the following checkpoints. */}
+        </Stack>
+
+        {/* The live plain-language summary + preview panel is added in a later
+            checkpoint. */}
+      </Box>
+
+      <Snackbar
+        open={Boolean(saveError)}
+        autoHideDuration={6000}
+        onClose={() => setSaveError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setSaveError(null)} severity="error" sx={{ width: '100%' }}>
+          {saveError}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
@@ -40,6 +40,7 @@ import {
 } from './builderState';
 import { SubjectBlock } from '../../components/workflows/builder/SubjectBlock';
 import { TriggerBlock } from '../../components/workflows/builder/TriggerBlock';
+import { ConditionsBlock } from '../../components/workflows/builder/ConditionsBlock';
 import type { CreateWorkflowDto, UpdateWorkflowDto } from '../../types/workflows';
 
 const GATED_ACTION_TYPES = new Set(['hard_delete']);
@@ -265,8 +266,18 @@ export default function WorkflowBuilderPage() {
             nameError={nameError}
           />
 
-          {/* Conditions (If), Actions (Then), and Safety blocks are added in
-              the following checkpoints. */}
+          {subjectEntry && (
+            <ConditionsBlock
+              circleId={activeCircle.id}
+              fields={subjectEntry.fields}
+              match={state.definition.match}
+              conditions={state.definition.conditions}
+              dispatch={dispatch}
+            />
+          )}
+
+          {/* Actions (Then) and Safety blocks are added in the following
+              checkpoints. */}
         </Stack>
 
         {/* The live plain-language summary + preview panel is added in a later

--- a/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
@@ -42,6 +42,7 @@ import { SubjectBlock } from '../../components/workflows/builder/SubjectBlock';
 import { TriggerBlock } from '../../components/workflows/builder/TriggerBlock';
 import { ConditionsBlock } from '../../components/workflows/builder/ConditionsBlock';
 import { ActionsBlock } from '../../components/workflows/builder/ActionsBlock';
+import { WorkflowPreviewPanel } from '../../components/workflows/builder/WorkflowPreviewPanel';
 import { api } from '../../services/api';
 import type { CreateWorkflowDto, UpdateWorkflowDto } from '../../types/workflows';
 
@@ -267,7 +268,14 @@ export default function WorkflowBuilderPage() {
         </Alert>
       )}
 
-      <Box sx={{ display: 'flex', gap: 3, alignItems: 'flex-start' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 3,
+          alignItems: 'flex-start',
+          flexDirection: { xs: 'column', md: 'row' },
+        }}
+      >
         {/* Main column — stacked blocks */}
         <Stack spacing={2.5} sx={{ flex: 1, minWidth: 0 }}>
           {subjects && (
@@ -319,8 +327,13 @@ export default function WorkflowBuilderPage() {
           {/* Safety block is added in a following checkpoint. */}
         </Stack>
 
-        {/* The live plain-language summary + preview panel is added in a later
-            checkpoint. */}
+        <WorkflowPreviewPanel
+          circleId={activeCircle.id}
+          definition={state.definition}
+          subjectEntry={subjectEntry}
+          trigger={state.trigger}
+          cronExpression={state.cronExpression}
+        />
       </Box>
 
       <Snackbar

--- a/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowBuilderPage.tsx
@@ -43,7 +43,13 @@ import { TriggerBlock } from '../../components/workflows/builder/TriggerBlock';
 import { ConditionsBlock } from '../../components/workflows/builder/ConditionsBlock';
 import { ActionsBlock } from '../../components/workflows/builder/ActionsBlock';
 import { WorkflowPreviewPanel } from '../../components/workflows/builder/WorkflowPreviewPanel';
+import { SafetyBlock } from '../../components/workflows/builder/SafetyBlock';
 import { api } from '../../services/api';
+
+// Fallback defaults mirroring the backend when the admin-only settings read is
+// unavailable (non-admin users get 403 on GET /system-settings).
+const DEFAULT_MAX_ITEMS_PER_RUN = 10000;
+const DEFAULT_REQUIRE_PREVIEW = true;
 import type { CreateWorkflowDto, UpdateWorkflowDto } from '../../types/workflows';
 
 /** Subset of `workflows.*` system settings the builder reads (admin-only). */
@@ -100,6 +106,9 @@ export default function WorkflowBuilderPage() {
   const hardDeleteAllowed: boolean | null = sysWorkflows
     ? sysWorkflows.allowHardDelete ?? false
     : null;
+  const systemCap = sysWorkflows?.maxItemsPerRun ?? DEFAULT_MAX_ITEMS_PER_RUN;
+  const systemRequiresPreview =
+    sysWorkflows?.requirePreview ?? DEFAULT_REQUIRE_PREVIEW;
 
   const canManage =
     (activeCircleRole === 'collaborator' || activeCircleRole === 'circle_admin') &&
@@ -324,7 +333,14 @@ export default function WorkflowBuilderPage() {
             />
           )}
 
-          {/* Safety block is added in a following checkpoint. */}
+          <SafetyBlock
+            maxItems={state.definition.options?.maxItems}
+            requirePreview={state.definition.options?.requirePreview}
+            systemCap={systemCap}
+            systemRequiresPreview={systemRequiresPreview}
+            hasGatedAction={hasGatedAction}
+            dispatch={dispatch}
+          />
         </Stack>
 
         <WorkflowPreviewPanel

--- a/apps/web/src/pages/Workflows/WorkflowListPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowListPage.tsx
@@ -1,15 +1,292 @@
-// TODO(#141): full list page + templates gallery implemented in checkpoint 3
-import { Box, Typography } from '@mui/material';
+import { useEffect, useState, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+  Grid,
+  Snackbar,
+  Divider,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from '@mui/material';
+import { Add as AddIcon, AccountTree as AccountTreeIcon } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useCircle } from '../../hooks/useCircle';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useWorkflows } from '../../hooks/useWorkflows';
+import { useWorkflowMutations } from '../../hooks/useWorkflowMutations';
+import { WorkflowCard } from '../../components/workflows/WorkflowCard';
+import { WorkflowTemplatesGallery } from '../../components/workflows/WorkflowTemplatesGallery';
+import type { WorkflowTemplate } from '../../constants/workflowTemplates';
+import type { Workflow } from '../../types/workflows';
 
 export default function WorkflowListPage() {
+  const navigate = useNavigate();
+  const { activeCircle, activeCircleRole } = useCircle();
+  const { hasPermission } = usePermissions();
+  const { workflows, isLoading, error, fetchWorkflows } = useWorkflows();
+  const { runWorkflow, duplicateWorkflow, deleteWorkflow, setEnabled } =
+    useWorkflowMutations();
+
+  // Local mirror of the fetched list so the enabled Switch can flip optimistically.
+  const [items, setItems] = useState<Workflow[]>([]);
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Workflow | null>(null);
+
+  const canManage =
+    (activeCircleRole === 'collaborator' || activeCircleRole === 'circle_admin') &&
+    hasPermission('media:write');
+
+  const refetch = useCallback(() => {
+    if (!activeCircle) return;
+    void fetchWorkflows({ circleId: activeCircle.id, pageSize: 100 });
+  }, [activeCircle, fetchWorkflows]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  useEffect(() => {
+    setItems(workflows);
+  }, [workflows]);
+
+  const handleSelectTemplate = useCallback(
+    (t: WorkflowTemplate) => {
+      // Template hydration contract: pass the full template via router state
+      // (primary) and its id via the ?template= query param (fallback).
+      navigate(`/workflows/new?template=${t.id}`, { state: { template: t } });
+    },
+    [navigate],
+  );
+
+  const handleOpen = useCallback(
+    (w: Workflow) => {
+      navigate(`/workflows/${w.id}`);
+    },
+    [navigate],
+  );
+
+  const handleToggleEnabled = useCallback(
+    async (w: Workflow, enabled: boolean) => {
+      // Optimistic flip.
+      setItems((prev) =>
+        prev.map((item) => (item.id === w.id ? { ...item, enabled } : item)),
+      );
+      try {
+        await setEnabled(w.id, enabled);
+      } catch (err) {
+        // Revert to the server truth and surface the error.
+        setItems((prev) =>
+          prev.map((item) =>
+            item.id === w.id ? { ...item, enabled: w.enabled } : item,
+          ),
+        );
+        setErrorMsg(err instanceof Error ? err.message : 'Failed to update workflow');
+      }
+    },
+    [setEnabled],
+  );
+
+  const handleRunNow = useCallback(
+    async (w: Workflow) => {
+      try {
+        const result = await runWorkflow(w.id);
+        setSuccessMsg('Run started');
+        navigate(`/workflows/${w.id}/runs/${result.runId}`);
+      } catch (err) {
+        setErrorMsg(err instanceof Error ? err.message : 'Failed to start run');
+      }
+    },
+    [runWorkflow, navigate],
+  );
+
+  const handleDuplicate = useCallback(
+    async (w: Workflow) => {
+      try {
+        await duplicateWorkflow(w);
+        setSuccessMsg('Workflow duplicated');
+        refetch();
+      } catch (err) {
+        setErrorMsg(err instanceof Error ? err.message : 'Failed to duplicate workflow');
+      }
+    },
+    [duplicateWorkflow, refetch],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    setDeleteTarget(null);
+    try {
+      await deleteWorkflow(target.id);
+      setSuccessMsg('Workflow deleted');
+      refetch();
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to delete workflow');
+    }
+  }, [deleteTarget, deleteWorkflow, refetch]);
+
+  if (!activeCircle) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <Alert severity="info">Select a circle to view workflows.</Alert>
+      </Box>
+    );
+  }
+
   return (
     <Box sx={{ p: { xs: 2, md: 3 } }}>
-      <Typography variant="h5" gutterBottom>
-        Workflows
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        Workflow list — coming up in this turn. (Placeholder stub.)
-      </Typography>
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 3,
+          flexWrap: 'wrap',
+          gap: 1,
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          Workflows
+        </Typography>
+        {canManage && (
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Button
+              variant="outlined"
+              onClick={() => setShowTemplates((v) => !v)}
+              sx={{ minHeight: 44 }}
+            >
+              Browse templates
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => navigate('/workflows/new')}
+              sx={{ minHeight: 44 }}
+            >
+              New workflow
+            </Button>
+          </Box>
+        )}
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {isLoading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && items.length === 0 && (
+        <>
+          {canManage ? (
+            <Box>
+              <Typography variant="body1" sx={{ mb: 2 }}>
+                Automate your library. Start from a template:
+              </Typography>
+              <WorkflowTemplatesGallery
+                onSelect={handleSelectTemplate}
+                onStartFromScratch={() => navigate('/workflows/new')}
+                heading=""
+              />
+            </Box>
+          ) : (
+            <Box sx={{ textAlign: 'center', py: 8 }}>
+              <AccountTreeIcon sx={{ fontSize: 56, color: 'text.disabled', mb: 1 }} />
+              <Typography variant="h6" color="text.secondary">
+                No workflows yet.
+              </Typography>
+            </Box>
+          )}
+        </>
+      )}
+
+      {/* Non-empty: card grid */}
+      {!isLoading && !error && items.length > 0 && (
+        <Grid container spacing={2}>
+          {items.map((w) => (
+            <Grid key={w.id} size={{ xs: 12, sm: 6, md: 4 }}>
+              <WorkflowCard
+                workflow={w}
+                canManage={canManage}
+                onToggleEnabled={handleToggleEnabled}
+                onOpen={handleOpen}
+                onRunNow={handleRunNow}
+                onDuplicate={handleDuplicate}
+                onDelete={setDeleteTarget}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {/* Templates section (toggled from the header, only when there are workflows) */}
+      {canManage && showTemplates && items.length > 0 && (
+        <Box sx={{ mt: 4 }}>
+          <Divider sx={{ mb: 3 }} />
+          <WorkflowTemplatesGallery onSelect={handleSelectTemplate} />
+        </Box>
+      )}
+
+      {/* Delete confirm dialog */}
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onClose={() => setDeleteTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete workflow?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This permanently deletes <strong>{deleteTarget?.name}</strong>. This action
+            cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={() => void handleDeleteConfirm()}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Success feedback */}
+      <Snackbar
+        open={Boolean(successMsg)}
+        autoHideDuration={4000}
+        onClose={() => setSuccessMsg(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setSuccessMsg(null)} severity="success" sx={{ width: '100%' }}>
+          {successMsg}
+        </Alert>
+      </Snackbar>
+
+      {/* Error feedback */}
+      <Snackbar
+        open={Boolean(errorMsg)}
+        autoHideDuration={6000}
+        onClose={() => setErrorMsg(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setErrorMsg(null)} severity="error" sx={{ width: '100%' }}>
+          {errorMsg}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/apps/web/src/pages/Workflows/WorkflowListPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowListPage.tsx
@@ -1,0 +1,15 @@
+// TODO(#141): full list page + templates gallery implemented in checkpoint 3
+import { Box, Typography } from '@mui/material';
+
+export default function WorkflowListPage() {
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 } }}>
+      <Typography variant="h5" gutterBottom>
+        Workflows
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Workflow list — coming up in this turn. (Placeholder stub.)
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
@@ -19,6 +19,14 @@ import {
   List,
   ListItem,
   ListItemText,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Link,
+  Tooltip,
 } from '@mui/material';
 import {
   BrokenImage as BrokenImageIcon,
@@ -175,6 +183,30 @@ function RunCountsSummary({ run }: { run: WorkflowRunDetail }) {
   );
 }
 
+/** Severity + message for a terminal run status. */
+function terminalSummary(run: WorkflowRunDetail): {
+  severity: 'success' | 'warning' | 'error' | 'info';
+  message: string;
+} {
+  switch (run.status) {
+    case 'completed':
+      return { severity: 'success', message: 'All actions applied successfully.' };
+    case 'completed_with_errors':
+      return {
+        severity: 'warning',
+        message: 'The run completed, but some items failed. Review them below.',
+      };
+    case 'failed':
+      return { severity: 'error', message: run.lastError ?? 'The run failed.' };
+    case 'cancelled':
+      return { severity: 'info', message: 'This run was cancelled.' };
+    case 'expired':
+      return { severity: 'warning', message: 'This run expired before it was approved.' };
+    default:
+      return { severity: 'info', message: '' };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -197,6 +229,7 @@ export default function WorkflowRunPage() {
   const [excluded, setExcluded] = useState<Set<string>>(new Set());
   const [confirmText, setConfirmText] = useState('');
   const [itemsPage, setItemsPage] = useState(1);
+  const [failedPage, setFailedPage] = useState(1);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
@@ -246,6 +279,17 @@ export default function WorkflowRunPage() {
       pageSize: ITEMS_PAGE_SIZE,
     });
   }, [runId, run?.status, itemsPage, fetchItems]);
+
+  // Load the failed-item table once the run is terminal and has failures.
+  const isTerminal = run ? isTerminalRunStatus(run.status) : false;
+  useEffect(() => {
+    if (!runId || !run || !isTerminal || run.failedCount <= 0) return;
+    void fetchItems(runId, {
+      status: 'failed',
+      page: failedPage,
+      pageSize: ITEMS_PAGE_SIZE,
+    });
+  }, [runId, run, isTerminal, failedPage, fetchItems]);
 
   const effectiveMatched = useMemo(
     () => (run ? Math.max(0, run.matchedCount - excluded.size) : 0),
@@ -549,11 +593,30 @@ export default function WorkflowRunPage() {
         </Box>
       )}
 
-      {/* Running + terminal (compact summary — expanded in the next checkpoint) */}
-      {(run.status === 'running' || isTerminalRunStatus(run.status)) && (
+      {/* Running */}
+      {run.status === 'running' && (
         <Box>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="subtitle1" gutterBottom>
+                Applying actions…
+              </Typography>
+              <LinearProgress
+                variant={run.matchedCount > 0 ? 'determinate' : 'indeterminate'}
+                value={
+                  run.matchedCount > 0
+                    ? Math.min(100, (run.processedCount / run.matchedCount) * 100)
+                    : undefined
+                }
+                sx={{ height: 8, borderRadius: 1, mb: 1 }}
+              />
+              <Typography variant="body2" color="text.secondary">
+                {formatCount(run.processedCount)} of {formatCount(run.matchedCount)} processed
+              </Typography>
+            </CardContent>
+          </Card>
           <RunCountsSummary run={run} />
-          {run.status === 'running' && canApprove && (
+          {canApprove && (
             <Button
               variant="outlined"
               disabled={isSaving}
@@ -563,10 +626,112 @@ export default function WorkflowRunPage() {
               Cancel
             </Button>
           )}
-          {run.lastError && (
-            <Alert severity="error" sx={{ mt: 2 }}>
-              {run.lastError}
-            </Alert>
+        </Box>
+      )}
+
+      {/* Terminal */}
+      {isTerminal && (
+        <Box>
+          {(() => {
+            const summary = terminalSummary(run);
+            return (
+              <Alert severity={summary.severity} sx={{ mb: 2 }}>
+                <AlertTitle>{runStatusLabel(run.status)}</AlertTitle>
+                {summary.message}
+              </Alert>
+            );
+          })()}
+
+          <RunCountsSummary run={run} />
+
+          {run.failedCount > 0 && (
+            <Card variant="outlined" sx={{ mt: 1 }}>
+              <CardContent>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    mb: 1.5,
+                    flexWrap: 'wrap',
+                    gap: 1,
+                  }}
+                >
+                  <Typography variant="subtitle2">
+                    Failed items ({formatCount(run.failedCount)})
+                  </Typography>
+                  {canApprove && (
+                    <Tooltip title="Coming soon">
+                      <span>
+                        <Button size="small" variant="outlined" disabled>
+                          Retry failed items
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  )}
+                </Box>
+                {itemsLoading && items.length === 0 ? (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                    <CircularProgress size={28} />
+                  </Box>
+                ) : (
+                  <>
+                    <TableContainer sx={{ overflowX: 'auto' }}>
+                      <Table size="small">
+                        <TableHead>
+                          <TableRow>
+                            <TableCell>File</TableCell>
+                            <TableCell>Error</TableCell>
+                            <TableCell align="right">Item</TableCell>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {items.map((item) => (
+                            <TableRow key={item.id}>
+                              <TableCell sx={{ maxWidth: 220 }}>
+                                <Typography variant="body2" noWrap title={item.media?.filename ?? undefined}>
+                                  {item.media?.filename ?? 'Untitled'}
+                                </Typography>
+                                <Typography variant="caption" color="text.secondary">
+                                  {formatCaptureDate(item.media?.capturedAt ?? null)}
+                                </Typography>
+                              </TableCell>
+                              <TableCell sx={{ maxWidth: 360 }}>
+                                <Typography variant="body2" color="error">
+                                  {item.error ?? 'Unknown error'}
+                                </Typography>
+                              </TableCell>
+                              <TableCell align="right">
+                                <Link
+                                  component="button"
+                                  type="button"
+                                  variant="body2"
+                                  onClick={() =>
+                                    navigate(`/media?item=${item.mediaItemId}`)
+                                  }
+                                >
+                                  View
+                                </Link>
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                    {itemsMeta && itemsMeta.totalPages > 1 && (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                        <Pagination
+                          count={itemsMeta.totalPages}
+                          page={failedPage}
+                          onChange={(_, p) => setFailedPage(p)}
+                          size="small"
+                        />
+                      </Box>
+                    )}
+                  </>
+                )}
+              </CardContent>
+            </Card>
           )}
         </Box>
       )}

--- a/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
@@ -1,18 +1,597 @@
-// TODO: Phase 3 turn C — run review & progress (evaluating → awaiting approval → running → terminal), 2s status poll, approval typed-confirmation gate, exclusion checkboxes.
-import { Box, Typography } from '@mui/material';
-import { useParams } from 'react-router-dom';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  CircularProgress,
+  LinearProgress,
+  Alert,
+  AlertTitle,
+  Grid,
+  Card,
+  CardContent,
+  Checkbox,
+  TextField,
+  Snackbar,
+  Pagination,
+  Stack,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+import {
+  BrokenImage as BrokenImageIcon,
+  ArrowBack as ArrowBackIcon,
+} from '@mui/icons-material';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useCircle } from '../../hooks/useCircle';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useWorkflowRun } from '../../hooks/useWorkflowRun';
+import { useWorkflowRunItems } from '../../hooks/useWorkflowRunItems';
+import { useWorkflowMutations } from '../../hooks/useWorkflowMutations';
+import {
+  runStatusColor,
+  runStatusLabel,
+  formatRelativeTime,
+  formatCount,
+  isTerminalRunStatus,
+  deriveActionImpacts,
+  definitionHasHardDelete,
+  hardDeleteConfirmationText,
+} from '../../utils/workflowFormat';
+import type { WorkflowRunDetail, WorkflowRunItem } from '../../types/workflows';
+
+const POLL_MS = 2000;
+const ITEMS_PAGE_SIZE = 24;
+const MAX_EXCLUSIONS = 500;
+
+/** Safe short date for a capture timestamp. Never throws. */
+function formatCaptureDate(iso: string | null): string {
+  if (!iso) return 'No date';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return 'No date';
+    return d.toLocaleDateString();
+  } catch {
+    return 'No date';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run item tile — thumbnail + filename + capture date, optional exclude checkbox
+// ---------------------------------------------------------------------------
+
+interface RunItemTileProps {
+  item: WorkflowRunItem;
+  excluded: boolean;
+  checkboxDisabled: boolean;
+  onToggle?: (mediaItemId: string, next: boolean) => void;
+  showError?: boolean;
+}
+
+function RunItemTile({
+  item,
+  excluded,
+  checkboxDisabled,
+  onToggle,
+  showError,
+}: RunItemTileProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const filename = item.media?.filename ?? 'Untitled';
+  const captureDate = formatCaptureDate(item.media?.capturedAt ?? null);
+
+  return (
+    <Card variant="outlined" sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box
+        sx={{
+          position: 'relative',
+          width: '100%',
+          aspectRatio: '1 / 1',
+          bgcolor: 'action.hover',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          opacity: excluded ? 0.4 : 1,
+        }}
+      >
+        {item.thumbnailUrl && !imgFailed ? (
+          <Box
+            component="img"
+            src={item.thumbnailUrl}
+            alt={filename}
+            loading="lazy"
+            onError={() => setImgFailed(true)}
+            sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        ) : (
+          <BrokenImageIcon sx={{ fontSize: 40, color: 'text.disabled' }} />
+        )}
+        {onToggle && (
+          <Checkbox
+            checked={excluded}
+            disabled={checkboxDisabled}
+            onChange={(e) => onToggle(item.mediaItemId, e.target.checked)}
+            slotProps={{ input: { 'aria-label': `Exclude ${filename}` } }}
+            sx={{
+              position: 'absolute',
+              top: 4,
+              right: 4,
+              bgcolor: 'background.paper',
+              borderRadius: 1,
+              p: 0.5,
+              '&:hover': { bgcolor: 'background.paper' },
+            }}
+          />
+        )}
+      </Box>
+      <CardContent sx={{ py: 1, px: 1.5, flexGrow: 1 }}>
+        <Typography variant="body2" noWrap title={filename} sx={{ fontWeight: 500 }}>
+          {filename}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+          {captureDate}
+        </Typography>
+        {showError && item.error && (
+          <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
+            {item.error}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compact counts summary (shared by running/terminal placeholders)
+// ---------------------------------------------------------------------------
+
+function RunCountsSummary({ run }: { run: WorkflowRunDetail }) {
+  const stats: { label: string; value: number; color?: string }[] = [
+    { label: 'Matched', value: run.matchedCount },
+    { label: 'Processed', value: run.processedCount },
+    { label: 'Succeeded', value: run.succeededCount, color: 'success.main' },
+    { label: 'Failed', value: run.failedCount, color: 'error.main' },
+    { label: 'Skipped', value: run.skippedCount },
+  ];
+  return (
+    <Grid container spacing={2} sx={{ mb: 2 }}>
+      {stats.map((s) => (
+        <Grid key={s.label} size={{ xs: 6, sm: 4, md: 2.4 }}>
+          <Card variant="outlined">
+            <CardContent sx={{ textAlign: 'center', py: 2 }}>
+              <Typography variant="h5" sx={{ color: s.color }}>
+                {formatCount(s.value)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {s.label}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 
 export default function WorkflowRunPage() {
-  const { runId } = useParams<{ id: string; runId: string }>();
+  const { id: workflowId, runId } = useParams<{ id: string; runId: string }>();
+  const navigate = useNavigate();
+  const { activeCircleRole } = useCircle();
+  const { hasPermission } = usePermissions();
+
+  const { run, isLoading, error, fetchRun } = useWorkflowRun();
+  const {
+    items,
+    meta: itemsMeta,
+    isLoading: itemsLoading,
+    fetchItems,
+  } = useWorkflowRunItems();
+  const { approveRun, cancelRun, isSaving } = useWorkflowMutations();
+
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [confirmText, setConfirmText] = useState('');
+  const [itemsPage, setItemsPage] = useState(1);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Permission gates (mirror the list page: per-circle role + system permission).
+  const canApprove =
+    (activeCircleRole === 'collaborator' || activeCircleRole === 'circle_admin') &&
+    hasPermission('media:write');
+  const canHardDelete = canApprove && hasPermission('media:delete');
+
+  const hasHardDelete = definitionHasHardDelete(run?.definitionSnapshot);
+
+  // Initial load.
+  useEffect(() => {
+    if (runId) void fetchRun(runId);
+  }, [runId, fetchRun]);
+
+  // Poll every 2s while the run is non-terminal (matches the enhancement drawer).
+  useEffect(() => {
+    if (!runId || !run) return;
+    if (isTerminalRunStatus(run.status)) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
+    if (pollRef.current) clearInterval(pollRef.current);
+    pollRef.current = setInterval(() => {
+      void fetchRun(runId);
+    }, POLL_MS);
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [runId, run, fetchRun]);
+
+  // Load the matched-item grid while awaiting approval.
+  useEffect(() => {
+    if (!runId || run?.status !== 'awaiting_approval') return;
+    void fetchItems(runId, {
+      status: 'matched',
+      page: itemsPage,
+      pageSize: ITEMS_PAGE_SIZE,
+    });
+  }, [runId, run?.status, itemsPage, fetchItems]);
+
+  const effectiveMatched = useMemo(
+    () => (run ? Math.max(0, run.matchedCount - excluded.size) : 0),
+    [run, excluded.size],
+  );
+
+  const impacts = useMemo(
+    () =>
+      run
+        ? deriveActionImpacts(
+            run.definitionSnapshot?.actions,
+            effectiveMatched,
+            run.actionSummary?.byActionType,
+          )
+        : [],
+    [run, effectiveMatched],
+  );
+
+  const handleToggleExclude = useCallback((mediaItemId: string, next: boolean) => {
+    setExcluded((prev) => {
+      const copy = new Set(prev);
+      if (next) {
+        if (copy.size >= MAX_EXCLUSIONS && !copy.has(mediaItemId)) return prev;
+        copy.add(mediaItemId);
+      } else {
+        copy.delete(mediaItemId);
+      }
+      return copy;
+    });
+  }, []);
+
+  const confirmValid =
+    !hasHardDelete || confirmText === hardDeleteConfirmationText(run?.matchedCount ?? 0);
+
+  const handleApprove = useCallback(async () => {
+    if (!runId) return;
+    try {
+      await approveRun(runId, {
+        excludedItemIds: excluded.size > 0 ? Array.from(excluded) : undefined,
+        confirmation: hasHardDelete
+          ? hardDeleteConfirmationText(run?.matchedCount ?? 0)
+          : undefined,
+      });
+      setSuccessMsg('Run approved — applying actions…');
+      void fetchRun(runId);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to approve run');
+    }
+  }, [runId, excluded, hasHardDelete, run?.matchedCount, approveRun, fetchRun]);
+
+  const handleCancel = useCallback(async () => {
+    if (!runId) return;
+    try {
+      await cancelRun(runId);
+      setSuccessMsg('Run cancelled');
+      void fetchRun(runId);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to cancel run');
+    }
+  }, [runId, cancelRun, fetchRun]);
+
+  // First-load spinner (only when we have no run yet).
+  if (!run && isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!run) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <Alert severity="error">{error ?? 'Workflow run not found.'}</Alert>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          sx={{ mt: 2 }}
+          onClick={() => navigate(workflowId ? `/workflows/${workflowId}` : '/workflows')}
+        >
+          Back to workflow
+        </Button>
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ p: { xs: 2, md: 3 } }}>
-      <Typography variant="h5" gutterBottom>
-        Workflow run
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        Run {runId} — review & progress coming in a later turn. (Placeholder stub.)
-      </Typography>
+      {/* Header */}
+      <Box sx={{ mb: 2 }}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          size="small"
+          onClick={() => navigate(workflowId ? `/workflows/${workflowId}` : '/workflows')}
+          sx={{ mb: 1 }}
+        >
+          Back to workflow
+        </Button>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+          <Typography variant="h5" component="h1">
+            Workflow run
+          </Typography>
+          <Chip
+            label={runStatusLabel(run.status)}
+            color={runStatusColor(run.status)}
+            size="small"
+          />
+          <Typography variant="body2" color="text.secondary">
+            {formatRelativeTime(run.createdAt)}
+          </Typography>
+        </Box>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Evaluating */}
+      {run.status === 'evaluating' && (
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="subtitle1" gutterBottom>
+              Evaluating your library…
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Finding items that match this workflow's conditions. This can take a
+              moment for large libraries.
+            </Typography>
+            <LinearProgress />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Awaiting approval */}
+      {run.status === 'awaiting_approval' && (
+        <Box>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="h6">
+                {formatCount(run.matchedCount)} item{run.matchedCount === 1 ? '' : 's'} matched
+              </Typography>
+              {run.truncated && (
+                <Alert severity="warning" sx={{ mt: 1.5 }}>
+                  <AlertTitle>Results truncated</AlertTitle>
+                  This run hit the maximum item cap. Only the first{' '}
+                  {formatCount(run.matchedCount)} matching items will be affected — narrow
+                  the workflow's conditions if you need to cover more.
+                </Alert>
+              )}
+              {excluded.size > 0 && (
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  {formatCount(excluded.size)} excluded · {formatCount(effectiveMatched)} will
+                  be affected
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Per-action impact list */}
+          {impacts.length > 0 && (
+            <Card variant="outlined" sx={{ mb: 2 }}>
+              <CardContent>
+                <Typography variant="subtitle2" gutterBottom>
+                  What this run will do
+                </Typography>
+                <List dense disablePadding>
+                  {impacts.map((impact) => (
+                    <ListItem key={impact.key} disableGutters>
+                      <ListItemText
+                        primary={
+                          <Typography variant="body2">
+                            <strong>{impact.label}:</strong> {formatCount(impact.count)}
+                          </Typography>
+                        }
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Hard-delete safety panel */}
+          {hasHardDelete && canHardDelete && (
+            <Alert severity="error" variant="outlined" sx={{ mb: 2 }}>
+              <AlertTitle>Permanent deletion</AlertTitle>
+              <Typography variant="body2" sx={{ mb: 1.5 }}>
+                This workflow permanently deletes matching items. This cannot be undone —
+                deleted files are not recoverable from Trash. To confirm, type{' '}
+                <strong>{hardDeleteConfirmationText(run.matchedCount)}</strong> below.
+              </Typography>
+              <TextField
+                size="small"
+                fullWidth
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={hardDeleteConfirmationText(run.matchedCount)}
+                error={confirmText.length > 0 && !confirmValid}
+                helperText={
+                  confirmText.length > 0 && !confirmValid
+                    ? 'Confirmation text does not match.'
+                    : ' '
+                }
+              />
+            </Alert>
+          )}
+
+          {/* Item grid with exclude checkboxes */}
+          {canApprove && (
+            <Card variant="outlined" sx={{ mb: 2 }}>
+              <CardContent>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    mb: 1.5,
+                    flexWrap: 'wrap',
+                    gap: 1,
+                  }}
+                >
+                  <Typography variant="subtitle2">
+                    Review matched items
+                  </Typography>
+                  {excluded.size >= MAX_EXCLUSIONS && (
+                    <Typography variant="caption" color="warning.main">
+                      Exclusion limit reached ({formatCount(MAX_EXCLUSIONS)}).
+                    </Typography>
+                  )}
+                </Box>
+                {itemsLoading && items.length === 0 ? (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                    <CircularProgress size={28} />
+                  </Box>
+                ) : (
+                  <>
+                    <Grid container spacing={1.5}>
+                      {items.map((item) => {
+                        const isExcluded = excluded.has(item.mediaItemId);
+                        return (
+                          <Grid
+                            key={item.id}
+                            size={{ xs: 6, sm: 4, md: 3, lg: 2 }}
+                          >
+                            <RunItemTile
+                              item={item}
+                              excluded={isExcluded}
+                              checkboxDisabled={
+                                !isExcluded && excluded.size >= MAX_EXCLUSIONS
+                              }
+                              onToggle={handleToggleExclude}
+                            />
+                          </Grid>
+                        );
+                      })}
+                    </Grid>
+                    {itemsMeta && itemsMeta.totalPages > 1 && (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                        <Pagination
+                          count={itemsMeta.totalPages}
+                          page={itemsPage}
+                          onChange={(_, p) => setItemsPage(p)}
+                          size="small"
+                        />
+                      </Box>
+                    )}
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Primary actions */}
+          {canApprove ? (
+            <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap' }}>
+              <Button
+                variant="contained"
+                color={hasHardDelete ? 'error' : 'primary'}
+                disabled={isSaving || !confirmValid}
+                onClick={() => void handleApprove()}
+                sx={{ minHeight: 44 }}
+              >
+                Approve &amp; run
+              </Button>
+              <Button
+                variant="outlined"
+                disabled={isSaving}
+                onClick={() => void handleCancel()}
+                sx={{ minHeight: 44 }}
+              >
+                Cancel
+              </Button>
+            </Stack>
+          ) : (
+            <Alert severity="info">
+              This run is awaiting approval. You have read-only access — a circle
+              collaborator can approve or cancel it.
+            </Alert>
+          )}
+        </Box>
+      )}
+
+      {/* Running + terminal (compact summary — expanded in the next checkpoint) */}
+      {(run.status === 'running' || isTerminalRunStatus(run.status)) && (
+        <Box>
+          <RunCountsSummary run={run} />
+          {run.status === 'running' && canApprove && (
+            <Button
+              variant="outlined"
+              disabled={isSaving}
+              onClick={() => void handleCancel()}
+              sx={{ minHeight: 44 }}
+            >
+              Cancel
+            </Button>
+          )}
+          {run.lastError && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {run.lastError}
+            </Alert>
+          )}
+        </Box>
+      )}
+
+      {/* Feedback */}
+      <Snackbar
+        open={Boolean(successMsg)}
+        autoHideDuration={4000}
+        onClose={() => setSuccessMsg(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setSuccessMsg(null)} severity="success" sx={{ width: '100%' }}>
+          {successMsg}
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={Boolean(errorMsg)}
+        autoHideDuration={6000}
+        onClose={() => setErrorMsg(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setErrorMsg(null)} severity="error" sx={{ width: '100%' }}>
+          {errorMsg}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
@@ -1,0 +1,18 @@
+// TODO: Phase 3 turn C — run review & progress (evaluating → awaiting approval → running → terminal), 2s status poll, approval typed-confirmation gate, exclusion checkboxes.
+import { Box, Typography } from '@mui/material';
+import { useParams } from 'react-router-dom';
+
+export default function WorkflowRunPage() {
+  const { runId } = useParams<{ id: string; runId: string }>();
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 } }}>
+      <Typography variant="h5" gutterBottom>
+        Workflow run
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Run {runId} — review & progress coming in a later turn. (Placeholder stub.)
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Workflows/builderState.ts
+++ b/apps/web/src/pages/Workflows/builderState.ts
@@ -86,6 +86,29 @@ export function cloneDefinition(def: WorkflowDefinition): WorkflowDefinition {
   return JSON.parse(JSON.stringify(def)) as WorkflowDefinition;
 }
 
+const isCompleteLeaf = (leaf: WorkflowLeafCondition): boolean =>
+  leaf.field.trim() !== '' && leaf.op.trim() !== '';
+
+/**
+ * Produce a preview-safe definition: drop half-built leaf rows (no field/op)
+ * and any group left empty, so the live preview doesn't 400 while the user is
+ * mid-edit. Does not mutate the input.
+ */
+export function sanitizeDefinitionForPreview(
+  def: WorkflowDefinition,
+): WorkflowDefinition {
+  const conditions: WorkflowTopCondition[] = [];
+  for (const c of def.conditions) {
+    if (isWorkflowGroupCondition(c)) {
+      const kept = c.conditions.filter(isCompleteLeaf);
+      if (kept.length > 0) conditions.push({ ...c, conditions: kept });
+    } else if (isCompleteLeaf(c)) {
+      conditions.push(c);
+    }
+  }
+  return { ...def, conditions };
+}
+
 // ---------------------------------------------------------------------------
 // Reducer
 // ---------------------------------------------------------------------------

--- a/apps/web/src/pages/Workflows/builderState.ts
+++ b/apps/web/src/pages/Workflows/builderState.ts
@@ -1,0 +1,300 @@
+// ---------------------------------------------------------------------------
+// Workflow builder — central draft state + reducer (pure, serializable).
+//
+// The draft is a superset of what the create/update DTOs need: name /
+// description / enabled / trigger / cronExpression plus the full versioned,
+// Subject-tagged `WorkflowDefinition` (match + conditions + actions + options).
+// Preview and save consume `state.definition` directly.
+//
+// Conditions support exactly ONE nesting level (matching the backend): the top
+// list holds leaves and groups; a group holds only leaves. All reducer branches
+// return new objects/arrays so React sees fresh references.
+// ---------------------------------------------------------------------------
+
+import type {
+  Workflow,
+  WorkflowDefinition,
+  WorkflowLeafCondition,
+  WorkflowGroupCondition,
+  WorkflowTopCondition,
+  WorkflowMatch,
+  WorkflowActionInstance,
+  WorkflowTriggerType,
+} from '../../types/workflows';
+import { isWorkflowGroupCondition } from '../../types/workflows';
+import type { WorkflowTemplate } from '../../constants/workflowTemplates';
+
+export interface BuilderState {
+  name: string;
+  description: string;
+  enabled: boolean;
+  trigger: WorkflowTriggerType;
+  cronExpression: string;
+  definition: WorkflowDefinition;
+}
+
+function blankDefinition(): WorkflowDefinition {
+  return {
+    version: 1,
+    subject: 'media_item',
+    match: 'all',
+    conditions: [],
+    actions: [],
+    options: { requirePreview: true },
+  };
+}
+
+/** A brand-new, empty builder draft. */
+export function blankState(): BuilderState {
+  return {
+    name: '',
+    description: '',
+    enabled: false,
+    trigger: 'manual',
+    cronExpression: '',
+    definition: blankDefinition(),
+  };
+}
+
+/** Hydrate a draft from a template (templates gallery / ?template=). */
+export function stateFromTemplate(t: WorkflowTemplate): BuilderState {
+  return {
+    name: t.name,
+    description: t.description,
+    enabled: false,
+    trigger: t.suggestedTrigger,
+    cronExpression: t.suggestedCron ?? '',
+    // Deep clone so edits never mutate the shared template constant.
+    definition: cloneDefinition(t.definition),
+  };
+}
+
+/** Hydrate a draft from an existing workflow (edit mode). */
+export function stateFromWorkflow(w: Workflow): BuilderState {
+  return {
+    name: w.name,
+    description: w.description ?? '',
+    enabled: w.enabled,
+    trigger: w.trigger,
+    cronExpression: w.cronExpression ?? '',
+    definition: cloneDefinition(w.definition),
+  };
+}
+
+/** Structured deep clone of a definition (safe for our JSON-only shapes). */
+export function cloneDefinition(def: WorkflowDefinition): WorkflowDefinition {
+  return JSON.parse(JSON.stringify(def)) as WorkflowDefinition;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+export type BuilderAction =
+  // Trigger block / metadata
+  | { kind: 'setName'; value: string }
+  | { kind: 'setDescription'; value: string }
+  | { kind: 'setEnabled'; value: boolean }
+  | { kind: 'setTrigger'; value: WorkflowTriggerType }
+  | { kind: 'setCron'; value: string }
+  // Conditions — top level
+  | { kind: 'setMatch'; value: WorkflowMatch }
+  | { kind: 'addLeaf' }
+  | { kind: 'addGroup' }
+  | { kind: 'removeTop'; index: number }
+  | { kind: 'updateLeaf'; index: number; patch: Partial<WorkflowLeafCondition> }
+  // Conditions — group level
+  | { kind: 'setGroupMatch'; groupIndex: number; value: WorkflowMatch }
+  | { kind: 'addGroupLeaf'; groupIndex: number }
+  | { kind: 'removeGroupLeaf'; groupIndex: number; childIndex: number }
+  | {
+      kind: 'updateGroupLeaf';
+      groupIndex: number;
+      childIndex: number;
+      patch: Partial<WorkflowLeafCondition>;
+    }
+  // Actions
+  | { kind: 'addAction'; action: WorkflowActionInstance }
+  | { kind: 'setAction'; index: number; action: WorkflowActionInstance }
+  | { kind: 'removeAction'; index: number }
+  | { kind: 'moveAction'; index: number; direction: -1 | 1 }
+  // Safety options
+  | { kind: 'setMaxItems'; value: number | undefined }
+  | { kind: 'setRequirePreview'; value: boolean }
+  // Wholesale replace (template/workflow hydration)
+  | { kind: 'replace'; state: BuilderState };
+
+const emptyLeaf = (): WorkflowLeafCondition => ({ field: '', op: '' });
+
+function withDefinition(
+  state: BuilderState,
+  def: WorkflowDefinition,
+): BuilderState {
+  return { ...state, definition: def };
+}
+
+function mapTop(
+  def: WorkflowDefinition,
+  conditions: WorkflowTopCondition[],
+): WorkflowDefinition {
+  return { ...def, conditions };
+}
+
+export function builderReducer(
+  state: BuilderState,
+  action: BuilderAction,
+): BuilderState {
+  const def = state.definition;
+  switch (action.kind) {
+    case 'setName':
+      return { ...state, name: action.value };
+    case 'setDescription':
+      return { ...state, description: action.value };
+    case 'setEnabled':
+      return { ...state, enabled: action.value };
+    case 'setTrigger':
+      return { ...state, trigger: action.value };
+    case 'setCron':
+      return { ...state, cronExpression: action.value };
+
+    case 'setMatch':
+      return withDefinition(state, { ...def, match: action.value });
+
+    case 'addLeaf':
+      return withDefinition(
+        state,
+        mapTop(def, [...def.conditions, emptyLeaf()]),
+      );
+
+    case 'addGroup': {
+      const group: WorkflowGroupCondition = {
+        match: 'all',
+        conditions: [emptyLeaf()],
+      };
+      return withDefinition(state, mapTop(def, [...def.conditions, group]));
+    }
+
+    case 'removeTop':
+      return withDefinition(
+        state,
+        mapTop(
+          def,
+          def.conditions.filter((_, i) => i !== action.index),
+        ),
+      );
+
+    case 'updateLeaf':
+      return withDefinition(
+        state,
+        mapTop(
+          def,
+          def.conditions.map((c, i) => {
+            if (i !== action.index || isWorkflowGroupCondition(c)) return c;
+            return { ...c, ...action.patch };
+          }),
+        ),
+      );
+
+    case 'setGroupMatch':
+      return withDefinition(
+        state,
+        mapTop(
+          def,
+          def.conditions.map((c, i) => {
+            if (i !== action.groupIndex || !isWorkflowGroupCondition(c)) return c;
+            return { ...c, match: action.value };
+          }),
+        ),
+      );
+
+    case 'addGroupLeaf':
+      return withDefinition(
+        state,
+        mapTop(
+          def,
+          def.conditions.map((c, i) => {
+            if (i !== action.groupIndex || !isWorkflowGroupCondition(c)) return c;
+            return { ...c, conditions: [...c.conditions, emptyLeaf()] };
+          }),
+        ),
+      );
+
+    case 'removeGroupLeaf':
+      return withDefinition(
+        state,
+        mapTop(
+          def,
+          def.conditions.map((c, i) => {
+            if (i !== action.groupIndex || !isWorkflowGroupCondition(c)) return c;
+            return {
+              ...c,
+              conditions: c.conditions.filter((_, j) => j !== action.childIndex),
+            };
+          }),
+        ),
+      );
+
+    case 'updateGroupLeaf':
+      return withDefinition(
+        state,
+        mapTop(
+          def,
+          def.conditions.map((c, i) => {
+            if (i !== action.groupIndex || !isWorkflowGroupCondition(c)) return c;
+            return {
+              ...c,
+              conditions: c.conditions.map((leaf, j) =>
+                j === action.childIndex ? { ...leaf, ...action.patch } : leaf,
+              ),
+            };
+          }),
+        ),
+      );
+
+    case 'addAction':
+      return withDefinition(state, {
+        ...def,
+        actions: [...def.actions, action.action],
+      });
+
+    case 'setAction':
+      return withDefinition(state, {
+        ...def,
+        actions: def.actions.map((a, i) => (i === action.index ? action.action : a)),
+      });
+
+    case 'removeAction':
+      return withDefinition(state, {
+        ...def,
+        actions: def.actions.filter((_, i) => i !== action.index),
+      });
+
+    case 'moveAction': {
+      const target = action.index + action.direction;
+      if (target < 0 || target >= def.actions.length) return state;
+      const next = [...def.actions];
+      const [moved] = next.splice(action.index, 1);
+      next.splice(target, 0, moved);
+      return withDefinition(state, { ...def, actions: next });
+    }
+
+    case 'setMaxItems': {
+      const options = { ...(def.options ?? {}) };
+      if (action.value === undefined) delete options.maxItems;
+      else options.maxItems = action.value;
+      return withDefinition(state, { ...def, options });
+    }
+
+    case 'setRequirePreview':
+      return withDefinition(state, {
+        ...def,
+        options: { ...(def.options ?? {}), requirePreview: action.value },
+      });
+
+    case 'replace':
+      return action.state;
+
+    default:
+      return state;
+  }
+}

--- a/apps/web/src/services/workflows.ts
+++ b/apps/web/src/services/workflows.ts
@@ -1,0 +1,153 @@
+import { api } from './api';
+import type {
+  Workflow,
+  WorkflowListResponse,
+  WorkflowsQueryParams,
+  CreateWorkflowDto,
+  UpdateWorkflowDto,
+  WorkflowPreviewRequest,
+  WorkflowPreviewResponse,
+  WorkflowSubjectsResponse,
+  CreateRunDto,
+  RunsQueryParams,
+  RunItemsQueryParams,
+  WorkflowRunStatus,
+  WorkflowRunListResponse,
+  WorkflowRunDetail,
+  WorkflowRunItemsResponse,
+  ApproveRunDto,
+} from '../types/workflows';
+
+// ---------------------------------------------------------------------------
+// Workflow CRUD
+// ---------------------------------------------------------------------------
+
+export async function listWorkflows(
+  params: WorkflowsQueryParams,
+): Promise<WorkflowListResponse> {
+  const searchParams = new URLSearchParams();
+  searchParams.set('circleId', params.circleId);
+  if (params.page) searchParams.set('page', String(params.page));
+  if (params.pageSize) searchParams.set('pageSize', String(params.pageSize));
+  return api.get<WorkflowListResponse>(`/workflows?${searchParams.toString()}`);
+}
+
+export async function getWorkflow(id: string): Promise<Workflow> {
+  return api.get<Workflow>(`/workflows/${id}`);
+}
+
+export async function createWorkflow(dto: CreateWorkflowDto): Promise<Workflow> {
+  return api.post<Workflow>('/workflows', dto);
+}
+
+export async function updateWorkflow(
+  id: string,
+  dto: UpdateWorkflowDto,
+): Promise<Workflow> {
+  return api.patch<Workflow>(`/workflows/${id}`, dto);
+}
+
+export async function deleteWorkflow(id: string): Promise<void> {
+  await api.delete<void>(`/workflows/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Preview + subject registry
+// ---------------------------------------------------------------------------
+
+export async function previewWorkflow(
+  body: WorkflowPreviewRequest,
+): Promise<WorkflowPreviewResponse> {
+  return api.post<WorkflowPreviewResponse>('/workflows/preview', body);
+}
+
+export async function getWorkflowSubjects(): Promise<WorkflowSubjectsResponse> {
+  return api.get<WorkflowSubjectsResponse>('/workflows/subjects');
+}
+
+// ---------------------------------------------------------------------------
+// Runs — note the TWO base paths:
+//   - `/workflows/:id/runs`   (list runs for a workflow)
+//   - `/workflow-runs/:id`    (run detail / items / approve / cancel)
+// ---------------------------------------------------------------------------
+
+export async function runWorkflow(
+  id: string,
+  body?: CreateRunDto,
+): Promise<{ runId: string; status: WorkflowRunStatus }> {
+  return api.post<{ runId: string; status: WorkflowRunStatus }>(
+    `/workflows/${id}/run`,
+    body ?? {},
+  );
+}
+
+export async function listWorkflowRuns(
+  id: string,
+  params?: RunsQueryParams,
+): Promise<WorkflowRunListResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.page) searchParams.set('page', String(params.page));
+  if (params?.pageSize) searchParams.set('pageSize', String(params.pageSize));
+  const qs = searchParams.toString();
+  return api.get<WorkflowRunListResponse>(
+    `/workflows/${id}/runs${qs ? `?${qs}` : ''}`,
+  );
+}
+
+export async function getWorkflowRun(runId: string): Promise<WorkflowRunDetail> {
+  return api.get<WorkflowRunDetail>(`/workflow-runs/${runId}`);
+}
+
+export async function listWorkflowRunItems(
+  runId: string,
+  params?: RunItemsQueryParams,
+): Promise<WorkflowRunItemsResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.status) searchParams.set('status', params.status);
+  if (params?.page) searchParams.set('page', String(params.page));
+  if (params?.pageSize) searchParams.set('pageSize', String(params.pageSize));
+  const qs = searchParams.toString();
+  return api.get<WorkflowRunItemsResponse>(
+    `/workflow-runs/${runId}/items${qs ? `?${qs}` : ''}`,
+  );
+}
+
+export async function approveWorkflowRun(
+  runId: string,
+  body: ApproveRunDto,
+): Promise<{ runId: string; status: WorkflowRunStatus }> {
+  return api.post<{ runId: string; status: WorkflowRunStatus }>(
+    `/workflow-runs/${runId}/approve`,
+    body,
+  );
+}
+
+export async function cancelWorkflowRun(
+  runId: string,
+): Promise<{ runId: string; status: WorkflowRunStatus }> {
+  return api.post<{ runId: string; status: WorkflowRunStatus }>(
+    `/workflow-runs/${runId}/cancel`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Client-side composite
+// ---------------------------------------------------------------------------
+
+/**
+ * Duplicate a workflow. There is NO server duplicate endpoint — this is a
+ * client-side composite that calls `createWorkflow` with a copied definition,
+ * a "Copy of …" name, and `enabled: false` so the clone never runs until the
+ * user reviews it.
+ */
+export async function duplicateWorkflow(source: Workflow): Promise<Workflow> {
+  return createWorkflow({
+    circleId: source.circleId,
+    name: `Copy of ${source.name}`,
+    description: source.description,
+    enabled: false,
+    trigger: source.trigger,
+    cronExpression: source.cronExpression,
+    definition: source.definition,
+  });
+}

--- a/apps/web/src/types/workflows.ts
+++ b/apps/web/src/types/workflows.ts
@@ -1,0 +1,375 @@
+// ---------------------------------------------------------------------------
+// Workflows — domain types (Phase 3)
+//
+// Mirrors the backend Phase 1/2 shapes exactly. All date-ish fields are typed
+// as `string` because JSON transports ISO 8601 strings.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Workflow definition + condition/action model
+// ---------------------------------------------------------------------------
+
+export type WorkflowSubjectType = 'media_item';
+
+export type WorkflowTriggerType = 'manual' | 'on_media_enriched' | 'scheduled';
+
+export type WorkflowMatch = 'all' | 'any';
+
+export interface WorkflowLeafCondition {
+  field: string;
+  op: string;
+  value?: unknown;
+}
+
+export interface WorkflowGroupCondition {
+  match: WorkflowMatch;
+  conditions: WorkflowLeafCondition[];
+}
+
+export type WorkflowTopCondition = WorkflowLeafCondition | WorkflowGroupCondition;
+
+/**
+ * Narrow a top-level condition to a group (nested match + conditions[]) vs. a
+ * leaf (field/op/value). True only when both `match` and `conditions` keys are
+ * present.
+ */
+export function isWorkflowGroupCondition(
+  c: WorkflowTopCondition,
+): c is WorkflowGroupCondition {
+  return (
+    typeof c === 'object' &&
+    c !== null &&
+    'match' in c &&
+    'conditions' in c
+  );
+}
+
+/**
+ * A single action instance. IMPORTANT: action params are TOP-LEVEL siblings of
+ * `type`, not nested under a `params` key — e.g.
+ *   { type: 'add_to_album', createAlbumNamed: 'Italy 2025' }
+ *   { type: 'resolve_duplicate_group', action: 'trash' }
+ */
+export interface WorkflowActionInstance {
+  type: string;
+  [param: string]: unknown;
+}
+
+export interface WorkflowDefinition {
+  version: 1;
+  subject: WorkflowSubjectType;
+  match: WorkflowMatch;
+  conditions: WorkflowTopCondition[];
+  actions: WorkflowActionInstance[];
+  options?: {
+    maxItems?: number;
+    requirePreview?: boolean;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Subject registry (GET /api/workflows/subjects)
+// ---------------------------------------------------------------------------
+
+export type WorkflowFieldGroup =
+  | 'File'
+  | 'Dates'
+  | 'Location'
+  | 'Tags'
+  | 'People'
+  | 'Media'
+  | 'Organization'
+  | 'Review';
+
+export type WorkflowFieldType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'date'
+  | 'geo-radius'
+  | 'tag-set'
+  | 'person-set'
+  | 'uuid';
+
+export type WorkflowValueType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'iso-date'
+  | 'date-range'
+  | 'positive-int'
+  | 'string-list'
+  | 'person-set'
+  | 'geo-radius'
+  | 'uuid'
+  | 'none';
+
+export type WorkflowOperator =
+  | 'contains'
+  | 'starts_with'
+  | 'ends_with'
+  | 'equals'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'between'
+  | 'before'
+  | 'after'
+  | 'older_than_days'
+  | 'within_last_days'
+  | 'is'
+  | 'is_set'
+  | 'has_any'
+  | 'has_all'
+  | 'has_none'
+  | 'has_person'
+  | 'not_has_person'
+  | 'in_album'
+  | 'not_in_album'
+  | 'near';
+
+export type WorkflowDependency =
+  | 'metadata'
+  | 'tags'
+  | 'faces'
+  | 'bursts'
+  | 'duplicates'
+  | 'locationSuggestions';
+
+export interface WorkflowFieldDescriptor {
+  key: string;
+  label: string;
+  group: WorkflowFieldGroup;
+  type: WorkflowFieldType;
+  operators: WorkflowOperator[];
+  valueType: WorkflowValueType;
+  enumValues?: string[];
+  dependency: WorkflowDependency;
+  readTimeRefinement?: boolean;
+}
+
+export interface WorkflowActionDescriptor {
+  type: string;
+  label: string;
+  destructive?: boolean;
+}
+
+export interface SubjectRegistryEntry {
+  subject: WorkflowSubjectType;
+  label: string;
+  triggers: WorkflowTriggerType[];
+  fields: WorkflowFieldDescriptor[];
+  actions: WorkflowActionDescriptor[];
+}
+
+export interface WorkflowSubjectsResponse {
+  subjects: SubjectRegistryEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Workflow entity + list
+// ---------------------------------------------------------------------------
+
+export interface WorkflowRunSummary {
+  id: string;
+  status: WorkflowRunStatus;
+  matchedCount: number;
+  succeededCount: number;
+  failedCount: number;
+  skippedCount: number;
+  finishedAt: string | null;
+  createdAt: string;
+}
+
+export interface Workflow {
+  id: string;
+  circleId: string;
+  name: string;
+  description: string | null;
+  subjectType: WorkflowSubjectType;
+  enabled: boolean;
+  trigger: WorkflowTriggerType;
+  cronExpression: string | null;
+  nextRunAt: string | null;
+  definition: WorkflowDefinition;
+  dependencies: string[];
+  createdById: string | null;
+  createdAt: string;
+  updatedAt: string;
+  /**
+   * NOTE: not currently returned by the list/get API (Phase 1/2 `serialize`
+   * omits it); typed optional for forward-compat and defensive UI rendering.
+   */
+  lastRun?: WorkflowRunSummary | null;
+}
+
+export interface WorkflowListMeta {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface WorkflowListResponse {
+  items: Workflow[];
+  meta: WorkflowListMeta;
+}
+
+// ---------------------------------------------------------------------------
+// Preview (POST /api/workflows/preview)
+// ---------------------------------------------------------------------------
+
+export interface WorkflowPreviewRequest {
+  circleId: string;
+  definition: WorkflowDefinition;
+}
+
+export interface WorkflowPreviewSampleItem {
+  id: string;
+  type: string;
+  capturedAt: string | null;
+  filename: string | null;
+  width: number | null;
+  height: number | null;
+  thumbnailUrl: string | null;
+}
+
+export interface WorkflowPreviewResponse {
+  matchedCount: number;
+  capped: boolean;
+  sample: WorkflowPreviewSampleItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+export type WorkflowRunStatus =
+  | 'evaluating'
+  | 'awaiting_approval'
+  | 'running'
+  | 'completed'
+  | 'completed_with_errors'
+  | 'failed'
+  | 'cancelled'
+  | 'expired';
+
+export type WorkflowRunItemStatus =
+  | 'matched'
+  | 'excluded'
+  | 'applied'
+  | 'partially_applied'
+  | 'failed'
+  | 'skipped';
+
+export interface WorkflowRun {
+  id: string;
+  workflowId: string;
+  circleId: string;
+  status: WorkflowRunStatus;
+  triggerType: WorkflowTriggerType;
+  matchedCount: number;
+  truncated: boolean;
+  processedCount: number;
+  succeededCount: number;
+  failedCount: number;
+  skippedCount: number;
+  startedById: string | null;
+  approvedById: string | null;
+  createdAt: string;
+  updatedAt: string;
+  approvedAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  lastError: string | null;
+}
+
+export interface WorkflowRunActionSummary {
+  scanned: number;
+  partial: boolean;
+  byActionType: Record<string, { applied: number; failed: number; skipped: number }>;
+}
+
+export interface WorkflowRunDetail extends WorkflowRun {
+  definitionSnapshot: WorkflowDefinition;
+  itemStatusCounts: Record<string, number>;
+  actionSummary: WorkflowRunActionSummary;
+}
+
+export interface WorkflowRunListResponse {
+  items: WorkflowRun[];
+  meta: WorkflowListMeta;
+}
+
+export interface WorkflowRunItem {
+  id: string;
+  mediaItemId: string;
+  status: WorkflowRunItemStatus;
+  actionResults: unknown;
+  error: string | null;
+  updatedAt: string;
+  media: {
+    type: string;
+    capturedAt: string | null;
+    filename: string | null;
+    width: number | null;
+    height: number | null;
+  } | null;
+  thumbnailUrl: string | null;
+}
+
+export interface WorkflowRunItemsResponse {
+  items: WorkflowRunItem[];
+  meta: WorkflowListMeta;
+}
+
+// ---------------------------------------------------------------------------
+// DTOs / query params
+// ---------------------------------------------------------------------------
+
+export interface CreateWorkflowDto {
+  circleId: string;
+  name: string;
+  description?: string | null;
+  enabled?: boolean;
+  trigger?: WorkflowTriggerType;
+  cronExpression?: string | null;
+  definition: WorkflowDefinition;
+}
+
+export interface UpdateWorkflowDto {
+  name?: string;
+  description?: string | null;
+  enabled?: boolean;
+  trigger?: WorkflowTriggerType;
+  cronExpression?: string | null;
+  definition?: WorkflowDefinition;
+}
+
+export interface CreateRunDto {
+  maxItems?: number;
+}
+
+export interface ApproveRunDto {
+  excludedItemIds?: string[];
+  confirmation?: string;
+}
+
+export interface WorkflowsQueryParams {
+  circleId: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RunsQueryParams {
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RunItemsQueryParams {
+  status?: WorkflowRunItemStatus;
+  page?: number;
+  pageSize?: number;
+}

--- a/apps/web/src/utils/workflowCron.ts
+++ b/apps/web/src/utils/workflowCron.ts
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------------
+// Cron helpers for the workflow scheduler (pure, never throw).
+//
+// The builder only needs standard 5-field cron (`min hour dom month dow`) with a
+// minimum interval of one hour (the epic's stated floor — no sub-hourly runs).
+// `cronToText` for human rendering already lives in `workflowFormat.ts`; this
+// module adds validation + the preset catalog.
+// ---------------------------------------------------------------------------
+
+export interface CronPreset {
+  id: string;
+  label: string;
+  expression: string;
+}
+
+/** Ready-made schedules surfaced as quick-pick buttons. */
+export const CRON_PRESETS: CronPreset[] = [
+  { id: 'nightly', label: 'Nightly (3:00 AM)', expression: '0 3 * * *' },
+  { id: 'weekly', label: 'Weekly (Sun 4:00 AM)', expression: '0 4 * * 0' },
+  { id: 'monthly', label: 'Monthly (1st, 5:00 AM)', expression: '0 5 1 * *' },
+];
+
+/** Static hint shown when the settings-derived minimum interval is unavailable. */
+export const CRON_MIN_INTERVAL_HINT =
+  'Scheduled workflows run at most once per hour — sub-hourly schedules are not allowed.';
+
+const FIELD_RANGES: Array<[number, number]> = [
+  [0, 59], // minute
+  [0, 23], // hour
+  [1, 31], // day of month
+  [1, 12], // month
+  [0, 7], // day of week (0 and 7 both = Sunday)
+];
+
+/**
+ * Validate a single cron field token against its numeric range. Supports the
+ * wildcard, step (`slash n`), range (`a-b`), list (`a,b`), and single-number forms.
+ */
+function isValidField(token: string, min: number, max: number): boolean {
+  if (token === '*') return true;
+
+  // Step: */n or a-b/n
+  if (token.includes('/')) {
+    const [range, stepStr] = token.split('/');
+    const step = Number(stepStr);
+    if (!Number.isInteger(step) || step <= 0) return false;
+    return range === '*' || isValidField(range, min, max);
+  }
+
+  // List: a,b,c
+  if (token.includes(',')) {
+    return token.split(',').every((part) => isValidField(part, min, max));
+  }
+
+  // Range: a-b
+  if (token.includes('-')) {
+    const [aStr, bStr] = token.split('-');
+    const a = Number(aStr);
+    const b = Number(bStr);
+    if (!Number.isInteger(a) || !Number.isInteger(b)) return false;
+    return a >= min && b <= max && a <= b;
+  }
+
+  // Single number
+  const n = Number(token);
+  return Number.isInteger(n) && n >= min && n <= max;
+}
+
+/**
+ * True when `expr` is a syntactically valid 5-field cron expression that also
+ * runs no more often than hourly (the minute field must be a single fixed value,
+ * so a wildcard or every-N-minutes minute field is rejected as sub-hourly).
+ */
+export function isValidCron(expr: string): boolean {
+  if (!expr || typeof expr !== 'string') return false;
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return false;
+
+  for (let i = 0; i < 5; i++) {
+    const [min, max] = FIELD_RANGES[i];
+    if (!isValidField(parts[i], min, max)) return false;
+  }
+
+  // Enforce the hourly floor: the minute field must be a single fixed number.
+  const minuteField = parts[0];
+  if (!/^\d+$/.test(minuteField)) return false;
+
+  return true;
+}

--- a/apps/web/src/utils/workflowFormat.ts
+++ b/apps/web/src/utils/workflowFormat.ts
@@ -225,7 +225,7 @@ function paramStringList(value: unknown): string[] {
  * Examples:
  *   { type: 'move_to_trash' }                              → "Move to Trash"
  *   { type: 'archive' }                                    → "Archive"
- *   { type: 'add_tag', tags: ['screenshot'] }              → "Add tag 'screenshot'"
+ *   { type: 'add_tags', names: ['screenshot'] }             → "Add tag 'screenshot'"
  *   { type: 'add_to_album', createAlbumNamed: 'Italy' }    → "Add to album 'Italy'"
  *   { type: 'resolve_duplicate_group', action: 'trash' }   → "Resolve duplicate groups: keep best, trash the rest"
  */
@@ -257,12 +257,16 @@ export function describeWorkflowAction(action: WorkflowActionInstance): string {
         paramString(action.albumId);
       return name ? `Add to album '${name}'` : 'Add to album';
     }
-    case 'add_tag': {
-      const tags = paramStringList(action.tags ?? action.tag ?? action.tagName);
+    case 'add_tags': {
+      // `names` is the actual param key (see ACTION_PARAM_KIND in
+      // workflowActionMeta.ts and the backend registry); `tags`/`tag`/
+      // `tagName` are accepted defensively in case an older payload shape
+      // is ever encountered, but `names` is always checked first.
+      const tags = paramStringList(action.names ?? action.tags ?? action.tag ?? action.tagName);
       return tags.length > 0 ? `Add tag ${tags.map((t) => `'${t}'`).join(', ')}` : 'Add tag';
     }
-    case 'remove_tag': {
-      const tags = paramStringList(action.tags ?? action.tag ?? action.tagName);
+    case 'remove_tags': {
+      const tags = paramStringList(action.names ?? action.tags ?? action.tag ?? action.tagName);
       return tags.length > 0 ? `Remove tag ${tags.map((t) => `'${t}'`).join(', ')}` : 'Remove tag';
     }
     case 'set_location':

--- a/apps/web/src/utils/workflowFormat.ts
+++ b/apps/web/src/utils/workflowFormat.ts
@@ -1,4 +1,9 @@
-import type { WorkflowTriggerType, WorkflowRunStatus } from '../types/workflows';
+import type {
+  WorkflowTriggerType,
+  WorkflowRunStatus,
+  WorkflowActionInstance,
+  WorkflowDefinition,
+} from '../types/workflows';
 
 // ---------------------------------------------------------------------------
 // Pure formatting helpers for the Workflows UI. No React, never throw.
@@ -151,4 +156,171 @@ export function runStatusLabel(status: WorkflowRunStatus): string {
   return words
     .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
     .join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Run-page helpers
+// ---------------------------------------------------------------------------
+
+/** The set of run statuses that are final (no more polling). */
+const TERMINAL_RUN_STATUSES: ReadonlySet<WorkflowRunStatus> = new Set([
+  'completed',
+  'completed_with_errors',
+  'failed',
+  'cancelled',
+  'expired',
+]);
+
+/** True when the run has reached a final state and polling can stop. */
+export function isTerminalRunStatus(status: WorkflowRunStatus): boolean {
+  return TERMINAL_RUN_STATUSES.has(status);
+}
+
+/** Format an integer with locale thousands separators, e.g. 2481 → "2,481". */
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n)) return '0';
+  return Math.round(n).toLocaleString();
+}
+
+/**
+ * The literal string the user must type to confirm a hard-delete run. Must
+ * match the backend contract exactly: `DELETE {matchedCount}` where
+ * matchedCount is the RAW integer (no thousands separators).
+ */
+export function hardDeleteConfirmationText(matchedCount: number): string {
+  return `DELETE ${matchedCount}`;
+}
+
+/** True when a workflow definition contains a `hard_delete` action. */
+export function definitionHasHardDelete(
+  definition: WorkflowDefinition | null | undefined,
+): boolean {
+  if (!definition || !Array.isArray(definition.actions)) return false;
+  return definition.actions.some((a) => a.type === 'hard_delete');
+}
+
+/** Coerce an unknown action param to a trimmed non-empty string, else null. */
+function paramString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const t = value.trim();
+    return t.length > 0 ? t : null;
+  }
+  return null;
+}
+
+/** Coerce an unknown action param to a string list (accepts string or string[]). */
+function paramStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+  }
+  const single = paramString(value);
+  return single ? [single] : [];
+}
+
+/**
+ * Human-readable label for a single workflow action, derived from its `type`
+ * and top-level param siblings. Best-effort and defensive — an unknown action
+ * type falls back to a prettified version of its snake_case type. Never throws.
+ *
+ * Examples:
+ *   { type: 'move_to_trash' }                              → "Move to Trash"
+ *   { type: 'archive' }                                    → "Archive"
+ *   { type: 'add_tag', tags: ['screenshot'] }              → "Add tag 'screenshot'"
+ *   { type: 'add_to_album', createAlbumNamed: 'Italy' }    → "Add to album 'Italy'"
+ *   { type: 'resolve_duplicate_group', action: 'trash' }   → "Resolve duplicate groups: keep best, trash the rest"
+ */
+export function describeWorkflowAction(action: WorkflowActionInstance): string {
+  const prettyType = action.type
+    .split('_')
+    .map((w) => (w.length > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+
+  switch (action.type) {
+    case 'move_to_trash':
+      return 'Move to Trash';
+    case 'archive':
+      return 'Archive';
+    case 'unarchive':
+      return 'Unarchive';
+    case 'set_favorite':
+      return action.favorite === false ? 'Unmark favorite' : 'Mark favorite';
+    case 'hard_delete':
+      return 'Permanently delete';
+    case 'move_to_circle': {
+      const target = paramString(action.targetCircleName) ?? paramString(action.targetCircleId);
+      return target ? `Move to circle '${target}'` : 'Move to circle';
+    }
+    case 'add_to_album': {
+      const name =
+        paramString(action.createAlbumNamed) ??
+        paramString(action.albumName) ??
+        paramString(action.albumId);
+      return name ? `Add to album '${name}'` : 'Add to album';
+    }
+    case 'add_tag': {
+      const tags = paramStringList(action.tags ?? action.tag ?? action.tagName);
+      return tags.length > 0 ? `Add tag ${tags.map((t) => `'${t}'`).join(', ')}` : 'Add tag';
+    }
+    case 'remove_tag': {
+      const tags = paramStringList(action.tags ?? action.tag ?? action.tagName);
+      return tags.length > 0 ? `Remove tag ${tags.map((t) => `'${t}'`).join(', ')}` : 'Remove tag';
+    }
+    case 'set_location':
+      return 'Set location';
+    case 'clear_location':
+      return 'Clear location';
+    case 'set_capture_date':
+      return 'Set capture date';
+    case 'shift_capture_date':
+      return 'Shift capture date';
+    case 'clear_capture_date':
+      return 'Clear capture date';
+    case 'add_person': {
+      const name = paramString(action.personName) ?? paramString(action.name);
+      return name ? `Tag person '${name}'` : 'Tag person';
+    }
+    case 'resolve_duplicate_group': {
+      const rest = action.action === 'archive' ? 'archive the rest' : 'trash the rest';
+      return `Resolve duplicate groups: keep best, ${rest}`;
+    }
+    case 'resolve_burst_group': {
+      const rest = action.action === 'archive' ? 'archive the rest' : 'trash the rest';
+      return `Resolve burst groups: keep best, ${rest}`;
+    }
+    default:
+      return prettyType;
+  }
+}
+
+export interface WorkflowActionImpact {
+  /** Stable key for React lists (action type + ordinal). */
+  key: string;
+  /** Human-readable action label. */
+  label: string;
+  /** Number of items this action will affect / has affected. */
+  count: number;
+}
+
+/**
+ * Derive the per-action impact list shown on the run page. For each action in
+ * the run's `definitionSnapshot`, pair its human label with the count of items
+ * it affects: the applied count from `byActionType` once the run has begun
+ * applying, otherwise the effective matched count (matched minus exclusions)
+ * for the awaiting-approval preview. Defensive — never throws.
+ */
+export function deriveActionImpacts(
+  actions: WorkflowActionInstance[] | null | undefined,
+  effectiveCount: number,
+  byActionType?: Record<string, { applied: number; failed: number; skipped: number }>,
+): WorkflowActionImpact[] {
+  if (!Array.isArray(actions)) return [];
+  return actions.map((action, index) => {
+    const applied = byActionType?.[action.type]?.applied;
+    const count = typeof applied === 'number' ? applied : Math.max(0, effectiveCount);
+    return {
+      key: `${action.type}-${index}`,
+      label: describeWorkflowAction(action),
+      count,
+    };
+  });
 }

--- a/apps/web/src/utils/workflowFormat.ts
+++ b/apps/web/src/utils/workflowFormat.ts
@@ -1,0 +1,154 @@
+import type { WorkflowTriggerType, WorkflowRunStatus } from '../types/workflows';
+
+// ---------------------------------------------------------------------------
+// Pure formatting helpers for the Workflows UI. No React, never throw.
+// ---------------------------------------------------------------------------
+
+/** Human label for a workflow trigger type. */
+export function triggerLabel(trigger: WorkflowTriggerType): string {
+  switch (trigger) {
+    case 'manual':
+      return 'Manual';
+    case 'on_media_enriched':
+      return 'On new media';
+    case 'scheduled':
+      return 'Scheduled';
+    default:
+      return trigger;
+  }
+}
+
+/** Zero-pad a number to two digits. */
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** Format an (hour, minute) 24h pair as a 12-hour clock string, e.g. "3:00 AM". */
+function formatTime12(hour: number, minute: number): string {
+  const period = hour < 12 ? 'AM' : 'PM';
+  let h12 = hour % 12;
+  if (h12 === 0) h12 = 12;
+  return `${h12}:${pad(minute)} ${period}`;
+}
+
+const WEEKDAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+/**
+ * Human-readable text for the common cron presets used by workflow templates.
+ * Falls back to `Cron: <expr>` for anything it can't confidently parse.
+ * Defensive — never throws.
+ */
+export function cronToText(expr: string | null): string {
+  if (!expr) return '';
+  const fallback = `Cron: ${expr}`;
+  try {
+    const parts = expr.trim().split(/\s+/);
+    if (parts.length !== 5) return fallback;
+    const [minStr, hourStr, dom, month, dow] = parts;
+
+    const minute = Number(minStr);
+    const hour = Number(hourStr);
+    if (!Number.isInteger(minute) || !Number.isInteger(hour)) return fallback;
+    if (minute < 0 || minute > 59 || hour < 0 || hour > 23) return fallback;
+
+    const time = formatTime12(hour, minute);
+
+    // Daily: 'm h * * *'
+    if (dom === '*' && month === '*' && dow === '*') {
+      return `Daily at ${time}`;
+    }
+
+    // Weekly: 'm h * * D'
+    if (dom === '*' && month === '*' && dow !== '*') {
+      const dowNum = Number(dow);
+      if (Number.isInteger(dowNum) && dowNum >= 0 && dowNum <= 7) {
+        const weekday = WEEKDAYS[dowNum % 7];
+        return `Weekly on ${weekday} at ${time}`;
+      }
+      return fallback;
+    }
+
+    // Monthly: 'm h D * *'
+    if (dom !== '*' && month === '*' && dow === '*') {
+      const domNum = Number(dom);
+      if (Number.isInteger(domNum) && domNum >= 1 && domNum <= 31) {
+        return `Monthly on day ${domNum} at ${time}`;
+      }
+      return fallback;
+    }
+
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Format an ISO timestamp as a coarse relative time ("just now", "N minutes
+ * ago", …), falling back to a localized date for anything older than a day.
+ * Returns '' for null. Defensive — never throws.
+ */
+export function formatRelativeTime(iso: string | null): string {
+  if (!iso) return '';
+  try {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '';
+    const diffMs = Date.now() - then;
+
+    if (diffMs < 0) return 'just now';
+
+    const minutes = Math.floor(diffMs / 60_000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return '';
+  }
+}
+
+/** MUI color token for a run-status chip. */
+export function runStatusColor(
+  status: WorkflowRunStatus,
+): 'default' | 'info' | 'success' | 'warning' | 'error' {
+  switch (status) {
+    case 'evaluating':
+    case 'running':
+      return 'info';
+    case 'awaiting_approval':
+      return 'warning';
+    case 'completed':
+      return 'success';
+    case 'completed_with_errors':
+      return 'warning';
+    case 'failed':
+      return 'error';
+    case 'cancelled':
+    case 'expired':
+      return 'default';
+    default:
+      return 'default';
+  }
+}
+
+/** Title-cased, space-separated label for a run status. */
+export function runStatusLabel(status: WorkflowRunStatus): string {
+  const words = status.split('_');
+  return words
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}

--- a/apps/web/src/utils/workflowSentence.ts
+++ b/apps/web/src/utils/workflowSentence.ts
@@ -1,0 +1,259 @@
+// ---------------------------------------------------------------------------
+// definitionToSentence — render a workflow draft as one plain-English sentence
+// that updates live above the preview panel, e.g.
+//   "When new media is enriched, if the filename contains 'screenshot' or it's
+//    a PNG with no camera and no date, move it to Trash."
+//
+// Pure and defensive — never throws; unknown fields/operators/actions fall back
+// to their raw keys/labels. Kept out of React so it is unit-testable.
+// ---------------------------------------------------------------------------
+
+import type {
+  WorkflowDefinition,
+  WorkflowLeafCondition,
+  WorkflowTopCondition,
+  WorkflowFieldDescriptor,
+  WorkflowMatch,
+  WorkflowActionInstance,
+  WorkflowTriggerType,
+  SubjectRegistryEntry,
+} from '../types/workflows';
+import { isWorkflowGroupCondition } from '../types/workflows';
+import { cronToText } from './workflowFormat';
+
+function lc(s: string): string {
+  return s.charAt(0).toLowerCase() + s.slice(1);
+}
+
+function quote(v: unknown): string {
+  return `“${String(v)}”`;
+}
+
+function joinList(parts: string[], conj: 'and' | 'or'): string {
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0];
+  if (parts.length === 2) return `${parts[0]} ${conj} ${parts[1]}`;
+  return `${parts.slice(0, -1).join(', ')} ${conj} ${parts[parts.length - 1]}`;
+}
+
+function conjFor(match: WorkflowMatch): 'and' | 'or' {
+  return match === 'any' ? 'or' : 'and';
+}
+
+// ---- Leaf phrasing --------------------------------------------------------
+
+function leafPhrase(
+  leaf: WorkflowLeafCondition,
+  field: WorkflowFieldDescriptor | undefined,
+): string {
+  if (!field) return '(incomplete condition)';
+  const label = lc(field.label);
+  const v = leaf.value;
+
+  switch (leaf.op) {
+    case 'contains':
+      return `the ${label} contains ${quote(v)}`;
+    case 'starts_with':
+      return `the ${label} starts with ${quote(v)}`;
+    case 'ends_with':
+      return `the ${label} ends with ${quote(v)}`;
+    case 'equals':
+      return `the ${label} is ${field.type === 'enum' ? String(v) : quote(v)}`;
+    case 'is': {
+      // Boolean field: value true → the label reads as the state; false → negated.
+      if (field.valueType === 'boolean') {
+        return v === false ? `not ${label}` : label;
+      }
+      return `the ${label} is ${String(v)}`;
+    }
+    case 'is_set':
+      return `the ${label} is set`;
+    case 'gt':
+      return `the ${label} is greater than ${String(v)}`;
+    case 'lt':
+      return `the ${label} is less than ${String(v)}`;
+    case 'gte':
+      return `the ${label} is at least ${String(v)}`;
+    case 'between': {
+      const range = (v ?? {}) as { from?: string; to?: string };
+      if (range.from && range.to) return `the ${label} is between ${range.from} and ${range.to}`;
+      if (range.from) return `the ${label} is on or after ${range.from}`;
+      if (range.to) return `the ${label} is on or before ${range.to}`;
+      return `the ${label} is in a date range`;
+    }
+    case 'before':
+      return `the ${label} is before ${String(v)}`;
+    case 'after':
+      return `the ${label} is after ${String(v)}`;
+    case 'older_than_days':
+      return `the ${label} is older than ${String(v)} days`;
+    case 'within_last_days':
+      return `the ${label} is within the last ${String(v)} days`;
+    case 'has_any':
+      return `it has any of the tags ${tagList(v)}`;
+    case 'has_all':
+      return `it has all of the tags ${tagList(v)}`;
+    case 'has_none':
+      return `it has none of the tags ${tagList(v)}`;
+    case 'has_person':
+      return 'it includes the selected people';
+    case 'not_has_person':
+      return 'it excludes the selected people';
+    case 'in_album':
+      return 'it is in the selected album';
+    case 'not_in_album':
+      return 'it is not in the selected album';
+    case 'near': {
+      const geo = (v ?? {}) as { radiusKm?: number };
+      return `it is within ${geo.radiusKm ?? '?'} km of the selected location`;
+    }
+    default:
+      return `the ${label} ${leaf.op} ${v !== undefined ? quote(v) : ''}`.trim();
+  }
+}
+
+function tagList(v: unknown): string {
+  if (!Array.isArray(v) || v.length === 0) return '(none)';
+  return (v as unknown[]).map((t) => quote(t)).join(', ');
+}
+
+// ---- Conditions clause ----------------------------------------------------
+
+function conditionsClause(
+  def: WorkflowDefinition,
+  fieldByKey: Map<string, WorkflowFieldDescriptor>,
+): string {
+  if (def.conditions.length === 0) return 'for every item';
+
+  const topConj = conjFor(def.match);
+  const parts = def.conditions.map((c: WorkflowTopCondition) => {
+    if (isWorkflowGroupCondition(c)) {
+      const groupConj = conjFor(c.match);
+      const inner = c.conditions.map((leaf) =>
+        leafPhrase(leaf, fieldByKey.get(leaf.field)),
+      );
+      return `(${joinList(inner, groupConj)})`;
+    }
+    return leafPhrase(c, fieldByKey.get(c.field));
+  });
+
+  return `if ${joinList(parts, topConj)}`;
+}
+
+// ---- Action phrasing ------------------------------------------------------
+
+function actionPhrase(
+  action: WorkflowActionInstance,
+  labelByType: Map<string, string>,
+): string {
+  const a = action as Record<string, unknown>;
+  switch (action.type) {
+    case 'move_to_trash':
+      return 'move it to Trash';
+    case 'hard_delete':
+      return 'permanently delete it';
+    case 'archive':
+      return 'archive it';
+    case 'unarchive':
+      return 'unarchive it';
+    case 'add_to_album':
+      return typeof a.createAlbumNamed === 'string' && a.createAlbumNamed
+        ? `add it to a new album ${quote(a.createAlbumNamed)}`
+        : 'add it to the selected album';
+    case 'remove_from_album':
+      return 'remove it from the selected album';
+    case 'add_tags':
+      return Array.isArray(a.names) && a.names.length
+        ? `tag it ${(a.names as unknown[]).map(quote).join(', ')}`
+        : 'add tags';
+    case 'remove_tags':
+      return Array.isArray(a.names) && a.names.length
+        ? `remove the tags ${(a.names as unknown[]).map(quote).join(', ')}`
+        : 'remove tags';
+    case 'set_favorite':
+      return a.value === false ? 'un-favorite it' : 'mark it a favorite';
+    case 'set_captured_at':
+      if (a.mode === 'clear') return 'clear its capture date';
+      if (a.mode === 'shift') return `shift its capture date by ${String(a.shiftMinutes ?? 0)} minutes`;
+      return 'set its capture date';
+    case 'assign_person':
+      return 'assign the selected person';
+    case 'remove_person':
+      return 'remove the selected person';
+    case 'set_location':
+      return 'set its location';
+    case 'clear_location':
+      return 'clear its location';
+    case 'move_to_circle':
+      return 'move it to another circle';
+    case 'rerun_enrichment':
+      return Array.isArray(a.kinds) && a.kinds.length
+        ? `re-run enrichment (${(a.kinds as unknown[]).join(', ')})`
+        : 're-run enrichment';
+    case 'resolve_burst_group':
+      return a.action === 'archive'
+        ? 'keep the best shot and archive the rest of its burst'
+        : 'keep the best shot and trash the rest of its burst';
+    case 'dismiss_burst_group':
+      return 'dismiss its burst group';
+    case 'resolve_duplicate_group':
+      return a.action === 'archive'
+        ? 'keep the best copy and archive the duplicates'
+        : 'keep the best copy and trash the duplicates';
+    case 'dismiss_duplicate_group':
+      return 'dismiss its duplicate group';
+    case 'accept_location_suggestion':
+      return 'accept its location suggestion';
+    case 'reject_location_suggestion':
+      return 'reject its location suggestion';
+    default:
+      return lc(labelByType.get(action.type) ?? action.type.replace(/_/g, ' '));
+  }
+}
+
+// ---- Trigger clause -------------------------------------------------------
+
+function triggerClause(
+  trigger: WorkflowTriggerType | undefined,
+  cronExpression: string | undefined,
+): string {
+  switch (trigger) {
+    case 'on_media_enriched':
+      return 'When new media is enriched';
+    case 'scheduled': {
+      const text = cronExpression ? cronToText(cronExpression) : '';
+      return text ? text : 'On a schedule';
+    }
+    case 'manual':
+    default:
+      return 'When you run this workflow';
+  }
+}
+
+// ---- Public entry ---------------------------------------------------------
+
+export function definitionToSentence(
+  def: WorkflowDefinition,
+  subjectEntry?: SubjectRegistryEntry,
+  trigger?: WorkflowTriggerType,
+  cronExpression?: string,
+): string {
+  const fieldByKey = new Map<string, WorkflowFieldDescriptor>(
+    (subjectEntry?.fields ?? []).map((f) => [f.key, f]),
+  );
+  const labelByType = new Map<string, string>(
+    (subjectEntry?.actions ?? []).map((a) => [a.type, a.label]),
+  );
+
+  const when = triggerClause(trigger, cronExpression);
+  const cond = conditionsClause(def, fieldByKey);
+  const actions =
+    def.actions.length === 0
+      ? 'do nothing yet'
+      : joinList(
+          def.actions.map((a) => actionPhrase(a, labelByType)),
+          'and',
+        );
+
+  return `${when}, ${cond}, ${actions}.`;
+}


### PR DESCRIPTION
Part of #138. Depends on Phases 1–2 (#139, #140, merged). **Closes #141.**

The web UI for Media Workflow Automation — React + MUI, circle-scoped, mobile-responsive, presented as **On [Subject] · When [Trigger] · If [conditions] · Then [actions]** in the familiar IFTTT applet shape, built within our existing MUI theme.

## What's in this PR

**Foundation** — typed API client (`services/workflows.ts`), TypeScript types mirroring the Phase 1 definition/registry shapes, and hooks (`useWorkflows`, `useWorkflow`, `useWorkflowSubjects`, `useWorkflowPreview`, `useWorkflowRun(s)`, `useWorkflowRunItems`, mutations). Feature-gated `/workflows` sidebar entry + routes.

**List page + templates gallery** — applet-style card grid (Subject chip, trigger badge with human-readable cron, optimistic enabled `Switch`, last-run chip, next-run, kebab: Run now / Duplicate / Delete). Empty state is a **templates gallery** with 5 starters (Clean up screenshots, Archive social videos, Trip album, Tag WhatsApp images, Clean up duplicates) — each a full valid definition that pre-fills the builder.

**Builder** — five stacked blocks driven by `GET /api/workflows/subjects`: Subject → Trigger (Manual / On new media / Scheduled + cron helper) → Conditions (grouped field picker, operator filtering, one nesting level, all/any) → Actions (per-action param editors; `hard_delete` error-colored + admin-gated, `move_to_circle` high-impact) → Safety (max-items cap + require-preview). Reuses existing SearchPanel editors (person/location/tag/date). A **live plain-language summary** sentence and a sticky **live match preview** panel (debounced 600ms, `10,000+` when capped, 12-thumbnail sample).

**Run review & progress page** — evaluating (2s poll) → awaiting-approval (matched-count header + truncation banner, per-action impact list, paginated item grid with exclude checkboxes ≤500, typed `DELETE {count}` hard-delete gate) → running (determinate bar + live counters) → terminal (final counts + failed-item table).

**Permission-aware** throughout (viewers read-only; collaborator + `media:write` unlocks mutations; `media:delete` gates hard-delete).

**Tests** (`testing-dev`) — **163 new unit + RTL tests** (subject-driven form population, live summary, condition/group add-remove, preview debounce + capped rendering, template hydration, approval typed-confirmation gate, exclusion-checkbox 500-cap, 2s progress polling). Full web suite (3,072 tests) green; **full-worktree `tsc --noEmit` exits 0**.

## Notes
- Two correctness fixes landed here: the templates gallery icon (`AddCircleOutline` → `AddCircle`, not present in the image's `@mui/icons-material`) and `describeWorkflowAction` matching the real plural `add_tags`/`remove_tags` types (the run-page impact list was falling through to a generic label).
- Feature-gated on `features.workflows` — invisible until the flag is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7pn41YVW5ixYGyT29ntkU