### PR TITLE
feat(ui): allow fixing/removing mistagged faces in videos (#119)

### DIFF
--- a/apps/web/src/__tests__/components/media/FaceThumbnails.test.tsx
+++ b/apps/web/src/__tests__/components/media/FaceThumbnails.test.tsx
@@ -16,7 +16,7 @@
  *   - Shows error alert when error is set
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
 import { FaceThumbnails } from '../../../components/media/FaceThumbnails';
@@ -30,9 +30,35 @@ vi.mock('../../../hooks/useMediaFaces', () => ({
   useMediaFaces: vi.fn(),
 }));
 
+// Mock face service — listPeople, assignFaces, unassignFace, createPerson,
+// purgeFaces (the shared AssignFaceDialog's dependencies).
+vi.mock('../../../services/face', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../services/face')>();
+  return {
+    ...original,
+    listPeople: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+    assignFaces: vi.fn().mockResolvedValue({ personId: 'p1', assignedCount: 1 }),
+    unassignFace: vi.fn().mockResolvedValue(undefined),
+    createPerson: vi.fn().mockResolvedValue({ id: 'p-new', name: 'New Person', circleId: 'circle-1' }),
+    purgeFaces: vi.fn().mockResolvedValue({ deleted: 1 }),
+  };
+});
+
 import { useMediaFaces } from '../../../hooks/useMediaFaces';
+import {
+  listPeople,
+  assignFaces,
+  unassignFace,
+  createPerson,
+  purgeFaces,
+} from '../../../services/face';
 
 const mockUseMediaFaces = vi.mocked(useMediaFaces);
+const mockListPeople = vi.mocked(listPeople);
+const mockAssignFaces = vi.mocked(assignFaces);
+const mockUnassignFace = vi.mocked(unassignFace);
+const mockCreatePerson = vi.mocked(createPerson);
+const mockPurgeFaces = vi.mocked(purgeFaces);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -87,6 +113,7 @@ describe('FaceThumbnails', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseMediaFaces.mockReturnValue(defaultHookReturn());
+    mockListPeople.mockResolvedValue({ items: [], total: 0 });
   });
 
   // -------------------------------------------------------------------------
@@ -302,6 +329,135 @@ describe('FaceThumbnails', () => {
       render(<FaceThumbnails mediaId="media-1" />);
 
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Assign / reassign / unassign / create via the shared AssignFaceDialog
+  // (issue #119 — AssignFaceDialog was extracted out of this component)
+  // -------------------------------------------------------------------------
+  describe('face assignment via AssignFaceDialog', () => {
+    it('calls assignFaces(personId, [face.id]) when assigning an unassigned face to an existing person', async () => {
+      const user = userEvent.setup();
+      const face = makeFace('face-1', { personId: null, personName: null });
+      mockUseMediaFaces.mockReturnValue(defaultHookReturn({ faces: [face] }));
+      mockListPeople.mockResolvedValue({
+        items: [
+          {
+            id: 'p1',
+            name: 'Alice',
+            isUnlabeled: false,
+            faceCount: 0,
+            coverFace: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            favorite: false,
+          },
+        ],
+        total: 1,
+      });
+
+      render(
+        <FaceThumbnails
+          mediaId="media-1"
+          circleId="circle-1"
+          thumbnailUrl="https://example.com/thumb.jpg"
+        />,
+      );
+
+      await user.click(screen.getByText('Unassigned'));
+
+      const dialog = await screen.findByRole('dialog');
+      const combobox = within(dialog).getByRole('combobox');
+      await user.click(combobox);
+      const aliceOption = await screen.findByRole('option', { name: /alice/i });
+      await user.click(aliceOption);
+      await user.click(within(dialog).getByRole('button', { name: /^assign$/i }));
+
+      await waitFor(() => {
+        expect(mockAssignFaces).toHaveBeenCalledWith('p1', ['face-1']);
+      });
+    });
+
+    it('calls unassignFace(personId, face.id) when unassigning an already-assigned face', async () => {
+      const user = userEvent.setup();
+      const face = makeFace('face-1', { personId: 'p1', personName: 'Alice' });
+      mockUseMediaFaces.mockReturnValue(defaultHookReturn({ faces: [face] }));
+
+      render(
+        <FaceThumbnails
+          mediaId="media-1"
+          circleId="circle-1"
+          thumbnailUrl="https://example.com/thumb.jpg"
+        />,
+      );
+
+      await user.click(screen.getByText('Alice'));
+
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /unassign/i }));
+
+      await waitFor(() => {
+        expect(mockUnassignFace).toHaveBeenCalledWith('p1', 'face-1');
+      });
+    });
+
+    it('calls createPerson({..., faceIds:[face.id]}) when creating a new person for an unassigned face', async () => {
+      const user = userEvent.setup();
+      const face = makeFace('face-1', { personId: null, personName: null });
+      mockUseMediaFaces.mockReturnValue(defaultHookReturn({ faces: [face] }));
+
+      render(
+        <FaceThumbnails
+          mediaId="media-1"
+          circleId="circle-1"
+          thumbnailUrl="https://example.com/thumb.jpg"
+        />,
+      );
+
+      await user.click(screen.getByText('Unassigned'));
+
+      const dialog = await screen.findByRole('dialog');
+      await user.type(within(dialog).getByLabelText(/person name/i), 'Charlie');
+      await user.click(within(dialog).getByRole('button', { name: /create person/i }));
+
+      await waitFor(() => {
+        expect(mockCreatePerson).toHaveBeenCalledWith({
+          circleId: 'circle-1',
+          name: 'Charlie',
+          faceIds: ['face-1'],
+        });
+      });
+    });
+
+    it('calls purgeFaces(circleId, [face.id]) when confirming "Delete detection permanently"', async () => {
+      const user = userEvent.setup();
+      const face = makeFace('face-1', { personId: null, personName: null });
+      mockUseMediaFaces.mockReturnValue(defaultHookReturn({ faces: [face] }));
+
+      render(
+        <FaceThumbnails
+          mediaId="media-1"
+          circleId="circle-1"
+          thumbnailUrl="https://example.com/thumb.jpg"
+        />,
+      );
+
+      await user.click(screen.getByText('Unassigned'));
+
+      const editDialog = await screen.findByRole('dialog');
+      await user.click(
+        within(editDialog).getByRole('button', { name: /delete detection permanently/i }),
+      );
+
+      const purgeDialog = await screen.findByRole('dialog', { name: /delete permanently\?/i });
+      await user.click(
+        within(purgeDialog).getByRole('button', { name: /^delete permanently$/i }),
+      );
+
+      await waitFor(() => {
+        expect(mockPurgeFaces).toHaveBeenCalledWith('circle-1', ['face-1']);
+      });
     });
   });
 });

--- a/apps/web/src/__tests__/components/media/VideoFacePanel.test.tsx
+++ b/apps/web/src/__tests__/components/media/VideoFacePanel.test.tsx
@@ -15,7 +15,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
 import { VideoFacePanel } from '../../../components/media/VideoFacePanel';
 import type { DetectedFaceDto, MediaFaceStatusDto } from '../../../services/face';
@@ -28,7 +29,8 @@ vi.mock('../../../hooks/useMediaFaces', () => ({
   useMediaFaces: vi.fn(),
 }));
 
-// Mock face service — listPeople, addPersonToMedia, removePersonFromMedia
+// Mock face service — listPeople, addPersonToMedia, removePersonFromMedia,
+// assignFaces, unassignFace, createPerson, purgeFaces (AssignFaceDialog deps)
 vi.mock('../../../services/face', async (importOriginal) => {
   const original = await importOriginal<typeof import('../../../services/face')>();
   return {
@@ -36,11 +38,25 @@ vi.mock('../../../services/face', async (importOriginal) => {
     listPeople: vi.fn().mockResolvedValue({ items: [], total: 0 }),
     addPersonToMedia: vi.fn().mockResolvedValue({ personId: 'p1', personName: 'Alice', faceId: 'f1', mediaItemId: 'm1' }),
     removePersonFromMedia: vi.fn().mockResolvedValue(undefined),
+    assignFaces: vi.fn().mockResolvedValue({ personId: 'p1', assignedCount: 1 }),
+    unassignFace: vi.fn().mockResolvedValue(undefined),
+    createPerson: vi.fn().mockResolvedValue({ id: 'p-new', name: 'New Person', circleId: 'circle-1' }),
+    purgeFaces: vi.fn().mockResolvedValue({ deleted: 1 }),
   };
 });
 
 import { useMediaFaces } from '../../../hooks/useMediaFaces';
+import {
+  listPeople,
+  assignFaces,
+  unassignFace,
+  purgeFaces,
+} from '../../../services/face';
 const mockUseMediaFaces = vi.mocked(useMediaFaces);
+const mockListPeople = vi.mocked(listPeople);
+const mockAssignFaces = vi.mocked(assignFaces);
+const mockUnassignFace = vi.mocked(unassignFace);
+const mockPurgeFaces = vi.mocked(purgeFaces);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -116,6 +132,7 @@ describe('VideoFacePanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockListPeople.mockResolvedValue({ items: [], total: 0 });
   });
 
   // -------------------------------------------------------------------------
@@ -323,6 +340,181 @@ describe('VideoFacePanel', () => {
     it('disables the button while rerunLoading=true', () => {
       renderPanel({}, { rerunLoading: true });
       expect(screen.getByRole('button', { name: /re-run face detection/i })).toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edit face icon button (issue #119 — AssignFaceDialog integration)
+  // -------------------------------------------------------------------------
+  describe('edit face icon button', () => {
+    it('renders the "Edit face" icon button on a detected row when circleId is provided', () => {
+      const face = makeFace('f1', {
+        personId: 'p1',
+        personName: 'Alice',
+        faceThumbnailUrl: 'https://cdn.example.com/f1.jpg',
+      });
+      renderPanel({ circleId: 'circle-1' }, { faces: [face] });
+
+      expect(screen.getByRole('button', { name: /edit face/i })).toBeInTheDocument();
+    });
+
+    it('does not render the "Edit face" icon button when circleId is undefined', () => {
+      const face = makeFace('f1', {
+        personId: 'p1',
+        personName: 'Alice',
+        faceThumbnailUrl: 'https://cdn.example.com/f1.jpg',
+      });
+      renderPanel({ circleId: undefined }, { faces: [face] });
+
+      expect(screen.queryByRole('button', { name: /edit face/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AssignFaceDialog preview (video uses the Avatar thumbnail, not FaceCrop)
+  // -------------------------------------------------------------------------
+  describe('edit face dialog preview', () => {
+    it('shows the representative-frame Avatar (not FaceCrop) when faceThumbnailUrl is set', async () => {
+      const face = makeFace('f1', {
+        personId: 'p1',
+        personName: 'Alice',
+        faceThumbnailUrl: 'https://cdn.example.com/frame.jpg',
+      });
+      renderPanel({ circleId: 'circle-1' }, { faces: [face] });
+
+      fireEvent.click(screen.getByRole('button', { name: /edit face/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      const img = dialog.querySelector('img');
+      expect(img).toHaveAttribute('src', 'https://cdn.example.com/frame.jpg');
+      // FaceCrop renders role="img" aria-label="Face crop" — must NOT be present
+      // for the video path (no imageUrl is passed to AssignFaceDialog).
+      expect(within(dialog).queryByRole('img', { name: 'Face crop' })).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reassign flow — operates on every detected face id for the person
+  // -------------------------------------------------------------------------
+  describe('reassign flow (edit dialog)', () => {
+    it('calls assignFaces with all detected face ids belonging to the person, and refreshes', async () => {
+      const user = userEvent.setup();
+      const face1 = makeFace('f1', { personId: 'p1', personName: 'Alice', videoTimestampMs: 5000 });
+      const face2 = makeFace('f2', { personId: 'p1', personName: 'Alice', videoTimestampMs: 10000 });
+      mockListPeople.mockResolvedValue({
+        items: [
+          {
+            id: 'p2',
+            name: 'Bob',
+            isUnlabeled: false,
+            faceCount: 0,
+            coverFace: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            favorite: false,
+          },
+        ],
+        total: 1,
+      });
+      const onFacesChanged = vi.fn();
+      const refresh = vi.fn().mockResolvedValue(undefined);
+      renderPanel(
+        { circleId: 'circle-1', onFacesChanged },
+        { faces: [face1, face2], refresh },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /edit face/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      const combobox = within(dialog).getByRole('combobox');
+      await user.click(combobox);
+      const bobOption = await screen.findByRole('option', { name: /bob/i });
+      await user.click(bobOption);
+      await user.click(within(dialog).getByRole('button', { name: /^reassign$/i }));
+
+      await waitFor(() => {
+        expect(mockAssignFaces).toHaveBeenCalledTimes(1);
+      });
+      const [calledPersonId, calledFaceIds] = mockAssignFaces.mock.calls[0];
+      expect(calledPersonId).toBe('p2');
+      expect([...calledFaceIds].sort()).toEqual(['f1', 'f2']);
+
+      await waitFor(() => {
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(onFacesChanged).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unassign flow — one unassignFace call per detected face id
+  // -------------------------------------------------------------------------
+  describe('unassign flow (edit dialog)', () => {
+    it('calls unassignFace once per detected face id belonging to the person, and refreshes', async () => {
+      const face1 = makeFace('f1', { personId: 'p1', personName: 'Alice', videoTimestampMs: 5000 });
+      const face2 = makeFace('f2', { personId: 'p1', personName: 'Alice', videoTimestampMs: 10000 });
+      const onFacesChanged = vi.fn();
+      const refresh = vi.fn().mockResolvedValue(undefined);
+      renderPanel(
+        { circleId: 'circle-1', onFacesChanged },
+        { faces: [face1, face2], refresh },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /edit face/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: /unassign/i }));
+
+      await waitFor(() => {
+        expect(mockUnassignFace).toHaveBeenCalledTimes(2);
+      });
+      expect(mockUnassignFace).toHaveBeenCalledWith('p1', 'f1');
+      expect(mockUnassignFace).toHaveBeenCalledWith('p1', 'f2');
+
+      await waitFor(() => {
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(onFacesChanged).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Permanent delete flow — purgeFaces via the nested PurgeFacesDialog confirm
+  // -------------------------------------------------------------------------
+  describe('permanent delete flow (edit dialog)', () => {
+    it('calls purgeFaces with all detected face ids after confirming, and refreshes', async () => {
+      const face1 = makeFace('f1', { personId: 'p1', personName: 'Alice', videoTimestampMs: 5000 });
+      const face2 = makeFace('f2', { personId: 'p1', personName: 'Alice', videoTimestampMs: 10000 });
+      const onFacesChanged = vi.fn();
+      const refresh = vi.fn().mockResolvedValue(undefined);
+      renderPanel(
+        { circleId: 'circle-1', onFacesChanged },
+        { faces: [face1, face2], refresh },
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /edit face/i }));
+
+      const editDialog = await screen.findByRole('dialog');
+      fireEvent.click(
+        within(editDialog).getByRole('button', { name: /delete detection permanently/i }),
+      );
+
+      const purgeDialog = await screen.findByRole('dialog', { name: /delete permanently\?/i });
+      fireEvent.click(
+        within(purgeDialog).getByRole('button', { name: /^delete permanently$/i }),
+      );
+
+      await waitFor(() => {
+        expect(mockPurgeFaces).toHaveBeenCalledTimes(1);
+      });
+      const [calledCircleId, calledFaceIds] = mockPurgeFaces.mock.calls[0];
+      expect(calledCircleId).toBe('circle-1');
+      expect([...calledFaceIds].sort()).toEqual(['f1', 'f2']);
+
+      await waitFor(() => {
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(onFacesChanged).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/apps/web/src/components/media/AssignFaceDialog.tsx
+++ b/apps/web/src/components/media/AssignFaceDialog.tsx
@@ -1,0 +1,296 @@
+/**
+ * AssignFaceDialog — shared dialog for assigning, reassigning, unassigning, or
+ * permanently deleting a detected face (or a set of detected faces).
+ *
+ * Used by FaceThumbnails (photos — a single face crop) and VideoFacePanel
+ * (videos — a representative face row that stands in for every detected face of
+ * the same person). Pass `faceIds` to operate on a whole set; when omitted the
+ * dialog operates on the single `face.id`, preserving the original photo
+ * behavior.
+ */
+
+import { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Alert,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Autocomplete,
+  Divider,
+  Avatar,
+} from '@mui/material';
+import type { DetectedFaceDto } from '../../services/face';
+import {
+  listPeople,
+  createPerson,
+  assignFaces,
+  unassignFace,
+  purgeFaces,
+} from '../../services/face';
+import type { PersonListItem } from '../../services/face';
+import { FaceCrop } from '../people/FaceCrop';
+import { PurgeFacesDialog } from '../people/PurgeFacesDialog';
+
+interface AssignFaceDialogProps {
+  open: boolean;
+  face: DetectedFaceDto | null;
+  /** Full-resolution URL preferred; falls back to thumbnailUrl for sharp crop preview.
+   *  Omit for videos — the representative-frame thumbnail is used instead. */
+  imageUrl?: string;
+  circleId: string;
+  /** When provided, all actions operate on this full set of face IDs (e.g. every
+   *  detected face for a person in a video). Defaults to the single `face.id`. */
+  faceIds?: string[];
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function AssignFaceDialog({
+  open,
+  face,
+  imageUrl,
+  circleId,
+  faceIds,
+  onClose,
+  onSuccess,
+}: AssignFaceDialogProps) {
+  const [people, setPeople] = useState<PersonListItem[]>([]);
+  const [peopleLoading, setPeopleLoading] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [selectedPerson, setSelectedPerson] = useState<PersonListItem | null>(null);
+  const [assigning, setAssigning] = useState(false);
+  const [unassigning, setUnassigning] = useState(false);
+  const [showPurgeConfirm, setShowPurgeConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !circleId) return;
+    setPeopleLoading(true);
+    setError(null);
+    listPeople(circleId, { pageSize: 100 })
+      .then((res) => setPeople(res.items))
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load people'))
+      .finally(() => setPeopleLoading(false));
+  }, [open, circleId]);
+
+  useEffect(() => {
+    if (!open) {
+      setNewName('');
+      setSelectedPerson(null);
+      setShowPurgeConfirm(false);
+      setError(null);
+    }
+  }, [open]);
+
+  if (!face) return null;
+  const isAssigned = face.personId !== null;
+  const targetFaceIds = faceIds ?? (face ? [face.id] : []);
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      await createPerson({ circleId, name: newName.trim(), faceIds: targetFaceIds });
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create person');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleAssign = async () => {
+    if (!selectedPerson) return;
+    setAssigning(true);
+    setError(null);
+    try {
+      await assignFaces(selectedPerson.id, targetFaceIds);
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to assign face');
+    } finally {
+      setAssigning(false);
+    }
+  };
+
+  const handleUnassign = async () => {
+    if (!face.personId) return;
+    setUnassigning(true);
+    setError(null);
+    try {
+      await Promise.all(targetFaceIds.map((id) => unassignFace(face.personId!, id)));
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to unassign face');
+    } finally {
+      setUnassigning(false);
+    }
+  };
+
+  const getPersonLabel = (p: PersonListItem) =>
+    p.name ?? `Unlabeled (${p.id.slice(0, 6)})`;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      sx={{ zIndex: (theme) => theme.zIndex.modal + 2 }}
+    >
+      <DialogTitle>
+        {isAssigned ? 'Reassign or Unassign Face' : 'Assign Face to Person'}
+      </DialogTitle>
+      <DialogContent>
+        {/* Face preview — video uses the pre-cropped representative frame directly,
+            photos crop the full-res image to the bounding box. */}
+        {face.faceThumbnailUrl ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+            <Avatar
+              src={face.faceThumbnailUrl}
+              variant="rounded"
+              sx={{ width: 96, height: 96 }}
+            />
+          </Box>
+        ) : (
+          imageUrl && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+              <FaceCrop imageUrl={imageUrl} boundingBox={face.boundingBox} size={96} />
+            </Box>
+          )
+        )}
+
+        {isAssigned && (
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            Currently assigned to: <strong>{face.personName ?? 'Unknown'}</strong>
+          </Typography>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Unassign option — only when assigned */}
+        {isAssigned && (
+          <>
+            <Button
+              fullWidth
+              variant="outlined"
+              color="error"
+              onClick={() => void handleUnassign()}
+              disabled={unassigning || assigning}
+              startIcon={unassigning ? <CircularProgress size={14} /> : undefined}
+              sx={{ mb: 2 }}
+            >
+              {unassigning ? 'Unassigning…' : 'Unassign (return to unknown pool)'}
+            </Button>
+            <Divider sx={{ mb: 2 }}>
+              <Typography variant="caption">or reassign to</Typography>
+            </Divider>
+          </>
+        )}
+
+        {/* Assign to existing person */}
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          {isAssigned ? 'Reassign to existing person' : 'Assign to existing person'}
+        </Typography>
+        <Autocomplete
+          options={people}
+          getOptionLabel={getPersonLabel}
+          value={selectedPerson}
+          onChange={(_, val) => setSelectedPerson(val)}
+          loading={peopleLoading}
+          renderInput={(params) => (
+            <TextField {...params} size="small" label="Select person" sx={{ mb: 1 }} />
+          )}
+          sx={{ mb: 1 }}
+          slotProps={{ popper: { sx: { zIndex: (theme) => theme.zIndex.modal + 3 } } }}
+        />
+        <Button
+          fullWidth
+          variant="contained"
+          onClick={() => void handleAssign()}
+          disabled={!selectedPerson || assigning || unassigning}
+          startIcon={assigning ? <CircularProgress size={14} /> : undefined}
+          sx={{ mb: 2 }}
+        >
+          {assigning ? 'Assigning…' : isAssigned ? 'Reassign' : 'Assign'}
+        </Button>
+
+        {/* Create new person — only when unassigned */}
+        {!isAssigned && (
+          <>
+            <Divider sx={{ mb: 2 }}>
+              <Typography variant="caption">or create new</Typography>
+            </Divider>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Create new person
+            </Typography>
+            <TextField
+              fullWidth
+              size="small"
+              label="Person name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleCreate();
+              }}
+              sx={{ mb: 1 }}
+            />
+            <Button
+              fullWidth
+              variant="outlined"
+              onClick={() => void handleCreate()}
+              disabled={!newName.trim() || creating || assigning}
+              startIcon={creating ? <CircularProgress size={14} /> : undefined}
+            >
+              {creating ? 'Creating…' : 'Create person'}
+            </Button>
+          </>
+        )}
+
+        {/* Permanent deletion — available whether assigned or not */}
+        <Divider sx={{ my: 2 }}>
+          <Typography variant="caption">or</Typography>
+        </Divider>
+        <Button
+          fullWidth
+          variant="outlined"
+          color="error"
+          onClick={() => setShowPurgeConfirm(true)}
+          disabled={assigning || unassigning || creating}
+        >
+          Delete detection permanently
+        </Button>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+      </DialogActions>
+
+      {/* Confirm permanent deletion */}
+      <PurgeFacesDialog
+        open={showPurgeConfirm}
+        count={targetFaceIds.length}
+        onClose={() => setShowPurgeConfirm(false)}
+        onConfirm={async () => {
+          await purgeFaces(circleId, targetFaceIds);
+          onSuccess();
+          onClose();
+        }}
+      />
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/media/FaceThumbnails.tsx
+++ b/apps/web/src/components/media/FaceThumbnails.tsx
@@ -9,13 +9,8 @@ import {
   Tooltip,
   Skeleton,
   Stack,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   TextField,
   Autocomplete,
-  Divider,
 } from '@mui/material';
 import { Face as FaceIcon, Refresh as RefreshIcon } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
@@ -24,15 +19,12 @@ import { useMediaFaces } from '../../hooks/useMediaFaces';
 import type { MediaFaceStatusType, DetectedFaceDto } from '../../services/face';
 import {
   listPeople,
-  createPerson,
-  assignFaces,
-  unassignFace,
   addPersonToMedia,
   removePersonFromMedia,
 } from '../../services/face';
 import type { PersonListItem } from '../../services/face';
-import { FaceCrop } from '../people/FaceCrop';
 import { PersonAvatar } from '../people/PersonAvatar';
+import { AssignFaceDialog } from './AssignFaceDialog';
 
 function statusChipProps(status: MediaFaceStatusType): {
   label: string;
@@ -62,223 +54,6 @@ interface FaceThumbnailsProps {
    *  for face crops and the overlay image so crops are sharp. */
   downloadUrl?: string;
   circleId?: string;
-}
-
-// ---------------------------------------------------------------------------
-// AssignFaceDialog — inline in same file
-// ---------------------------------------------------------------------------
-
-interface AssignFaceDialogProps {
-  open: boolean;
-  face: DetectedFaceDto | null;
-  /** Full-resolution URL preferred; falls back to thumbnailUrl for sharp crop preview. */
-  imageUrl: string | undefined;
-  circleId: string;
-  onClose: () => void;
-  onSuccess: () => void;
-}
-
-function AssignFaceDialog({
-  open,
-  face,
-  imageUrl,
-  circleId,
-  onClose,
-  onSuccess,
-}: AssignFaceDialogProps) {
-  const [people, setPeople] = useState<PersonListItem[]>([]);
-  const [peopleLoading, setPeopleLoading] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [selectedPerson, setSelectedPerson] = useState<PersonListItem | null>(null);
-  const [assigning, setAssigning] = useState(false);
-  const [unassigning, setUnassigning] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!open || !circleId) return;
-    setPeopleLoading(true);
-    setError(null);
-    listPeople(circleId, { pageSize: 100 })
-      .then((res) => setPeople(res.items))
-      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load people'))
-      .finally(() => setPeopleLoading(false));
-  }, [open, circleId]);
-
-  useEffect(() => {
-    if (!open) {
-      setNewName('');
-      setSelectedPerson(null);
-      setError(null);
-    }
-  }, [open]);
-
-  if (!face) return null;
-  const isAssigned = face.personId !== null;
-
-  const handleCreate = async () => {
-    if (!newName.trim()) return;
-    setCreating(true);
-    setError(null);
-    try {
-      await createPerson({ circleId, name: newName.trim(), faceIds: [face.id] });
-      onSuccess();
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create person');
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleAssign = async () => {
-    if (!selectedPerson) return;
-    setAssigning(true);
-    setError(null);
-    try {
-      await assignFaces(selectedPerson.id, [face.id]);
-      onSuccess();
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to assign face');
-    } finally {
-      setAssigning(false);
-    }
-  };
-
-  const handleUnassign = async () => {
-    if (!face.personId) return;
-    setUnassigning(true);
-    setError(null);
-    try {
-      await unassignFace(face.personId, face.id);
-      onSuccess();
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to unassign face');
-    } finally {
-      setUnassigning(false);
-    }
-  };
-
-  const getPersonLabel = (p: PersonListItem) =>
-    p.name ?? `Unlabeled (${p.id.slice(0, 6)})`;
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      maxWidth="xs"
-      fullWidth
-      sx={{ zIndex: (theme) => theme.zIndex.modal + 2 }}
-    >
-      <DialogTitle>
-        {isAssigned ? 'Reassign or Unassign Face' : 'Assign Face to Person'}
-      </DialogTitle>
-      <DialogContent>
-        {/* Face crop preview — use full-res imageUrl for a sharp crop */}
-        {imageUrl && face && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
-            <FaceCrop imageUrl={imageUrl} boundingBox={face.boundingBox} size={96} />
-          </Box>
-        )}
-
-        {isAssigned && (
-          <Typography variant="body2" sx={{ mb: 2 }}>
-            Currently assigned to: <strong>{face.personName ?? 'Unknown'}</strong>
-          </Typography>
-        )}
-
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            {error}
-          </Alert>
-        )}
-
-        {/* Unassign option — only when assigned */}
-        {isAssigned && (
-          <>
-            <Button
-              fullWidth
-              variant="outlined"
-              color="error"
-              onClick={() => void handleUnassign()}
-              disabled={unassigning || assigning}
-              startIcon={unassigning ? <CircularProgress size={14} /> : undefined}
-              sx={{ mb: 2 }}
-            >
-              {unassigning ? 'Unassigning…' : 'Unassign (return to unknown pool)'}
-            </Button>
-            <Divider sx={{ mb: 2 }}>
-              <Typography variant="caption">or reassign to</Typography>
-            </Divider>
-          </>
-        )}
-
-        {/* Assign to existing person */}
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>
-          {isAssigned ? 'Reassign to existing person' : 'Assign to existing person'}
-        </Typography>
-        <Autocomplete
-          options={people}
-          getOptionLabel={getPersonLabel}
-          value={selectedPerson}
-          onChange={(_, val) => setSelectedPerson(val)}
-          loading={peopleLoading}
-          renderInput={(params) => (
-            <TextField {...params} size="small" label="Select person" sx={{ mb: 1 }} />
-          )}
-          sx={{ mb: 1 }}
-          slotProps={{ popper: { sx: { zIndex: (theme) => theme.zIndex.modal + 3 } } }}
-        />
-        <Button
-          fullWidth
-          variant="contained"
-          onClick={() => void handleAssign()}
-          disabled={!selectedPerson || assigning || unassigning}
-          startIcon={assigning ? <CircularProgress size={14} /> : undefined}
-          sx={{ mb: 2 }}
-        >
-          {assigning ? 'Assigning…' : isAssigned ? 'Reassign' : 'Assign'}
-        </Button>
-
-        {/* Create new person — only when unassigned */}
-        {!isAssigned && (
-          <>
-            <Divider sx={{ mb: 2 }}>
-              <Typography variant="caption">or create new</Typography>
-            </Divider>
-            <Typography variant="subtitle2" sx={{ mb: 1 }}>
-              Create new person
-            </Typography>
-            <TextField
-              fullWidth
-              size="small"
-              label="Person name"
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') void handleCreate();
-              }}
-              sx={{ mb: 1 }}
-            />
-            <Button
-              fullWidth
-              variant="outlined"
-              onClick={() => void handleCreate()}
-              disabled={!newName.trim() || creating || assigning}
-              startIcon={creating ? <CircularProgress size={14} /> : undefined}
-            >
-              {creating ? 'Creating…' : 'Create person'}
-            </Button>
-          </>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-      </DialogActions>
-    </Dialog>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/media/MediaDetailDrawer.tsx
+++ b/apps/web/src/components/media/MediaDetailDrawer.tsx
@@ -951,6 +951,7 @@ export function MediaDetailDrawer({
             onSeek={handleSeek}
             selectedFaceId={selectedFaceId}
             onSelectFace={setSelectedFaceId}
+            onFacesChanged={() => void videoFacesResult.refresh()}
           />
         ) : (
           <FaceThumbnails

--- a/apps/web/src/components/media/VideoFacePanel.tsx
+++ b/apps/web/src/components/media/VideoFacePanel.tsx
@@ -32,6 +32,7 @@ import {
   Refresh as RefreshIcon,
   AccessTime as AccessTimeIcon,
   Person as PersonIcon,
+  Edit as EditIcon,
 } from '@mui/icons-material';
 import { useMediaFaces } from '../../hooks/useMediaFaces';
 import type { MediaFaceStatusType, DetectedFaceDto } from '../../services/face';
@@ -42,6 +43,7 @@ import {
 } from '../../services/face';
 import type { PersonListItem } from '../../services/face';
 import { PersonAvatar } from '../people/PersonAvatar';
+import { AssignFaceDialog } from './AssignFaceDialog';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -112,6 +114,26 @@ function deduplicateFaces(faces: DetectedFaceDto[]): DetectedFaceDto[] {
   return [...byPerson.values(), ...unassigned];
 }
 
+/**
+ * Builds a map of personId → all detected face IDs for that person, from the
+ * pre-dedup detected-face array. Used so an edit action on a representative row
+ * can operate on every detected face of that person (a person may be observed
+ * across many sampled frames, each a separate Face row).
+ */
+function buildPersonFaceIds(faces: DetectedFaceDto[]): Map<string, string[]> {
+  const byPerson = new Map<string, string[]>();
+  for (const face of faces) {
+    if (face.personId === null) continue;
+    const existing = byPerson.get(face.personId);
+    if (existing) {
+      existing.push(face.id);
+    } else {
+      byPerson.set(face.personId, [face.id]);
+    }
+  }
+  return byPerson;
+}
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -126,6 +148,9 @@ interface VideoFacePanelProps {
   /** ID of the currently selected face row (for highlight). */
   selectedFaceId?: string | null;
   onSelectFace?: (faceId: string | null) => void;
+  /** Called after any face mutation so an external face consumer (e.g. the
+   *  marker strip) can refresh its own copy of the faces. */
+  onFacesChanged?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +163,7 @@ export function VideoFacePanel({
   onSeek,
   selectedFaceId,
   onSelectFace,
+  onFacesChanged,
 }: VideoFacePanelProps) {
   const { faces, status, loading, error, rerun, rerunLoading, refresh } =
     useMediaFaces(mediaId);
@@ -148,6 +174,9 @@ export function VideoFacePanel({
   const [removingPersonId, setRemovingPersonId] = useState<string | null>(null);
   const [manualPeopleError, setManualPeopleError] = useState<string | null>(null);
   const [personInputValue, setPersonInputValue] = useState('');
+
+  // Edit-face dialog (assign / reassign / unassign / delete a detected face)
+  const [editFace, setEditFace] = useState<DetectedFaceDto | null>(null);
 
   const canAssign = Boolean(circleId);
 
@@ -167,6 +196,7 @@ export function VideoFacePanel({
       await addPersonToMedia(mediaId, personId ? { personId } : { name: name!.trim() });
       setPersonInputValue('');
       void refresh();
+      onFacesChanged?.();
     } catch (err) {
       setManualPeopleError(err instanceof Error ? err.message : 'Failed to add person');
     } finally {
@@ -180,6 +210,7 @@ export function VideoFacePanel({
     try {
       await removePersonFromMedia(mediaId, personId);
       void refresh();
+      onFacesChanged?.();
     } catch (err) {
       setManualPeopleError(err instanceof Error ? err.message : 'Failed to remove person');
     } finally {
@@ -207,6 +238,12 @@ export function VideoFacePanel({
   const manualFaces = faces.filter((f) => f.providerKey === 'manual');
   const detectedFaces = faces.filter((f) => f.providerKey !== 'manual');
   const dedupedFaces = deduplicateFaces(detectedFaces);
+  const personFaceIds = buildPersonFaceIds(detectedFaces);
+
+  // Resolve every detected face ID a representative row stands for: for an
+  // unassigned face just the face itself, otherwise all of its person's faces.
+  const resolvedFaceIdsFor = (face: DetectedFaceDto): string[] =>
+    face.personId === null ? [face.id] : personFaceIds.get(face.personId) ?? [face.id];
 
   return (
     <Box>
@@ -301,6 +338,22 @@ export function VideoFacePanel({
                       </Typography>
                     )}
                   </Box>
+
+                  {/* Edit face — assign / reassign / unassign / delete */}
+                  {canAssign && (
+                    <Tooltip title="Edit face">
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditFace(face);
+                        }}
+                        aria-label="Edit face"
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
 
                   {/* Jump-to-timestamp button */}
                   {hasTimestamp && onSeek && (
@@ -424,6 +477,22 @@ export function VideoFacePanel({
             </Alert>
           )}
         </Box>
+      )}
+
+      {/* Edit-face dialog — video faces use the representative-frame thumbnail
+          preview (no imageUrl passed). */}
+      {circleId && (
+        <AssignFaceDialog
+          open={editFace !== null}
+          face={editFace}
+          circleId={circleId}
+          faceIds={editFace ? resolvedFaceIdsFor(editFace) : []}
+          onClose={() => setEditFace(null)}
+          onSuccess={() => {
+            void refresh();
+            onFacesChanged?.();
+          }}
+        />
       )}
     </Box>
   );

--- a/docs/specs/face-recognition.md
+++ b/docs/specs/face-recognition.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 3.6 |
+| **Version** | 3.7 |
 | **Last Updated** | July 2026 |
 | **Status** | All phases implemented |
 
@@ -338,6 +338,19 @@ For each cluster's representative frame, the handler:
 `GET /api/media/:id/faces` signs `frameThumbnailKey` via `MediaThumbnailService.signThumb` and returns it as `faceThumbnailUrl`.
 
 Thumbnail upload failure is non-fatal: the `Face` row is created without `frameThumbnailKey`, and `faceThumbnailUrl` is `null` in the API response.
+
+### Manual Correction (Photo/Video Parity, Issue #119)
+
+Detected faces on a video can now be corrected from the UI exactly like faces on a photo — unassign, reassign, create a new person, or permanently delete. Before this, `VideoFacePanel`'s "People in this video" rows were read-only: clicking a row only highlighted/seeked the video, with no way to fix a wrong assignment or remove a false-positive detection. This was frontend-only work — no backend or schema change — reusing the pre-existing generic Face endpoints unchanged:
+
+- **Unassign** a face, returning it to the unknown pool — `DELETE /api/people/:id/faces/:faceId`.
+- **Reassign** to an existing person — `POST /api/people/:id/faces`.
+- **Create a new person** and assign to them — `POST /api/people` (optionally with initial `faceIds`).
+- **Permanently delete** a spurious/false-positive detection — `POST /api/people/faces/bulk/purge`; requires `media:delete` + collaborator role, confirmed through a `PurgeFacesDialog` step.
+
+`AssignFaceDialog` — previously used only by `FaceThumbnails` on the photo detail view — is now a shared component used by both `FaceThumbnails` (photos) and `VideoFacePanel` (videos). Each detected-face row in `VideoFacePanel` gained an "Edit face" action that opens the same dialog. For video faces, the dialog's preview uses the representative-frame thumbnail (`faceThumbnailUrl`, see [Frame Thumbnail Storage](#frame-thumbnail-storage) above) rather than the bounding-box crop over the original image that photos use (see [Face-Crop Previews](#face-crop-previews)).
+
+**Per-person, not per-frame, semantics.** A person can be sampled across many frames of the same video — see [Cross-Frame Deduplication](#cross-frame-deduplication) above — and while dedup consolidates similar detections into one cluster per pass, distinct clusters within the same video can still independently match to the same `Person` (see [Face-to-Person Matching](#face-to-person-matching)), so one person's row in `VideoFacePanel` can correspond to more than one `Face` row for that video. An action taken from a person's row — unassign, reassign, or delete — applies to **all** of that person's detected `Face` rows in the video, not just the single representative face/frame the row displays.
 
 ### Settings
 
@@ -1118,3 +1131,4 @@ A job stuck in `running` status indicates the worker crashed or the container re
 | 3.4 | June 2026 | AI Assistant | Added Hide/Purge subsection in §8: `Person.hiddenAt` column (migration `20260628000000_person_hidden_at`), bulk hide/unhide/purge endpoints, search-inclusion asymmetry, audit events, and frontend People/Hidden tab integration |
 | 3.5 | July 2026 | AI Assistant | Added Individual Face Archive and Purge subsection in §8: `Face.hiddenAt` column and `(circleId, hiddenAt)` indexes on both `faces` and `people` (migration `20260704000000_add_face_hidden_at`), `PATCH /api/people/faces/bulk/hide`/`unhide` and `POST /api/people/faces/bulk/purge` endpoints scoped to unassigned (`personId=null`) faces, `archived` param on `GET /api/people/unassigned`, clustering-exclusion behavior, and archive-first permanent-delete UX |
 | 3.6 | July 2026 | AI Assistant | Added Auto-Archive on Match subsection in §8: `features.faceAutoArchive` + `face.autoArchive.matchThreshold` settings, `Face.hiddenReason` provenance column (migration `20260712000000_add_face_hidden_reason`), `FACE_ARCHIVE_MATCH_THRESHOLD`/`FACE_ARCHIVE_MAX_CANDIDATES`/`FACE_AUTO_ARCHIVE` env vars, the three trigger paths (detection-time, archive-time retroactive sweep, admin backfill), the server-only `face_auto_archive_sweep` job type and node-parity note, and `POST /api/admin/face/auto-archive/backfill` |
+| 3.7 | July 2026 | AI Assistant | Added Manual Correction (Photo/Video Parity, Issue #119) subsection in §6: `AssignFaceDialog` is now shared between `FaceThumbnails` (photos) and `VideoFacePanel` (videos), a new "Edit face" row action in `VideoFacePanel`, per-person (not per-frame) action semantics, the `faceThumbnailUrl` preview for video faces, and confirmation that this was frontend-only — no backend/schema change, reusing the pre-existing unassign/reassign/create-person/purge Face endpoints |


### PR DESCRIPTION
## Summary

Videos now have the same face-correction capability as photos. Previously, `VideoFacePanel`'s "People in this video" rows were read-only (click = highlight/seek only), so a mistagged or false-positive face detected in a video could not be corrected. This adds per-row **unassign / reassign / create-new-person / permanently-delete** actions, reusing the existing generic `Face` endpoints — no backend or database changes.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Fixes #119

## Changes Made

- Extracted the previously-inline, photo-only `AssignFaceDialog` into a shared `apps/web/src/components/media/AssignFaceDialog.tsx` and generalized it:
  - Operates on a **set** of face IDs (`faceIds?`, defaulting to `[face.id]` so photo behavior is unchanged).
  - Preview **auto-detects** media type — video representative-frame `faceThumbnailUrl` avatar vs. the photo `FaceCrop` bounding-box crop.
  - Added a **"Delete detection permanently"** action via the existing `PurgeFacesDialog` confirm (`purgeFaces`, backend enforces `media:delete`).
- Wired the dialog into `VideoFacePanel` via a per-row **"Edit face"** icon button. Actions target **all** of a person's detected faces in the video (faces are sampled across many frames), so the deduped row fully reflects the change.
- Added an `onFacesChanged` prop so `MediaDetailDrawer`'s `FaceMarkerStrip` stays in sync after edits.
- Documented the capability in `docs/specs/face-recognition.md` (§6, "Manual Correction — Photo/Video Parity").

Reused endpoints: `DELETE /api/people/:id/faces/:faceId`, `POST /api/people/:id/faces`, `POST /api/people`, `POST /api/people/faces/bulk/purge`.

## Testing

- [x] Unit tests pass (`vitest run` — 2 files, **50 tests passed**)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

Added/extended `VideoFacePanel.test.tsx` and `FaceThumbnails.test.tsx`: edit-icon visibility, avatar-vs-FaceCrop preview, multi-face reassign/unassign targeting all of a person's face IDs, permanent-delete confirm flow, and refresh/`onFacesChanged` callbacks.

### Test Instructions

1. Open a video's detail drawer → "People in this video".
2. Click the **Edit face** icon on a detected row → dialog shows the cropped video-frame avatar.
3. Reassign to another person → row updates; marker-strip label updates too.
4. Unassign → row returns to "Unassigned"; create a new person from an unassigned detection.
5. **Delete detection permanently** → confirm → row disappears; the photo/video itself is NOT deleted.
6. Confirm photo face editing (`FaceThumbnails`) still behaves exactly as before.

## Additional Notes

Frontend-only. Commits will appear "Unverified" on GitHub — the committer email is correct but this environment has no signing key available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw55HfoQJheiGc7oqXv9QG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw55HfoQJheiGc7oqXv9QG)_