### PR TITLE
fix(web): repair CI-blocking stale LocationInferenceSettingsPage test

### DIFF
--- a/apps/web/src/__tests__/pages/LocationInferenceSettingsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/LocationInferenceSettingsPage.test.tsx
@@ -106,6 +106,7 @@ function makeSystemSettingsMock(locationInference = false) {
         requireSameDevice: true,
         maxAnchorDistanceKm: 2,
         maxImpliedSpeedKmh: 150,
+        bulkAcceptThreshold: 80,
       },
       ui: { allowUserThemeOverride: true },
       updatedAt: new Date().toISOString(),
@@ -271,6 +272,14 @@ describe('LocationInferenceSettingsPage', () => {
       expect(sliders.find((s) => s.getAttribute('aria-valuenow') === '150')).toBeTruthy();
     });
 
+    it('renders the bulk-accept confidence threshold slider with the value from settings', () => {
+      render(<LocationInferenceSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText(/bulk-accept confidence threshold/i)).toBeInTheDocument();
+      const sliders = screen.getAllByRole('slider');
+      expect(sliders.find((s) => s.getAttribute('aria-valuenow') === '80')).toBeTruthy();
+    });
+
     it('renders the "Require matching camera make/model between anchors" switch, checked by default', () => {
       render(<LocationInferenceSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
 
@@ -305,6 +314,7 @@ describe('LocationInferenceSettingsPage', () => {
             requireSameDevice: expect.any(Boolean),
             maxAnchorDistanceKm: expect.any(Number),
             maxImpliedSpeedKmh: expect.any(Number),
+            bulkAcceptThreshold: expect.any(Number),
           },
         });
       });


### PR DESCRIPTION
## Summary

- CI has been red on `main` for two consecutive pushes (`3a77533`, `4275089`, and now the tip `b7a3885`) due to a single stale frontend test.
- `LocationInferenceSettingsPage.tsx`'s `handleSaveParams` sends a `bulkAcceptThreshold` field (added by PR #170) that `LocationInferenceSettingsPage.test.tsx`'s mock and assertion never accounted for.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #174

## Changes Made

- Added `bulkAcceptThreshold: 80` to the `settings.locationInference` mock in `makeSystemSettingsMock()`.
- Added a test for the "Bulk-accept confidence threshold" slider render, matching the pattern of its sibling slider tests.
- Added `bulkAcceptThreshold: expect.any(Number)` to the "calls updateSettings with the locationInference.* shape" assertion.

No component code changed — `LocationInferenceSettingsPage.tsx` was already correct.

## Testing

- [x] Unit tests pass (`npx vitest run src/__tests__/pages/LocationInferenceSettingsPage.test.tsx` — 28/28 passed)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed (verified diff is test-only, minimal, and scoped to the one stale file)

## Additional Notes

Filed via #174 per this repo's issue-driven development requirement. This branch was reset from `main` (not stacked on the already-merged #173) per the merged-PR follow-up convention, so its history includes everything currently on `main` plus this one fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw55HfoQJheiGc7oqXv9QG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw55HfoQJheiGc7oqXv9QG)_