### PR TITLE
fix(api): wrap review-run strategy service injections in forwardRef

### DIFF
--- a/apps/api/src/review-runs/strategies/burst-group.strategy.ts
+++ b/apps/api/src/review-runs/strategies/burst-group.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
 import {
   BurstGroupStatus,
   Prisma,
@@ -49,6 +49,10 @@ export class BurstGroupReviewStrategy implements ReviewRunSubjectStrategy {
 
   constructor(
     private readonly prisma: PrismaService,
+    // Circular by nature: BurstService injects ReviewRunService (wrapped in its own
+    // forwardRef), and ReviewRunService pulls in this strategy via the subject registry —
+    // this is the reverse edge of that same cycle, so it needs forwardRef too.
+    @Inject(forwardRef(() => BurstService))
     private readonly burstService: BurstService,
   ) {}
 

--- a/apps/api/src/review-runs/strategies/duplicate-group.strategy.ts
+++ b/apps/api/src/review-runs/strategies/duplicate-group.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import {
   DuplicateGroupStatus,
   Prisma,
@@ -49,6 +49,10 @@ export class DuplicateGroupReviewStrategy implements ReviewRunSubjectStrategy {
 
   constructor(
     private readonly prisma: PrismaService,
+    // Circular by nature: DuplicateService injects ReviewRunService (wrapped in its own
+    // forwardRef), and ReviewRunService pulls in this strategy via the subject registry —
+    // this is the reverse edge of that same cycle, so it needs forwardRef too.
+    @Inject(forwardRef(() => DuplicateService))
     private readonly duplicateService: DuplicateService,
   ) {}
 


### PR DESCRIPTION
## Summary

Hotfix for #197 — the Review Runs feature (#190) crash-loops the API in production.

`DuplicateGroupReviewStrategy` injected `DuplicateService` directly, while `DuplicateService` injects `ReviewRunService` back through `forwardRef()`. The strategy side was the **unwrapped reverse edge** of that cycle, so depending on module load order `DuplicateService` was still unresolved (mid-load circular import) when Nest read the strategy's constructor metadata:

```
UndefinedDependencyException [Error]: Nest can't resolve dependencies of the
DuplicateGroupReviewStrategy (PrismaService, ?).
```

`BurstGroupReviewStrategy` → `BurstService` has the identical structural cycle and only avoided tripping by load-order luck. Fixed proactively in the same change.

## Changes

- `apps/api/src/review-runs/strategies/duplicate-group.strategy.ts` — `@Inject(forwardRef(() => DuplicateService))`
- `apps/api/src/review-runs/strategies/burst-group.strategy.ts` — `@Inject(forwardRef(() => BurstService))`

`ReviewRunsModule` already imports `BurstModule` / `DedupModule` via `forwardRef`, so no module wiring changes were needed — only the provider-level reverse edges were missing.

No schema or migration changes: the already-applied `20260726010000_review_runs` migration is additive and compatible with both the old and new code.

## Verification

- `tsc --noEmit` on `apps/api` — clean
- Review-runs suites: **163 passed**, 0 failed (7 suites)
- Full CI gate: **5331 passed, 1 failed** — the single failure (`social-media-ocr.service.spec.ts`) was confirmed **pre-existing on `main`** by re-running it at `000cb59d` with this change reverted.

Fixes #197