### PR TITLE
fix(cli): stop TUI hard-crash on setRawMode EIO; recover via /dev/tty

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/tui/JobsDashboard.tsx
+++ b/apps/cli/src/tui/JobsDashboard.tsx
@@ -10,12 +10,13 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Box, Text, render, useApp, useInput } from 'ink';
+import { Box, Text, useApp, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 
 import type { ApiClient, JobInsights } from '../api.js';
 import { formatDuration } from '../format-duration.js';
 import { BOX_BORDER } from './theme.js';
+import { renderTui } from './raw-mode.js';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -39,8 +40,7 @@ export interface JobsDashboardProps {
 // ---------------------------------------------------------------------------
 
 export async function renderJobsDashboard(props: JobsDashboardProps): Promise<void> {
-  const { waitUntilExit } = render(<JobsDashboard {...props} />);
-  await waitUntilExit();
+  await renderTui(<JobsDashboard {...props} />);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/tui/ScanDashboard.tsx
+++ b/apps/cli/src/tui/ScanDashboard.tsx
@@ -11,12 +11,13 @@
  */
 
 import React from 'react';
-import { Box, Text, render, useApp, useInput } from 'ink';
+import { Box, Text, useApp, useInput } from 'ink';
 
 import type { ScanReport } from '../scan/report.js';
 import { formatBytes } from '../format-bytes.js';
 import { formatDuration } from '../format-duration.js';
 import { BOX_BORDER, METER } from './theme.js';
+import { renderTui } from './raw-mode.js';
 
 export interface ScanDashboardProps {
   report: ScanReport;
@@ -28,8 +29,7 @@ export interface ScanDashboardProps {
 // ---------------------------------------------------------------------------
 
 export async function renderScanDashboard(props: ScanDashboardProps): Promise<void> {
-  const { waitUntilExit } = render(<ScanDashboard {...props} />);
-  await waitUntilExit();
+  await renderTui(<ScanDashboard {...props} />);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Box, Text, render, useApp, useInput } from 'ink';
+import { Box, Text, useApp, useInput } from 'ink';
 
 import { loadConfig, type CliConfig } from '../config.js';
 import { maybeReexecWithHeapLimit } from '../node/runtime-tuning.js';
@@ -23,6 +23,7 @@ import { factoryReset } from '../reset.js';
 import { resolveUpdateStatus } from '../version-check.js';
 import type BetterSqlite3 from 'better-sqlite3';
 
+import { renderTui } from './raw-mode.js';
 import { HomeMenu } from './HomeMenu.js';
 import { Menu } from './Menu.js';
 import { LoginScreen } from './LoginScreen.js';
@@ -796,14 +797,5 @@ export async function launchTui(opts?: { currentVersion?: string }): Promise<voi
   // a transparent signal-forwarding shim and must not render the UI.
   if (maybeReexecWithHeapLimit()) return;
 
-  if (!process.stdout.isTTY) {
-    process.stdout.write(
-      'The interactive UI needs a real terminal. ' +
-      'Use `memoriahub sync --all` or `memoriahub --help`.\n',
-    );
-    return;
-  }
-
-  const { waitUntilExit } = render(<App currentVersion={opts?.currentVersion ?? '0.0.0'} />);
-  await waitUntilExit();
+  await renderTui(<App currentVersion={opts?.currentVersion ?? '0.0.0'} />);
 }

--- a/apps/cli/src/tui/raw-mode.ts
+++ b/apps/cli/src/tui/raw-mode.ts
@@ -1,0 +1,104 @@
+/**
+ * tui/raw-mode.ts — safe Ink launch + raw-mode resolution.
+ *
+ * Ink calls `setRawMode` on stdin to capture keystrokes. On serial /
+ * hypervisor / LXC consoles, or when stdin (fd0) is redirected while stdout is
+ * still a TTY, that call throws `setRawMode EIO` and — because Ink surfaces it
+ * synchronously from render — crashes the whole CLI with a stack trace.
+ *
+ * This module centralizes the fix:
+ *   1. `canUseRawMode` probes a stream for a working `setRawMode`.
+ *   2. `resolveInteractiveStdin` falls back to the controlling terminal
+ *      (`/dev/tty`) when `process.stdin` itself can't do raw mode.
+ *   3. `renderTui` is the single safe entry used by every top-level render
+ *      site — it never lets a raw-mode failure hard-crash the process.
+ */
+
+import fs from 'node:fs';
+import tty from 'node:tty';
+import { render } from 'ink';
+import type { ReactElement } from 'react';
+
+/**
+ * True only when `stream` is a TTY whose `setRawMode` actually works. The probe
+ * toggles raw mode on then immediately off; any throw means the terminal can't
+ * support it (serial/LXC/hypervisor consoles, redirected fds).
+ */
+export function canUseRawMode(stream: unknown): stream is NodeJS.ReadStream {
+  const s = stream as Partial<NodeJS.ReadStream> | null | undefined;
+  if (!s || !s.isTTY || typeof s.setRawMode !== 'function') return false;
+  try {
+    s.setRawMode(true);
+    s.setRawMode(false);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a stdin stream Ink can drive in raw mode, or null when none exists.
+ *
+ * Prefers `process.stdin`; when that can't do raw mode (fd0 redirected/broken)
+ * it opens the process's controlling terminal directly via `/dev/tty`, which
+ * often still works. Returns null on platforms/consoles with no usable tty
+ * (e.g. Windows without `/dev/tty`, or a truly non-interactive console). Never
+ * throws.
+ */
+export function resolveInteractiveStdin(): NodeJS.ReadStream | null {
+  try {
+    if (canUseRawMode(process.stdin)) return process.stdin;
+
+    // fd0 may be redirected or broken even though a real controlling terminal
+    // exists — try to attach to it directly.
+    try {
+      const fd = fs.openSync('/dev/tty', 'r');
+      const stream = new tty.ReadStream(fd) as unknown as NodeJS.ReadStream;
+      if (canUseRawMode(stream)) return stream;
+      (stream as unknown as { destroy?: () => void }).destroy?.();
+    } catch {
+      /* no /dev/tty (e.g. Windows) — fall through to null */
+    }
+  } catch {
+    /* defensive: never let stdin resolution throw */
+  }
+  return null;
+}
+
+/**
+ * The single safe entry point for launching an Ink UI. Guards against a missing
+ * TTY and against `setRawMode` failures, printing a friendly message and
+ * returning cleanly instead of crashing with a stack trace in any of them.
+ */
+export async function renderTui(element: ReactElement): Promise<void> {
+  if (!process.stdout.isTTY) {
+    process.stdout.write(
+      'The interactive UI needs a real terminal. ' +
+      'Use `memoriahub sync --all` or `memoriahub --help`.\n',
+    );
+    return;
+  }
+
+  const stdin = resolveInteractiveStdin();
+  if (stdin === null) {
+    process.stdout.write(
+      "This terminal can't run the interactive UI (raw keyboard input is unavailable).\n" +
+      'This usually happens on serial/hypervisor/LXC consoles. Options:\n' +
+      '  • Connect over SSH with a PTY:   ssh -t <user>@<host> memoriahub\n' +
+      '  • Or use headless commands:      memoriahub --help, memoriahub status, memoriahub node status\n',
+    );
+    return;
+  }
+
+  try {
+    const instance = render(element, { stdin });
+    await instance.waitUntilExit();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stdout.write(
+      `The interactive UI could not start (${message}).\n` +
+      'Try connecting over SSH with a PTY (ssh -t <user>@<host> memoriahub), ' +
+      'or use headless commands like `memoriahub --help` / `memoriahub status`.\n',
+    );
+  }
+}

--- a/apps/cli/test/tui/raw-mode.spec.ts
+++ b/apps/cli/test/tui/raw-mode.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * test/tui/raw-mode.spec.ts
+ *
+ * Unit tests for tui/raw-mode.ts — the safe Ink launch + raw-mode resolution
+ * module that fixes the `setRawMode EIO` crash on terminals that can't
+ * support raw mode (serial/LXC/hypervisor consoles, redirected stdin).
+ *
+ * `canUseRawMode` is tested directly. `resolveInteractiveStdin` has no
+ * separate export (it reads the real `process.stdin` / opens `/dev/tty`
+ * internally), so it is exercised indirectly through `renderTui`, with
+ * `process.stdin`/`process.stdout.isTTY` stubbed and `node:fs`'s `openSync`
+ * mocked. Ink's `render` is mocked via jest.unstable_mockModule since this
+ * module calls it directly as a side-effecting launcher rather than being a
+ * component itself — there's no existing ink-testing-library precedent for
+ * that shape in this repo.
+ */
+
+import { jest } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Mocks — registered BEFORE importing the module under test.
+// ---------------------------------------------------------------------------
+
+const mockRender = jest.fn();
+jest.unstable_mockModule('ink', () => ({
+  render: mockRender,
+}));
+
+const mockOpenSync = jest.fn();
+jest.unstable_mockModule('node:fs', () => ({
+  default: { openSync: mockOpenSync },
+  openSync: mockOpenSync,
+}));
+
+const { canUseRawMode, renderTui } = await import('../../src/tui/raw-mode.js');
+
+// ---------------------------------------------------------------------------
+// canUseRawMode
+// ---------------------------------------------------------------------------
+
+describe('canUseRawMode', () => {
+  it('returns false for null and undefined', () => {
+    expect(canUseRawMode(null)).toBe(false);
+    expect(canUseRawMode(undefined)).toBe(false);
+  });
+
+  it('returns false when isTTY is falsy', () => {
+    const stream = { isTTY: false, setRawMode: jest.fn() };
+    expect(canUseRawMode(stream)).toBe(false);
+  });
+
+  it('returns false when setRawMode is missing', () => {
+    const stream = { isTTY: true };
+    expect(canUseRawMode(stream)).toBe(false);
+  });
+
+  it('returns false when setRawMode is not a function', () => {
+    const stream = { isTTY: true, setRawMode: 'nope' };
+    expect(canUseRawMode(stream)).toBe(false);
+  });
+
+  it('returns false and does not throw when setRawMode throws (EIO case)', () => {
+    const stream = {
+      isTTY: true,
+      setRawMode: () => {
+        throw new Error('EIO');
+      },
+    };
+    let result: boolean | undefined;
+    expect(() => {
+      result = canUseRawMode(stream);
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+
+  it('returns true and toggles raw mode on then off for a working stream', () => {
+    const setRawMode = jest.fn();
+    const stream = { isTTY: true, setRawMode };
+    expect(canUseRawMode(stream)).toBe(true);
+    expect(setRawMode.mock.calls).toEqual([[true], [false]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderTui (and resolveInteractiveStdin, exercised indirectly)
+// ---------------------------------------------------------------------------
+
+describe('renderTui', () => {
+  let stdoutWriteSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let originalStdoutIsTTY: PropertyDescriptor | undefined;
+  let originalStdin: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    mockRender.mockReset();
+    mockOpenSync.mockReset();
+    stdoutWriteSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    originalStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+    if (originalStdoutIsTTY) {
+      Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY);
+    }
+    if (originalStdin) {
+      Object.defineProperty(process, 'stdin', originalStdin);
+    }
+  });
+
+  const element = { type: 'fake-element' } as unknown as import('react').ReactElement;
+
+  it('writes the needs-a-real-terminal message and does not render when stdout is not a TTY', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    await renderTui(element);
+
+    expect(mockRender).not.toHaveBeenCalled();
+    const written = stdoutWriteSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toContain('needs a real terminal');
+  });
+
+  it('calls Ink render with the resolved stdin when stdout is a TTY and stdin supports raw mode', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const fakeStdin = { isTTY: true, setRawMode: jest.fn() };
+    Object.defineProperty(process, 'stdin', { value: fakeStdin, configurable: true });
+    mockRender.mockReturnValue({ waitUntilExit: () => Promise.resolve() });
+
+    await renderTui(element);
+
+    expect(mockRender).toHaveBeenCalledTimes(1);
+    const [renderedElement, options] = mockRender.mock.calls[0] as [unknown, { stdin: unknown }];
+    expect(renderedElement).toBe(element);
+    expect(options.stdin).toBe(fakeStdin);
+  });
+
+  it("writes the can't-run-interactive-UI message and does not render when stdin can't do raw mode and /dev/tty is unavailable", async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const fakeStdin = { isTTY: false, setRawMode: jest.fn() };
+    Object.defineProperty(process, 'stdin', { value: fakeStdin, configurable: true });
+    mockOpenSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file or directory, open \'/dev/tty\'');
+    });
+
+    await renderTui(element);
+
+    expect(mockRender).not.toHaveBeenCalled();
+    const written = stdoutWriteSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toContain("can't run the interactive UI");
+  });
+
+  it('resolves (does not reject) and writes a degraded message when Ink render throws synchronously', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const fakeStdin = { isTTY: true, setRawMode: jest.fn() };
+    Object.defineProperty(process, 'stdin', { value: fakeStdin, configurable: true });
+    mockRender.mockImplementation(() => {
+      throw new Error('EIO');
+    });
+
+    await expect(renderTui(element)).resolves.toBeUndefined();
+
+    const written = stdoutWriteSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toContain('could not start');
+    expect(written).toContain('EIO');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",
@@ -8883,7 +8883,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -17062,7 +17062,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -19937,7 +19937,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
## Problem

Running the CLI's Ink terminal UI on terminals that can't enter raw mode — serial / LXC / hypervisor consoles, or any environment where `setRawMode` on stdin fails — throws an **uncaught** `setRawMode EIO` and crashes bare `memoriahub` with a full stack trace:

```
Error: setRawMode EIO ... syscall: 'setRawMode', errno: -5
    at ReadStream.setRawMode (node:tty:81:24)
    at .../node_modules/ink/build/components/App.js:128:23
```

Root cause: the TUI launch guarded only on `process.stdout.isTTY`, but Ink calls `setRawMode` on **stdin**, and nothing caught the failure.

## Fix

New shared safe launcher `apps/cli/src/tui/raw-mode.ts`, wired into all three top-level Ink render sites (main TUI, Scan dashboard, Jobs dashboard):

- `canUseRawMode(stream)` — probes a stream by toggling `setRawMode(true)/(false)` in a try/catch.
- `resolveInteractiveStdin()` — prefers `process.stdin`; when it can't do raw mode (e.g. fd0 redirected), falls back to the controlling terminal `/dev/tty` and probes that; returns `null` if neither works. Never throws.
- `renderTui(element)` — guards `stdout.isTTY`, guards raw-mode availability, and wraps `render()`/`waitUntilExit()` in try/catch. On any failure it prints a friendly message (use `ssh -t` / headless commands) instead of crashing.

Net effect: bare `memoriahub` on a terminal that can't do raw mode now **degrades gracefully** instead of dumping a stack trace, and **recovers the TUI** in the common case where only fd0 was redirected.

## Tests

`apps/cli/test/tui/raw-mode.spec.ts` — 10 unit tests covering the `canUseRawMode` probe (including the EIO-swallow path), the `/dev/tty` fallback, and all `renderTui` branches (non-TTY bail, successful render with the resolved stdin, no-interactive-stdin friendly message, and Ink `render` throwing without rejecting). All passing.

## Version

CLI bumped `1.2.12` → `1.2.13`, lockfile synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)