### PR TITLE
fix(api): import SettingsModule into ReviewRunsModule

### DIFF
--- a/apps/api/src/review-runs/review-runs.module.ts
+++ b/apps/api/src/review-runs/review-runs.module.ts
@@ -3,6 +3,7 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { CirclesModule } from '../circles/circles.module';
 import { EnrichmentModule } from '../enrichment/enrichment.module';
 import { MediaModule } from '../media/media.module';
+import { SettingsModule } from '../settings/settings.module';
 import { BurstModule } from '../burst/burst.module';
 import { DedupModule } from '../dedup/dedup.module';
 import { ReviewRunsController } from './review-runs.controller';
@@ -23,8 +24,9 @@ import { LocationSuggestionReviewStrategy } from './strategies/location-suggesti
  * BurstModule and DedupModule are imported through `forwardRef` because the
  * dependency is genuinely mutual: the strategies here wrap `BurstService` /
  * `DuplicateService` primitives, while those services' threshold endpoints call
- * `ReviewRunService.createRun`. MediaModule (MediaThumbnailService) and the rest
- * are plain imports — none of them import this module.
+ * `ReviewRunService.createRun`. MediaModule (MediaThumbnailService), SettingsModule
+ * (SystemSettingsService, read by ReviewRunHistoryPurgeHandler for the retention
+ * window) and the rest are plain imports — none of them import this module.
  *
  * The location-suggestion strategy deliberately does NOT depend on
  * LocationInferenceModule: it owns the accept/reject transaction outright
@@ -37,6 +39,7 @@ import { LocationSuggestionReviewStrategy } from './strategies/location-suggesti
     CirclesModule,
     EnrichmentModule,
     MediaModule,
+    SettingsModule,
     forwardRef(() => BurstModule),
     forwardRef(() => DedupModule),
   ],


### PR DESCRIPTION
## Summary

Second hotfix for the Review Runs (#190) production crash-loop. Fixes #199.

The #198 `forwardRef` fix was correct and did resolve the `DuplicateGroupReviewStrategy` failure — but Nest reports only the **first** unresolved provider, so a second, unrelated wiring bug in the same module was hidden behind it. The API still crash-loops on `7e2ad7e0`:

```
UnknownDependenciesException [Error]: Nest can't resolve dependencies of the
ReviewRunHistoryPurgeHandler (EnrichmentHandlerRegistry, PrismaService, ?).
Please make sure that the argument SystemSettingsService at index [2] is
available in the ReviewRunsModule module.
```

`ReviewRunHistoryPurgeHandler` injects `SystemSettingsService` (to read `reviewRuns.runHistoryRetentionDays`), but `ReviewRunsModule` never imported `SettingsModule`. Unlike #197 this is **not** a cycle — the provider simply was never in scope. `SettingsModule` has no imports of its own, so no `forwardRef` is needed.

## Changes

- `apps/api/src/review-runs/review-runs.module.ts` — add `SettingsModule` to `imports`, and note in the module docblock why it's there.

## Verification

- Audited **every** provider in `ReviewRunsModule` against its imports. `SystemSettingsService` was the only unsatisfied dependency; all others (`CircleMembershipService`, `EnrichmentJobService`, `EnrichmentHandlerRegistry`, `MediaThumbnailService`, `BurstService`, `DuplicateService`) are exported by already-imported modules.
- `tsc --noEmit` — clean.
- Compiled the **real `AppModule` DI graph** via `Test.createTestingModule({ imports: [AppModule] }).compile()` — passes with this change. Negative control: reverting just the `SettingsModule` line makes that same check fail with the exact production error, so the check genuinely covers this bug. (Used as a scratch spec to verify; not committed — see below.)

## Follow-up worth doing

Neither #197 nor #199 could be caught by CI as configured: `test:ci` passes `--testPathIgnorePatterns 'integration\.spec\.ts$'`, so nothing in CI ever instantiates the real `AppModule`. Unit specs construct providers directly with mocks, which cannot surface a module-wiring error. A single committed spec doing `Test.createTestingModule({ imports: [AppModule] }).compile()` reproduces both bugs in ~0.3s. I left it out of this PR to keep the hotfix minimal while production is down — happy to open a separate PR for it.

Fixes #199