### PR TITLE
fix: recover fully-resumed multipart uploads at the complete step, and return 409 instead of 500 for a dead session

### DIFF
--- a/apps/api/src/storage/objects/objects.service.spec.ts
+++ b/apps/api/src/storage/objects/objects.service.spec.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  ConflictException,
 } from '@nestjs/common';
 import { Readable } from 'stream';
 
@@ -442,6 +443,76 @@ describe('ObjectsService', () => {
       await expect(
         service.completeUpload(mockStorageObject.id, dto, testUserId),
       ).rejects.toThrow('Upload ID not found');
+    });
+
+    // Issue #183: a multipart session the provider has dropped is a CLIENT-STATE
+    // error. Letting the raw SDK error escape reported it as a 500, which both
+    // misrepresents the condition and denies the client a status it can key
+    // recovery off (it must re-init the upload).
+    describe('stale multipart session', () => {
+      function arrangeCompleteFailure(error: unknown): { parts: Array<{ partNumber: number; eTag: string }> } {
+        const dto = { parts: [{ partNumber: 1, eTag: 'etag1' }] };
+        mockPrisma.storageObject.findUnique.mockResolvedValue({
+          ...mockStorageObject,
+          status: 'pending',
+          s3UploadId: 'upload-123',
+          chunks: [],
+        } as any);
+        mockPrisma.storageObjectChunk.upsert.mockResolvedValue({} as any);
+        mockStorageProvider.completeMultipartUpload.mockRejectedValue(error as never);
+        return dto;
+      }
+
+      it('maps NoSuchUpload to 409 Conflict', async () => {
+        const err = Object.assign(new Error('The specified multipart upload does not exist.'), {
+          name: 'NoSuchUpload',
+        });
+        const dto = arrangeCompleteFailure(err);
+
+        await expect(
+          service.completeUpload(mockStorageObject.id, dto, testUserId),
+        ).rejects.toThrow(ConflictException);
+      });
+
+      it('maps InvalidPart to 409 Conflict', async () => {
+        const err = Object.assign(
+          new Error('One or more of the specified parts could not be found.'),
+          { name: 'InvalidPart' },
+        );
+        const dto = arrangeCompleteFailure(err);
+
+        await expect(
+          service.completeUpload(mockStorageObject.id, dto, testUserId),
+        ).rejects.toThrow(ConflictException);
+      });
+
+      it('recognizes the condition from the message when the SDK omits the code', async () => {
+        // R2's error shapes are not always identical to AWS's, so the message
+        // fallback must carry the classification on its own.
+        const dto = arrangeCompleteFailure(
+          new Error('The specified multipart upload does not exist.'),
+        );
+
+        await expect(
+          service.completeUpload(mockStorageObject.id, dto, testUserId),
+        ).rejects.toThrow(ConflictException);
+      });
+
+      it('leaves an unrelated provider failure untouched', async () => {
+        const err = Object.assign(new Error('We encountered an internal error.'), {
+          name: 'InternalError',
+        });
+        const dto = arrangeCompleteFailure(err);
+
+        // Must NOT be converted to a 409 — a genuine provider fault is a 5xx and
+        // is legitimately retryable by the client.
+        await expect(
+          service.completeUpload(mockStorageObject.id, dto, testUserId),
+        ).rejects.toThrow('We encountered an internal error.');
+        await expect(
+          service.completeUpload(mockStorageObject.id, dto, testUserId),
+        ).rejects.not.toThrow(ConflictException);
+      });
     });
   });
 

--- a/apps/api/src/storage/objects/objects.service.ts
+++ b/apps/api/src/storage/objects/objects.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  ConflictException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -58,6 +59,34 @@ export interface MultipartFile {
 // Derived/internal storage objects that should not appear in user-facing browse lists.
 // These are auto-generated blobs, not user-uploaded files.
 const DERIVED_KEY_PREFIXES = ['thumbnails/', 'video-faces/'];
+
+/**
+ * S3/R2 error codes meaning the client's multipart session is unusable:
+ *  - NoSuchUpload — the upload id is gone (provider GC'd an abandoned upload)
+ *  - InvalidPart / InvalidPartOrder — the submitted ETags don't belong to it
+ *
+ * Matched on `name` (AWS SDK v3 surfaces the code there) with a message
+ * fallback, since R2's error shapes are not always identical to AWS's.
+ */
+const STALE_MULTIPART_ERROR_NAMES = new Set([
+  'NoSuchUpload',
+  'InvalidPart',
+  'InvalidPartOrder',
+]);
+
+const STALE_MULTIPART_MESSAGE_RE =
+  /multipart upload does not exist|parts could not be found|NoSuchUpload|InvalidPart/i;
+
+/** True when a provider error means the client must re-init the upload. */
+function isStaleMultipartSessionError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') return false;
+  const name = (error as { name?: unknown }).name;
+  if (typeof name === 'string' && STALE_MULTIPART_ERROR_NAMES.has(name)) {
+    return true;
+  }
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && STALE_MULTIPART_MESSAGE_RE.test(message);
+}
 
 @Injectable()
 export class ObjectsService {
@@ -326,12 +355,33 @@ export class ObjectsService {
       storageObject.bucket,
     );
 
-    // Complete upload with storage provider
-    await completeProvider.completeMultipartUpload(
-      storageObject.storageKey,
-      storageObject.s3UploadId,
-      parts,
-    );
+    // Complete upload with storage provider.
+    //
+    // A dead client-held session (the provider garbage-collected an abandoned
+    // multipart upload, or the client's persisted ETags belong to one) is a
+    // CLIENT-STATE error, not a server fault. Letting the raw SDK error escape
+    // made Nest report it as a 500, which both misrepresents the condition and
+    // leaves the client no status to key recovery off — it must instead restart
+    // the upload from a fresh init (issue #183).
+    try {
+      await completeProvider.completeMultipartUpload(
+        storageObject.storageKey,
+        storageObject.s3UploadId,
+        parts,
+      );
+    } catch (error) {
+      if (isStaleMultipartSessionError(error)) {
+        this.logger.warn(
+          `Multipart session for object ${objectId} is no longer valid on the ` +
+            `storage provider; the client must re-initialize the upload.`,
+        );
+        throw new ConflictException(
+          'The multipart upload session is no longer valid on the storage ' +
+            'provider. Re-initialize the upload and send the parts again.',
+        );
+      }
+      throw error;
+    }
 
     // Update status to processing
     const updated = await this.prisma.storageObject.update({

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/http/retry.ts
+++ b/apps/cli/src/http/retry.ts
@@ -38,6 +38,18 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
  */
 export const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 
+/**
+ * Provider/server messages meaning a multipart session is permanently dead.
+ *
+ * These arrive on a `500` from an API deployment that lets the raw S3/R2 error
+ * escape `completeMultipartUpload` (newer servers map them to 409). Since 500
+ * is otherwise retryable, without this the client spends its whole retry budget
+ * on a condition that can never succeed — the upload must be re-initialized
+ * instead (issue #183).
+ */
+export const STALE_SESSION_MESSAGE_RE =
+  /multipart upload does not exist|parts could not be found|NoSuchUpload|InvalidPart/i;
+
 /** Transient network error codes that warrant a retry. */
 const RETRYABLE_NET_CODES = new Set([
   'ECONNRESET',
@@ -72,6 +84,16 @@ export function classifyError(err: unknown): RetryableInfo {
   const status = typeof e.status === 'number' ? e.status : undefined;
   const retryAfterMs =
     typeof e.retryAfterMs === 'number' ? e.retryAfterMs : undefined;
+
+  // A dead multipart session is terminal no matter what status carries it.
+  // Checked BEFORE every retryable rule (including the 500 added for transient
+  // provider faults) so the budget is not burned on an unwinnable call — the
+  // caller re-initializes the upload instead (issue #183).
+  const serverMessage =
+    typeof e.serverMessage === 'string' ? e.serverMessage : undefined;
+  if (serverMessage && STALE_SESSION_MESSAGE_RE.test(serverMessage)) {
+    return { retryable: false, status, retryAfterMs };
+  }
 
   // Explicit retryable marker (e.g. an S3 `SlowDown` body on a non-429 status).
   if (e.retryable === true) {

--- a/apps/cli/src/upload.ts
+++ b/apps/cli/src/upload.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { ApiClient, ApiError } from './api.js';
+import { STALE_SESSION_MESSAGE_RE } from './http/retry.js';
 
 export interface UploadResult {
   objectId: string;
@@ -118,12 +119,13 @@ function readFileSlice(
  */
 class StaleUploadSessionError extends Error {
   constructor(
-    readonly partNumber: number,
+    /** Where the dead session surfaced — a part PUT, or the complete call. */
+    readonly stage: string,
     readonly detail: string,
   ) {
     super(
       `Multipart upload session no longer exists on the storage provider ` +
-        `(part ${partNumber}): ${detail}`,
+        `(${stage}): ${detail}`,
     );
     this.name = 'StaleUploadSessionError';
   }
@@ -141,6 +143,26 @@ class StaleUploadSessionError extends Error {
  */
 function isStaleUploadSession(err: unknown): boolean {
   return err instanceof ApiError && err.status === 404;
+}
+
+/**
+ * True when a failed `POST /upload/complete` means the multipart session is
+ * unusable and the file must restart from a fresh init.
+ *
+ * Two response shapes are accepted so a CLI upgraded ahead of its server still
+ * recovers (issue #183):
+ *   - 409 Conflict — what the API returns once it maps the provider's
+ *     `NoSuchUpload`/`InvalidPart` itself.
+ *   - 500 carrying the provider's message — an older deployment letting the
+ *     raw SDK error escape as a generic server error.
+ *
+ * The message test is deliberately narrow: a bare 500 is a genuine (retryable)
+ * server fault and must NOT be mistaken for a dead session.
+ */
+function isStaleCompleteResponse(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status === 409) return true;
+  return STALE_SESSION_MESSAGE_RE.test(err.serverMessage);
 }
 
 /**
@@ -163,7 +185,7 @@ async function uploadPart(
   } catch (err) {
     const msg = describeStorageFailure(err);
     if (isStaleUploadSession(err)) {
-      throw new StaleUploadSessionError(partNumber, msg);
+      throw new StaleUploadSessionError(`part ${partNumber}`, msg);
     }
     throw new Error(`Part ${partNumber} failed: ${msg}`);
   }
@@ -442,9 +464,24 @@ async function runUploadSession(
   // ------------------------------------------------------------------
   // 4. Finalize the upload on the server
   // ------------------------------------------------------------------
-  await api.post(`/api/storage/objects/${objectId}/upload/complete`, {
-    parts: completedParts,
-  });
+  // The complete call is the ONLY network round-trip left when a resume state
+  // already covers every part — the loop above is skipped entirely in that
+  // case, so the part-PUT stale-session check never runs. Guarding here is what
+  // makes a fully-resumed file recoverable rather than permanently stuck
+  // (issue #183).
+  try {
+    await api.post(`/api/storage/objects/${objectId}/upload/complete`, {
+      parts: completedParts,
+    });
+  } catch (err) {
+    if (isStaleCompleteResponse(err)) {
+      throw new StaleUploadSessionError(
+        'completing the upload',
+        describeStorageFailure(err),
+      );
+    }
+    throw err;
+  }
 
   // ------------------------------------------------------------------
   // 5. Clear in-progress state now that the upload is fully committed

--- a/apps/cli/test/http/retry.spec.ts
+++ b/apps/cli/test/http/retry.spec.ts
@@ -100,6 +100,24 @@ describe('classifyError / isRetryable', () => {
     expect(calls).toBe(3);
   });
 
+  // Issue #183: a dead multipart session is terminal regardless of the status
+  // carrying it. Since 500 became retryable in #179, without this the client
+  // spends its whole retry budget on a call that can never succeed.
+  it('treats a stale multipart-session message as non-retryable on any status', () => {
+    expect(
+      isRetryable({ status: 500, serverMessage: 'The specified multipart upload does not exist.' }),
+    ).toBe(false);
+    expect(
+      isRetryable({ status: 500, serverMessage: 'One or more of the specified parts could not be found.' }),
+    ).toBe(false);
+    expect(isRetryable({ status: 503, serverMessage: 'NoSuchUpload' })).toBe(false);
+  });
+
+  it('still retries an ordinary 500 with no stale-session signature', () => {
+    expect(isRetryable({ status: 500, serverMessage: 'Internal server error' })).toBe(true);
+    expect(isRetryable({ status: 500 })).toBe(true);
+  });
+
   it('treats other 4xx as non-retryable', () => {
     for (const status of [400, 401, 403, 404, 409, 413, 422]) {
       expect(isRetryable({ status })).toBe(false);

--- a/apps/cli/test/upload.spec.ts
+++ b/apps/cli/test/upload.spec.ts
@@ -539,4 +539,146 @@ describe('uploadFile', () => {
       ).rejects.toThrow('Part 1 failed: storage provider returned HTTP 403 AccessDenied');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // 5. Stale session detected at the COMPLETE step (issue #183)
+  //
+  // When the resume state already covers EVERY part, the part-upload loop is
+  // skipped entirely — so #179's part-PUT detection never runs and the complete
+  // call is the only place a dead session can surface. This is the exact gap
+  // that left files permanently stuck.
+  // -------------------------------------------------------------------------
+
+  describe('stale multipart session — surfaced at the complete step', () => {
+    /** Resume state covering all parts, so NO part PUT is attempted. */
+    const fullyResumed: UploadResumeState = {
+      objectId: 'obj-resumed',
+      uploadId: 'upload-resumed',
+      partSize: PART_SIZE,
+      completedParts: Array.from({ length: TOTAL_PARTS }, (_, i) => ({
+        partNumber: i + 1,
+        eTag: `etag-${i + 1}`,
+      })),
+    };
+
+    /**
+     * Fake api whose FIRST complete call rejects with `completeError` and whose
+     * subsequent calls succeed — modelling recovery via a fresh session.
+     */
+    function makeApiFailingComplete(completeError: unknown) {
+      const { api, postSpy, getSpy, putRawSpy } = makeFakeApi({
+        statusResponse: { uploadId: 'upload-resumed', status: 'uploading' },
+      });
+      let completeCalls = 0;
+      const inner = postSpy.getMockImplementation() as (
+        url: string,
+        body: unknown,
+      ) => Promise<unknown>;
+      (postSpy as jest.Mock).mockImplementation(((url: string, body: unknown) => {
+        if (String(url).includes('/upload/complete')) {
+          completeCalls++;
+          if (completeCalls === 1) return Promise.reject(completeError);
+          return Promise.resolve({});
+        }
+        return inner(url, body);
+      }) as ApiClient['post']);
+      return { api, postSpy, getSpy, putRawSpy };
+    }
+
+    it('recovers from a 409 Conflict by re-initializing the upload', async () => {
+      const { api, postSpy, putRawSpy } = makeApiFailingComplete(
+        new ApiError(409, 'The multipart upload session is no longer valid.'),
+      );
+      const { persistence, onComplete } = makePersistence(fullyResumed);
+
+      const result = await uploadFile(
+        api as unknown as ApiClient,
+        filePath,
+        'image/jpeg',
+        undefined,
+        persistence,
+      );
+
+      // A fresh init ran and the file finished on the new session.
+      expect(
+        postSpy.mock.calls.filter((c) => c[0] === '/api/storage/objects/upload/init'),
+      ).toHaveLength(1);
+      expect(result.objectId).toBe('obj-1');
+      expect(onComplete).toHaveBeenCalled();
+
+      // The whole point: the first pass uploaded NOTHING (all parts resumed),
+      // so every part had to be re-sent on the clean session.
+      expect(putRawSpy).toHaveBeenCalledTimes(TOTAL_PARTS);
+    });
+
+    it('recovers from a legacy 500 carrying the provider message', async () => {
+      // An API deployment older than the 409 mapping still lets the raw S3/R2
+      // error through as a 500 — the CLI must recover against it too.
+      const { api, postSpy } = makeApiFailingComplete(
+        new ApiError(500, 'The specified multipart upload does not exist.'),
+      );
+      const { persistence } = makePersistence(fullyResumed);
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).resolves.toEqual({ objectId: 'obj-1' });
+
+      expect(
+        postSpy.mock.calls.filter((c) => c[0] === '/api/storage/objects/upload/init'),
+      ).toHaveLength(1);
+    });
+
+    it('recovers from an InvalidPart 500 (stale ETags in the ledger)', async () => {
+      const { api } = makeApiFailingComplete(
+        new ApiError(500, 'One or more of the specified parts could not be found.'),
+      );
+      const { persistence } = makePersistence(fullyResumed);
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).resolves.toEqual({ objectId: 'obj-1' });
+    });
+
+    it('does NOT treat an ordinary 500 as a dead session', async () => {
+      // A genuine server fault must propagate, not silently re-upload the file.
+      const { api, postSpy } = makeApiFailingComplete(
+        new ApiError(500, 'Internal server error'),
+      );
+      const { persistence } = makePersistence(fullyResumed);
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).rejects.toThrow(/Internal server error/);
+
+      expect(
+        postSpy.mock.calls.filter((c) => c[0] === '/api/storage/objects/upload/init'),
+      ).toHaveLength(0);
+    });
+
+    it('gives up after one restart when the fresh session also reports a dead upload', async () => {
+      const { api, postSpy } = makeFakeApi({
+        statusResponse: { uploadId: 'upload-resumed', status: 'uploading' },
+      });
+      const inner = postSpy.getMockImplementation() as (
+        url: string,
+        body: unknown,
+      ) => Promise<unknown>;
+      (postSpy as jest.Mock).mockImplementation(((url: string, body: unknown) => {
+        if (String(url).includes('/upload/complete')) {
+          return Promise.reject(new ApiError(409, 'still gone'));
+        }
+        return inner(url, body);
+      }) as ApiClient['post']);
+      const { persistence } = makePersistence(fullyResumed);
+
+      await expect(
+        uploadFile(api as unknown as ApiClient, filePath, 'image/jpeg', undefined, persistence),
+      ).rejects.toThrow(/no longer exists on the storage provider/i);
+
+      // One re-init only — no unbounded loop.
+      expect(
+        postSpy.mock.calls.filter((c) => c[0] === '/api/storage/objects/upload/init'),
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

Follow-up to #179. That fix recovers a stale multipart session when it surfaces on a **part PUT**, but it cannot fire when the resume state already covers **every** part: the upload loop is skipped entirely and `POST /upload/complete` becomes the only remaining round-trip. Files stranded that way still failed permanently, with no re-init ever attempted — the outcome #179 set out to eliminate.

Two things made it worse. The API let the raw AWS SDK error escape `completeMultipartUpload`, so `NoSuchUpload` / `InvalidPart` arrived as a generic **500** — misreporting client state as a server fault and leaving the client no status to key recovery off. And because #179 made 500 retryable, the CLI spent its full retry budget on a call that could never succeed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #183
Relates to #179

## Changes Made

- **`apps/api/.../objects.service.ts`** — `completeUpload` now catches provider errors and maps the stale-session signature (`NoSuchUpload`, `InvalidPart`, `InvalidPartOrder`, by SDK error `name` with a message fallback for R2's differing shapes) to a **409 Conflict**. Every other provider failure is untouched and still surfaces as a retryable 5xx.
- **`apps/cli/src/upload.ts`** — the complete call is guarded, raising `StaleUploadSessionError` so #179's existing one-shot re-init applies. Accepts **both** the new 409 and the legacy 500-carrying-the-provider-message, so a CLI upgraded ahead of its server still recovers. `StaleUploadSessionError` now takes a stage label so its message reads correctly from either call site.
- **`apps/cli/src/http/retry.ts`** — `classifyError` treats the stale-session signature as terminal on any status, checked before every retryable rule. Exported as `STALE_SESSION_MESSAGE_RE` so the CLI has one definition rather than two.
- **`apps/cli/package.json`** — `1.2.16 → 1.2.17`, lockfile synced.

### Implementation notes

**Why the message test is narrow.** A bare 500 with no stale-session signature is a genuine server fault: still retryable, and it must not trigger a silent full re-upload. There's an explicit test for that.

**Why both response shapes.** Users upgrade the CLI and the server independently. Keying only on 409 would leave every already-deployed server unfixed; keying only on the message would ignore the cleaner contract. Accepting both means recovery works during the rollout window in either order.

**Recovery is still bounded at one restart** — inherited from #179. A fresh session that also reports a dead upload propagates rather than looping; covered by a test.

## Testing

- [x] Unit tests pass — CLI `npm run test:ci`: **99 suites / 1299 tests**; API `objects.service.spec.ts`: **44 tests**
- [x] Type checks pass — `tsc --noEmit` clean for both `apps/cli` and `apps/api`
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed (reproduced against a live R2 deployment; captured `files.last_error` evidence in #183)

11 new tests:

- **`apps/api/.../objects.service.spec.ts`** (4) — `NoSuchUpload` → 409; `InvalidPart` → 409; classification works from the message alone when the SDK omits the code; an unrelated provider failure is *not* converted to 409
- **`apps/cli/test/upload.spec.ts`** (5) — the all-parts-resumed path recovers from a 409 and re-sends every part on the fresh session; recovers from a legacy 500 `NoSuchUpload`; recovers from a 500 `InvalidPart`; an ordinary 500 is *not* mistaken for a dead session and never triggers a re-init; a persistently-dead upload gives up after exactly one restart
- **`apps/cli/test/http/retry.spec.ts`** (2) — a stale-session message is non-retryable on any status; an ordinary 500 still retries

### Test Instructions

1. Interrupt a large upload after every part has been PUT but before `POST /upload/complete` returns, so the ledger holds `upload_id` plus a `file_upload_parts` row per part.
2. Abort the multipart upload on the provider side (or wait for R2 to GC it).
3. Run `memoriahub sync --all --circle CIRCLE_ID`. Before this change the file failed with `API error 500: The specified multipart upload does not exist.` on every attempt; it should now re-initialize, re-upload, and complete.
4. Confirm an ordinary API 500 during complete still surfaces as an error rather than silently re-uploading.

## Additional Notes

Anyone already holding files stranded this way recovers automatically on the next `sync`/`retry` after upgrading — no SQLite surgery needed. The manual workaround in #183 remains valid for anyone on an older CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4TXs5tvFS1pvVoS35YDKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4TXs5tvFS1pvVoS35YDKh)_