### PR TITLE
Containerized worker: fail-fast operational self-test on startup + heartbeat surfacing

### DIFF
--- a/apps/api/src/doctor/doctor.service.spec.ts
+++ b/apps/api/src/doctor/doctor.service.spec.ts
@@ -1094,4 +1094,142 @@ describe('DoctorService', () => {
       expect(check.message).toContain('off');
     });
   });
+
+  // =========================================================================
+  // 11. nodes.capabilityHealth — issue #148 operational-self-test overlay
+  // =========================================================================
+
+  describe('nodes.capabilityHealth', () => {
+    beforeEach(() => {
+      process.env = healthyEnv();
+      mockSystemSettings.getSettings.mockResolvedValue(makeHealthySettings());
+      mockQueryRawByText(mockPrisma, healthyQueryRawHandlers());
+      (mockPrisma.user.count as jest.Mock).mockResolvedValue(1);
+      (mockPrisma.storageProviderCredential.findFirst as jest.Mock).mockResolvedValue({
+        provider: 's3',
+        enabled: true,
+      });
+      mockAiSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockAiSettings.testEmbedding.mockResolvedValue({ ok: true, dimensions: 1536 } as any);
+      mockFaceSettings.testProvider.mockResolvedValue({ ok: true } as any);
+      mockGeoSettings.testProvider.mockResolvedValue({ ok: true, sample: {} } as any);
+      mockStorageSettings.testConnection.mockResolvedValue({ ok: true, bucket: 'my-bucket' } as any);
+      mockEnrichmentAdmin.getStats.mockResolvedValue(HEALTHY_STATS as any);
+      (mockPrisma.enrichmentJob.count as jest.Mock).mockResolvedValue(0);
+      // One online node with a fresh heartbeat so nodes.heartbeatFreshness stays
+      // 'ok' and doesn't interfere with this check's isolated assertions —
+      // checkNodesHeartbeat and checkNodesCapabilityHealth both read from the
+      // same mocked workerNode.findMany() call.
+      (mockPrisma.workerNode.count as jest.Mock).mockResolvedValue(1);
+    });
+
+    /** A single online node fixture with a fresh heartbeat. */
+    function nodeFixture(opts: { name?: string; eligibleTypes: string[]; capabilities: unknown }): any[] {
+      return [
+        {
+          name: opts.name ?? 'worker-1',
+          eligibleTypes: opts.eligibleTypes,
+          capabilities: opts.capabilities,
+          lastHeartbeatAt: new Date(),
+        },
+      ];
+    }
+
+    it('is status:warning when a node reports operational:false on a capability backing one of its eligibleTypes (#148 shape)', async () => {
+      (mockPrisma.workerNode.findMany as jest.Mock).mockResolvedValue(
+        nodeFixture({
+          eligibleTypes: ['face_detection'],
+          capabilities: {
+            human: {
+              available: true,
+              detail: '@vladmandic/human',
+              operational: false,
+              operationalDetail: 'Human self-test failed: model load error',
+            },
+            sharp: { available: true, detail: 'sharp', operational: true },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'nodes.capabilityHealth');
+
+      expect(check.status).toBe('warning');
+      expect(check.message).toContain('worker-1 (human)');
+      expect(check.actionItem).toBeTruthy();
+    });
+
+    it('does not flag operational:false for a capability that backs none of the node eligibleTypes', async () => {
+      (mockPrisma.workerNode.findMany as jest.Mock).mockResolvedValue(
+        nodeFixture({
+          // geocode has no capability requirements at all (JOB_TYPE_REQUIREMENTS.geocode === []),
+          // and tesseract only backs social_media_detection — not eligible here.
+          eligibleTypes: ['geocode'],
+          capabilities: {
+            tesseract: {
+              available: true,
+              detail: 'tesseract.js',
+              operational: false,
+              operationalDetail: 'language data not present',
+            },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'nodes.capabilityHealth');
+
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('healthy capabilities');
+    });
+
+    it('backward-compat: a node reporting presence-only capabilities (no operational field, pre-#148 shape) is classified exactly as before this change — not degraded', async () => {
+      (mockPrisma.workerNode.findMany as jest.Mock).mockResolvedValue(
+        nodeFixture({
+          eligibleTypes: ['face_detection'],
+          capabilities: {
+            // Older CLI: presence-only shape, no 'status' and no 'operational' field
+            // at all — collectCapabilityEntries has nothing to key on for either of
+            // them, so (both before and after #148) this produces no entry and the
+            // node is never flagged as degraded by this check, regardless of
+            // whether the capability itself is actually present.
+            human: { available: false, detail: '@vladmandic/human not installed' },
+            sharp: { available: true, detail: 'sharp' },
+          },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'nodes.capabilityHealth');
+
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('healthy capabilities');
+    });
+
+    it('still recognizes the legacy flat-string status shape ({ face: "error" }) as degraded — unchanged by #148', async () => {
+      (mockPrisma.workerNode.findMany as jest.Mock).mockResolvedValue(
+        nodeFixture({
+          eligibleTypes: ['face_detection'],
+          capabilities: { face: 'error' },
+        }),
+      );
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'nodes.capabilityHealth');
+
+      expect(check.status).toBe('warning');
+      expect(check.message).toContain('worker-1 (face)');
+    });
+
+    it('is status:skipped when no online node has reported a capability summary at all', async () => {
+      (mockPrisma.workerNode.findMany as jest.Mock).mockResolvedValue(
+        nodeFixture({ eligibleTypes: ['face_detection'], capabilities: undefined }),
+      );
+
+      const report = await service.runDiagnostics();
+      const check = findCheck(report, 'nodes.capabilityHealth');
+
+      expect(check.status).toBe('skipped');
+    });
+  });
 });

--- a/apps/api/src/doctor/doctor.service.ts
+++ b/apps/api/src/doctor/doctor.service.ts
@@ -1203,7 +1203,14 @@ export class DoctorService {
         consider(name, value);
       } else if (value && typeof value === 'object') {
         const rec = value as Record<string, unknown>;
-        if (typeof rec['status'] === 'string') consider(name, rec['status']);
+        if (typeof rec['status'] === 'string') {
+          consider(name, rec['status']);
+        } else if (rec['operational'] === false) {
+          // #148: enriched worker-node capability payload — a startup
+          // operational self-test that FAILED is a degrade distinct from a
+          // merely-absent package (available:false with no operational field).
+          consider(name, 'error');
+        }
       }
     }
 
@@ -1225,8 +1232,13 @@ export class DoctorService {
 
     const capToJobTypes: Record<string, string[]> = {
       face: ['face_detection', 'video_face_detection'],
+      human: ['face_detection', 'video_face_detection'],
+      compreface: ['face_detection', 'video_face_detection'],
       clip: ['duplicate_detection', 'duplicate_detection_batch'],
+      onnxruntime: ['duplicate_detection', 'duplicate_detection_batch'],
       ocr: ['social_media_detection'],
+      tesseract: ['social_media_detection'],
+      ffprobe: ['video_face_detection', 'social_media_detection'],
       ffmpeg: ['video_face_detection', 'social_media_detection'],
       sharp: [
         'face_detection',

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/node.ts
+++ b/apps/cli/src/commands/node.ts
@@ -54,6 +54,7 @@ import { runApiAccessChecks, checkDaemonLiveness } from '../node/doctor-checks.j
 import {
   summarizeCapabilities,
   summarizeJobReadiness,
+  summarizeStartupGate,
   apiAccessLevel,
   WORKER_NODE_SETUP_GUIDE_URL,
   type CapabilityRowSummary,
@@ -1296,6 +1297,27 @@ function doctorCmd(): Command {
       } else if (jobSummary.totalCount > 0) {
         ui.success(`All ${jobSummary.totalCount} job type(s) ready.`);
       }
+      ui.blank();
+
+      // 4.5. Startup gate — the exact operational-gate verdict `node start`
+      //      uses to decide whether a headless container may boot (issue #148).
+      //      Reuses evaluateStartupSelfTest() against the SAME operational
+      //      snapshot and eligibleTypes resolved above: a REQUIRED capability
+      //      whose self-test failed BLOCKS; an optional/degradable one only
+      //      DEGRADES. Both surfaces (this section and the TUI doctor row)
+      //      render the shared summarizeStartupGate() output so they never drift.
+      ui.step('Startup gate');
+      const startupGate = summarizeStartupGate(
+        evaluateStartupSelfTest(caps, operationalCaps, eligibleTypes, faceProvider),
+      );
+      if (startupGate.ok) {
+        ui.success('Startup gate: PASS — all required capabilities operational.');
+      } else {
+        hasError = true;
+        ui.error('Startup gate: BLOCKED — a required capability is not operational:');
+        for (const b of startupGate.blockers) ui.error(`  • ${b}`);
+      }
+      for (const d of startupGate.degrades) ui.warn(d);
       ui.blank();
 
       // 5. Model presence (download-and-verify, as `node start` does).

--- a/apps/cli/src/commands/node.ts
+++ b/apps/cli/src/commands/node.ts
@@ -45,6 +45,7 @@ import {
   isNodeJobType,
   ComputeDispatcher,
   DEFAULT_COMPREFACE_URL,
+  evaluateStartupSelfTest,
   type CapabilityStatus,
 } from '../node/capabilities.js';
 import { ensureModels } from '../node/models.js';
@@ -62,6 +63,7 @@ import {
   defaultHeadlessNodeName,
   supportedTypes,
   registerWorkerNode,
+  resolveStartupSelfTest,
   DEFAULT_NODE_POLL_MS as DEFAULT_POLL_MS,
 } from '../node/register.js';
 import {
@@ -568,6 +570,56 @@ function startCmd(): Command {
           );
         }
 
+        // 1.5. Startup operational self-test (issue #148). Runs the same real
+        //      decode/embed/detect/OCR-init pass as `node doctor`, then
+        //      FAIL-FAST if a capability REQUIRED by this node's eligible types
+        //      is not operational — so a container with a broken baked
+        //      capability crash-loops visibly (compose restart: unless-stopped)
+        //      instead of silently failing every claimed job. Optional/
+        //      degradable capabilities (OCR Tier-2, CLIP dHash-fallback) never
+        //      block. Default ON in headless/container mode; gated by
+        //      MEMORIAHUB_STARTUP_SELFTEST. Runs AFTER the model-ensure above so
+        //      the CLIP/Human self-tests find their freshly-downloaded models.
+        let operationalSnapshot: Record<string, CapabilityStatus> | undefined;
+        if (resolveStartupSelfTest(headless)) {
+          ui.step('Running startup operational self-tests…');
+          const selfTestComprefaceOpts =
+            resolvedFaceProvider === 'compreface'
+              ? { comprefaceUrl: resolvedComprefaceUrl }
+              : undefined;
+          const selfTestCaps = await detectCapabilities(selfTestComprefaceOpts);
+          operationalSnapshot = await runOperationalSelfTests(selfTestCaps, selfTestComprefaceOpts);
+          const evaluation = evaluateStartupSelfTest(
+            selfTestCaps,
+            operationalSnapshot,
+            eligibleTypes,
+            resolvedFaceProvider,
+          );
+          for (const d of evaluation.degraded) {
+            ui.warn(
+              `Capability degraded (non-fatal): ${d.capability}` +
+                (d.detail ? ` — ${d.detail}` : ''),
+            );
+          }
+          if (!evaluation.ok) {
+            ui.error('Startup operational self-test FAILED for required capability(ies):');
+            for (const b of evaluation.blockingFailures) {
+              ui.error(
+                `  • ${b.capability} (required by ${b.jobType})` +
+                  (b.detail ? `: ${b.detail}` : ''),
+              );
+            }
+            ui.error(
+              'Refusing to start — a broken required capability would fail every claimed job. ' +
+                'Diagnose with `memoriahub node doctor`, or set MEMORIAHUB_STARTUP_SELFTEST=0 to skip this check.',
+            );
+            process.exit(1);
+          }
+          ui.success('Startup operational self-test passed for all required capabilities.');
+        } else {
+          ui.dim('Startup operational self-test skipped (MEMORIAHUB_STARTUP_SELFTEST disabled).');
+        }
+
         // 2. Build the engine with file logging and the IPC daemon host, so
         //    every run (foreground or daemonized) is attachable by a second
         //    CLI instance.
@@ -585,6 +637,7 @@ function startCmd(): Command {
           dispatcher: new ComputeDispatcher(),
           nodeId,
           options,
+          ...(operationalSnapshot ? { operationalCapabilities: operationalSnapshot } : {}),
         });
 
         const logger = createNodeLogger();

--- a/apps/cli/src/node/capabilities.ts
+++ b/apps/cli/src/node/capabilities.ts
@@ -254,6 +254,121 @@ export function missingRequirements(
 }
 
 // ---------------------------------------------------------------------------
+// Startup operational self-test evaluation (issue #148)
+// ---------------------------------------------------------------------------
+
+/** A required capability whose operational self-test failed for an eligible type. */
+export interface StartupSelfTestBlocker {
+  capability: string;
+  jobType: NodeJobType;
+  detail?: string;
+}
+
+/** An optional/degradable capability that failed its self-test but does not block. */
+export interface StartupSelfTestDegrade {
+  capability: string;
+  detail?: string;
+}
+
+export interface StartupSelfTestEvaluation {
+  /** True when no REQUIRED capability failed — safe to start the engine. */
+  ok: boolean;
+  blockingFailures: StartupSelfTestBlocker[];
+  degraded: StartupSelfTestDegrade[];
+}
+
+/**
+ * Decide whether a node may start given its startup operational self-test.
+ *
+ * Reuses `missingRequirements()` — the exact readiness logic `node doctor`
+ * uses — against the OPERATIONAL snapshot (not mere presence), so a required
+ * capability whose real decode/embed/detect self-test failed is a blocker,
+ * while an optional/degradable one (e.g. tesseract for social_media_detection
+ * Tier-2 OCR, onnxruntime for duplicate_detection's CLIP) is never listed as a
+ * requirement and therefore only surfaces in `degraded`, never `blockingFailures`.
+ *
+ * Pure — no process side effects; the command layer owns the exit.
+ */
+export function evaluateStartupSelfTest(
+  caps: Record<string, CapabilityStatus>,
+  operationalResults: Record<string, CapabilityStatus>,
+  eligibleTypes: string[],
+  faceProvider: 'human' | 'compreface' = 'human',
+): StartupSelfTestEvaluation {
+  const types = eligibleTypes.filter(isNodeJobType);
+  const blockingFailures: StartupSelfTestBlocker[] = [];
+  const blockingCaps = new Set<string>();
+  for (const t of types) {
+    for (const cap of missingRequirements(t, operationalResults, faceProvider)) {
+      blockingFailures.push({
+        capability: cap,
+        jobType: t,
+        detail: operationalResults[cap]?.detail,
+      });
+      blockingCaps.add(cap);
+    }
+  }
+
+  const degraded: StartupSelfTestDegrade[] = [];
+  for (const [cap, presence] of Object.entries(caps)) {
+    if (blockingCaps.has(cap)) continue;
+    const op = operationalResults[cap];
+    // Installed (presence ok) but its operational self-test did not pass, and it
+    // is not a hard requirement of any eligible type → a non-fatal degrade.
+    if (presence.available && op && !op.available) {
+      degraded.push({ capability: cap, detail: op.detail });
+    }
+  }
+
+  return { ok: blockingFailures.length === 0, blockingFailures, degraded };
+}
+
+// ---------------------------------------------------------------------------
+// Heartbeat capability payload enrichment (issue #148)
+// ---------------------------------------------------------------------------
+
+/**
+ * A capability status enriched with the STARTUP operational self-test outcome.
+ * Backward-compatible superset of {@link CapabilityStatus}: the `operational*`
+ * fields are optional and omitted for capabilities that were never
+ * operationally tested (or are simply absent), so a payload without them is
+ * exactly the pre-#148 presence-only shape an older API already tolerates.
+ */
+export interface OperationalCapabilityStatus extends CapabilityStatus {
+  /** Result of the startup operational self-test; absent = not tested. */
+  operational?: boolean;
+  operationalDetail?: string;
+}
+
+/**
+ * Merge a FRESH presence snapshot (probed every heartbeat) with the CACHED
+ * startup operational self-test result, producing the heartbeat capability
+ * payload. Presence stays live; the (expensive) operational result is only ever
+ * computed once at startup and carried forward here.
+ *
+ * Only present capabilities carry an `operational` field — an absent capability
+ * stays presence-only so the server can distinguish "operational self-test
+ * failed" from "package not installed".
+ */
+export function mergeOperationalCapabilities(
+  presence: Record<string, CapabilityStatus>,
+  operational?: Record<string, CapabilityStatus>,
+): Record<string, OperationalCapabilityStatus> {
+  const out: Record<string, OperationalCapabilityStatus> = {};
+  for (const [key, status] of Object.entries(presence)) {
+    const op = status.available ? operational?.[key] : undefined;
+    out[key] = op
+      ? {
+          ...status,
+          operational: op.available,
+          ...(op.detail ? { operationalDetail: op.detail } : {}),
+        }
+      : { ...status };
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Compute dispatcher
 // ---------------------------------------------------------------------------
 

--- a/apps/cli/src/node/doctor-summary.ts
+++ b/apps/cli/src/node/doctor-summary.ts
@@ -20,7 +20,7 @@
  * vice versa).
  */
 
-import type { CapabilityStatus } from './capabilities.js';
+import type { CapabilityStatus, StartupSelfTestEvaluation } from './capabilities.js';
 import type { ApiAccessCheckResult } from './doctor-checks.js';
 
 // ---------------------------------------------------------------------------
@@ -150,6 +150,52 @@ export function apiAccessLevel(access: ApiAccessCheckResult): HealthLevel {
   if (!access.authOk) return 'error';
   if (access.nodeRegistrationOk === false || !access.manifestOk) return 'warn';
   return 'ok';
+}
+
+// ---------------------------------------------------------------------------
+// Startup operational gate (issue #148)
+// ---------------------------------------------------------------------------
+
+/**
+ * A render-agnostic, pre-formatted verdict of the startup operational gate —
+ * the evaluation `evaluateStartupSelfTest()` (node/capabilities.ts) produces —
+ * shaped so both `doctorCmd()` (CLI `ui.*`) and the TUI doctor row render
+ * identical wording from a single place. `blockers`/`degrades` are
+ * ready-to-print strings; `level` maps to the shared {@link HealthLevel} so the
+ * TUI picks its glyph/color exactly as it does for every other doctor row.
+ *
+ *   - 'error' — at least one REQUIRED capability for an eligible job type
+ *     failed its operational self-test (a startup blocker).
+ *   - 'warn'  — no blockers, but at least one optional/degradable capability
+ *     failed (e.g. OCR Tier-2, CLIP dHash fallback) — non-fatal.
+ *   - 'ok'    — every required capability is operational and nothing degraded.
+ */
+export interface StartupGateSummary {
+  /** True when no REQUIRED capability failed its operational self-test. */
+  ok: boolean;
+  level: HealthLevel;
+  /** Blocking-failure lines (a required cap for an eligible job type). */
+  blockers: string[];
+  /** Degrade lines (optional/degradable cap failed, non-blocking). */
+  degrades: string[];
+}
+
+/**
+ * Format a startup-gate evaluation into the shared, render-agnostic summary.
+ * Pure; the wording lives here so the CLI section and the TUI row never drift.
+ * Both surfaces consume this rather than re-formatting the evaluation twice.
+ */
+export function summarizeStartupGate(
+  evaluation: StartupSelfTestEvaluation,
+): StartupGateSummary {
+  const blockers = evaluation.blockingFailures.map(
+    (b) => `${b.capability} (required by ${b.jobType})` + (b.detail ? `: ${b.detail}` : ''),
+  );
+  const degrades = evaluation.degraded.map(
+    (d) => `${d.capability} — degraded but non-blocking` + (d.detail ? ` (${d.detail})` : ''),
+  );
+  const level: HealthLevel = blockers.length > 0 ? 'error' : degrades.length > 0 ? 'warn' : 'ok';
+  return { ok: evaluation.ok, level, blockers, degrades };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/node/node-engine.ts
+++ b/apps/cli/src/node/node-engine.ts
@@ -51,6 +51,7 @@ import { downloadToFile } from './download.js';
 import {
   ComputeDispatcher,
   detectCapabilities,
+  mergeOperationalCapabilities,
   type CapabilityStatus,
 } from './capabilities.js';
 import { ProviderRateLimitError } from '@memoriahub/enrichment-compute/rate-limit';
@@ -91,6 +92,13 @@ export interface NodeEngineDeps {
   downloadFn?: typeof downloadToFile;
   /** Injectable for tests — defaults to the real capability probe. */
   detectFn?: (opts?: { comprefaceUrl?: string }) => Promise<Record<string, CapabilityStatus>>;
+  /**
+   * Cached STARTUP operational self-test snapshot (issue #148). Merged into the
+   * reported capabilities on every heartbeat WITHOUT being re-run (self-tests
+   * are far too expensive for a ~20s cadence). Undefined → presence-only
+   * heartbeat, exactly the pre-#148 behaviour.
+   */
+  operationalCapabilities?: Record<string, CapabilityStatus>;
   /** Injectable temp directory (defaults to os.tmpdir()). */
   tmpDir?: () => string;
 }
@@ -163,6 +171,8 @@ export class NodeEngine extends NodeTypedEmitter {
   private readonly dispatcher: ComputeDispatcher;
   private readonly nodeId: string;
   private readonly opts: NodeEngineOptions;
+  /** Cached startup operational self-test snapshot; see NodeEngineDeps. */
+  private readonly operationalSnapshot?: Record<string, CapabilityStatus>;
   private readonly resolved: Resolved;
 
   private running = false;
@@ -195,6 +205,7 @@ export class NodeEngine extends NodeTypedEmitter {
     this.dispatcher = deps.dispatcher;
     this.nodeId = deps.nodeId;
     this.opts = deps.options;
+    this.operationalSnapshot = deps.operationalCapabilities;
     this.concurrencyCap = Math.max(1, Math.floor(deps.options.concurrency));
     this.resolved = {
       downloadFn: deps.downloadFn ?? downloadToFile,
@@ -515,9 +526,13 @@ export class NodeEngine extends NodeTypedEmitter {
   /** Send one heartbeat with the current capability summary. */
   private async beat(): Promise<void> {
     try {
-      const capabilities = await this.resolved.detectFn({
+      const presence = await this.resolved.detectFn({
         comprefaceUrl: this.opts.comprefaceUrl,
       });
+      // #148: enrich the live presence probe with the cached startup
+      // operational self-test result (not re-run per heartbeat — far too
+      // expensive) so the admin Doctor sees true operational health.
+      const capabilities = mergeOperationalCapabilities(presence, this.operationalSnapshot);
       await this.api.heartbeatNode(this.nodeId, {
         status: this.draining ? 'draining' : 'online',
         capabilities,

--- a/apps/cli/src/node/register.ts
+++ b/apps/cli/src/node/register.ts
@@ -38,6 +38,23 @@ export function resolveHeadless(
 }
 
 /**
+ * Whether `node start` should run the startup operational self-test (issue #148).
+ * Explicit `MEMORIAHUB_STARTUP_SELFTEST` wins (`1`/`true` → on, `0`/`false` →
+ * off); otherwise it defaults ON in headless (container) mode — where a broken
+ * baked capability must crash-loop visibly — and OFF for an interactive
+ * `node start`, which has `node doctor` a keystroke away.
+ */
+export function resolveStartupSelfTest(
+  headless: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env['MEMORIAHUB_STARTUP_SELFTEST']?.trim().toLowerCase();
+  if (raw === '1' || raw === 'true') return true;
+  if (raw === '0' || raw === 'false') return false;
+  return headless;
+}
+
+/**
  * Node name used by headless auto-registration when none is configured.
  * Precedence: persisted/env-overlaid config name (Phase 1 already overlays
  * MEMORIAHUB_NODE_NAME into cfg.node.name) → raw MEMORIAHUB_NODE_NAME env

--- a/apps/cli/src/tui/NodeDashboard.tsx
+++ b/apps/cli/src/tui/NodeDashboard.tsx
@@ -44,6 +44,7 @@ import { runNodeDoctorSweep, type DoctorSweepState } from './useNodeDoctorSweep.
 import {
   summarizeCapabilities,
   summarizeJobReadiness,
+  summarizeStartupGate,
   WORKER_NODE_SETUP_GUIDE_URL,
 } from '../node/doctor-summary.js';
 import {
@@ -494,6 +495,7 @@ export function NodeDashboard({ config, onBack, onOpenConfig }: NodeDashboardPro
         ? summarizeCapabilities(doctorSweep.caps, doctorSweep.operationalCaps)
         : null;
     const jobsSummary = doctorSweep?.jobReadiness ? summarizeJobReadiness(doctorSweep.jobReadiness) : null;
+    const gateSummary = doctorSweep?.startupGate ? summarizeStartupGate(doctorSweep.startupGate) : null;
     return (
       <Box borderStyle={BOX_BORDER} borderColor="cyan" flexDirection="column" paddingX={2} paddingY={1}>
         <Text bold color="cyan">Worker Node — Doctor</Text>
@@ -566,6 +568,29 @@ export function NodeDashboard({ config, onBack, onOpenConfig }: NodeDashboardPro
                 ))}
               </>
             )}
+          </Box>
+        )}
+        {gateSummary && (
+          <Box flexDirection="column" marginTop={1}>
+            {gateSummary.ok ? (
+              <Text color="green">✔ Startup gate: PASS — all required capabilities operational.</Text>
+            ) : (
+              <>
+                <Text color="red">✖ Startup gate: BLOCKED — a required capability is not operational:</Text>
+                {gateSummary.blockers.map((b, i) => (
+                  <Text key={`gate-block-${i}`} color="red">
+                    {'  ✖ '}
+                    {truncate(b, 40)}
+                  </Text>
+                ))}
+              </>
+            )}
+            {gateSummary.degrades.map((d, i) => (
+              <Text key={`gate-degrade-${i}`} color="yellow">
+                {'  ⚠ '}
+                {truncate(d, 40)}
+              </Text>
+            ))}
           </Box>
         )}
         {doctorSweep?.done && (

--- a/apps/cli/src/tui/NodeDoctor.tsx
+++ b/apps/cli/src/tui/NodeDoctor.tsx
@@ -50,6 +50,7 @@ import {
   apiAccessLevel,
   summarizeCapabilities,
   summarizeJobReadiness,
+  summarizeStartupGate,
   WORKER_NODE_SETUP_GUIDE_URL,
   type CapabilityRowSummary,
   type HealthLevel,
@@ -121,6 +122,11 @@ function computeStepLevel(step: DoctorStepKey, state: DoctorSweepState): StepDis
       if (!state.jobReadiness) return running ? 'running' : 'pending';
       const summary = summarizeJobReadiness(state.jobReadiness);
       return summary.issues.length > 0 ? 'error' : 'ok';
+    }
+
+    case 'startupGate': {
+      if (!state.startupGate) return running ? 'running' : 'pending';
+      return summarizeStartupGate(state.startupGate).level;
     }
 
     case 'models': {
@@ -227,6 +233,7 @@ export function NodeDoctor({ config, onBack, variant = 'screen' }: NodeDoctorPro
   const capsSummary =
     state.caps && state.operationalCaps ? summarizeCapabilities(state.caps, state.operationalCaps) : null;
   const jobsSummary = state.jobReadiness ? summarizeJobReadiness(state.jobReadiness) : null;
+  const gateSummary = state.startupGate ? summarizeStartupGate(state.startupGate) : null;
 
   return (
     <Box
@@ -325,6 +332,37 @@ export function NodeDoctor({ config, onBack, variant = 'screen' }: NodeDoctorPro
               ))}
             </>
           )}
+        </Box>
+      )}
+
+      {/* Startup gate — the same fail-fast verdict `node start` uses to decide
+          whether a headless container may boot. Collapses to one green line on
+          PASS; a blocked gate lists each required capability that failed, and
+          any optional/degradable failures render as non-blocking warnings.
+          Renders in both variants, mirroring the Capabilities/Job-readiness
+          sections. */}
+      {gateSummary && (
+        <Box flexDirection="column" marginTop={1}>
+          {!compact && <Text bold color="cyan">Startup gate</Text>}
+          {gateSummary.ok ? (
+            <Text color="green">✔ Startup gate: PASS — all required capabilities operational.</Text>
+          ) : (
+            <>
+              <Text color="red">✖ Startup gate: BLOCKED — a required capability is not operational:</Text>
+              {gateSummary.blockers.map((b, i) => (
+                <Text key={`gate-block-${i}`} color="red">
+                  {'  ✖ '}
+                  {truncate(b, compact ? 40 : 84)}
+                </Text>
+              ))}
+            </>
+          )}
+          {gateSummary.degrades.map((d, i) => (
+            <Text key={`gate-degrade-${i}`} color="yellow">
+              {'  ⚠ '}
+              {truncate(d, compact ? 40 : 84)}
+            </Text>
+          ))}
         </Box>
       )}
 

--- a/apps/cli/src/tui/useNodeDoctorSweep.ts
+++ b/apps/cli/src/tui/useNodeDoctorSweep.ts
@@ -39,10 +39,12 @@ import type { CliConfig } from '../config.js';
 import {
   detectCapabilities,
   missingRequirements,
+  evaluateStartupSelfTest,
   NODE_JOB_TYPES,
   isNodeJobType,
   type CapabilityStatus,
   type NodeJobType,
+  type StartupSelfTestEvaluation,
 } from '../node/capabilities.js';
 import { ensureModels } from '../node/models.js';
 import { runOperationalSelfTests } from '../node/self-test.js';
@@ -66,15 +68,17 @@ export type DoctorStepKey =
   | 'capabilities'
   | 'selfTest'
   | 'jobReadiness'
+  | 'startupGate'
   | 'models'
   | 'daemon';
 
-/** Sweep step order — mirrors doctorCmd()'s six sections, in order. */
+/** Sweep step order — mirrors doctorCmd()'s sections, in order. */
 export const DOCTOR_STEP_ORDER: DoctorStepKey[] = [
   'apiAccess',
   'capabilities',
   'selfTest',
   'jobReadiness',
+  'startupGate',
   'models',
   'daemon',
 ];
@@ -84,6 +88,7 @@ export const DOCTOR_STEP_LABELS: Record<DoctorStepKey, string> = {
   capabilities: 'Capabilities (installed)',
   selfTest: 'Operational self-tests',
   jobReadiness: 'Job-type readiness',
+  startupGate: 'Startup gate',
   models: 'Models',
   daemon: 'Daemon',
 };
@@ -116,6 +121,12 @@ export interface DoctorSweepState {
   /** Real self-test result — `runOperationalSelfTests()`. */
   operationalCaps: Record<string, CapabilityStatus> | null;
   jobReadiness: JobReadinessRow[] | null;
+  /**
+   * The startup operational-gate verdict — the exact `evaluateStartupSelfTest()`
+   * result `node start` uses to fail-fast a headless container: which required
+   * capabilities BLOCK startup vs. which optional ones only DEGRADE.
+   */
+  startupGate: StartupSelfTestEvaluation | null;
   models: ModelsSweepResult | null;
   daemon: DaemonLivenessResult | null;
   /** True once every step has finished (success or failure). */
@@ -138,6 +149,7 @@ export function initialDoctorSweepState(): DoctorSweepState {
     caps: null,
     operationalCaps: null,
     jobReadiness: null,
+    startupGate: null,
     models: null,
     daemon: null,
     done: false,
@@ -252,6 +264,18 @@ export async function runNodeDoctorSweep(
     return { type: t, ready: missing.length === 0, missing };
   });
   leaveStep('jobReadiness', { jobReadiness });
+
+  // 4.5. Startup gate — the exact operational-gate verdict `node start` uses
+  //      to fail-fast a headless container (issue #148). Reuses the SAME
+  //      operational snapshot and eligibleTypes resolution as job readiness
+  //      above: a REQUIRED capability for an eligible type that failed its
+  //      self-test is a blocker; an optional/degradable one only degrades.
+  //      Pure — never throws — so it needs no per-step try/catch (like the
+  //      job-readiness step above).
+  enterStep('startupGate');
+  const startupGate = evaluateStartupSelfTest(caps, operationalCaps, eligibleTypes, faceProvider);
+  if (!startupGate.ok) hasError = true;
+  leaveStep('startupGate', { startupGate });
 
   // 5. Models — download-and-verify, as `node start` does.
   enterStep('models');

--- a/apps/cli/test/node/capabilities-startup-selftest.spec.ts
+++ b/apps/cli/test/node/capabilities-startup-selftest.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * test/node/capabilities-startup-selftest.spec.ts
+ *
+ * Unit tests for node/capabilities.ts's issue #148 additions:
+ *   - evaluateStartupSelfTest() — decides which operational self-test failures
+ *     BLOCK node startup (required by an eligible job type) vs. are DEGRADE-only
+ *     (optional/degradable capability, e.g. tesseract OCR, onnxruntime CLIP).
+ *   - mergeOperationalCapabilities() — merges a live presence probe with a
+ *     cached startup operational self-test snapshot into the heartbeat payload,
+ *     staying backward-compatible with the pre-#148 presence-only shape.
+ *
+ * Pure functions — no mocking required, no network/filesystem access.
+ */
+
+import {
+  evaluateStartupSelfTest,
+  mergeOperationalCapabilities,
+  type CapabilityStatus,
+} from '../../src/node/capabilities.js';
+
+describe('evaluateStartupSelfTest', () => {
+  it('is ok with no blocking failures or degrades when every required capability passes its operational self-test', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+      human: { available: true, detail: '@vladmandic/human' },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'roundtrip ok' },
+      human: { available: true, detail: 'ran end-to-end' },
+    };
+
+    const result = evaluateStartupSelfTest(caps, operationalResults, ['face_detection']);
+
+    expect(result.ok).toBe(true);
+    expect(result.blockingFailures).toEqual([]);
+    expect(result.degraded).toEqual([]);
+  });
+
+  it('reports a non-empty blockingFailures and ok:false when a required capability fails its operational self-test', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+      human: { available: true, detail: '@vladmandic/human' },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'roundtrip ok' },
+      human: { available: false, detail: 'Human self-test failed: model load error' },
+    };
+
+    const result = evaluateStartupSelfTest(caps, operationalResults, ['face_detection']);
+
+    expect(result.ok).toBe(false);
+    expect(result.blockingFailures).toEqual([
+      {
+        capability: 'human',
+        jobType: 'face_detection',
+        detail: 'Human self-test failed: model load error',
+      },
+    ]);
+    expect(result.degraded).toEqual([]);
+  });
+
+  it('treats a tesseract (OCR) operational failure as a non-blocking degrade when eligibleTypes only needs Tier-1 social_media_detection', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      ffprobe: { available: true, detail: 'ffprobe on PATH' },
+      tesseract: { available: true, detail: 'tesseract.js' },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      ffprobe: { available: true, detail: 'ffprobe on PATH' },
+      tesseract: { available: false, detail: 'language data not present' },
+    };
+
+    const result = evaluateStartupSelfTest(caps, operationalResults, ['social_media_detection']);
+
+    expect(result.ok).toBe(true);
+    expect(result.blockingFailures).toEqual([]);
+    expect(result.degraded).toEqual([
+      { capability: 'tesseract', detail: 'language data not present' },
+    ]);
+  });
+
+  it('treats a tesseract operational failure as a non-blocking degrade even when eligibleTypes does not include social_media_detection at all', () => {
+    // tesseract is never a hard requirement for any NODE_JOB_TYPE (it's always
+    // optional/degraded — Tier-2 OCR only), so this holds regardless of eligibleTypes.
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+      tesseract: { available: true, detail: 'tesseract.js' },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'roundtrip ok' },
+      tesseract: { available: false, detail: 'language data not present' },
+    };
+
+    const result = evaluateStartupSelfTest(caps, operationalResults, ['auto_tagging']);
+
+    expect(result.ok).toBe(true);
+    expect(result.blockingFailures).toEqual([]);
+    expect(result.degraded).toEqual([
+      { capability: 'tesseract', detail: 'language data not present' },
+    ]);
+  });
+
+  it('gates by eligibleTypes: the same failing capability blocks when required by an eligible type, but only degrades when no eligible type needs it', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      sharp: { available: false, detail: 'sharp self-test failed' },
+    };
+
+    // auto_tagging requires sharp -> blocks.
+    const blockingResult = evaluateStartupSelfTest(caps, operationalResults, ['auto_tagging']);
+    expect(blockingResult.ok).toBe(false);
+    expect(blockingResult.blockingFailures).toEqual([
+      { capability: 'sharp', jobType: 'auto_tagging', detail: 'sharp self-test failed' },
+    ]);
+    expect(blockingResult.degraded).toEqual([]);
+
+    // geocode has NO capability requirements -> the identical sharp failure is
+    // only a degrade, never a blocker, when no eligible type needs sharp.
+    const degradeResult = evaluateStartupSelfTest(caps, operationalResults, ['geocode']);
+    expect(degradeResult.ok).toBe(true);
+    expect(degradeResult.blockingFailures).toEqual([]);
+    expect(degradeResult.degraded).toEqual([
+      { capability: 'sharp', detail: 'sharp self-test failed' },
+    ]);
+  });
+
+  it('filters out eligibleTypes entries that are not valid NodeJobTypes', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      sharp: { available: false, detail: 'sharp self-test failed' },
+    };
+
+    // 'thumbnail_repair' is a global sweep type, never node-eligible; it should
+    // be filtered by isNodeJobType and contribute no requirements.
+    const result = evaluateStartupSelfTest(caps, operationalResults, ['thumbnail_repair']);
+
+    expect(result.ok).toBe(true);
+    expect(result.blockingFailures).toEqual([]);
+    expect(result.degraded).toEqual([{ capability: 'sharp', detail: 'sharp self-test failed' }]);
+  });
+
+  it('substitutes the compreface capability for human when faceProvider=compreface', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true },
+      compreface: { available: true },
+    };
+    const operationalResults: Record<string, CapabilityStatus> = {
+      sharp: { available: true },
+      compreface: { available: false, detail: 'compreface self-test failed: HTTP 503' },
+    };
+
+    const result = evaluateStartupSelfTest(
+      caps,
+      operationalResults,
+      ['face_detection'],
+      'compreface',
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.blockingFailures).toEqual([
+      {
+        capability: 'compreface',
+        jobType: 'face_detection',
+        detail: 'compreface self-test failed: HTTP 503',
+      },
+    ]);
+  });
+
+  it('never degrades a capability whose operational result is missing entirely (not tested)', () => {
+    const caps: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+    };
+    // sharp was probed present but never operationally tested (absent from
+    // operationalResults) — should not appear in blockingFailures OR degraded.
+    const operationalResults: Record<string, CapabilityStatus> = {};
+
+    const result = evaluateStartupSelfTest(caps, operationalResults, ['geocode']);
+
+    expect(result.ok).toBe(true);
+    expect(result.blockingFailures).toEqual([]);
+    expect(result.degraded).toEqual([]);
+  });
+});
+
+describe('mergeOperationalCapabilities', () => {
+  it('leaves a presence entry unchanged (no operational field added) when no operational snapshot is supplied', () => {
+    const presence: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+      human: { available: false, detail: '@vladmandic/human not installed' },
+    };
+
+    const merged = mergeOperationalCapabilities(presence);
+
+    expect(merged).toEqual({
+      sharp: { available: true, detail: 'sharp' },
+      human: { available: false, detail: '@vladmandic/human not installed' },
+    });
+    expect(merged['sharp']).not.toHaveProperty('operational');
+    expect(merged['human']).not.toHaveProperty('operational');
+  });
+
+  it('overlays operational:false plus operationalDetail onto a present capability', () => {
+    const presence: Record<string, CapabilityStatus> = {
+      human: { available: true, detail: '@vladmandic/human' },
+    };
+    const operational: Record<string, CapabilityStatus> = {
+      human: { available: false, detail: 'Human self-test failed: model load error' },
+    };
+
+    const merged = mergeOperationalCapabilities(presence, operational);
+
+    expect(merged['human']).toEqual({
+      available: true,
+      detail: '@vladmandic/human',
+      operational: false,
+      operationalDetail: 'Human self-test failed: model load error',
+    });
+  });
+
+  it('overlays operational:true without an operationalDetail key when the operational result has no detail', () => {
+    const presence: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+    };
+    const operational: Record<string, CapabilityStatus> = {
+      sharp: { available: true },
+    };
+
+    const merged = mergeOperationalCapabilities(presence, operational);
+
+    expect(merged['sharp']).toEqual({ available: true, detail: 'sharp', operational: true });
+    expect(merged['sharp']).not.toHaveProperty('operationalDetail');
+  });
+
+  it('leaves a capability unchanged when it is absent from the operational snapshot (partial/backward-compat snapshot)', () => {
+    const presence: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'sharp' },
+      human: { available: true, detail: '@vladmandic/human' },
+    };
+    // Only sharp was operationally tested; human is absent (e.g. an older
+    // snapshot, or a capability the startup self-test never covers).
+    const operational: Record<string, CapabilityStatus> = {
+      sharp: { available: true, detail: 'roundtrip ok' },
+    };
+
+    const merged = mergeOperationalCapabilities(presence, operational);
+
+    expect(merged['sharp']).toEqual({
+      available: true,
+      detail: 'sharp',
+      operational: true,
+      operationalDetail: 'roundtrip ok',
+    });
+    // human is passed through exactly as in presence — presence-only shape.
+    expect(merged['human']).toEqual({ available: true, detail: '@vladmandic/human' });
+    expect(merged['human']).not.toHaveProperty('operational');
+  });
+
+  it('never consults the operational snapshot for a capability whose presence is unavailable', () => {
+    const presence: Record<string, CapabilityStatus> = {
+      human: { available: false, detail: '@vladmandic/human not installed' },
+    };
+    // Even if a (stale/nonsensical) operational entry exists for a
+    // not-installed capability, it must not be applied.
+    const operational: Record<string, CapabilityStatus> = {
+      human: { available: true, detail: 'ran end-to-end' },
+    };
+
+    const merged = mergeOperationalCapabilities(presence, operational);
+
+    expect(merged['human']).toEqual({
+      available: false,
+      detail: '@vladmandic/human not installed',
+    });
+    expect(merged['human']).not.toHaveProperty('operational');
+  });
+
+  it('returns an empty object for an empty presence map regardless of the operational snapshot', () => {
+    expect(mergeOperationalCapabilities({}, { sharp: { available: true } })).toEqual({});
+    expect(mergeOperationalCapabilities({})).toEqual({});
+  });
+});

--- a/apps/cli/test/node/doctor-summary.spec.ts
+++ b/apps/cli/test/node/doctor-summary.spec.ts
@@ -11,10 +11,14 @@ import {
   capabilityRowLevel,
   summarizeCapabilities,
   summarizeJobReadiness,
+  summarizeStartupGate,
   apiAccessLevel,
   type HealthLevel,
 } from '../../src/node/doctor-summary.js';
-import type { CapabilityStatus } from '../../src/node/capabilities.js';
+import type {
+  CapabilityStatus,
+  StartupSelfTestEvaluation,
+} from '../../src/node/capabilities.js';
 import type { ApiAccessCheckResult } from '../../src/node/doctor-checks.js';
 
 function status(available: boolean, detail?: string): CapabilityStatus {
@@ -157,6 +161,71 @@ describe('summarizeJobReadiness', () => {
     expect(summary.issues).toHaveLength(0);
     expect(summary.readyCount).toBe(0);
     expect(summary.totalCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeStartupGate
+// ---------------------------------------------------------------------------
+
+describe('summarizeStartupGate', () => {
+  it('is level "ok" with no lines when the gate passes clean', () => {
+    const evaluation: StartupSelfTestEvaluation = { ok: true, blockingFailures: [], degraded: [] };
+    const summary = summarizeStartupGate(evaluation);
+    expect(summary.ok).toBe(true);
+    expect(summary.level).toBe('ok');
+    expect(summary.blockers).toEqual([]);
+    expect(summary.degrades).toEqual([]);
+  });
+
+  it('formats each blocking failure with its capability, required job type, and detail; level "error"', () => {
+    const evaluation: StartupSelfTestEvaluation = {
+      ok: false,
+      blockingFailures: [
+        { capability: 'human', jobType: 'face_detection', detail: 'model missing' },
+        { capability: 'sharp', jobType: 'auto_tagging' },
+      ],
+      degraded: [],
+    };
+    const summary = summarizeStartupGate(evaluation);
+    expect(summary.ok).toBe(false);
+    expect(summary.level).toBe('error');
+    expect(summary.blockers).toEqual([
+      'human (required by face_detection): model missing',
+      'sharp (required by auto_tagging)',
+    ]);
+    expect(summary.degrades).toEqual([]);
+  });
+
+  it('is level "warn" for a degrade-only verdict and formats the degrade lines', () => {
+    const evaluation: StartupSelfTestEvaluation = {
+      ok: true,
+      blockingFailures: [],
+      degraded: [
+        { capability: 'tesseract', detail: 'OCR data not present' },
+        { capability: 'onnxruntime' },
+      ],
+    };
+    const summary = summarizeStartupGate(evaluation);
+    expect(summary.ok).toBe(true);
+    expect(summary.level).toBe('warn');
+    expect(summary.blockers).toEqual([]);
+    expect(summary.degrades).toEqual([
+      'tesseract — degraded but non-blocking (OCR data not present)',
+      'onnxruntime — degraded but non-blocking',
+    ]);
+  });
+
+  it('is level "error" when both blockers and degrades are present (blockers dominate)', () => {
+    const evaluation: StartupSelfTestEvaluation = {
+      ok: false,
+      blockingFailures: [{ capability: 'ffmpeg', jobType: 'video_face_detection' }],
+      degraded: [{ capability: 'tesseract' }],
+    };
+    const summary = summarizeStartupGate(evaluation);
+    expect(summary.level).toBe('error');
+    expect(summary.blockers).toHaveLength(1);
+    expect(summary.degrades).toHaveLength(1);
   });
 });
 

--- a/apps/cli/test/node/register.spec.ts
+++ b/apps/cli/test/node/register.spec.ts
@@ -13,6 +13,7 @@
 import { jest } from '@jest/globals';
 import {
   resolveHeadless,
+  resolveStartupSelfTest,
   defaultHeadlessNodeName,
   supportedTypes,
   registerWorkerNode,
@@ -56,6 +57,66 @@ describe('resolveHeadless', () => {
   it('does not treat other MEMORIAHUB_HEADLESS values as headless', () => {
     expect(resolveHeadless({}, { MEMORIAHUB_HEADLESS: '0' })).toBe(false);
     expect(resolveHeadless({}, { MEMORIAHUB_HEADLESS: 'true' })).toBe(false);
+  });
+});
+
+describe('resolveStartupSelfTest', () => {
+  // resolveStartupSelfTest falls back to the real process.env when no env
+  // argument is supplied, so save/restore around every test to avoid leaking
+  // mutations across the suite even though most cases pass an explicit env.
+  const ENV_KEY = 'MEMORIAHUB_STARTUP_SELFTEST';
+  let prevValue: string | undefined;
+
+  beforeEach(() => {
+    prevValue = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (prevValue === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = prevValue;
+  });
+
+  it('defaults ON in headless mode when the env var is unset', () => {
+    expect(resolveStartupSelfTest(true, {})).toBe(true);
+  });
+
+  it('defaults OFF in interactive mode when the env var is unset', () => {
+    expect(resolveStartupSelfTest(false, {})).toBe(false);
+  });
+
+  it('MEMORIAHUB_STARTUP_SELFTEST=0 disables the self-test even in headless mode', () => {
+    expect(resolveStartupSelfTest(true, { [ENV_KEY]: '0' })).toBe(false);
+  });
+
+  it('MEMORIAHUB_STARTUP_SELFTEST=false disables the self-test even in headless mode', () => {
+    expect(resolveStartupSelfTest(true, { [ENV_KEY]: 'false' })).toBe(false);
+  });
+
+  it('MEMORIAHUB_STARTUP_SELFTEST=1 forces the self-test on in interactive mode', () => {
+    expect(resolveStartupSelfTest(false, { [ENV_KEY]: '1' })).toBe(true);
+  });
+
+  it('MEMORIAHUB_STARTUP_SELFTEST=true forces the self-test on in interactive mode', () => {
+    expect(resolveStartupSelfTest(false, { [ENV_KEY]: 'true' })).toBe(true);
+  });
+
+  it('trims whitespace and is case-insensitive', () => {
+    expect(resolveStartupSelfTest(true, { [ENV_KEY]: ' FALSE ' })).toBe(false);
+    expect(resolveStartupSelfTest(false, { [ENV_KEY]: ' TRUE ' })).toBe(true);
+  });
+
+  it('falls back to the headless default for an unrecognized value', () => {
+    expect(resolveStartupSelfTest(true, { [ENV_KEY]: 'yes' })).toBe(true);
+    expect(resolveStartupSelfTest(false, { [ENV_KEY]: 'yes' })).toBe(false);
+  });
+
+  it('reads from the real process.env by default (no env argument supplied)', () => {
+    process.env[ENV_KEY] = '0';
+    expect(resolveStartupSelfTest(true)).toBe(false);
+
+    process.env[ENV_KEY] = '1';
+    expect(resolveStartupSelfTest(false)).toBe(true);
   });
 });
 

--- a/apps/cli/test/tui/node-dashboard-doctor-overlay.spec.tsx
+++ b/apps/cli/test/tui/node-dashboard-doctor-overlay.spec.tsx
@@ -31,16 +31,20 @@ const NODE_JOB_TYPES = ['face_detection', 'auto_tagging'] as const;
 
 const mockDetectCapabilities = jest.fn();
 const mockMissingRequirements = jest.fn();
+const mockEvaluateStartupSelfTest = jest.fn();
 jest.unstable_mockModule('../../src/node/capabilities.js', () => ({
   NODE_JOB_TYPES,
   isNodeJobType: (t: string) => (NODE_JOB_TYPES as readonly string[]).includes(t),
   detectCapabilities: mockDetectCapabilities,
   missingRequirements: mockMissingRequirements,
-  // Unused by this suite (no engine is ever started), but NodeDashboard.tsx
-  // imports it at module scope, so the mock factory must provide it.
+  evaluateStartupSelfTest: mockEvaluateStartupSelfTest,
+  // Unused by this suite (no engine is ever started), but NodeDashboard.tsx →
+  // NodeEngine imports these at module scope, so the mock factory must provide
+  // them or the ESM linker rejects the whole graph before any test runs.
   ComputeDispatcher: class {
     compute = jest.fn();
   },
+  mergeOperationalCapabilities: (presence: unknown) => presence,
 }));
 
 const mockRunOperationalSelfTests = jest.fn();
@@ -126,6 +130,9 @@ beforeEach(() => {
     human: { available: true, detail: '@vladmandic/human' },
   });
   mockMissingRequirements.mockReset().mockReturnValue([]);
+  mockEvaluateStartupSelfTest
+    .mockReset()
+    .mockReturnValue({ ok: true, blockingFailures: [], degraded: [] });
   mockRunOperationalSelfTests.mockReset().mockImplementation(async (caps: unknown) => caps);
   mockRunApiAccessChecks.mockReset().mockResolvedValue(OK_ACCESS);
   mockCheckDaemonLiveness.mockReset().mockResolvedValue(OK_DAEMON);
@@ -160,6 +167,7 @@ describe('NodeDashboard doctor overlay ([r]) — all healthy', () => {
     expect(plain).toContain('Worker Node — Doctor');
     expect(plain).toContain('✔ All 2 capabilities operational.');
     expect(plain).toContain('✔ All 2 job type(s) ready.');
+    expect(plain).toContain('✔ Startup gate: PASS — all required capabilities operational.');
     expect(plain).toContain('✔ Doctor: all checks passed.');
     expect(plain).toContain('https://github.com/marinoscar/MemoriaHub/blob/main/docs/worker-node-setup.md');
     // The per-row table must not render when nothing needs attention.
@@ -186,6 +194,23 @@ describe('NodeDashboard doctor overlay ([r]) — one capability issue', () => {
     expect(plain).toContain('human');
     expect(plain).toContain('human model not downloaded yet');
     expect(plain).not.toContain('sharp');
+    unmount();
+  });
+});
+
+describe('NodeDashboard doctor overlay ([r]) — startup gate blocked', () => {
+  it('renders the BLOCKED verdict and lists the required capability that failed', async () => {
+    mockEvaluateStartupSelfTest.mockReturnValue({
+      ok: false,
+      blockingFailures: [{ capability: 'human', jobType: 'face_detection', detail: 'model missing' }],
+      degraded: [],
+    });
+
+    const { plain, unmount } = await openDoctorOverlay();
+
+    expect(plain).toContain('✖ Startup gate: BLOCKED');
+    expect(plain).toContain('human (required by face_detection)');
+    expect(plain).toContain('✖ Doctor found problems.');
     unmount();
   });
 });

--- a/apps/cli/test/tui/node-doctor-render.spec.tsx
+++ b/apps/cli/test/tui/node-doctor-render.spec.tsx
@@ -38,6 +38,7 @@ const DOCTOR_STEP_ORDER: DoctorStepKey[] = [
   'capabilities',
   'selfTest',
   'jobReadiness',
+  'startupGate',
   'models',
   'daemon',
 ];
@@ -47,6 +48,7 @@ const DOCTOR_STEP_LABELS: Record<DoctorStepKey, string> = {
   capabilities: 'Capabilities (installed)',
   selfTest: 'Operational self-tests',
   jobReadiness: 'Job-type readiness',
+  startupGate: 'Startup gate',
   models: 'Models',
   daemon: 'Daemon',
 };
@@ -110,6 +112,7 @@ function healthyState(): DoctorSweepState {
       { type: 'face_detection', ready: true, missing: [] },
       { type: 'auto_tagging', ready: true, missing: [] },
     ],
+    startupGate: { ok: true, blockingFailures: [], degraded: [] },
     models: {
       manifestCount: 2,
       downloaded: [],
@@ -229,6 +232,36 @@ describe('NodeDoctor — one not-ready job type', () => {
     expect(plain).toContain('✖ auto_tagging');
     expect(plain).toContain('missing sharp');
     expect(plain).not.toContain('face_detection');
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Startup gate section (issue #148)
+// ---------------------------------------------------------------------------
+
+describe('NodeDoctor — startup gate', () => {
+  it('collapses to a single PASS line when the gate is ok', () => {
+    const { plain, unmount } = renderDoctor(healthyState());
+    expect(plain).toContain('✔ Startup gate: PASS — all required capabilities operational.');
+    unmount();
+  });
+
+  it('renders the BLOCKED verdict and each required capability that failed', () => {
+    const state = healthyState();
+    state.startupGate = {
+      ok: false,
+      blockingFailures: [{ capability: 'human', jobType: 'face_detection', detail: 'model missing' }],
+      degraded: [{ capability: 'tesseract', detail: 'OCR data not present' }],
+    };
+    state.hasError = true;
+
+    const { plain, unmount } = renderDoctor(state);
+    expect(plain).toContain('✖ Startup gate: BLOCKED');
+    expect(plain).toContain('human (required by face_detection)');
+    expect(plain).toContain('tesseract — degraded but non-blocking');
+    // Top-checklist row reflects the error, not a plain check.
+    expect(plain).toContain('✖ Startup gate');
     unmount();
   });
 });

--- a/apps/cli/test/tui/node-doctor-sweep.spec.ts
+++ b/apps/cli/test/tui/node-doctor-sweep.spec.ts
@@ -26,11 +26,13 @@ const NODE_JOB_TYPES = ['face_detection', 'auto_tagging'] as const;
 
 const mockDetectCapabilities = jest.fn();
 const mockMissingRequirements = jest.fn();
+const mockEvaluateStartupSelfTest = jest.fn();
 jest.unstable_mockModule('../../src/node/capabilities.js', () => ({
   NODE_JOB_TYPES,
   isNodeJobType: (t: string) => (NODE_JOB_TYPES as readonly string[]).includes(t),
   detectCapabilities: mockDetectCapabilities,
   missingRequirements: mockMissingRequirements,
+  evaluateStartupSelfTest: mockEvaluateStartupSelfTest,
 }));
 
 const mockRunOperationalSelfTests = jest.fn();
@@ -86,6 +88,9 @@ beforeEach(() => {
     human: { available: false, detail: 'human not installed' },
   });
   mockMissingRequirements.mockReset().mockReturnValue([]);
+  mockEvaluateStartupSelfTest
+    .mockReset()
+    .mockReturnValue({ ok: true, blockingFailures: [], degraded: [] });
   mockRunOperationalSelfTests.mockReset().mockImplementation(async (caps: unknown) => caps);
   mockRunApiAccessChecks.mockReset().mockResolvedValue(OK_ACCESS);
   mockCheckDaemonLiveness.mockReset().mockResolvedValue(OK_DAEMON);
@@ -323,6 +328,65 @@ describe('runNodeDoctorSweep — threads faceProvider/comprefaceUrl from config'
     for (const t of NODE_JOB_TYPES) {
       expect(mockMissingRequirements).toHaveBeenCalledWith(t, expect.anything(), 'human');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Startup gate step (issue #148)
+// ---------------------------------------------------------------------------
+
+describe('runNodeDoctorSweep — startup gate', () => {
+  it('evaluates the gate against the operational snapshot + resolved eligibleTypes/faceProvider and stores the verdict', async () => {
+    const evaluation = { ok: true, blockingFailures: [], degraded: [] };
+    mockEvaluateStartupSelfTest.mockReturnValue(evaluation);
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, {
+      nodeId: undefined,
+      node: { faceProvider: 'compreface', eligibleTypes: ['face_detection'] },
+    });
+
+    expect(mockEvaluateStartupSelfTest).toHaveBeenCalledWith(
+      result.caps,
+      result.operationalCaps,
+      ['face_detection'],
+      'compreface',
+    );
+    expect(result.startupGate).toEqual(evaluation);
+    expect(result.completedSteps).toContain('startupGate');
+    expect(result.hasError).toBe(false);
+  });
+
+  it('sets hasError when the gate reports a blocking failure, even if job readiness passed', async () => {
+    // Job readiness sees no missing requirements (default mock), but the gate
+    // independently reports a required capability that failed its self-test.
+    mockEvaluateStartupSelfTest.mockReturnValue({
+      ok: false,
+      blockingFailures: [{ capability: 'sharp', jobType: 'face_detection', detail: 'decode failed' }],
+      degraded: [],
+    });
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, {
+      nodeId: undefined,
+      node: { eligibleTypes: ['face_detection'] },
+    });
+
+    expect(result.hasError).toBe(true);
+    expect(result.startupGate?.blockingFailures).toHaveLength(1);
+    expect(result.done).toBe(true);
+    expect(result.completedSteps).toEqual(DOCTOR_STEP_ORDER);
+  });
+
+  it('does NOT set hasError for a degrade-only gate verdict', async () => {
+    mockEvaluateStartupSelfTest.mockReturnValue({
+      ok: true,
+      blockingFailures: [],
+      degraded: [{ capability: 'tesseract', detail: 'OCR data missing' }],
+    });
+
+    const result = await runNodeDoctorSweep(fakeApi() as never, { nodeId: undefined, node: undefined });
+
+    expect(result.hasError).toBe(false);
+    expect(result.startupGate?.degraded).toHaveLength(1);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

Closes #148. A running worker container previously never proved its compute was **operational** — it only checked capability *presence* + CompreFace reachability on boot, then started claiming jobs. This adds an automatic, fail-fast operational self-test on headless `node start` and surfaces the result to the server-side admin Doctor via heartbeat. No CI changes (per the issue's explicit out-of-scope decision — CI build time is already the slow path).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Closes #148. Follow-up to the containerized worker fleet (#108); complements the on-demand `node doctor` (CLI + TUI) by giving the container an automatic operational check it lacked.

## Changes Made

- **Startup operational self-test (fail-fast)** — headless `node start` runs `runOperationalSelfTests()` once at boot (real sharp decode / CLIP embed / Human detect / OCR init) and `process.exit(1)`s when a capability that the node's `eligibleTypes` actually require fails, so a broken image crash-loops visibly under `restart: unless-stopped` instead of silently failing every job. Optional/degradable capabilities (OCR for Tier-1 social-media detection) never block. New pure helper `evaluateStartupSelfTest` (`capabilities.ts`) reuses the existing eligible-type→capability logic; `resolveStartupSelfTest` (`register.ts`, mirrors `resolveHeadless`) resolves the `MEMORIAHUB_STARTUP_SELFTEST` env gate (default on in headless, opt-in interactive, `=0` disables).
- **Heartbeat carries the operational snapshot** — the startup result is cached and merged into the heartbeat `capabilities` payload via `mergeOperationalCapabilities` (**not** re-run per ~20s beat). The server-side Doctor `nodes.capabilityHealth` treats `operational: false` (for a capability backing an eligible type) as an error-level degrade, distinct from a merely-absent package.
- **Backward-compatible payload** — older nodes report presence-only (no `operational` field) and are classified exactly as before; an older API stores the enriched JSON opaquely.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

CLI `test/node/`: 19 suites / 232 tests pass (28 new across `evaluateStartupSelfTest`/`mergeOperationalCapabilities`/`resolveStartupSelfTest`, covering blocking-vs-degrade gating by `eligibleTypes`, the OCR-never-blocks case, and backward-compat merges). API `src/doctor src/nodes`: 8 suites / 178 tests pass (new `nodes.capabilityHealth` cases for `operational:false` degrade + presence-only backward-compat). Both typechecks clean; CLI bumped to 1.2.6 with lockfile synced. Pre-existing unrelated failures (`face-detection.controller.spec` PeopleService DI; CLI db/export/sync fixture specs) confirmed unchanged.

### Test Instructions

1. `cd apps/cli && NODE_OPTIONS=--experimental-vm-modules npx jest --config jest.config.js test/node`
2. `cd apps/api && npx jest --config ./test/jest.config.js src/doctor src/nodes`
3. Container behavior: a worker image with a broken required capability exits non-zero on startup (visible crash-loop); a healthy image starts normally; `MEMORIAHUB_STARTUP_SELFTEST=0` restores fast-boot.

## Additional Notes

Explicitly **not** included (accepted limitation, documented in #148): running the golden-vector parity gate on arm64 / any CI change. arm64 operational correctness continues to rest on the amd64 build-time gate + pinned native deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spti78XMuA494aAqZGYnrX)_