### PR TITLE
fix(core): CLI bulk-import resilience — retry transient 500s, recover stranded multipart uploads, fix retry/import circle resolution, abort on 401

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -25,9 +25,10 @@ export function importCommand(): Command {
     .description('One-shot import: register a folder and sync it immediately (alias for sync <folder>)')
     .argument('<folder>', 'Path to the folder to import')
     .option('-r, --recursive', 'Descend into sub-directories', false)
-    .option('--dry-run', 'Show what would be uploaded without actually uploading', false);
+    .option('--dry-run', 'Show what would be uploaded without actually uploading', false)
+    .option('--circle <id>', 'Target circle ID (overrides active circle in config)');
 
-  cmd.action(async (folder: string, options: { recursive: boolean; dryRun: boolean }) => {
+  cmd.action(async (folder: string, options: { recursive: boolean; dryRun: boolean; circle?: string }) => {
     const cfg = requireConfig();
     const api  = new ApiClient({ serverUrl: cfg.serverUrl, pat: cfg.pat });
     const db   = getDb();
@@ -62,6 +63,10 @@ export function importCommand(): Command {
       await engine.run({
         folderIds: [f.id],
         dryRun:    options.dryRun,
+        // `import` registers the folder itself, so folder.circle_id is always
+        // null on a first run — without this the command could never resolve a
+        // circle (same defect as `retry`, issue #179).
+        circleId:  options.circle ?? cfg.activeCircleId,
         trigger:   'cli',
       });
     } catch (err) {

--- a/apps/cli/src/commands/retry.ts
+++ b/apps/cli/src/commands/retry.ts
@@ -4,9 +4,10 @@
  * Re-queues failed files and runs the engine for a retry pass.
  *
  * Usage:
- *   memoriahub retry [--all] [--folder <id|path>] [--force]
+ *   memoriahub retry [--all] [--folder <id|path>] [--force] [--circle <id>]
  *
  * --force: also re-queue files blocked at the attempts cap.
+ * --circle: target circle for files whose folder has no bound circle_id.
  */
 
 import { Command } from 'commander';
@@ -31,9 +32,10 @@ export function retryCommand(): Command {
     )
     .option('--all', 'Retry failed files across all folders', false)
     .option('--folder <id|path>', 'Limit retry to a specific folder (ID or path)')
-    .option('--force', 'Also retry files blocked at the attempts cap (resets their attempt count)', false);
+    .option('--force', 'Also retry files blocked at the attempts cap (resets their attempt count)', false)
+    .option('--circle <id>', 'Target circle ID (overrides active circle in config)');
 
-  cmd.action(async (opts: { all: boolean; folder?: string; force: boolean }) => {
+  cmd.action(async (opts: { all: boolean; folder?: string; force: boolean; circle?: string }) => {
     const cfg = requireConfig();
     const api  = new ApiClient({ serverUrl: cfg.serverUrl, pat: cfg.pat });
     const db   = getDb();
@@ -100,6 +102,11 @@ export function retryCommand(): Command {
         folderIds,
         retryFailedOnly: true,
         force: opts.force,
+        // Mirror `sync`: the engine resolves folder.circle_id → this → error.
+        // Omitting it made retry unusable for any folder registered without a
+        // bound circle_id, while pointing at a --circle flag that did not
+        // exist (issue #179).
+        circleId: opts.circle ?? cfg.activeCircleId,
         trigger: 'retry',
       });
     } catch (err) {

--- a/apps/cli/src/http/retry.ts
+++ b/apps/cli/src/http/retry.ts
@@ -2,7 +2,7 @@
  * http/retry.ts — Rate-limit-aware HTTP retry engine.
  *
  * A single retry engine shared by the ApiClient (JSON requests) and the
- * presigned-PUT path. Retries only transient failures — HTTP 429/502/503/504
+ * presigned-PUT path. Retries only transient failures — HTTP 429/500/502/503/504
  * and network errors — with exponential backoff + full jitter, honoring the
  * server's `Retry-After` header as a floor. Non-retryable errors (other 4xx)
  * are rethrown immediately.
@@ -26,8 +26,17 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
   maxMs: 30_000,
 };
 
-/** HTTP statuses that warrant a retry. */
-export const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+/**
+ * HTTP statuses that warrant a retry.
+ *
+ * 500 is included deliberately. S3 and Cloudflare R2 both return a transient
+ * `500 InternalError` on presigned part PUTs under load, and both document it
+ * as retry-and-it-succeeds. Treating it as permanent failed the part, failed
+ * the whole file, and consumed a sync attempt — see issue #179, where a single
+ * transient 500 was the root cause of files being permanently lost during a
+ * bulk import.
+ */
+export const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 
 /** Transient network error codes that warrant a retry. */
 const RETRYABLE_NET_CODES = new Set([

--- a/apps/cli/src/sync/sync-engine.ts
+++ b/apps/cli/src/sync/sync-engine.ts
@@ -437,6 +437,12 @@ export class SyncEngine extends TypedEmitter {
     const cap = settings.attemptsCap();
     const isDryRun = opts.dryRun ?? false;
 
+    // Set when a file fails with HTTP 401. An expired/revoked token is not a
+    // per-file condition — every remaining file would fail identically — so the
+    // pool stops dequeuing rather than marching through the queue marking
+    // thousands of untried files failed and burning their attempts (issue #179).
+    let authFailure: string | null = null;
+
     await runPool(workList, concurrency, async (item) => {
       const { fileId, filePath, mimeType, folderId } = item;
 
@@ -716,13 +722,15 @@ export class SyncEngine extends TypedEmitter {
       } catch (err) {
         // Give an actionable message when the token has expired mid-run so the
         // user knows exactly what to do and the last_error is not cryptic.
-        // 401 is intentionally NOT in the retryable set; it is surfaced here as
-        // a permanent failure so the file is marked failed and the run continues.
+        // 401 is intentionally NOT in the retryable set; the file is marked
+        // failed AND the run is aborted (see `authFailure` above) — retrying
+        // the rest of the queue against a dead token can only fail.
         let errorMsg = err instanceof Error ? err.message : String(err);
         if (err instanceof ApiError && err.status === 401) {
           errorMsg =
             'Access token expired or invalid (HTTP 401). ' +
             'Run `memoriahub login` to re-authenticate, then `memoriahub retry` to resume.';
+          authFailure = errorMsg;
         }
         files.setError(fileId, errorMsg);
         files.setStatus(fileId, 'failed');
@@ -736,9 +744,28 @@ export class SyncEngine extends TypedEmitter {
         });
 
         this._emitProgress(files, targetFolderIds, total);
-        // Per-file failure intentionally does NOT propagate — the pool continues.
+        // Per-file failure intentionally does NOT propagate — the pool
+        // continues, unless `authFailure` stopped it (see shouldStop below).
       }
-    });
+    }, () => authFailure !== null);
+
+    // ------------------------------------------------------------------
+    // 5b. Aborted run: the token died mid-flight
+    // ------------------------------------------------------------------
+    // Close out the run record with the counts actually achieved, but do NOT
+    // touch last_sync — the folders were not fully synced, and claiming they
+    // were would make the next run skip work. Files never dequeued keep their
+    // prior status and attempt_count, so `retry` resumes cleanly after login.
+    if (authFailure !== null) {
+      const aborted = files.counts(targetFolderIds);
+      runs.finishRun(runId, {
+        uploaded: aborted.uploaded,
+        skipped:  aborted.skipped + unchangedSkippedCount + outOfRangeSkippedCount,
+        failed:   aborted.failed,
+      });
+      this.emit(EV.ERROR, { message: authFailure });
+      throw new Error(authFailure);
+    }
 
     // ------------------------------------------------------------------
     // 6. Post-run: touch last_sync, finish run, emit run:done

--- a/apps/cli/src/sync/worker-pool.ts
+++ b/apps/cli/src/sync/worker-pool.ts
@@ -16,11 +16,18 @@
  *
  * A worker that throws does NOT stop the pool; other workers continue.
  * The returned promise resolves once all items have been processed.
+ *
+ * `shouldStop` provides cooperative early exit: it is consulted before each
+ * item is dequeued, so in-flight work always finishes cleanly and no further
+ * items are started. Used for conditions that make continuing pointless rather
+ * than merely failing one item — e.g. an expired token, where every remaining
+ * file would fail identically (issue #179).
  */
 export async function runPool<T>(
   items: T[],
   concurrency: number,
   worker: (item: T, index: number) => Promise<void>,
+  shouldStop?: () => boolean,
 ): Promise<void> {
   if (items.length === 0) return;
 
@@ -34,6 +41,8 @@ export async function runPool<T>(
    */
   async function runSlot(): Promise<void> {
     while (true) {
+      if (shouldStop?.()) break;
+
       const index = cursor++;
       if (index >= items.length) break;
 

--- a/apps/cli/src/upload.ts
+++ b/apps/cli/src/upload.ts
@@ -161,12 +161,32 @@ async function uploadPart(
   try {
     return await api.putRaw(url, buffer, mimeType);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = describeStorageFailure(err);
     if (isStaleUploadSession(err)) {
       throw new StaleUploadSessionError(partNumber, msg);
     }
     throw new Error(`Part ${partNumber} failed: ${msg}`);
   }
+}
+
+/**
+ * Render a failed presigned PUT as a message that names the right system.
+ *
+ * A part PUT goes DIRECTLY to S3/R2 — the MemoriaHub API is not in the path —
+ * but it flows through the same ApiClient plumbing, so its failures arrived
+ * labelled `API error 500: …`. That prefix sent operators debugging their
+ * MemoriaHub deployment when the response actually came from the storage
+ * provider (issue #179). Surface the provider's own error code where S3/R2
+ * supplied one, since that is the detail that identifies the fault.
+ */
+function describeStorageFailure(err: unknown): string {
+  if (!(err instanceof ApiError)) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  const code = /<Code>([^<]+)<\/Code>/.exec(err.serverMessage)?.[1];
+  return code
+    ? `storage provider returned HTTP ${err.status} ${code}`
+    : `storage provider returned HTTP ${err.status}: ${err.serverMessage}`;
 }
 
 /**

--- a/apps/cli/src/upload.ts
+++ b/apps/cli/src/upload.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { ApiClient } from './api.js';
+import { ApiClient, ApiError } from './api.js';
 
 export interface UploadResult {
   objectId: string;
@@ -111,9 +111,45 @@ function readFileSlice(
 }
 
 /**
- * Upload one part. Transient/throttle retries (429/503/5xx/network) are owned
- * by ApiClient.putRaw via the shared retry + cooldown machinery; here we only
- * add part-number context to a terminal failure. Returns the ETag.
+ * Internal signal: the storage provider no longer knows about this multipart
+ * upload, so the persisted resume state is worthless and the file must be
+ * re-initialized from scratch. Never escapes {@link uploadFile} — it is caught
+ * there and converted into one fresh upload session.
+ */
+class StaleUploadSessionError extends Error {
+  constructor(
+    readonly partNumber: number,
+    readonly detail: string,
+  ) {
+    super(
+      `Multipart upload session no longer exists on the storage provider ` +
+        `(part ${partNumber}): ${detail}`,
+    );
+    this.name = 'StaleUploadSessionError';
+  }
+}
+
+/**
+ * True when a failed presigned part PUT means the multipart upload itself is
+ * gone rather than the part being individually rejected.
+ *
+ * S3/R2 answer a part PUT with 404 only when the upload or the bucket cannot be
+ * found (`NoSuchUpload` / `NoSuchBucket`) — never for a transient condition —
+ * so any 404 here invalidates the session. This is what a stranded upload looks
+ * like after the provider garbage-collected an abandoned multipart upload while
+ * our own DB row still advertised it as resumable (issue #179).
+ */
+function isStaleUploadSession(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
+
+/**
+ * Upload one part. Transient/throttle retries (429/500/502/503/504/network) are
+ * owned by ApiClient.putRaw via the shared retry + cooldown machinery; here we
+ * only add part-number context to a terminal failure. Returns the ETag.
+ *
+ * A 404 is translated into {@link StaleUploadSessionError} so the caller can
+ * restart the upload instead of reporting a permanent per-part failure.
  */
 async function uploadPart(
   api: ApiClient,
@@ -126,6 +162,9 @@ async function uploadPart(
     return await api.putRaw(url, buffer, mimeType);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    if (isStaleUploadSession(err)) {
+      throw new StaleUploadSessionError(partNumber, msg);
+    }
     throw new Error(`Part ${partNumber} failed: ${msg}`);
   }
 }
@@ -191,6 +230,48 @@ async function isServerSessionValid(
 /**
  * Upload a file using the resumable multipart upload flow.
  *
+ * Delegates to {@link runUploadSession}, retrying ONCE from a clean slate when
+ * the storage provider reports that the multipart upload no longer exists.
+ *
+ * Why a retry loop lives here: `isServerSessionValid` can only ask OUR API
+ * whether the upload is still live, and the API answers from its own
+ * `storage_objects` row — it never asks S3/R2. When the provider has garbage-
+ * collected an abandoned multipart upload (which is exactly what happens after
+ * a failed part PUT strands one), the DB still advertises a resumable session
+ * and every subsequent part PUT 404s with `NoSuchUpload`, forever. Detecting
+ * that reactively and re-initializing is the only way the file can recover
+ * without manual intervention (issue #179).
+ *
+ * The re-upload re-sends bytes that were already transferred. That waste is
+ * bounded by a single file and is strictly better than the alternative, which
+ * was losing the file permanently.
+ */
+export async function uploadFile(
+  api: ApiClient,
+  filePath: string,
+  mimeType: string,
+  onProgress?: (fraction: number) => void,
+  persistence?: UploadPersistence,
+): Promise<UploadResult> {
+  try {
+    return await runUploadSession(api, filePath, mimeType, onProgress, persistence);
+  } catch (err) {
+    if (!(err instanceof StaleUploadSessionError)) throw err;
+
+    // Drop the dead session (clears upload_id, part_size and every persisted
+    // part row) so the retry below cannot resume into it again, then run a
+    // single fresh session. A second stale-session failure is a real problem
+    // (e.g. a missing bucket) and propagates to the caller.
+    persistence?.onComplete();
+    return runUploadSession(api, filePath, mimeType, onProgress, persistence, {
+      ignoreResumeState: true,
+    });
+  }
+}
+
+/**
+ * One attempt at the resumable multipart upload flow.
+ *
  * Flow:
  *   1. If `persistence` provides resume state, validate the server session.
  *      - Valid session: skip already-completed parts, continue from there.
@@ -204,13 +285,17 @@ async function isServerSessionValid(
  *      - Call persistence.onPartComplete(partNumber, eTag) immediately.
  *   4. POST :id/upload/complete with the full merged part list.
  *   5. Call persistence.onComplete() to clear in-progress state.
+ *
+ * `opts.ignoreResumeState` forces step 1 to be skipped entirely — used by the
+ * caller's stale-session retry so a known-dead session is never consulted.
  */
-export async function uploadFile(
+async function runUploadSession(
   api: ApiClient,
   filePath: string,
   mimeType: string,
   onProgress?: (fraction: number) => void,
   persistence?: UploadPersistence,
+  opts?: { ignoreResumeState?: boolean },
 ): Promise<UploadResult> {
   const stat = fs.statSync(filePath);
   const fileSize = stat.size;
@@ -231,7 +316,9 @@ export async function uploadFile(
   // ------------------------------------------------------------------
   // 1. Attempt to resume an interrupted upload
   // ------------------------------------------------------------------
-  const resumeState = persistence?.getResumeState() ?? null;
+  const resumeState = opts?.ignoreResumeState
+    ? null
+    : persistence?.getResumeState() ?? null;
   let resumed = false;
 
   if (resumeState) {

--- a/apps/cli/test/http/retry.spec.ts
+++ b/apps/cli/test/http/retry.spec.ts
@@ -70,10 +70,34 @@ describe('computeBackoffMs', () => {
 });
 
 describe('classifyError / isRetryable', () => {
-  it('treats 429/502/503/504 as retryable', () => {
-    for (const status of [429, 502, 503, 504]) {
+  it('treats 429/500/502/503/504 as retryable', () => {
+    for (const status of [429, 500, 502, 503, 504]) {
       expect(isRetryable({ status })).toBe(true);
     }
+  });
+
+  // Issue #179: R2/S3 return a transient `500 InternalError` on presigned part
+  // PUTs under load. Treating it as permanent lost whole files during a bulk
+  // import, so 500 must retry rather than fail the part outright.
+  it('retries a transient storage-provider 500 InternalError', async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) {
+        throw {
+          status: 500,
+          serverMessage:
+            '<?xml version="1.0" encoding="UTF-8"?><Error><Code>InternalError</Code>' +
+            '<Message>We encountered an internal error. Please try again.</Message></Error>',
+        };
+      }
+      return 'etag-ok';
+    };
+
+    await expect(
+      withRetry(fn, { maxRetries: 5, baseMs: 1, maxMs: 2 }, { sleep: async () => {} }),
+    ).resolves.toBe('etag-ok');
+    expect(calls).toBe(3);
   });
 
   it('treats other 4xx as non-retryable', () => {

--- a/apps/cli/test/sync/sync-engine.spec.ts
+++ b/apps/cli/test/sync/sync-engine.spec.ts
@@ -33,6 +33,7 @@ import type {
   RunProgressPayload,
 } from '../../src/sync/events.js';
 import type { SyncEngineDeps } from '../../src/sync/sync-engine.js';
+import { ApiError } from '../../src/api.js';
 import type { ApiClient } from '../../src/api.js';
 import type BetterSqlite3 from 'better-sqlite3';
 
@@ -1158,6 +1159,162 @@ describe('SyncEngine', () => {
       expect(rec.sha256).toBe('ffffffff' + 'ffffffff'.repeat(7));
       expect(typeof rec.mtime_ms).toBe('number');
       expect(rec.mtime_ms).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth failure aborts the run (issue #179)
+  // -------------------------------------------------------------------------
+
+  describe('HTTP 401 mid-run', () => {
+    /** Upload fn that always 401s, as an expired/revoked token would. */
+    function make401UploadFn(): AnyFn {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fn = jest.fn<(...args: any[]) => any>();
+      fn.mockRejectedValue(new ApiError(401, 'Unauthorized'));
+      return fn;
+    }
+
+    it('aborts the run instead of marching through the remaining queue', async () => {
+      for (let i = 0; i < 6; i++) writeTmpJpeg(tmpDir, `auth-${i}.jpg`);
+
+      const ctx = makeEngine(db, {}, make401UploadFn());
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      await expect(
+        ctx.engine.run({ trigger: 'cli', folderIds: [folder.id], concurrency: 1 }),
+      ).rejects.toThrow(/HTTP 401/);
+
+      // Only the file that actually hit the dead token is failed; the rest were
+      // never dequeued, so they keep their prior status and are retryable.
+      const recs = ctx.files.listByFolder(folder.id);
+      const failed = recs.filter((r) => r.status === 'failed');
+      expect(failed).toHaveLength(1);
+      expect(recs.filter((r) => r.status === 'queued').length).toBeGreaterThan(0);
+    });
+
+    it('does not charge an attempt to files it never dequeued', async () => {
+      for (let i = 0; i < 5; i++) writeTmpJpeg(tmpDir, `attempt-${i}.jpg`);
+
+      const ctx = makeEngine(db, {}, make401UploadFn());
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      await expect(
+        ctx.engine.run({ trigger: 'cli', folderIds: [folder.id], concurrency: 1 }),
+      ).rejects.toThrow(/HTTP 401/);
+
+      const untouched = ctx.files
+        .listByFolder(folder.id)
+        .filter((r) => r.status !== 'failed');
+      expect(untouched.length).toBeGreaterThan(0);
+      for (const rec of untouched) {
+        expect(rec.attempt_count).toBe(0);
+      }
+    });
+
+    it('emits an error event carrying the actionable re-auth message', async () => {
+      writeTmpJpeg(tmpDir, 'auth-single.jpg');
+
+      const ctx = makeEngine(db, {}, make401UploadFn());
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      const errors: Array<{ message: string }> = [];
+      ctx.engine.on(EV.ERROR, (p) => errors.push(p as { message: string }));
+
+      await expect(
+        ctx.engine.run({ trigger: 'cli', folderIds: [folder.id] }),
+      ).rejects.toThrow();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toMatch(/memoriahub login/);
+    });
+
+    it('leaves last_sync untouched so the next run does not skip work', async () => {
+      writeTmpJpeg(tmpDir, 'auth-lastsync.jpg');
+
+      const ctx = makeEngine(db, {}, make401UploadFn());
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      await expect(
+        ctx.engine.run({ trigger: 'cli', folderIds: [folder.id] }),
+      ).rejects.toThrow();
+
+      expect(ctx.folders.getById(folder.id)?.last_sync_at ?? null).toBeNull();
+    });
+
+    it('still fails only the offending file for a non-401 error', async () => {
+      for (let i = 0; i < 4; i++) writeTmpJpeg(tmpDir, `boom-${i}.jpg`);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const failUpload = jest.fn<(...args: any[]) => any>();
+      failUpload.mockRejectedValue(new ApiError(500, 'InternalError'));
+
+      const ctx = makeEngine(db, {}, failUpload);
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'test-circle' });
+
+      // A non-auth failure must NOT abort — the run completes normally.
+      await ctx.engine.run({ trigger: 'cli', folderIds: [folder.id], concurrency: 1 });
+
+      const recs = ctx.files.listByFolder(folder.id);
+      expect(recs.filter((r) => r.status === 'failed')).toHaveLength(4);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Circle resolution precedence (issue #179)
+  // -------------------------------------------------------------------------
+
+  describe('target circle resolution', () => {
+    it('falls back to opts.circleId when the folder has no bound circle_id', async () => {
+      writeTmpJpeg(tmpDir, 'no-folder-circle.jpg');
+
+      const ctx = makeEngine(db, {}, makeUploadFn('obj-circle'));
+      // Registered WITHOUT a circle — what `folders add` and `import` produce.
+      const folder = ctx.folders.add({ path: tmpDir });
+      expect(folder.circle_id).toBeNull();
+
+      await ctx.engine.run({
+        trigger: 'cli',
+        folderIds: [folder.id],
+        circleId: 'circle-from-opts',
+      });
+
+      const recs = ctx.files.listByFolder(folder.id);
+      expect(recs[0].status).toBe('uploaded');
+      expect(recs[0].last_error).toBeNull();
+    });
+
+    it('fails with the actionable message when no circle can be resolved at all', async () => {
+      writeTmpJpeg(tmpDir, 'no-circle-anywhere.jpg');
+
+      const ctx = makeEngine(db, {}, makeUploadFn('obj-none'));
+      const folder = ctx.folders.add({ path: tmpDir });
+
+      await ctx.engine.run({ trigger: 'cli', folderIds: [folder.id] });
+
+      const recs = ctx.files.listByFolder(folder.id);
+      expect(recs[0].status).toBe('failed');
+      expect(recs[0].last_error).toMatch(/No target circle/);
+    });
+
+    it('prefers the folder circle over opts.circleId', async () => {
+      writeTmpJpeg(tmpDir, 'folder-circle-wins.jpg');
+
+      const getSpy = mockResolving({ items: [] });
+      const ctx = makeEngine(db, { get: getSpy }, makeUploadFn('obj-pref'));
+      const folder = ctx.folders.add({ path: tmpDir, circleId: 'circle-folder' });
+
+      await ctx.engine.run({
+        trigger: 'cli',
+        folderIds: [folder.id],
+        circleId: 'circle-opts',
+      });
+
+      // The dedup GET is circle-scoped, so it reveals which circle won.
+      const dedupCall = getSpy.mock.calls.find((c) =>
+        String(c[0]).includes('/api/media?'),
+      );
+      expect(String(dedupCall?.[0])).toContain('circleId=circle-folder');
     });
   });
 });

--- a/apps/cli/test/upload.spec.ts
+++ b/apps/cli/test/upload.spec.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { uploadFile, UploadPersistence, UploadResumeState } from '../src/upload.js';
+import { ApiError } from '../src/api.js';
 import type { ApiClient } from '../src/api.js';
 
 // ---------------------------------------------------------------------------
@@ -419,6 +420,104 @@ describe('uploadFile', () => {
       );
 
       expect(result.objectId).toBe('obj-1'); // new objectId from fresh init
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Provider-side stale session (issue #179)
+  //
+  // The API's /upload/status only reads its own DB row, so it happily reports a
+  // resumable session for a multipart upload that S3/R2 has already garbage-
+  // collected. The part PUT is the first place the truth surfaces — as a 404
+  // NoSuchUpload — and before this fix that 404 was permanent for the file.
+  // -------------------------------------------------------------------------
+
+  describe('stale multipart session — provider reports NoSuchUpload', () => {
+    const NO_SUCH_UPLOAD_XML =
+      '<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchUpload</Code>' +
+      '<Message>The specified multipart upload does not exist.</Message></Error>';
+
+    /** A resume state the API still considers valid (status check succeeds). */
+    const resumeState: UploadResumeState = {
+      objectId: 'obj-stale',
+      uploadId: 'upload-stale',
+      partSize: PART_SIZE,
+      completedParts: [{ partNumber: 1, eTag: 'etag-1' }],
+    };
+
+    /** Fake api whose first N part PUTs 404 with NoSuchUpload, then succeed. */
+    function makeApiWith404Until(failCalls: number) {
+      const { api, postSpy, getSpy, putRawSpy } = makeFakeApi({
+        statusResponse: { uploadId: 'upload-stale', status: 'uploading' },
+      });
+      let calls = 0;
+      (putRawSpy as jest.Mock).mockImplementation((() => {
+        calls++;
+        if (calls <= failCalls) {
+          return Promise.reject(new ApiError(404, NO_SUCH_UPLOAD_XML));
+        }
+        return Promise.resolve(`etag-${calls}`);
+      }) as ApiClient['putRaw']);
+      return { api, postSpy, getSpy, putRawSpy };
+    }
+
+    it('discards the dead session and re-inits instead of failing the file', async () => {
+      const { api, postSpy } = makeApiWith404Until(1);
+      const { persistence, onComplete } = makePersistence(resumeState);
+
+      const result = await uploadFile(
+        api as unknown as ApiClient,
+        filePath,
+        'image/jpeg',
+        undefined,
+        persistence,
+      );
+
+      // Recovered: a fresh init ran and the upload finished on the new session.
+      const initCalls = postSpy.mock.calls.filter(
+        (c) => c[0] === '/api/storage/objects/upload/init',
+      );
+      expect(initCalls).toHaveLength(1);
+      expect(result.objectId).toBe('obj-1');
+
+      // The dead session was cleared before re-initializing, so the retry
+      // cannot resume into it again.
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    it('re-uploads every part on the fresh session, ignoring resumed parts', async () => {
+      const { api, putRawSpy } = makeApiWith404Until(1);
+      const { persistence } = makePersistence(resumeState);
+
+      await uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence);
+
+      // 1 failed PUT (part 2, the first not already resumed) + all 3 parts
+      // re-sent on the clean session.
+      expect(putRawSpy).toHaveBeenCalledTimes(1 + TOTAL_PARTS);
+    });
+
+    it('gives up after one restart when the fresh session also 404s', async () => {
+      // A persistently-404ing provider (e.g. a missing bucket) must not loop.
+      const { api, putRawSpy } = makeApiWith404Until(Number.MAX_SAFE_INTEGER);
+      const { persistence } = makePersistence(resumeState);
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).rejects.toThrow(/no longer exists on the storage provider/i);
+
+      // Exactly two attempts: the stale session, then one clean retry.
+      expect(putRawSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('still reports a non-404 part failure as a normal per-part error', async () => {
+      const { api, putRawSpy } = makeFakeApi({});
+      (putRawSpy as jest.Mock).mockImplementation((() =>
+        Promise.reject(new ApiError(403, 'AccessDenied'))) as ApiClient['putRaw']);
+      const { persistence } = makePersistence();
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).rejects.toThrow(/^Part 1 failed:/);
     });
   });
 });

--- a/apps/cli/test/upload.spec.ts
+++ b/apps/cli/test/upload.spec.ts
@@ -519,5 +519,24 @@ describe('uploadFile', () => {
         uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
       ).rejects.toThrow(/^Part 1 failed:/);
     });
+
+    // A part PUT never touches the MemoriaHub API, so its failures must not be
+    // labelled "API error" — that misdirection cost real diagnostic time.
+    it('attributes a part failure to the storage provider, surfacing its error code', async () => {
+      const { api, putRawSpy } = makeFakeApi({});
+      (putRawSpy as jest.Mock).mockImplementation((() =>
+        Promise.reject(
+          new ApiError(
+            403,
+            '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code>' +
+              '<Message>Access Denied</Message></Error>',
+          ),
+        )) as ApiClient['putRaw']);
+      const { persistence } = makePersistence();
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).rejects.toThrow('Part 1 failed: storage provider returned HTTP 403 AccessDenied');
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

A bulk `memoriahub sync` against Cloudflare R2 was permanently losing files as a result of a single *transient* R2 error that should have retried successfully. Four defects in `apps/cli` compounded into one failure chain: a transient `500 InternalError` failed a whole file, the failed part stranded a multipart upload that could never be resumed or re-initialized, the recovery command couldn't run at all, and a separate token expiry drained the remaining queue.

The chain: R2 returns a transient 500 → the CLI treats it as permanent and fails the file → the next attempt resumes into a multipart upload R2 has since garbage-collected → every retry 404s with `NoSuchUpload`, forever → `retry` refuses to run. Recovery required hand-editing the CLI's SQLite ledger.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #179

## Changes Made

- **`http/retry.ts`** — added **500** to `RETRYABLE_STATUSES`. S3 and R2 both return a transient `500 InternalError` on presigned part PUTs under load and both document it as retry-and-it-succeeds; treating it as permanent was the root cause.
- **`upload.ts`** — a **404 on a part PUT** now raises `StaleUploadSessionError`, which `uploadFile` answers by clearing the dead session and running exactly one clean re-init. `isServerSessionValid` can only ask our own API, which answers from its `storage_objects` row without ever consulting S3/R2 — so reactive detection is the only way a stranded file can recover.
- **`commands/retry.ts` + `commands/import.ts`** — both now accept a `--circle` option and fall back to `cfg.activeCircleId`, matching `sync`. `retry` previously passed no `circleId` at all while its error message pointed at a `--circle` flag it didn't define. `import` had the same bug and is worse in practice: it registers the folder itself, so `folder.circle_id` is always null on a first run.
- **`sync/worker-pool.ts` + `sync/sync-engine.ts`** — `runPool` gains a cooperative `shouldStop` predicate; the engine sets it on the first **401** and aborts with the actionable re-auth message instead of draining the queue.
- **`upload.ts`** — part failures now read `storage provider returned HTTP 500 InternalError` rather than `API error 500:` followed by the raw XML body. A part PUT never touches the MemoriaHub API, and that prefix sent debugging at the wrong system.
- **`package.json`** — CLI `1.2.14 → 1.2.15`, lockfile synced.

### Implementation notes

**Stale-session recovery is bounded at one restart.** A second stale-session failure (a genuinely missing bucket, say) propagates rather than looping. The re-upload does re-send bytes already transferred, but that waste is capped at a single file and is strictly better than losing it. `ignoreResumeState` is threaded through so the retry can never consult the session it just discarded.

**Detection keys on HTTP 404, not the `NoSuchUpload` string.** S3/R2 answer a part PUT with 404 only when the upload or bucket cannot be found — never transiently — so matching the status is both sufficient and robust against providers that word the body differently.

**The 401 abort deliberately does not touch `last_sync`.** The folders were not fully synced, and marking them as such would make the next run skip work. `shouldStop` is checked before each dequeue, so in-flight uploads finish cleanly and nothing is orphaned mid-part. Files never dequeued keep their prior status and `attempt_count: 0`, so `retry` resumes cleanly after `login` without needing `--force`.

## Testing

- [x] Unit tests pass (`npm run test:ci` — 96 suites / 1255 tests)
- [x] Type checks pass (`npx tsc --noEmit` — clean)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed (root cause reproduced and diagnosed against a live R2 deployment; see #179 for the captured `files.last_error` evidence)

15 new tests:

- **`test/http/retry.spec.ts`** — a 500 retries and eventually succeeds
- **`test/upload.spec.ts`** (5) — stale session re-inits and completes; the dead session is cleared before retrying; all parts re-send on the fresh session ignoring resumed ones; a persistently-404ing provider gives up after exactly one restart; a non-404 part failure still reports as a normal per-part error; failures name the storage provider and surface its error code
- **`test/sync/sync-engine.spec.ts`** (9) — 401 aborts rather than draining the queue; untouched files keep `attempt_count: 0`; the error event carries the re-auth message; `last_sync` stays null; a non-401 failure still does *not* abort; plus circle-resolution precedence (`folder.circle_id` wins over `opts.circleId`; falls back to `opts.circleId`; actionable error when neither resolves)

Two suites (`test/db/migrations.spec.ts`, `test/sync/sync-engine-date-range.spec.ts`) fail on this branch **and on `main` identically** — both are already in the `test:ci` ignore list. Verified pre-existing by stashing the changes and re-running; unrelated to this work.

### Test Instructions

1. Configure R2 as the active storage provider and register a folder of large videos without binding a circle (`memoriahub folders add PATH`).
2. Run `memoriahub sync --all --circle CIRCLE_ID` and let it hit a transient R2 500 — the part should now retry and the file complete, rather than failing.
3. For a file already stranded by the old behavior (`files.last_error` showing `NoSuchUpload`, `attempt_count` at the cap), run `memoriahub retry --all --force` — it should resolve the circle, discard the dead session, re-init, and complete with no SQLite surgery.
4. Revoke the PAT mid-run to confirm the sync aborts immediately with the re-auth message instead of marking every remaining file failed.

## Additional Notes

Not addressed here: the 28-character truncation in the live progress renderer (`apps/cli/src/render/headless-sync.ts:252`) still hides the provider error code during a run. It's a fixed-width column and widening it risks breaking the layout — the full text is already in `files.last_error`, the end-of-run failures table, and the Excel report. Worth its own issue if the live view should surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4TXs5tvFS1pvVoS35YDKh