### PR TITLE
fix(cli): stop interactive TUI heap re-exec that breaks raw-mode input

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -16,7 +16,6 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 
 import { loadConfig, type CliConfig } from '../config.js';
-import { maybeReexecWithHeapLimit } from '../node/runtime-tuning.js';
 import { openDb } from '../db/database.js';
 import { ApiClient, type Circle } from '../api.js';
 import { factoryReset } from '../reset.js';
@@ -790,12 +789,12 @@ function App({ currentVersion }: { currentVersion: string }): React.ReactElement
 // ---------------------------------------------------------------------------
 
 export async function launchTui(opts?: { currentVersion?: string }): Promise<void> {
-  // The Tools › Worker Node dashboard can own an in-process engine that runs
-  // for hours under sustained load — the same OOM exposure as `node start`.
-  // Raise V8's old-space ceiling to a RAM-aware value before Ink renders (see
-  // runtime-tuning.ts). Re-execs once; when it returns true this process is now
-  // a transparent signal-forwarding shim and must not render the UI.
-  if (maybeReexecWithHeapLimit()) return;
-
+  // NOTE: do NOT re-exec here to raise the V8 heap ceiling. A re-exec turns
+  // this process into a signal-forwarding shim whose child loses interactive
+  // raw-mode control of the terminal (setRawMode EIO), which breaks the TUI on
+  // machines where the re-exec fires. Sustained/high-memory worker load has its
+  // own tuned, non-interactive path (`memoriahub node start` / the daemon the
+  // Worker Node dashboard attaches to), so the lightweight interactive menu
+  // stays in-process and untuned.
   await renderTui(<App currentVersion={opts?.currentVersion ?? '0.0.0'} />);
 }

--- a/apps/cli/test/tui/app-launch.spec.ts
+++ b/apps/cli/test/tui/app-launch.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * test/tui/app-launch.spec.ts
+ *
+ * Regression guard for the `launchTui()` re-exec bug: `launchTui()` in
+ * tui/app.tsx used to call `maybeReexecWithHeapLimit()` (from
+ * ../node/runtime-tuning.js) before rendering the Ink UI. That re-exec spawns
+ * a child node process with a different heap-limit flag, and the re-exec'd
+ * child loses raw-mode control over the terminal (`setRawMode EIO`), breaking
+ * the interactive TUI. The fix removed that call from `launchTui`; this test
+ * fails if it is ever reintroduced.
+ *
+ * (`node start`'s use of `maybeReexecWithHeapLimit()` for the long-running
+ * daemon in commands/node.ts is unrelated and correct — out of scope here.)
+ *
+ * Mirrors test/tui/raw-mode.spec.ts's conventions: this repo's Jest config
+ * runs ESM (`NODE_OPTIONS=--experimental-vm-modules`), so mocking is done via
+ * `jest.unstable_mockModule(...)` before any dynamic `await import(...)` of
+ * the module under test, and `ink`'s `render` is mocked the same way (a
+ * `jest.fn()` spy returning `{ waitUntilExit: () => Promise.resolve() }`).
+ */
+
+import { jest } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Mocks — registered BEFORE importing the module under test.
+// ---------------------------------------------------------------------------
+
+const mockRender = jest.fn();
+jest.unstable_mockModule('ink', () => ({
+  render: mockRender,
+  Box: () => null,
+  Text: () => null,
+  useApp: () => ({ exit: jest.fn() }),
+  useInput: () => {},
+}));
+
+// app.tsx imports `maybeReexecWithHeapLimit` from this sibling module. Stub
+// every export it might destructure so the mocked module import is complete
+// (an undefined export used as a function would throw at call time, but more
+// importantly we need to observe whether it's ever invoked).
+const mockMaybeReexecWithHeapLimit = jest.fn(() => false);
+jest.unstable_mockModule('../../src/node/runtime-tuning.js', () => ({
+  maybeReexecWithHeapLimit: mockMaybeReexecWithHeapLimit,
+  resolveHeapLimitMb: jest.fn(() => 0),
+  heapAlreadyTuned: jest.fn(() => true),
+  heapNodeFlags: jest.fn(() => []),
+  tunedChildEnv: jest.fn((env: unknown) => env),
+  configureSharpRuntime: jest.fn(async () => {}),
+  resolveSharpConcurrency: jest.fn(() => 1),
+  resolveDefaultConcurrency: jest.fn(() => 2),
+}));
+
+const { launchTui } = await import('../../src/tui/app.js');
+
+// ---------------------------------------------------------------------------
+// launchTui
+// ---------------------------------------------------------------------------
+
+describe('launchTui', () => {
+  let originalStdoutIsTTY: PropertyDescriptor | undefined;
+  let originalStdin: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    mockRender.mockClear();
+    mockMaybeReexecWithHeapLimit.mockClear();
+    mockRender.mockReturnValue({ waitUntilExit: () => Promise.resolve() });
+
+    originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    originalStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
+
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const fakeStdin = { isTTY: true, setRawMode: jest.fn() };
+    Object.defineProperty(process, 'stdin', { value: fakeStdin, configurable: true });
+  });
+
+  afterEach(() => {
+    if (originalStdoutIsTTY) {
+      Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY);
+    }
+    if (originalStdin) {
+      Object.defineProperty(process, 'stdin', originalStdin);
+    }
+  });
+
+  it('never calls maybeReexecWithHeapLimit and proceeds to render the Ink UI in-process', async () => {
+    await launchTui({ currentVersion: '9.9.9' });
+
+    // Core regression guard: the interactive TUI path must NEVER re-exec to
+    // tune the V8 heap — that re-exec breaks raw-mode terminal control.
+    expect(mockMaybeReexecWithHeapLimit).toHaveBeenCalledTimes(0);
+
+    // Confirms the TUI actually proceeded to render in-process (not exited
+    // early for some unrelated reason, e.g. a bad TTY stub).
+    expect(mockRender).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.13",
+      "version": "1.2.14",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Problem (regression from the 1.2.x worker-node work)

The interactive terminal UI (`memoriahub` with no args) stopped accepting keyboard input on some machines — `setRawMode EIO`, or since v1.2.13 a "This terminal can't run the interactive UI" message. It worked fine on other machines and in earlier CLI versions.

**Root cause (empirically confirmed):** `launchTui()` called `maybeReexecWithHeapLimit()` before rendering the Ink UI (added to raise V8's old-space ceiling for the worker-node in-process engine). On any machine where that re-exec fires — it fires based on the box's RAM vs. node's default heap — the original process becomes a signal-forwarding shim and the re-exec'd child loses raw-mode control of the terminal, so the TUI can't capture keystrokes.

Verified on an affected box: plain `node -e 'process.stdin.setRawMode(true)'` returns `RAWOK` (terminal + node are fine; nvm node, real `/dev/pts/0`), and `MEMORIAHUB_MAX_OLD_SPACE_MB=0 memoriahub` (which disables the re-exec) restores the TUI. A raised heap ceiling can only be set via a launch flag, so a re-exec is fundamentally incompatible with an interactive raw-mode TUI in the same process.

## Fix

Remove the `maybeReexecWithHeapLimit()` call from `launchTui()` — the lightweight interactive menu stays in-process and untuned. Sustained/high-memory worker load keeps its own tuned, **non-interactive** path: `memoriahub node start` / the daemon the Worker Node dashboard attaches to. `commands/node.ts`'s re-exec (the `node start` path) is **unchanged**.

## Tests

`apps/cli/test/tui/app-launch.spec.ts` — asserts `launchTui()` never calls `maybeReexecWithHeapLimit` and proceeds to render in-process. Guards against the re-exec ever being reintroduced into the interactive path. Passing.

## Version

CLI `1.2.13` → `1.2.14`, lockfile synced.

## Note
Builds on #158 (which made the failure degrade gracefully instead of crashing). This PR restores the TUI actually working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)