### PR TITLE
fix(web): guard hook state updates against post-teardown execution

### DIFF
--- a/apps/web/src/__tests__/components/media/MediaDetailDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/media/MediaDetailDrawer.test.tsx
@@ -18,10 +18,10 @@
  *   - Close behaviour and null item guard
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render } from '../../utils/test-utils';
+import { render, flushPendingAsyncWork } from '../../utils/test-utils';
 import { MediaDetailDrawer } from '../../../components/media/MediaDetailDrawer';
 import type { MediaItem } from '../../../types/media';
 
@@ -60,6 +60,37 @@ vi.mock('../../../services/face', () => ({
     lastError: null,
   }),
   rerunMediaFaces: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock tagging/metadata services — useMediaTags / useMediaMetadata (mounted
+// inside the drawer) fetch these on mount. Without these mocks the requests
+// fall through to MSW as unhandled, bypass to a real (failing) network call,
+// and settle on an unpredictable timeline instead of a deterministic
+// microtask — exactly the kind of dangling continuation
+// `flushPendingAsyncWork` below exists to drain before this file's tests
+// finish (issue #196).
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../services/tagging', () => ({
+  getMediaTagStatus: vi.fn().mockResolvedValue({
+    status: 'not_processed',
+    providerKey: null,
+    modelVersion: null,
+    tagCount: 0,
+    processedAt: null,
+    lastError: null,
+  }),
+  rerunMediaTags: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
+}));
+
+vi.mock('../../../services/metadata', () => ({
+  getMediaMetadataStatus: vi.fn().mockResolvedValue({
+    status: 'not_processed',
+    processedAt: null,
+    lastError: null,
+  }),
+  rerunMediaMetadata: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -243,6 +274,14 @@ describe('MediaDetailDrawer', () => {
     mockUseItemAutoAppliedSuggestion.mockReturnValue({ suggestionId: null, loading: false });
     mockRevertLocationSuggestion.mockResolvedValue({ id: 'suggestion-1', status: 'reverted' });
     mockRerunThumbnail.mockResolvedValue({ status: 'ready' });
+  });
+
+  // Drain any pending mocked-service continuations (useMediaFaces,
+  // useMediaTags, useMediaMetadata all fetch on mount) BEFORE the global
+  // `cleanup()` in setup.ts unmounts the tree — see `flushPendingAsyncWork`'s
+  // doc comment for why this matters (issue #196).
+  afterEach(async () => {
+    await flushPendingAsyncWork();
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/__tests__/components/media/MediaDetailDrawerArchive.test.tsx
+++ b/apps/web/src/__tests__/components/media/MediaDetailDrawerArchive.test.tsx
@@ -9,10 +9,10 @@
  *   - Delete confirmation dialog appears on click
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render } from '../../utils/test-utils';
+import { render, flushPendingAsyncWork } from '../../utils/test-utils';
 import { MediaDetailDrawer } from '../../../components/media/MediaDetailDrawer';
 import type { MediaItem } from '../../../types/media';
 
@@ -55,6 +55,35 @@ vi.mock('../../../services/face', () => ({
   getPerson: vi.fn().mockResolvedValue(null),
   createPerson: vi.fn().mockResolvedValue({}),
   updatePerson: vi.fn().mockResolvedValue({}),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock tagging/metadata services (useMediaTags / useMediaMetadata fetch these
+// on mount). Without these mocks the requests fall through to MSW as
+// unhandled, bypass to a real (failing) network call, and settle on an
+// unpredictable timeline instead of a deterministic microtask — exactly the
+// kind of dangling continuation `flushPendingAsyncWork` below exists to
+// drain before this file's tests finish.
+// ---------------------------------------------------------------------------
+vi.mock('../../../services/tagging', () => ({
+  getMediaTagStatus: vi.fn().mockResolvedValue({
+    status: 'not_processed',
+    providerKey: null,
+    modelVersion: null,
+    tagCount: 0,
+    processedAt: null,
+    lastError: null,
+  }),
+  rerunMediaTags: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
+}));
+
+vi.mock('../../../services/metadata', () => ({
+  getMediaMetadataStatus: vi.fn().mockResolvedValue({
+    status: 'not_processed',
+    processedAt: null,
+    lastError: null,
+  }),
+  rerunMediaMetadata: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -157,6 +186,14 @@ describe('MediaDetailDrawer — archive/trash actions', () => {
     mockBulkDelete.mockResolvedValue({ deleted: 1 });
     // getMedia is called after archive/unarchive to refresh the item
     mockGetMedia.mockResolvedValue(makeMediaItem({ downloadUrl: null }));
+  });
+
+  // Drain any pending mocked-service continuations (useMediaFaces,
+  // useMediaTags, useMediaMetadata, usePeople all fetch on mount) BEFORE the
+  // global `cleanup()` in setup.ts unmounts the tree — see
+  // `flushPendingAsyncWork`'s doc comment for why this matters (issue #196).
+  afterEach(async () => {
+    await flushPendingAsyncWork();
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/__tests__/components/media/MediaDetailDrawerOrigin.test.tsx
+++ b/apps/web/src/__tests__/components/media/MediaDetailDrawerOrigin.test.tsx
@@ -16,10 +16,10 @@
  *   - Clicking "View group" navigates to the correct route
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render } from '../../utils/test-utils';
+import { render, flushPendingAsyncWork } from '../../utils/test-utils';
 import { MediaDetailDrawer } from '../../../components/media/MediaDetailDrawer';
 import type { MediaItem } from '../../../types/media';
 
@@ -71,6 +71,35 @@ vi.mock('../../../services/face', () => ({
   getPerson: vi.fn().mockResolvedValue(null),
   createPerson: vi.fn().mockResolvedValue({}),
   updatePerson: vi.fn().mockResolvedValue({}),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock tagging/metadata services (useMediaTags / useMediaMetadata fetch these
+// on mount). Without these mocks the requests fall through to MSW as
+// unhandled, bypass to a real (failing) network call, and settle on an
+// unpredictable timeline instead of a deterministic microtask — exactly the
+// kind of dangling continuation `flushPendingAsyncWork` below exists to
+// drain before this file's tests finish.
+// ---------------------------------------------------------------------------
+vi.mock('../../../services/tagging', () => ({
+  getMediaTagStatus: vi.fn().mockResolvedValue({
+    status: 'not_processed',
+    providerKey: null,
+    modelVersion: null,
+    tagCount: 0,
+    processedAt: null,
+    lastError: null,
+  }),
+  rerunMediaTags: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
+}));
+
+vi.mock('../../../services/metadata', () => ({
+  getMediaMetadataStatus: vi.fn().mockResolvedValue({
+    status: 'not_processed',
+    processedAt: null,
+    lastError: null,
+  }),
+  rerunMediaMetadata: vi.fn().mockResolvedValue({ jobId: 'job-1', status: 'pending' }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -175,6 +204,14 @@ describe('MediaDetailDrawer — Origin section (issue #163)', () => {
     // undefined; every fixture below sets it to null explicitly, so this is
     // just a safety net.
     mockGetMedia.mockResolvedValue(makeMediaItem({ downloadUrl: null }));
+  });
+
+  // Drain any pending mocked-service continuations (useMediaFaces,
+  // useMediaTags, useMediaMetadata, usePeople all fetch on mount) BEFORE the
+  // global `cleanup()` in setup.ts unmounts the tree — see
+  // `flushPendingAsyncWork`'s doc comment for why this matters (issue #196).
+  afterEach(async () => {
+    await flushPendingAsyncWork();
   });
 
   describe('visibility gating', () => {

--- a/apps/web/src/__tests__/hooks/useIsMounted.test.ts
+++ b/apps/web/src/__tests__/hooks/useIsMounted.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for useIsMounted (issue #196).
+ *
+ * useIsMounted returns a stable getter that reports whether the calling
+ * component is currently mounted. Data-loading hooks call it after an
+ * `await` to decide whether it's still safe to call a React state setter —
+ * see `src/hooks/useIsMounted.ts`'s header comment for the full bug this
+ * guards against (a post-teardown continuation throwing
+ * "ReferenceError: window is not defined" deep inside React's
+ * `dispatchSetState`, sometimes during a LATER, unrelated Vitest file).
+ *
+ * Covers:
+ *   - returns true while the component is mounted
+ *   - returns false after the component unmounts
+ *   - the returned getter is referentially stable across re-renders (it's
+ *     wrapped in useCallback with an empty dependency array, so a caller may
+ *     safely capture it in a dependency array without causing effects to
+ *     re-run on every render)
+ *   - the StrictMode mount → unmount → remount cycle (React 18/19 double-
+ *     invokes effects in development) must end up reporting `true`, not
+ *     `false` — this is the specific subtlety the hook's mount-effect
+ *     re-assignment (`mountedRef.current = true`) guards against. A naive
+ *     `useRef(true)` + unmount-only cleanup would leave the ref permanently
+ *     `false` after StrictMode's synthetic unmount, even though the
+ *     component is still alive.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useIsMounted } from '../../hooks/useIsMounted';
+
+describe('useIsMounted', () => {
+  describe('while mounted', () => {
+    it('returns true immediately after mount', () => {
+      const { result } = renderHook(() => useIsMounted());
+
+      expect(result.current()).toBe(true);
+    });
+
+    it('keeps returning true across re-renders while still mounted', () => {
+      const { result, rerender } = renderHook(() => useIsMounted());
+
+      expect(result.current()).toBe(true);
+
+      rerender();
+
+      expect(result.current()).toBe(true);
+    });
+  });
+
+  describe('after unmount', () => {
+    it('returns false once the component has unmounted', () => {
+      const { result, unmount } = renderHook(() => useIsMounted());
+
+      expect(result.current()).toBe(true);
+
+      unmount();
+
+      expect(result.current()).toBe(false);
+    });
+  });
+
+  describe('referential stability', () => {
+    it('returns the SAME function reference across re-renders', () => {
+      const { result, rerender } = renderHook(() => useIsMounted());
+
+      const firstGetter = result.current;
+
+      rerender();
+
+      expect(result.current).toBe(firstGetter);
+    });
+
+    it('keeps the same reference even across multiple re-renders', () => {
+      const { result, rerender } = renderHook(() => useIsMounted());
+
+      const firstGetter = result.current;
+      rerender();
+      rerender();
+      rerender();
+
+      expect(result.current).toBe(firstGetter);
+      // And it still reports the live mounted state through that one stable
+      // reference — a caller closing over it in a dependency array (e.g.
+      // `useCallback(..., [isMounted])`) never sees it "go stale".
+      expect(firstGetter()).toBe(true);
+    });
+  });
+
+  describe('StrictMode mount/unmount/remount cycle', () => {
+    // Passing `wrapper: <React.StrictMode>` does NOT reliably trigger React's
+    // development-mode double-effect-invocation in this RTL/React 19 setup —
+    // verified empirically (a throwaway counter hook's effect only fired
+    // once through that path). RTL's dedicated `reactStrictMode` render
+    // option is the one that actually drives the mount -> cleanup -> remount
+    // cycle (confirmed the same way: the counter's effect fires twice with
+    // a cleanup in between), so that's what these tests use.
+    it('reports true after React 18/19 StrictMode double-invokes the mount effect', () => {
+      // React's development-mode StrictMode intentionally mounts, unmounts,
+      // then remounts every component once to surface effects that aren't
+      // idempotent. That means by the time this render settles, the hook's
+      // effect has already run: mount -> cleanup (simulated unmount, sets
+      // the ref false) -> mount again. Without the fix's
+      // `mountedRef.current = true` re-assignment inside the effect body
+      // (relying solely on the initial `useRef(true)` instead), the ref
+      // would be left permanently `false` here even though the component is
+      // very much alive and none of its "real" unmount cleanup has run.
+      const { result } = renderHook(() => useIsMounted(), {
+        reactStrictMode: true,
+      });
+
+      expect(result.current()).toBe(true);
+    });
+
+    it('still returns false after a REAL unmount that follows the StrictMode cycle', () => {
+      const { result, unmount } = renderHook(() => useIsMounted(), {
+        reactStrictMode: true,
+      });
+
+      // Settles true after StrictMode's synthetic mount/unmount/remount.
+      expect(result.current()).toBe(true);
+
+      // A genuine unmount afterwards must still be honored.
+      unmount();
+
+      expect(result.current()).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/__tests__/hooks/useMediaTags.test.ts
+++ b/apps/web/src/__tests__/hooks/useMediaTags.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression test for issue #196 — useMediaTags is the canonical hook cited
+ * in the issue: its `finally { setLoading(false) }` (originally at line 35,
+ * before the `useIsMounted` guard was added) was one of the two observed
+ * firing after teardown and crashing a LATER, unrelated Vitest file with
+ * "ReferenceError: window is not defined" from deep inside React's
+ * `dispatchSetState`.
+ *
+ * This test renders the hook with `getMediaTagStatus` mocked to return a
+ * still-pending promise, unmounts the component, THEN resolves the promise —
+ * reproducing exactly the race the bug depended on (a fetch still in flight
+ * when the component tears down). To reproduce the actual crash symptom
+ * (not just "component unmounted" — React 18+ silently no-ops a state
+ * update on an unmounted function component with no warning at all, so that
+ * alone would not fail without the fix), the test also removes the global
+ * `window` binding for the moment the mocked promise resolves, mirroring
+ * what really happens across Vitest file boundaries: the fetch's
+ * continuation fires after its own file's jsdom environment (and `window`)
+ * is gone. With the `useIsMounted` guard in place, `setStatus`/`setLoading`
+ * are never called once unmounted, so the missing `window` is never
+ * touched and nothing throws.
+ *
+ * This test is DELIBERATELY written to fail if the guard is removed — see
+ * the verification note at the bottom of this file for how that was
+ * confirmed during development.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMediaTags } from '../../hooks/useMediaTags';
+
+vi.mock('../../services/tagging', () => ({
+  getMediaTagStatus: vi.fn(),
+  rerunMediaTags: vi.fn(),
+}));
+
+import { getMediaTagStatus } from '../../services/tagging';
+
+const mockGetMediaTagStatus = vi.mocked(getMediaTagStatus);
+
+describe('useMediaTags — teardown-guard regression (issue #196)', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let unhandledRejections: unknown[];
+  let onUnhandledRejection: (reason: unknown) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    unhandledRejections = [];
+    onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+  });
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandledRejection);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not update state, warn, or reject when the in-flight fetch resolves AFTER unmount', async () => {
+    let resolveStatus!: (value: Awaited<ReturnType<typeof getMediaTagStatus>>) => void;
+    const pending = new Promise<Awaited<ReturnType<typeof getMediaTagStatus>>>((resolve) => {
+      resolveStatus = resolve;
+    });
+    mockGetMediaTagStatus.mockReturnValue(pending);
+
+    const onRefreshTags = vi.fn();
+    const { unmount } = renderHook(() => useMediaTags('media-1', onRefreshTags));
+
+    // The initial load's fetch is now in flight (mocked promise still
+    // pending). Unmount BEFORE it resolves — exactly the race in issue #196.
+    unmount();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const savedWindow = (globalThis as any).window;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).window;
+
+    // Now let the fetch resolve, well after teardown.
+    resolveStatus({
+      status: 'processed',
+      providerKey: 'openai',
+      modelVersion: 'v1',
+      tagCount: 3,
+      processedAt: new Date().toISOString(),
+      lastError: null,
+    });
+
+    // Give the resolved promise's continuation (the guarded
+    // `finally`/`then` block inside useMediaTags) every opportunity to run.
+    await pending;
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).window = savedWindow;
+
+    // No thrown/rejected error escaped the continuation.
+    expect(unhandledRejections).toEqual([]);
+    // No React "not wrapped in act" (or any other) warning fired — meaning
+    // no state update was attempted against the unmounted component.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * VERIFICATION NOTE (do not delete): confirming this test actually catches
+ * the regression.
+ *
+ * The guard in `apps/web/src/hooks/useMediaTags.ts` was temporarily reverted
+ * to the pre-fix shape (removing the `isMounted()` checks so the hook always
+ * calls `setStatus`/`setLoading` regardless of mount state):
+ *
+ *   const statusData = await getMediaTagStatus(mediaId);
+ *   setStatus(statusData);              // (no `if (!isMounted()) return;`)
+ *   ...
+ *   } finally {
+ *     setLoading(false);                // (no `if (isMounted())` guard)
+ *   }
+ *
+ * First attempt WITHOUT deleting `window` (just render -> unmount -> resolve)
+ * still PASSED even with the guard removed — React 18+ silently no-ops a
+ * state update on an unmounted function component in the same environment,
+ * with no warning and no throw, so that alone doesn't distinguish the buggy
+ * version from the fixed one. Removing the `globalThis.window` binding
+ * around the resolve (as this test now does) closes that gap by faithfully
+ * reproducing the real cross-file condition. Running the regression test
+ * above against the reverted hook, with that in place, FAILED with:
+ *
+ *   FAIL  src/__tests__/hooks/useMediaTags.test.ts > ... does not update
+ *   state, warn, or reject when the in-flight fetch resolves AFTER unmount
+ *   AssertionError: expected [ …(1) ] to deeply equal []
+ *
+ *   - Expected
+ *   + Received
+ *
+ *   - []
+ *   + [
+ *   +   ReferenceError {
+ *   +     "message": "window is not defined",
+ *   +   },
+ *   + ]
+ *
+ *     ❯ src/__tests__/hooks/useMediaTags.test.ts:93:33
+ *          expect(unhandledRejections).toEqual([]);
+ *
+ * i.e. removing the guard causes `setStatus` to genuinely fire on the
+ * unmounted component while `window` is gone, producing the EXACT
+ * "ReferenceError: window is not defined" from issue #196 as an unhandled
+ * rejection. The guard was then restored and this test verified green
+ * again before committing.
+ */

--- a/apps/web/src/__tests__/utils/test-utils.tsx
+++ b/apps/web/src/__tests__/utils/test-utils.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode } from 'react';
-import { render, RenderOptions, RenderResult } from '@testing-library/react';
+import { act, render, RenderOptions, RenderResult } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { CssBaseline } from '@mui/material';
 import { vi } from 'vitest';
@@ -185,6 +185,37 @@ export function renderWithProviders(
   return render(ui, {
     wrapper: createWrapper(wrapperOptions),
     ...renderOptions,
+  });
+}
+
+/**
+ * Flushes queued promise continuations (e.g. mocked service calls resolved
+ * via `vi.fn().mockResolvedValue(...)`) before the caller unmounts, or before
+ * Vitest's automatic `afterEach(cleanup)` (registered in `src/__tests__/setup.ts`)
+ * tears down the rendered tree.
+ *
+ * Several component specs (the MediaDetailDrawer family in particular) render
+ * a component whose hooks kick off fetches on mount and never await them
+ * before the test body returns. If a fetch's `.then`/`finally` continuation
+ * is still queued when the test FILE finishes, it fires later — potentially
+ * during an unrelated, later test file sharing the same Vitest worker, after
+ * that file's jsdom `window` has already been torn down. That's the exact
+ * mechanism behind issue #196 (a stray continuation touching a torn-down
+ * `window` inside `dispatchSetState`). The hook-level fix (`useIsMounted`)
+ * stops that continuation from crashing, but the continuation itself would
+ * still be dangling into the next file without this.
+ *
+ * Call this from a local `afterEach` in specs that render such components —
+ * local `afterEach` hooks run before global ones registered via `setupFiles`
+ * (Vitest/Jest run `afterEach` in LIFO order), so this settles pending work
+ * while the component is still mounted, before the global `cleanup()` runs.
+ */
+export async function flushPendingAsyncWork(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 10; i += 1) {
+      await Promise.resolve();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 

--- a/apps/web/src/hooks/useAiSettings.ts
+++ b/apps/web/src/hooks/useAiSettings.ts
@@ -13,25 +13,29 @@ import {
   putAiEnhanceFeature,
   getAiImageModels,
 } from '../services/ai';
+import { useIsMounted } from './useIsMounted';
 import type { AiSettingsResponse, AiTestResult, AiEmbeddingTestResult } from '../services/ai';
 
 export function useAiSettings() {
   const [settings, setSettings] = useState<AiSettingsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const data = await getAiSettings();
+      if (!isMounted()) return;
       setSettings(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load AI settings');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const saveCredentials = useCallback(
     async (

--- a/apps/web/src/hooks/useAlbums.ts
+++ b/apps/web/src/hooks/useAlbums.ts
@@ -6,6 +6,7 @@ import {
   updateAlbum as updateAlbumApi,
   deleteAlbum as deleteAlbumApi,
 } from '../services/media';
+import { useIsMounted } from './useIsMounted';
 
 interface UseAlbumsResult {
   albums: Album[];
@@ -23,22 +24,25 @@ export function useAlbums(): UseAlbumsResult {
   const [meta, setMeta] = useState<MediaListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchAlbums = useCallback(async (params?: AlbumQueryParams) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await listAlbumsApi(params);
+      if (!isMounted()) return;
       setAlbums(response.items);
       setMeta(response.meta);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch albums';
       setError(message);
       setAlbums([]);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const addAlbum = useCallback(
     async (dto: CreateAlbumDto) => {
@@ -49,11 +53,11 @@ export function useAlbums(): UseAlbumsResult {
         await fetchAlbums({ page: 1, pageSize: 100 });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to create album';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchAlbums],
+    [fetchAlbums, isMounted],
   );
 
   const updateAlbum = useCallback(
@@ -65,11 +69,11 @@ export function useAlbums(): UseAlbumsResult {
         await fetchAlbums({ page: 1, pageSize: 100 });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to update album';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchAlbums],
+    [fetchAlbums, isMounted],
   );
 
   const deleteAlbum = useCallback(
@@ -81,11 +85,11 @@ export function useAlbums(): UseAlbumsResult {
         await fetchAlbums({ page: 1, pageSize: 100 });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to delete album';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchAlbums],
+    [fetchAlbums, isMounted],
   );
 
   return {

--- a/apps/web/src/hooks/useAllowlist.ts
+++ b/apps/web/src/hooks/useAllowlist.ts
@@ -5,6 +5,7 @@ import {
   addToAllowlist as addToAllowlistApi,
   removeFromAllowlist as removeFromAllowlistApi,
 } from '../services/api';
+import { useIsMounted } from './useIsMounted';
 
 interface UseAllowlistResult {
   entries: AllowedEmailEntry[];
@@ -32,6 +33,7 @@ export function useAllowlist(): UseAllowlistResult {
   const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchAllowlist = useCallback(
     async (params?: {
@@ -44,20 +46,22 @@ export function useAllowlist(): UseAllowlistResult {
       setError(null);
       try {
         const response: AllowlistResponse = await fetchAllowlistApi(params);
+        if (!isMounted()) return;
         setEntries(response.items);
         setTotal(response.total);
         setPage(response.page);
         setPageSize(response.pageSize);
         setTotalPages(response.totalPages);
       } catch (err) {
+        if (!isMounted()) return;
         const message = err instanceof Error ? err.message : 'Failed to fetch allowlist';
         setError(message);
         setEntries([]);
       } finally {
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   const addEmail = useCallback(
@@ -69,11 +73,11 @@ export function useAllowlist(): UseAllowlistResult {
         await fetchAllowlist({ page, pageSize });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to add email';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchAllowlist, page, pageSize],
+    [fetchAllowlist, page, pageSize, isMounted],
   );
 
   const removeEmail = useCallback(
@@ -85,11 +89,11 @@ export function useAllowlist(): UseAllowlistResult {
         await fetchAllowlist({ page, pageSize });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to remove email';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchAllowlist, page, pageSize],
+    [fetchAllowlist, page, pageSize, isMounted],
   );
 
   return {

--- a/apps/web/src/hooks/useBackup.ts
+++ b/apps/web/src/hooks/useBackup.ts
@@ -3,6 +3,7 @@ import {
   triggerBackup as triggerBackupService,
   listBackupRuns,
 } from '../services/backup';
+import { useIsMounted } from './useIsMounted';
 import type { BackupRun, BackupRunRequest, BackupRunResult } from '../services/backup';
 
 export function useBackup() {
@@ -13,19 +14,22 @@ export function useBackup() {
   const [running, setRunning] = useState(false);
   const [runResult, setRunResult] = useState<BackupRunResult | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const refreshRuns = useCallback(async () => {
     setRunsLoading(true);
     setRunsError(null);
     try {
       const data = await listBackupRuns();
+      if (!isMounted()) return;
       setRuns(data);
     } catch (err) {
+      if (!isMounted()) return;
       setRunsError(err instanceof Error ? err.message : 'Failed to load backup runs');
     } finally {
-      setRunsLoading(false);
+      if (isMounted()) setRunsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const triggerBackup = useCallback(
     async (dto: BackupRunRequest): Promise<BackupRunResult> => {
@@ -34,18 +38,18 @@ export function useBackup() {
       setRunError(null);
       try {
         const result = await triggerBackupService(dto);
-        setRunResult(result);
+        if (isMounted()) setRunResult(result);
         await refreshRuns();
         return result;
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Backup failed';
-        setRunError(message);
+        if (isMounted()) setRunError(message);
         throw err;
       } finally {
-        setRunning(false);
+        if (isMounted()) setRunning(false);
       }
     },
-    [refreshRuns],
+    [refreshRuns, isMounted],
   );
 
   return {

--- a/apps/web/src/hooks/useBursts.ts
+++ b/apps/web/src/hooks/useBursts.ts
@@ -9,6 +9,7 @@ import {
   fetchAllPendingBurstGroupIds,
   dismissBurstGroup,
 } from '../services/bursts';
+import { useIsMounted } from './useIsMounted';
 import type { SortOrder } from '../types/media';
 import type {
   BurstGroupStatus,
@@ -56,6 +57,7 @@ export function useBurstGroups(): UseBurstGroupsResult {
 
   // Remember the last fetch params so bulkResolve can refresh the same view.
   const lastParamsRef = useRef<FetchBurstGroupsParams | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchGroups = useCallback(async (params: FetchBurstGroupsParams) => {
     lastParamsRef.current = params;
@@ -63,14 +65,16 @@ export function useBurstGroups(): UseBurstGroupsResult {
     setError(null);
     try {
       const result = await listBurstGroups(params);
+      if (!isMounted()) return;
       setItems(result.items);
       setMeta(result.meta);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load burst groups');
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const bulkResolve = useCallback(
     async (ids: string[], action: GroupResolveAction) => {
@@ -148,19 +152,22 @@ export function useBurstGroupDetail(groupId: string): UseBurstGroupDetailResult 
   const [error, setError] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
   const [dismissing, setDismissing] = useState(false);
+  const isMounted = useIsMounted();
 
   const fetchGroup = useCallback(async (id: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const result = await getBurstGroup(id);
+      if (!isMounted()) return;
       setGroup(result);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load burst group');
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const resolve = useCallback(
     async (keepIds: string[], action: GroupResolveAction) => {
@@ -168,10 +175,10 @@ export function useBurstGroupDetail(groupId: string): UseBurstGroupDetailResult 
       try {
         return await resolveBurstGroup(groupId, keepIds, action);
       } finally {
-        setResolving(false);
+        if (isMounted()) setResolving(false);
       }
     },
-    [groupId],
+    [groupId, isMounted],
   );
 
   const dismiss = useCallback(async () => {
@@ -179,9 +186,9 @@ export function useBurstGroupDetail(groupId: string): UseBurstGroupDetailResult 
     try {
       await dismissBurstGroup(groupId);
     } finally {
-      setDismissing(false);
+      if (isMounted()) setDismissing(false);
     }
-  }, [groupId]);
+  }, [groupId, isMounted]);
 
   return { group, isLoading, error, fetchGroup, resolve, dismiss, resolving, dismissing };
 }

--- a/apps/web/src/hooks/useCircleInvites.ts
+++ b/apps/web/src/hooks/useCircleInvites.ts
@@ -1,11 +1,13 @@
 import { useState, useCallback } from 'react';
 import { listInvites, createInvite, revokeInvite } from '../services/circles';
+import { useIsMounted } from './useIsMounted';
 import type { CircleInvite, CircleRole } from '../types/circles';
 
 export function useCircleInvites(circleId: string) {
   const [invites, setInvites] = useState<CircleInvite[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchInvites = useCallback(async () => {
     if (!circleId) return;
@@ -13,29 +15,31 @@ export function useCircleInvites(circleId: string) {
     setError(null);
     try {
       const resp = await listInvites(circleId);
+      if (!isMounted()) return;
       setInvites(resp.items);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load invites');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [circleId]);
+  }, [circleId, isMounted]);
 
   const sendInvite = useCallback(
     async (email: string, role: CircleRole, notes?: string) => {
       const inv = await createInvite(circleId, { email, role, notes });
-      setInvites((prev) => [...prev, inv]);
+      if (isMounted()) setInvites((prev) => [...prev, inv]);
       return inv;
     },
-    [circleId],
+    [circleId, isMounted],
   );
 
   const cancelInvite = useCallback(
     async (inviteId: string) => {
       await revokeInvite(circleId, inviteId);
-      setInvites((prev) => prev.filter((x) => x.id !== inviteId));
+      if (isMounted()) setInvites((prev) => prev.filter((x) => x.id !== inviteId));
     },
-    [circleId],
+    [circleId, isMounted],
   );
 
   return { invites, loading, error, fetchInvites, sendInvite, cancelInvite };

--- a/apps/web/src/hooks/useCircleMembers.ts
+++ b/apps/web/src/hooks/useCircleMembers.ts
@@ -1,11 +1,13 @@
 import { useState, useCallback } from 'react';
 import { listMembers, addMember, updateMemberRole, removeMember } from '../services/circles';
+import { useIsMounted } from './useIsMounted';
 import type { CircleMember, CircleRole } from '../types/circles';
 
 export function useCircleMembers(circleId: string) {
   const [members, setMembers] = useState<CircleMember[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchMembers = useCallback(async () => {
     if (!circleId) return;
@@ -13,37 +15,39 @@ export function useCircleMembers(circleId: string) {
     setError(null);
     try {
       const resp = await listMembers(circleId);
+      if (!isMounted()) return;
       setMembers(resp.items);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load members');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [circleId]);
+  }, [circleId, isMounted]);
 
   const inviteMember = useCallback(
     async (userId: string, role: CircleRole) => {
       const m = await addMember(circleId, { userId, role });
-      setMembers((prev) => [...prev, m]);
+      if (isMounted()) setMembers((prev) => [...prev, m]);
       return m;
     },
-    [circleId],
+    [circleId, isMounted],
   );
 
   const changeRole = useCallback(
     async (userId: string, role: CircleRole) => {
       const m = await updateMemberRole(circleId, userId, role);
-      setMembers((prev) => prev.map((x) => (x.userId === userId ? m : x)));
+      if (isMounted()) setMembers((prev) => prev.map((x) => (x.userId === userId ? m : x)));
     },
-    [circleId],
+    [circleId, isMounted],
   );
 
   const removeMemberById = useCallback(
     async (userId: string) => {
       await removeMember(circleId, userId);
-      setMembers((prev) => prev.filter((x) => x.userId !== userId));
+      if (isMounted()) setMembers((prev) => prev.filter((x) => x.userId !== userId));
     },
-    [circleId],
+    [circleId, isMounted],
   );
 
   return { members, loading, error, fetchMembers, inviteMember, changeRole, removeMemberById };

--- a/apps/web/src/hooks/useCircles.ts
+++ b/apps/web/src/hooks/useCircles.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { listCircles, createCircle, deleteCircle, updateCircle } from '../services/circles';
+import { useIsMounted } from './useIsMounted';
 import type { Circle } from '../types/circles';
 
 // Hook for managing circle list (admin pages, circle list page)
@@ -7,39 +8,42 @@ export function useCircles() {
   const [circles, setCircles] = useState<Circle[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchCircles = useCallback(async (all?: boolean) => {
     setLoading(true);
     setError(null);
     try {
       const resp = await listCircles(all);
+      if (!isMounted()) return;
       setCircles(resp.items);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load circles');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const addCircle = useCallback(async (dto: { name: string; description?: string }) => {
     const c = await createCircle(dto);
-    setCircles((prev) => [...prev, c]);
+    if (isMounted()) setCircles((prev) => [...prev, c]);
     return c;
-  }, []);
+  }, [isMounted]);
 
   const editCircle = useCallback(
     async (id: string, dto: { name?: string; description?: string }) => {
       const c = await updateCircle(id, dto);
-      setCircles((prev) => prev.map((x) => (x.id === id ? c : x)));
+      if (isMounted()) setCircles((prev) => prev.map((x) => (x.id === id ? c : x)));
       return c;
     },
-    [],
+    [isMounted],
   );
 
   const removeCircle = useCallback(async (id: string) => {
     await deleteCircle(id);
-    setCircles((prev) => prev.filter((x) => x.id !== id));
-  }, []);
+    if (isMounted()) setCircles((prev) => prev.filter((x) => x.id !== id));
+  }, [isMounted]);
 
   return { circles, loading, error, fetchCircles, addCircle, editCircle, removeCircle };
 }

--- a/apps/web/src/hooks/useDashboard.ts
+++ b/apps/web/src/hooks/useDashboard.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import type { DashboardResponse } from '../types/media';
 import { getDashboard } from '../services/media';
 import { useCircle } from './useCircle';
+import { useIsMounted } from './useIsMounted';
 
 interface UseDashboardResult {
   data: DashboardResponse | null;
@@ -15,20 +16,23 @@ export function useDashboard(): UseDashboardResult {
   const [data, setData] = useState<DashboardResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetch = useCallback(async (circleId: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await getDashboard(circleId);
+      if (!isMounted()) return;
       setData(response);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to load dashboard';
       setError(message);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     if (!activeCircleId) {

--- a/apps/web/src/hooks/useDoctor.ts
+++ b/apps/web/src/hooks/useDoctor.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { runDoctor } from '../services/doctor';
+import { useIsMounted } from './useIsMounted';
 import type { DoctorReport } from '../services/doctor';
 
 export interface UseDoctorResult {
@@ -13,19 +14,22 @@ export function useDoctor(): UseDoctorResult {
   const [report, setReport] = useState<DoctorReport | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const run = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const data = await runDoctor();
+      if (!isMounted()) return;
       setReport(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to run diagnostics');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     void run();

--- a/apps/web/src/hooks/useDuplicates.ts
+++ b/apps/web/src/hooks/useDuplicates.ts
@@ -9,6 +9,7 @@ import {
   fetchAllPendingDuplicateGroupIds,
   dismissDuplicateGroup,
 } from '../services/duplicates';
+import { useIsMounted } from './useIsMounted';
 import type { SortOrder } from '../types/media';
 import type {
   DuplicateGroupStatus,
@@ -59,6 +60,7 @@ export function useDuplicateGroups(): UseDuplicateGroupsResult {
 
   // Remember the last fetch params so bulkResolve can refresh the same view.
   const lastParamsRef = useRef<FetchDuplicateGroupsParams | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchGroups = useCallback(async (params: FetchDuplicateGroupsParams) => {
     lastParamsRef.current = params;
@@ -66,14 +68,16 @@ export function useDuplicateGroups(): UseDuplicateGroupsResult {
     setError(null);
     try {
       const result = await listDuplicateGroups(params);
+      if (!isMounted()) return;
       setItems(result.items);
       setMeta(result.meta);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load duplicate groups');
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const bulkResolve = useCallback(
     async (ids: string[], action: DuplicateResolveAction) => {
@@ -150,19 +154,22 @@ export function useDuplicateGroupDetail(groupId: string): UseDuplicateGroupDetai
   const [error, setError] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
   const [dismissing, setDismissing] = useState(false);
+  const isMounted = useIsMounted();
 
   const fetchGroup = useCallback(async (id: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const result = await getDuplicateGroup(id);
+      if (!isMounted()) return;
       setGroup(result);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load duplicate group');
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const resolve = useCallback(
     async (keepIds: string[], action: DuplicateResolveAction) => {
@@ -170,10 +177,10 @@ export function useDuplicateGroupDetail(groupId: string): UseDuplicateGroupDetai
       try {
         return await resolveDuplicateGroup(groupId, keepIds, action);
       } finally {
-        setResolving(false);
+        if (isMounted()) setResolving(false);
       }
     },
-    [groupId],
+    [groupId, isMounted],
   );
 
   const dismiss = useCallback(async () => {
@@ -181,9 +188,9 @@ export function useDuplicateGroupDetail(groupId: string): UseDuplicateGroupDetai
     try {
       return await dismissDuplicateGroup(groupId);
     } finally {
-      setDismissing(false);
+      if (isMounted()) setDismissing(false);
     }
-  }, [groupId]);
+  }, [groupId, isMounted]);
 
   return { group, isLoading, error, fetchGroup, resolve, dismiss, resolving, dismissing };
 }

--- a/apps/web/src/hooks/useEmailSettings.ts
+++ b/apps/web/src/hooks/useEmailSettings.ts
@@ -9,32 +9,36 @@ import type {
   UpdateEmailSettingsBody,
   TestEmailResult,
 } from '../services/email';
+import { useIsMounted } from './useIsMounted';
 
 export function useEmailSettings() {
   const [settings, setSettings] = useState<EmailSettings | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const data = await getEmailSettings();
+      if (!isMounted()) return;
       setSettings(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load email settings');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const saveSettings = useCallback(
     async (body: UpdateEmailSettingsBody): Promise<EmailSettings> => {
       const updated = await updateEmailSettings(body);
-      setSettings(updated);
+      if (isMounted()) setSettings(updated);
       return updated;
     },
-    [],
+    [isMounted],
   );
 
   const sendTest = useCallback(

--- a/apps/web/src/hooks/useEnhancements.ts
+++ b/apps/web/src/hooks/useEnhancements.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { listEnhancements } from '../services/enhance';
+import { useIsMounted } from './useIsMounted';
 import type {
   EnhancementListItem,
   EnhancementListMeta,
@@ -63,6 +64,8 @@ export function useEnhancements(
   paramsRef.current = params;
   const paramsKey = useMemo(() => (params ? JSON.stringify(params) : null), [params]);
 
+  const isMounted = useIsMounted();
+
   const load = useCallback(async (silent: boolean) => {
     const current = paramsRef.current;
     if (!current) {
@@ -74,15 +77,17 @@ export function useEnhancements(
     if (!silent) setIsLoading(true);
     try {
       const result = await listEnhancements(current);
+      if (!isMounted()) return;
       setItems(result.items);
       setMeta(result.meta);
       setError(null);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load enhancements');
     } finally {
-      if (!silent) setIsLoading(false);
+      if (!silent && isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     void load(false);

--- a/apps/web/src/hooks/useFaceSettings.ts
+++ b/apps/web/src/hooks/useFaceSettings.ts
@@ -7,25 +7,29 @@ import {
   getFaceModels,
   putFaceDetectionFeature,
 } from '../services/face';
+import { useIsMounted } from './useIsMounted';
 import type { FaceSettingsResponse, FaceTestResult } from '../services/face';
 
 export function useFaceSettings() {
   const [settings, setSettings] = useState<FaceSettingsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const data = await getFaceSettings();
+      if (!isMounted()) return;
       setSettings(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load face settings');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const saveCredentials = useCallback(
     async (

--- a/apps/web/src/hooks/useFeatureFlags.ts
+++ b/apps/web/src/hooks/useFeatureFlags.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ApiError } from '../services/api';
 import { getFeatures } from '../services/features';
+import { useIsMounted } from './useIsMounted';
 import type { FeatureFlags, PictureEnhancementPolicy } from '../services/features';
 
 // ---------------------------------------------------------------------------
@@ -63,22 +64,25 @@ export function useFeatureFlags(): UseFeatureFlagsReturn {
   const [flags, setFlags] = useState<FeatureFlags | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const load = useCallback(async (force: boolean) => {
     setIsLoading(true);
     setError(null);
     try {
       const data = await loadFeatures(force);
+      if (!isMounted()) return;
       setFlags(data);
     } catch (err) {
+      if (!isMounted()) return;
       const message =
         err instanceof ApiError ? err.message : 'Failed to load feature flags';
       setFlags(null);
       setError(message);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     let active = true;

--- a/apps/web/src/hooks/useGeoSettings.ts
+++ b/apps/web/src/hooks/useGeoSettings.ts
@@ -6,25 +6,29 @@ import {
   testGeoProvider,
   putGeoReverseFeature,
 } from '../services/geo';
+import { useIsMounted } from './useIsMounted';
 import type { GeoSettingsResponse, GeoTestResult, GeoReverseProvider } from '../services/geo';
 
 export function useGeoSettings() {
   const [settings, setSettings] = useState<GeoSettingsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const data = await getGeoSettings();
+      if (!isMounted()) return;
       setSettings(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load geo settings');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const saveCredentials = useCallback(
     async (

--- a/apps/web/src/hooks/useInfiniteArchived.ts
+++ b/apps/web/src/hooks/useInfiniteArchived.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { MediaItem } from '../types/media';
 import { listArchived } from '../services/media';
+import { useIsMounted } from './useIsMounted';
 
 interface UseInfiniteArchivedResult {
   items: MediaItem[];
@@ -26,6 +27,7 @@ export function useInfiniteArchived(
   const pageSizeRef = useRef(pageSize);
   const inflightRef = useRef(false);
   const genRef = useRef(0);
+  const isMounted = useIsMounted();
 
   circleIdRef.current = circleId;
   pageSizeRef.current = pageSize;
@@ -42,20 +44,22 @@ export function useInfiniteArchived(
         pageSize: pageSizeRef.current,
       });
       if (gen !== genRef.current) return;
+      if (!isMounted()) return;
       setItems((prev) =>
         targetPage === 1 ? response.items : [...prev, ...response.items],
       );
       setTotalPages(response.meta.totalPages);
     } catch (err) {
       if (gen !== genRef.current) return;
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load archived items');
     } finally {
       if (gen === genRef.current) {
         inflightRef.current = false;
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     if (!enabled || !circleId) return;

--- a/apps/web/src/hooks/useInfiniteMedia.ts
+++ b/apps/web/src/hooks/useInfiniteMedia.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { MediaItem, MediaQueryParams } from '../types/media';
 import { listMedia } from '../services/media';
+import { useIsMounted } from './useIsMounted';
 
 interface UseInfiniteMediaResult {
   items: MediaItem[];
@@ -61,6 +62,7 @@ export function useInfiniteMedia(
   const cursorRef = useRef<string | null>(null);
   // Generation counter: increments on reset so stale fetches are discarded
   const genRef = useRef(0);
+  const isMounted = useIsMounted();
 
   // Keep refs current
   paramsRef.current = params;
@@ -92,19 +94,21 @@ export function useInfiniteMedia(
             pageSize: pageSizeRef.current,
           }).then((r) => ({ items: r.items, nextCursor: r.meta.nextCursor }));
       if (gen !== genRef.current) return; // stale
+      if (!isMounted()) return;
       setItems((prev) => (initial ? response.items : [...prev, ...response.items]));
       cursorRef.current = response.nextCursor;
       setHasMore(response.nextCursor != null);
     } catch (err) {
       if (gen !== genRef.current) return;
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load media');
     } finally {
       if (gen === genRef.current) {
         inflightRef.current = false;
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     }
-  }, []); // stable — uses refs
+  }, [isMounted]); // otherwise stable — uses refs
 
   // Reset and refetch whenever params change or enabled toggles
   useEffect(() => {

--- a/apps/web/src/hooks/useInfiniteTrash.ts
+++ b/apps/web/src/hooks/useInfiniteTrash.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { MediaItem } from '../types/media';
 import { listTrash } from '../services/media';
+import { useIsMounted } from './useIsMounted';
 
 interface UseInfiniteTrashResult {
   items: MediaItem[];
@@ -26,6 +27,7 @@ export function useInfiniteTrash(
   const pageSizeRef = useRef(pageSize);
   const inflightRef = useRef(false);
   const genRef = useRef(0);
+  const isMounted = useIsMounted();
 
   circleIdRef.current = circleId;
   pageSizeRef.current = pageSize;
@@ -42,20 +44,22 @@ export function useInfiniteTrash(
         pageSize: pageSizeRef.current,
       });
       if (gen !== genRef.current) return;
+      if (!isMounted()) return;
       setItems((prev) =>
         targetPage === 1 ? response.items : [...prev, ...response.items],
       );
       setTotalPages(response.meta.totalPages);
     } catch (err) {
       if (gen !== genRef.current) return;
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load trash');
     } finally {
       if (gen === genRef.current) {
         inflightRef.current = false;
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     if (!enabled || !circleId) return;

--- a/apps/web/src/hooks/useInsights.ts
+++ b/apps/web/src/hooks/useInsights.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { getInsights, refreshInsights } from '../services/insights';
+import { useIsMounted } from './useIsMounted';
 import type { InsightsSnapshot, InsightsRefreshState } from '../services/insights';
 
 // Poll every 2.5 s while a job is pending/running
@@ -28,6 +29,7 @@ export function useInsights(): UseInsightsResult {
   // Stable refs for the polling cleanup / timeout
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMounted = useIsMounted();
 
   /** Clear any running poll interval and safety timeout. */
   const stopPolling = useCallback(() => {
@@ -55,6 +57,10 @@ export function useInsights(): UseInsightsResult {
     const tick = async () => {
       try {
         const snapshot = await getInsights();
+        if (!isMounted()) {
+          stopPolling();
+          return;
+        }
         setData(snapshot);
 
         if (snapshot.refresh.state === 'idle' || snapshot.refresh.state === 'failed') {
@@ -72,6 +78,7 @@ export function useInsights(): UseInsightsResult {
       } catch (err) {
         // On network error, stop polling and surface the message
         stopPolling();
+        if (!isMounted()) return;
         setRefreshing(false);
         setError(err instanceof Error ? err.message : 'Failed to poll insights');
       }
@@ -87,7 +94,7 @@ export function useInsights(): UseInsightsResult {
       setRefreshing(false);
       setError('Refresh timed out — the job may still be running in the background.');
     }, POLL_TIMEOUT_MS);
-  }, [stopPolling]);
+  }, [stopPolling, isMounted]);
 
   // Clean up on unmount
   useEffect(() => {
@@ -102,6 +109,7 @@ export function useInsights(): UseInsightsResult {
     setError(null);
     try {
       const snapshot = await getInsights();
+      if (!isMounted()) return;
       setData(snapshot);
 
       // A scheduled or manual job was already running when the page opened
@@ -112,11 +120,12 @@ export function useInsights(): UseInsightsResult {
         startPolling();
       }
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load insights');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [startPolling]);
+  }, [startPolling, isMounted]);
 
   // Run load once on mount
   useEffect(() => {
@@ -133,11 +142,13 @@ export function useInsights(): UseInsightsResult {
     setError(null);
     try {
       await refreshInsights();
+      if (!isMounted()) return;
       startPolling();
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to start refresh');
     }
-  }, [startPolling]);
+  }, [startPolling, isMounted]);
 
   const jobState: InsightsRefreshState = data?.refresh.state ?? 'idle';
 

--- a/apps/web/src/hooks/useIsMounted.ts
+++ b/apps/web/src/hooks/useIsMounted.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * useIsMounted — returns a getter that reports whether the calling component is
+ * still mounted.
+ *
+ * WHY THIS EXISTS (issue #196 — do not delete this as ceremony):
+ *
+ * Most data-loading hooks in this app follow the shape
+ *
+ *   setLoading(true);
+ *   try   { setData(await getX(id)); }
+ *   catch { setError(...); }
+ *   finally { setLoading(false); }
+ *
+ * If the component unmounts while `getX` is still in flight, the `finally`
+ * (and the `then`/`catch`) still runs — later, detached from any component.
+ * Under Vitest that continuation can land AFTER the test file that started it
+ * has finished and its jsdom environment has been torn down, so React's
+ * `dispatchSetState → requestUpdateLane → resolveUpdatePriority` touches a
+ * `window` global that no longer exists and throws
+ *
+ *   ReferenceError: window is not defined
+ *
+ * as an *unhandled rejection*, attributed to whatever unrelated test file
+ * happens to be running in that worker. Every assertion still passes; only the
+ * error count and the exit code change — which is exactly what made `apps/web`'s
+ * CI gate flaky and untrustworthy on the first run.
+ *
+ * Guarding each post-`await` state setter with `isMounted()` keeps the
+ * continuation from touching React at all once the component is gone. Behaviour
+ * for a MOUNTED component is unchanged — this is purely "don't touch state
+ * after teardown".
+ *
+ * Usage:
+ *
+ *   const isMounted = useIsMounted();
+ *   ...
+ *   try {
+ *     const data = await getX(id);
+ *     if (!isMounted()) return;
+ *     setData(data);
+ *   } catch (err) {
+ *     if (!isMounted()) return;
+ *     setError(...);
+ *   } finally {
+ *     if (isMounted()) setLoading(false);
+ *   }
+ *
+ * StrictMode note: the ref is initialised to `true` (so a synchronous call made
+ * during the first render pass, before effects flush, is not wrongly reported
+ * as unmounted) AND re-set to `true` on every mount. React 18/19 StrictMode
+ * mounts, unmounts, then remounts each component in development; the first
+ * unmount runs the cleanup and flips the ref to `false`, so without the
+ * re-assignment on mount the hook would permanently report "unmounted" for a
+ * component that is very much alive.
+ */
+export function useIsMounted(): () => boolean {
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  return useCallback(() => mountedRef.current, []);
+}

--- a/apps/web/src/hooks/useJobInsights.ts
+++ b/apps/web/src/hooks/useJobInsights.ts
@@ -1,23 +1,27 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getJobInsights, type JobInsights } from '../services/jobInsights';
+import { useIsMounted } from './useIsMounted';
 
 export function useJobInsights(windowDays?: number) {
   const [data, setData] = useState<JobInsights | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const result = await getJobInsights(windowDays);
+      if (!isMounted()) return;
       setData(result);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load job insights');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [windowDays]);
+  }, [windowDays, isMounted]);
 
   useEffect(() => {
     void refresh();

--- a/apps/web/src/hooks/useJobs.ts
+++ b/apps/web/src/hooks/useJobs.ts
@@ -8,6 +8,7 @@ import {
   repairThumbnails as repairThumbnailsService,
   deleteJob as deleteJobService,
 } from '../services/jobs';
+import { useIsMounted } from './useIsMounted';
 import type { JobStats, EnrichmentJobDto, JobsListResponse, ListJobsParams, JobStatus } from '../services/jobs';
 
 const POLL_INTERVAL_MS = 5000;
@@ -64,26 +65,32 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
 
+  const isMounted = useIsMounted();
+
   const fetchStats = useCallback(async () => {
     try {
       const data = await getJobStats();
+      if (!isMounted()) return;
       setStats(data);
       setStatsError(null);
     } catch (err) {
+      if (!isMounted()) return;
       setStatsError(err instanceof Error ? err.message : 'Failed to load job stats');
     }
-  }, []);
+  }, [isMounted]);
 
   const fetchJobs = useCallback(async (params: ListJobsParams) => {
     try {
       const data = await listJobs(params);
+      if (!isMounted()) return;
       setJobs(data.items);
       setMeta(data.meta);
       setJobsError(null);
     } catch (err) {
+      if (!isMounted()) return;
       setJobsError(err instanceof Error ? err.message : 'Failed to load jobs');
     }
-  }, []);
+  }, [isMounted]);
 
   // Full explicit refresh (sets loading indicators)
   const refresh = useCallback(async () => {
@@ -92,10 +99,12 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
     try {
       await Promise.all([fetchStats(), fetchJobs(filtersRef.current)]);
     } finally {
-      setStatsLoading(false);
-      setJobsLoading(false);
+      if (isMounted()) {
+        setStatsLoading(false);
+        setJobsLoading(false);
+      }
     }
-  }, [fetchStats, fetchJobs]);
+  }, [fetchStats, fetchJobs, isMounted]);
 
   // Silent background poll (no loading spinners)
   const silentPoll = useCallback(async () => {
@@ -116,8 +125,10 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
       return;
     }
     setJobsLoading(true);
-    void fetchJobs(filters).finally(() => setJobsLoading(false));
-  }, [filters, fetchJobs]);
+    void fetchJobs(filters).finally(() => {
+      if (isMounted()) setJobsLoading(false);
+    });
+  }, [filters, fetchJobs, isMounted]);
 
   // Auto-refresh polling
   useEffect(() => {
@@ -138,9 +149,9 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
       await retryJobService(id);
       await Promise.all([fetchStats(), fetchJobs(filtersRef.current)]);
     } finally {
-      setMutating(false);
+      if (isMounted()) setMutating(false);
     }
-  }, [fetchStats, fetchJobs]);
+  }, [fetchStats, fetchJobs, isMounted]);
 
   const retryAllFailed = useCallback(async (type?: string): Promise<{ retried: number }> => {
     setMutating(true);
@@ -149,9 +160,9 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
       await Promise.all([fetchStats(), fetchJobs(filtersRef.current)]);
       return result;
     } finally {
-      setMutating(false);
+      if (isMounted()) setMutating(false);
     }
-  }, [fetchStats, fetchJobs]);
+  }, [fetchStats, fetchJobs, isMounted]);
 
   const resetStuck = useCallback(async (olderThanMinutes?: number): Promise<{ reset: number }> => {
     setMutating(true);
@@ -160,9 +171,9 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
       await Promise.all([fetchStats(), fetchJobs(filtersRef.current)]);
       return result;
     } finally {
-      setMutating(false);
+      if (isMounted()) setMutating(false);
     }
-  }, [fetchStats, fetchJobs]);
+  }, [fetchStats, fetchJobs, isMounted]);
 
   const repairThumbnails = useCallback(async (): Promise<{ jobId: string; status: string }> => {
     setMutating(true);
@@ -171,9 +182,9 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
       await Promise.all([fetchStats(), fetchJobs(filtersRef.current)]);
       return result;
     } finally {
-      setMutating(false);
+      if (isMounted()) setMutating(false);
     }
-  }, [fetchStats, fetchJobs]);
+  }, [fetchStats, fetchJobs, isMounted]);
 
   const deleteJob = useCallback(async (id: string) => {
     setMutating(true);
@@ -181,9 +192,9 @@ export function useJobs(options: UseJobsOptions = {}): UseJobsResult {
       await deleteJobService(id);
       await Promise.all([fetchStats(), fetchJobs(filtersRef.current)]);
     } finally {
-      setMutating(false);
+      if (isMounted()) setMutating(false);
     }
-  }, [fetchStats, fetchJobs]);
+  }, [fetchStats, fetchJobs, isMounted]);
 
   return {
     stats,

--- a/apps/web/src/hooks/useLocationSuggestions.ts
+++ b/apps/web/src/hooks/useLocationSuggestions.ts
@@ -16,6 +16,7 @@ import type {
 } from '../services/locationSuggestions';
 import type { SortOrder } from '../types/media';
 import { getMedia } from '../services/media';
+import { useIsMounted } from './useIsMounted';
 
 /**
  * Params accepted by {@link useLocationSuggestions}'s `fetchSuggestions`.
@@ -48,6 +49,7 @@ export function useLocationSuggestions(): UseLocationSuggestionsResult {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actingIds, setActingIds] = useState<Set<string>>(new Set());
+  const isMounted = useIsMounted();
 
   const fetchSuggestions = useCallback(
     async (params: FetchLocationSuggestionsParams) => {
@@ -55,15 +57,17 @@ export function useLocationSuggestions(): UseLocationSuggestionsResult {
       setError(null);
       try {
         const result = await listLocationSuggestions(params);
+        if (!isMounted()) return;
         setItems(result.items);
         setMeta(result.meta);
       } catch (err) {
+        if (!isMounted()) return;
         setError(err instanceof Error ? err.message : 'Failed to load location suggestions');
       } finally {
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   const withActing = useCallback(async <T,>(id: string, fn: () => Promise<T>): Promise<T> => {
@@ -71,13 +75,15 @@ export function useLocationSuggestions(): UseLocationSuggestionsResult {
     try {
       return await fn();
     } finally {
-      setActingIds((prev) => {
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
+      if (isMounted()) {
+        setActingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
     }
-  }, []);
+  }, [isMounted]);
 
   const accept = useCallback(
     (id: string, lat?: number, lng?: number) => withActing(id, () => acceptLocationSuggestion(id, lat, lng)),
@@ -120,6 +126,7 @@ export function useSuggestLocation(mediaId: string, onRefresh: () => void) {
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
+  const isMounted = useIsMounted();
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -139,12 +146,17 @@ export function useSuggestLocation(mediaId: string, onRefresh: () => void) {
       stopPolling();
       try {
         await inferLocation(mediaId);
+        if (!isMounted()) return;
 
         pollCountRef.current = 0;
         pollRef.current = setInterval(() => {
           pollCountRef.current += 1;
           getMedia(mediaId)
             .then((item) => {
+              if (!isMounted()) {
+                stopPolling();
+                return;
+              }
               if (item.takenLat !== null && item.takenLng !== null) {
                 stopPolling();
                 setLoading(false);
@@ -160,17 +172,19 @@ export function useSuggestLocation(mediaId: string, onRefresh: () => void) {
             })
             .catch(() => {
               stopPolling();
+              if (!isMounted()) return;
               setLoading(false);
               onOutcome('error');
             });
         }, POLL_INTERVAL_MS);
       } catch (err) {
+        if (!isMounted()) return;
         setError(err instanceof Error ? err.message : 'Failed to queue location inference');
         setLoading(false);
         onOutcome('error');
       }
     },
-    [mediaId, onRefresh, stopPolling],
+    [mediaId, onRefresh, stopPolling, isMounted],
   );
 
   return { suggest, loading, error };

--- a/apps/web/src/hooks/useMedia.ts
+++ b/apps/web/src/hooks/useMedia.ts
@@ -10,6 +10,7 @@ import {
   patchMedia as patchMediaApi,
   deleteMedia as deleteMediaApi,
 } from '../services/media';
+import { useIsMounted } from './useIsMounted';
 
 // ---------------------------------------------------------------------------
 // Filter state shape — all optional so callers can compose them incrementally
@@ -55,6 +56,7 @@ export function useMedia(): UseMediaResult {
     sortOrder: 'desc',
     page: 1,
   });
+  const isMounted = useIsMounted();
 
   const setFilters = useCallback((newFilters: MediaFilters) => {
     setFiltersState(newFilters);
@@ -65,42 +67,46 @@ export function useMedia(): UseMediaResult {
     setError(null);
     try {
       const response = await listMediaApi(params);
-      setItems(response.items);
-      setMeta(response.meta);
+      if (isMounted()) {
+        setItems(response.items);
+        setMeta(response.meta);
+      }
       return response.items;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch media';
-      setError(message);
-      setItems([]);
+      if (isMounted()) {
+        setError(message);
+        setItems([]);
+      }
       return [];
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const patchMedia = useCallback(async (id: string, dto: PatchMediaDto) => {
     setError(null);
     try {
       const updated = await patchMediaApi(id, dto);
-      setItems((prev) => prev.map((item) => (item.id === id ? updated : item)));
+      if (isMounted()) setItems((prev) => prev.map((item) => (item.id === id ? updated : item)));
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update media item';
-      setError(message);
+      if (isMounted()) setError(message);
       throw err;
     }
-  }, []);
+  }, [isMounted]);
 
   const removeMedia = useCallback(async (id: string) => {
     setError(null);
     try {
       await deleteMediaApi(id);
-      setItems((prev) => prev.filter((item) => item.id !== id));
+      if (isMounted()) setItems((prev) => prev.filter((item) => item.id !== id));
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete media item';
-      setError(message);
+      if (isMounted()) setError(message);
       throw err;
     }
-  }, []);
+  }, [isMounted]);
 
   /** Apply a partial patch to an item in local state without an API call. */
   const updateItemLocally = useCallback((id: string, patch: Partial<MediaItem>) => {

--- a/apps/web/src/hooks/useMediaEnhance.ts
+++ b/apps/web/src/hooks/useMediaEnhance.ts
@@ -6,6 +6,7 @@ import {
   applyEnhancement,
   discardEnhancement,
 } from '../services/enhance';
+import { useIsMounted } from './useIsMounted';
 import type {
   EnhanceParams,
   EnhancementDto,
@@ -42,6 +43,7 @@ export function useMediaEnhance(mediaId: string) {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
   const idRef = useRef<string | null>(null);
+  const isMounted = useIsMounted();
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -62,6 +64,10 @@ export function useMediaEnhance(mediaId: string) {
         pollCountRef.current += 1;
         getEnhancement(mediaId, enhancementId)
           .then((d) => {
+            if (!isMounted()) {
+              stopPolling();
+              return;
+            }
             setData(d);
             setStatus(d.status);
             if (TERMINAL_STATUSES.includes(d.status)) {
@@ -80,6 +86,7 @@ export function useMediaEnhance(mediaId: string) {
           })
           .catch((err) => {
             stopPolling();
+            if (!isMounted()) return;
             // Same reason as the timeout branch above — resolve the UI to a
             // terminal state instead of an orphaned spinner.
             setStatus('failed');
@@ -87,7 +94,7 @@ export function useMediaEnhance(mediaId: string) {
           });
       }, POLL_INTERVAL_MS);
     },
-    [mediaId, stopPolling],
+    [mediaId, stopPolling, isMounted],
   );
 
   /** Kick off a new enhancement and start polling. */
@@ -100,9 +107,11 @@ export function useMediaEnhance(mediaId: string) {
       stopPolling();
       try {
         const res = await startEnhance(mediaId, params);
+        if (!isMounted()) return;
         idRef.current = res.enhancementId;
         beginPolling(res.enhancementId);
       } catch (err) {
+        if (!isMounted()) return;
         // Back to the params step. `error` is non-null, and the drawer renders
         // it there regardless of status (a 400 from the enhance endpoint used
         // to be silently swallowed).
@@ -111,7 +120,7 @@ export function useMediaEnhance(mediaId: string) {
         setError(err instanceof Error ? err.message : 'Failed to start enhancement');
       }
     },
-    [mediaId, beginPolling, stopPolling],
+    [mediaId, beginPolling, stopPolling, isMounted],
   );
 
   /**
@@ -130,7 +139,7 @@ export function useMediaEnhance(mediaId: string) {
       const latest = enhancementId
         ? await getEnhancement(mediaId, enhancementId)
         : await getLatestEnhancement(mediaId);
-      if (!latest) return;
+      if (!latest || !isMounted()) return;
       // Only resume enhancements that are still actionable in the drawer.
       if (['pending', 'processing', 'ready', 'failed'].includes(latest.status)) {
         idRef.current = latest.id;
@@ -145,7 +154,7 @@ export function useMediaEnhance(mediaId: string) {
     } catch {
       // Non-fatal — the drawer simply starts from the params step.
     }
-  }, [mediaId, beginPolling]);
+  }, [mediaId, beginPolling, isMounted]);
 
   /** Commit the current enhancement (keep_both / replace). */
   const apply = useCallback(

--- a/apps/web/src/hooks/useMediaFaces.ts
+++ b/apps/web/src/hooks/useMediaFaces.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { getMediaFaces, getMediaFaceStatus, rerunMediaFaces } from '../services/face';
+import { useIsMounted } from './useIsMounted';
 import type { DetectedFaceDto, MediaFaceStatusDto, MediaFaceStatusType } from '../services/face';
 
 const TERMINAL_STATUSES: MediaFaceStatusType[] = ['processed', 'failed', 'no_faces'];
@@ -14,6 +15,7 @@ export function useMediaFaces(mediaId: string) {
   const [rerunLoading, setRerunLoading] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
+  const isMounted = useIsMounted();
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -32,14 +34,16 @@ export function useMediaFaces(mediaId: string) {
         getMediaFaces(mediaId),
         getMediaFaceStatus(mediaId),
       ]);
+      if (!isMounted()) return;
       setFaces(facesData);
       setStatus(statusData);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load face data');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [mediaId]);
+  }, [mediaId, isMounted]);
 
   useEffect(() => {
     void loadData();
@@ -52,6 +56,7 @@ export function useMediaFaces(mediaId: string) {
     stopPolling();
     try {
       await rerunMediaFaces(mediaId);
+      if (!isMounted()) return;
       // Optimistically update status to pending
       setStatus((prev) =>
         prev
@@ -71,26 +76,33 @@ export function useMediaFaces(mediaId: string) {
         pollCountRef.current += 1;
         getMediaFaceStatus(mediaId)
           .then((s) => {
+            if (!isMounted()) {
+              stopPolling();
+              return;
+            }
             setStatus(s);
             if (TERMINAL_STATUSES.includes(s.status) || pollCountRef.current >= MAX_POLLS) {
               stopPolling();
               setRerunLoading(false);
               // Refresh faces after terminal status
               void getMediaFaces(mediaId)
-                .then(setFaces)
+                .then((f) => {
+                  if (isMounted()) setFaces(f);
+                })
                 .catch(() => undefined);
             }
           })
           .catch(() => {
             stopPolling();
-            setRerunLoading(false);
+            if (isMounted()) setRerunLoading(false);
           });
       }, POLL_INTERVAL_MS);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to rerun face detection');
       setRerunLoading(false);
     }
-  }, [mediaId, stopPolling]);
+  }, [mediaId, stopPolling, isMounted]);
 
   return { faces, status, loading, error, rerun, rerunLoading, refresh: loadData };
 }

--- a/apps/web/src/hooks/useMediaMetadata.ts
+++ b/apps/web/src/hooks/useMediaMetadata.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { getMediaMetadataStatus, rerunMediaMetadata } from '../services/metadata';
+import { useIsMounted } from './useIsMounted';
 import type { MediaMetadataStatusDto, MediaMetadataStatusType } from '../services/metadata';
 
 const TERMINAL_STATUSES: MediaMetadataStatusType[] = ['processed', 'failed'];
@@ -13,6 +14,7 @@ export function useMediaMetadata(mediaId: string, onRefresh: () => void) {
   const [rerunLoading, setRerunLoading] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
+  const isMounted = useIsMounted();
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -28,13 +30,15 @@ export function useMediaMetadata(mediaId: string, onRefresh: () => void) {
     setError(null);
     try {
       const statusData = await getMediaMetadataStatus(mediaId);
+      if (!isMounted()) return;
       setStatus(statusData);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load metadata status');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [mediaId]);
+  }, [mediaId, isMounted]);
 
   useEffect(() => {
     void loadData();
@@ -47,6 +51,7 @@ export function useMediaMetadata(mediaId: string, onRefresh: () => void) {
     stopPolling();
     try {
       await rerunMediaMetadata(mediaId);
+      if (!isMounted()) return;
       // Optimistically update status to pending
       setStatus((prev) =>
         prev
@@ -59,6 +64,10 @@ export function useMediaMetadata(mediaId: string, onRefresh: () => void) {
         pollCountRef.current += 1;
         getMediaMetadataStatus(mediaId)
           .then((s) => {
+            if (!isMounted()) {
+              stopPolling();
+              return;
+            }
             setStatus(s);
             if (TERMINAL_STATUSES.includes(s.status) || pollCountRef.current >= MAX_POLLS) {
               stopPolling();
@@ -68,14 +77,15 @@ export function useMediaMetadata(mediaId: string, onRefresh: () => void) {
           })
           .catch(() => {
             stopPolling();
-            setRerunLoading(false);
+            if (isMounted()) setRerunLoading(false);
           });
       }, POLL_INTERVAL_MS);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to rerun metadata extraction');
       setRerunLoading(false);
     }
-  }, [mediaId, stopPolling, onRefresh]);
+  }, [mediaId, stopPolling, onRefresh, isMounted]);
 
   return { status, loading, error, rerun, rerunLoading };
 }

--- a/apps/web/src/hooks/useMediaShares.ts
+++ b/apps/web/src/hooks/useMediaShares.ts
@@ -15,6 +15,7 @@ import {
   bulkShares as bulkSharesApi,
   type ShareListMeta,
 } from '../services/shareService';
+import { useIsMounted } from './useIsMounted';
 
 // ---------------------------------------------------------------------------
 // Hook params and return shape
@@ -49,21 +50,24 @@ export function useMediaShares(params?: UseMediaSharesParams): UseMediaSharesRes
   const [meta, setMeta] = useState<ShareListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const refetch = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
       const result = await listShares(params);
+      if (!isMounted()) return;
       setShares(result.items);
       setMeta(result.meta);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch shares';
       setError(message);
       setShares([]);
       setMeta(null);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
   }, [
     params?.scope,
@@ -71,6 +75,7 @@ export function useMediaShares(params?: UseMediaSharesParams): UseMediaSharesRes
     params?.targetType,
     params?.page,
     params?.pageSize,
+    isMounted,
   ]);
 
   const createShare = useCallback(
@@ -82,11 +87,11 @@ export function useMediaShares(params?: UseMediaSharesParams): UseMediaSharesRes
         return share;
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to create share';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [refetch],
+    [refetch, isMounted],
   );
 
   const updateShare = useCallback(
@@ -98,11 +103,11 @@ export function useMediaShares(params?: UseMediaSharesParams): UseMediaSharesRes
         return updated;
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to update share';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [refetch],
+    [refetch, isMounted],
   );
 
   const revokeShare = useCallback(
@@ -113,11 +118,11 @@ export function useMediaShares(params?: UseMediaSharesParams): UseMediaSharesRes
         await refetch();
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to revoke share';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [refetch],
+    [refetch, isMounted],
   );
 
   const bulkAction = useCallback(
@@ -129,11 +134,11 @@ export function useMediaShares(params?: UseMediaSharesParams): UseMediaSharesRes
         return result;
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to perform bulk action';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [refetch],
+    [refetch, isMounted],
   );
 
   useEffect(() => {

--- a/apps/web/src/hooks/useMediaTags.ts
+++ b/apps/web/src/hooks/useMediaTags.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { getMediaTagStatus, rerunMediaTags } from '../services/tagging';
+import { useIsMounted } from './useIsMounted';
 import type { MediaTagStatusDto, MediaTagStatusType } from '../services/tagging';
 
 const TERMINAL_STATUSES: MediaTagStatusType[] = ['processed', 'failed'];
@@ -13,6 +14,7 @@ export function useMediaTags(mediaId: string, onRefreshTags: () => void) {
   const [rerunLoading, setRerunLoading] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
+  const isMounted = useIsMounted();
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -28,13 +30,15 @@ export function useMediaTags(mediaId: string, onRefreshTags: () => void) {
     setError(null);
     try {
       const statusData = await getMediaTagStatus(mediaId);
+      if (!isMounted()) return;
       setStatus(statusData);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load tag status');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [mediaId]);
+  }, [mediaId, isMounted]);
 
   useEffect(() => {
     void loadData();
@@ -47,6 +51,7 @@ export function useMediaTags(mediaId: string, onRefreshTags: () => void) {
     stopPolling();
     try {
       await rerunMediaTags(mediaId);
+      if (!isMounted()) return;
       // Optimistically update status to pending
       setStatus((prev) =>
         prev
@@ -66,6 +71,10 @@ export function useMediaTags(mediaId: string, onRefreshTags: () => void) {
         pollCountRef.current += 1;
         getMediaTagStatus(mediaId)
           .then((s) => {
+            if (!isMounted()) {
+              stopPolling();
+              return;
+            }
             setStatus(s);
             if (TERMINAL_STATUSES.includes(s.status) || pollCountRef.current >= MAX_POLLS) {
               stopPolling();
@@ -76,14 +85,15 @@ export function useMediaTags(mediaId: string, onRefreshTags: () => void) {
           })
           .catch(() => {
             stopPolling();
-            setRerunLoading(false);
+            if (isMounted()) setRerunLoading(false);
           });
       }, POLL_INTERVAL_MS);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to rerun AI tagging');
       setRerunLoading(false);
     }
-  }, [mediaId, stopPolling, onRefreshTags]);
+  }, [mediaId, stopPolling, onRefreshTags, isMounted]);
 
   return { status, loading, error, rerun, rerunLoading };
 }

--- a/apps/web/src/hooks/useNodeCredentials.ts
+++ b/apps/web/src/hooks/useNodeCredentials.ts
@@ -4,6 +4,7 @@ import {
   createNodeCredential as createNodeCredentialService,
   revokeNodeCredential as revokeNodeCredentialService,
 } from '../services/workers';
+import { useIsMounted } from './useIsMounted';
 import type { AdminNodeCredentialDto, CreatedNodeCredentialDto } from '../services/workers';
 
 export interface UseNodeCredentialsResult {
@@ -23,17 +24,20 @@ export function useNodeCredentials(): UseNodeCredentialsResult {
   const [credentials, setCredentials] = useState<AdminNodeCredentialDto[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   // Silent fetch (no loading spinner toggling on repeated calls).
   const fetchCredentials = useCallback(async () => {
     try {
       const data = await getNodeCredentials();
+      if (!isMounted()) return;
       setCredentials(data);
       setError(null);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load node credentials');
     }
-  }, []);
+  }, [isMounted]);
 
   // Explicit refresh with a loading indicator.
   const refresh = useCallback(async () => {
@@ -41,9 +45,9 @@ export function useNodeCredentials(): UseNodeCredentialsResult {
     try {
       await fetchCredentials();
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [fetchCredentials]);
+  }, [fetchCredentials, isMounted]);
 
   // Initial load.
   useEffect(() => {

--- a/apps/web/src/hooks/usePeople.ts
+++ b/apps/web/src/hooks/usePeople.ts
@@ -11,6 +11,7 @@ import {
   bulkUnhidePeople,
   purgePeople,
 } from '../services/face';
+import { useIsMounted } from './useIsMounted';
 import type { PersonListResponse, PersonDetail, ClusterResult } from '../services/face';
 
 // Hook for listing people in a circle
@@ -21,6 +22,7 @@ export function usePeople(
   const [data, setData] = useState<PersonListResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const refresh = useCallback(async () => {
     if (!circleId) return;
@@ -32,13 +34,15 @@ export function usePeople(
         hidden: opts?.hidden,
         pageSize: 100,
       });
+      if (!isMounted()) return;
       setData(result);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load people');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [circleId, opts?.includeUnlabeled, opts?.hidden]);
+  }, [circleId, opts?.includeUnlabeled, opts?.hidden, isMounted]);
 
   useEffect(() => {
     void refresh();
@@ -136,6 +140,7 @@ export function usePerson(personId: string | null) {
   const [person, setPerson] = useState<PersonDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const refresh = useCallback(async () => {
     if (!personId) return;
@@ -143,13 +148,15 @@ export function usePerson(personId: string | null) {
     setError(null);
     try {
       const result = await getPerson(personId);
+      if (!isMounted()) return;
       setPerson(result);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load person');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [personId]);
+  }, [personId, isMounted]);
 
   useEffect(() => {
     void refresh();

--- a/apps/web/src/hooks/usePersonalAccessTokens.ts
+++ b/apps/web/src/hooks/usePersonalAccessTokens.ts
@@ -5,6 +5,7 @@ import {
   createPersonalAccessToken as createTokenApi,
   revokePersonalAccessToken as revokeTokenApi,
 } from '../services/api';
+import { useIsMounted } from './useIsMounted';
 
 interface UsePersonalAccessTokensResult {
   tokens: PersonalAccessToken[];
@@ -23,21 +24,24 @@ export function usePersonalAccessTokens(): UsePersonalAccessTokensResult {
   const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchTokens = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
       const result = await fetchTokensApi();
+      if (!isMounted()) return;
       setTokens(result);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch tokens';
       setError(message);
       setTokens([]);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const createToken = useCallback(
     async (data: {
@@ -53,11 +57,11 @@ export function usePersonalAccessTokens(): UsePersonalAccessTokensResult {
         return response;
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to create token';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchTokens],
+    [fetchTokens, isMounted],
   );
 
   const revokeToken = useCallback(
@@ -69,11 +73,11 @@ export function usePersonalAccessTokens(): UsePersonalAccessTokensResult {
         await fetchTokens();
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to revoke token';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [fetchTokens],
+    [fetchTokens, isMounted],
   );
 
   useEffect(() => {

--- a/apps/web/src/hooks/useReviewInsights.ts
+++ b/apps/web/src/hooks/useReviewInsights.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { getReviewInsights } from '../services/reviewInsights';
+import { useIsMounted } from './useIsMounted';
 import type { ReviewInsights } from '../services/reviewInsights';
 
 export interface UseReviewInsightsResult {
@@ -17,6 +18,7 @@ export function useReviewInsights(circleId: string | null): UseReviewInsightsRes
   const [data, setData] = useState<ReviewInsights | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const reload = useCallback(async () => {
     if (!circleId) return;
@@ -24,13 +26,15 @@ export function useReviewInsights(circleId: string | null): UseReviewInsightsRes
     setError(null);
     try {
       const result = await getReviewInsights(circleId);
+      if (!isMounted()) return;
       setData(result);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load review insights');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [circleId]);
+  }, [circleId, isMounted]);
 
   useEffect(() => {
     void reload();

--- a/apps/web/src/hooks/useReviewRun.ts
+++ b/apps/web/src/hooks/useReviewRun.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { ReviewRunDetail } from '../types/reviewRuns';
 import { getReviewRun as getReviewRunApi } from '../services/reviewRuns';
+import { useIsMounted } from './useIsMounted';
 
 interface UseReviewRunResult {
   run: ReviewRunDetail | null;
@@ -17,21 +18,24 @@ export function useReviewRun(): UseReviewRunResult {
   const [run, setRun] = useState<ReviewRunDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchRun = useCallback(async (runId: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await getReviewRunApi(runId);
+      if (!isMounted()) return;
       setRun(response);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch review run';
       setError(message);
       setRun(null);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return { run, isLoading, error, fetchRun };
 }

--- a/apps/web/src/hooks/useReviewRunItems.ts
+++ b/apps/web/src/hooks/useReviewRunItems.ts
@@ -5,6 +5,7 @@ import type {
   ReviewRunListMeta,
 } from '../types/reviewRuns';
 import { listReviewRunItems as listReviewRunItemsApi } from '../services/reviewRuns';
+import { useIsMounted } from './useIsMounted';
 
 interface UseReviewRunItemsResult {
   items: ReviewRunItem[];
@@ -19,6 +20,7 @@ export function useReviewRunItems(): UseReviewRunItemsResult {
   const [meta, setMeta] = useState<ReviewRunListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchItems = useCallback(
     async (runId: string, params?: ReviewRunItemsQueryParams) => {
@@ -26,18 +28,20 @@ export function useReviewRunItems(): UseReviewRunItemsResult {
       setError(null);
       try {
         const response = await listReviewRunItemsApi(runId, params);
+        if (!isMounted()) return;
         setItems(response.items);
         setMeta(response.meta);
       } catch (err) {
+        if (!isMounted()) return;
         const message =
           err instanceof Error ? err.message : 'Failed to fetch review run items';
         setError(message);
         setItems([]);
       } finally {
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   return { items, meta, isLoading, error, fetchItems };

--- a/apps/web/src/hooks/useSearch.ts
+++ b/apps/web/src/hooks/useSearch.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { getSearchFields, performSearch } from '../services/search';
+import { useIsMounted } from './useIsMounted';
 import type { SearchField, SearchRequest, SearchResponse } from '../services/search';
 import type { MediaItem, MediaListMeta } from '../types/media';
 
@@ -10,36 +11,41 @@ export function useSearch() {
   const [isLoadingFields, setIsLoadingFields] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchFields = useCallback(async () => {
     setIsLoadingFields(true);
     setError(null);
     try {
       const data = await getSearchFields();
+      if (!isMounted()) return;
       setFields(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load search fields');
     } finally {
-      setIsLoadingFields(false);
+      if (isMounted()) setIsLoadingFields(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const search = useCallback(async (body: SearchRequest): Promise<SearchResponse> => {
     setIsSearching(true);
     setError(null);
     try {
       const result = await performSearch(body);
-      setSearchResults(result.items);
-      setMeta(result.meta);
+      if (isMounted()) {
+        setSearchResults(result.items);
+        setMeta(result.meta);
+      }
       return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Search failed';
-      setError(message);
+      if (isMounted()) setError(message);
       throw err;
     } finally {
-      setIsSearching(false);
+      if (isMounted()) setIsSearching(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return {
     fields,

--- a/apps/web/src/hooks/useStorageMigration.ts
+++ b/apps/web/src/hooks/useStorageMigration.ts
@@ -5,6 +5,7 @@ import {
   getMigrationRun,
   cancelMigration,
 } from '../services/storage-providers';
+import { useIsMounted } from './useIsMounted';
 import type { MigrationRun, MigrationStatus } from '../services/storage-providers';
 
 const POLL_INTERVAL_MS = 5000;
@@ -28,24 +29,28 @@ export function useStorageMigration() {
   const activeRunIdRef = useRef<string | null>(null);
   activeRunIdRef.current = activeRun?.id ?? null;
 
+  const isMounted = useIsMounted();
+
   const fetchRuns = useCallback(async () => {
     try {
       const data = await listMigrationRuns();
+      if (!isMounted()) return;
       setRuns(data.items);
       setRunsError(null);
     } catch (err) {
+      if (!isMounted()) return;
       setRunsError(err instanceof Error ? err.message : 'Failed to load migration runs');
     }
-  }, []);
+  }, [isMounted]);
 
   const refresh = useCallback(async () => {
     setRunsLoading(true);
     try {
       await fetchRuns();
     } finally {
-      setRunsLoading(false);
+      if (isMounted()) setRunsLoading(false);
     }
-  }, [fetchRuns]);
+  }, [fetchRuns, isMounted]);
 
   // Silent background poll for active run status
   const silentPollActiveRun = useCallback(async () => {
@@ -53,17 +58,18 @@ export function useStorageMigration() {
     if (!runId) return;
     try {
       const updated = await getMigrationRun(runId);
+      if (!isMounted()) return;
       setActiveRun(updated);
       // Also refresh the runs list so history stays up to date
       await fetchRuns();
       // If terminal, clear active run
-      if (isTerminal(updated.status)) {
+      if (isTerminal(updated.status) && isMounted()) {
         setActiveRun(null);
       }
     } catch {
       // ignore poll errors
     }
-  }, [fetchRuns]);
+  }, [fetchRuns, isMounted]);
 
   // Initial load
   useEffect(() => {
@@ -93,25 +99,27 @@ export function useStorageMigration() {
         const result = await triggerMigration({ sourceProvider, targetProvider });
         // Immediately fetch the full run object so we have status/counts
         const run = await getMigrationRun(result.runId);
+        if (!isMounted()) return;
         setActiveRun(run);
         await fetchRuns();
       } finally {
-        setStarting(false);
+        if (isMounted()) setStarting(false);
       }
     },
-    [fetchRuns],
+    [fetchRuns, isMounted],
   );
 
   const cancel = useCallback(async (): Promise<void> => {
     if (!activeRun) return;
     try {
       const updated = await cancelMigration(activeRun.id);
+      if (!isMounted()) return;
       setActiveRun(updated);
       await fetchRuns();
     } catch (err) {
       throw err;
     }
-  }, [activeRun, fetchRuns]);
+  }, [activeRun, fetchRuns, isMounted]);
 
   return {
     runs,

--- a/apps/web/src/hooks/useStorageProviders.ts
+++ b/apps/web/src/hooks/useStorageProviders.ts
@@ -6,6 +6,7 @@ import {
   testStorageProvider,
   setActiveStorageProvider,
 } from '../services/storage-providers';
+import { useIsMounted } from './useIsMounted';
 import type {
   StorageSettingsResponse,
   StorageTestResult,
@@ -20,19 +21,22 @@ export function useStorageProviders() {
   // Per-provider test state
   const [testResults, setTestResults] = useState<Record<string, StorageTestResult | null>>({});
   const [testLoading, setTestLoading] = useState<Record<string, boolean>>({});
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const data = await getStorageSettings();
+      if (!isMounted()) return;
       setSettings(data);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load storage settings');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   const saveCredentials = useCallback(
     async (
@@ -70,20 +74,20 @@ export function useStorageProviders() {
       setTestResults((prev) => ({ ...prev, [provider]: null }));
       try {
         const result = await testStorageProvider({ provider, ...overrides });
-        setTestResults((prev) => ({ ...prev, [provider]: result }));
+        if (isMounted()) setTestResults((prev) => ({ ...prev, [provider]: result }));
         return result;
       } catch (err) {
         const result: StorageTestResult = {
           ok: false,
           error: err instanceof Error ? err.message : 'Test failed',
         };
-        setTestResults((prev) => ({ ...prev, [provider]: result }));
+        if (isMounted()) setTestResults((prev) => ({ ...prev, [provider]: result }));
         return result;
       } finally {
-        setTestLoading((prev) => ({ ...prev, [provider]: false }));
+        if (isMounted()) setTestLoading((prev) => ({ ...prev, [provider]: false }));
       }
     },
-    [],
+    [isMounted],
   );
 
   const setActive = useCallback(

--- a/apps/web/src/hooks/useSystemSettings.ts
+++ b/apps/web/src/hooks/useSystemSettings.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api, ApiError } from '../services/api';
 import { SystemSettings } from '../types';
+import { useIsMounted } from './useIsMounted';
 
 interface UseSystemSettingsReturn {
   settings: SystemSettings | null;
@@ -17,14 +18,17 @@ export function useSystemSettings(): UseSystemSettingsReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
       const data = await api.get<SystemSettings>('/system-settings');
+      if (!isMounted()) return;
       setSettings(data);
     } catch (err) {
+      if (!isMounted()) return;
       if (err instanceof ApiError && err.status === 403) {
         setError('You do not have permission to view system settings');
       } else {
@@ -32,9 +36,9 @@ export function useSystemSettings(): UseSystemSettingsReturn {
         setError(message);
       }
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   useEffect(() => {
     fetchSettings();
@@ -54,20 +58,20 @@ export function useSystemSettings(): UseSystemSettingsReturn {
           },
         });
 
-        setSettings(data);
+        if (isMounted()) setSettings(data);
       } catch (err) {
         if (err instanceof ApiError && err.status === 409) {
           await fetchSettings();
           throw new Error('Settings were updated elsewhere. Please review and try again.');
         }
         const message = err instanceof ApiError ? err.message : 'Failed to save settings';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       } finally {
-        setIsSaving(false);
+        if (isMounted()) setIsSaving(false);
       }
     },
-    [settings, fetchSettings],
+    [settings, fetchSettings, isMounted],
   );
 
   const replaceSettings = useCallback(
@@ -77,16 +81,16 @@ export function useSystemSettings(): UseSystemSettingsReturn {
         setError(null);
 
         const data = await api.put<SystemSettings>('/system-settings', newSettings);
-        setSettings(data);
+        if (isMounted()) setSettings(data);
       } catch (err) {
         const message = err instanceof ApiError ? err.message : 'Failed to save settings';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       } finally {
-        setIsSaving(false);
+        if (isMounted()) setIsSaving(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   return {

--- a/apps/web/src/hooks/useTrashEmptyRun.ts
+++ b/apps/web/src/hooks/useTrashEmptyRun.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { TrashEmptyRunDetail } from '../types/trashEmptyRuns';
 import { getTrashEmptyRun as getTrashEmptyRunApi } from '../services/trashEmptyRuns';
+import { useIsMounted } from './useIsMounted';
 
 interface UseTrashEmptyRunResult {
   run: TrashEmptyRunDetail | null;
@@ -17,21 +18,24 @@ export function useTrashEmptyRun(): UseTrashEmptyRunResult {
   const [run, setRun] = useState<TrashEmptyRunDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchRun = useCallback(async (runId: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await getTrashEmptyRunApi(runId);
+      if (!isMounted()) return;
       setRun(response);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch trash-empty run';
       setError(message);
       setRun(null);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return { run, isLoading, error, fetchRun };
 }

--- a/apps/web/src/hooks/useTrashEmptyRunItems.ts
+++ b/apps/web/src/hooks/useTrashEmptyRunItems.ts
@@ -5,6 +5,7 @@ import type {
   TrashEmptyRunItemsQueryParams,
 } from '../types/trashEmptyRuns';
 import { listTrashEmptyRunItems as listTrashEmptyRunItemsApi } from '../services/trashEmptyRuns';
+import { useIsMounted } from './useIsMounted';
 
 interface UseTrashEmptyRunItemsResult {
   items: TrashEmptyRunItem[];
@@ -19,6 +20,7 @@ export function useTrashEmptyRunItems(): UseTrashEmptyRunItemsResult {
   const [meta, setMeta] = useState<TrashEmptyRunListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchItems = useCallback(
     async (runId: string, params?: TrashEmptyRunItemsQueryParams) => {
@@ -26,18 +28,20 @@ export function useTrashEmptyRunItems(): UseTrashEmptyRunItemsResult {
       setError(null);
       try {
         const response = await listTrashEmptyRunItemsApi(runId, params);
+        if (!isMounted()) return;
         setItems(response.items);
         setMeta(response.meta);
       } catch (err) {
+        if (!isMounted()) return;
         const message =
           err instanceof Error ? err.message : 'Failed to fetch trash-empty run items';
         setError(message);
         setItems([]);
       } finally {
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   return { items, meta, isLoading, error, fetchItems };

--- a/apps/web/src/hooks/useUnassignedFaces.ts
+++ b/apps/web/src/hooks/useUnassignedFaces.ts
@@ -6,6 +6,7 @@ import {
   purgeFaces,
   purgeArchivedFaces,
 } from '../services/face';
+import { useIsMounted } from './useIsMounted';
 import type { UnassignedFaceDto } from '../services/face';
 
 export function useUnassignedFaces(
@@ -20,6 +21,7 @@ export function useUnassignedFaces(
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pageRef = useRef(1);
+  const isMounted = useIsMounted();
 
   const refresh = useCallback(async () => {
     if (!circleId) { setFaces([]); setTotal(0); return; }
@@ -27,15 +29,17 @@ export function useUnassignedFaces(
     setError(null);
     try {
       const result = await listUnassignedFaces(circleId, { page: 1, pageSize, archived });
+      if (!isMounted()) return;
       pageRef.current = 1;
       setFaces(result.items);
       setTotal(result.meta.totalItems);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load unassigned faces');
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [circleId, archived, pageSize]);
+  }, [circleId, archived, pageSize, isMounted]);
 
   useEffect(() => { void refresh(); }, [refresh]);
 
@@ -49,6 +53,7 @@ export function useUnassignedFaces(
         pageSize,
         archived,
       });
+      if (!isMounted()) return;
       pageRef.current += 1;
       setFaces((prev) => {
         const seen = new Set(prev.map((f) => f.faceId));
@@ -56,11 +61,12 @@ export function useUnassignedFaces(
       });
       setTotal(result.meta.totalItems);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load more faces');
     } finally {
-      setLoadingMore(false);
+      if (isMounted()) setLoadingMore(false);
     }
-  }, [circleId, archived, pageSize, loadingMore]);
+  }, [circleId, archived, pageSize, loadingMore, isMounted]);
 
   const hide = useCallback(
     async (ids: string[]) => {

--- a/apps/web/src/hooks/useUserSettings.ts
+++ b/apps/web/src/hooks/useUserSettings.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { api, ApiError } from '../services/api';
 import { UserSettings } from '../types';
 import { useThemeContext } from '../contexts/ThemeContext';
+import { useIsMounted } from './useIsMounted';
 
 interface UseUserSettingsReturn {
   settings: UserSettings | null;
@@ -20,22 +21,25 @@ export function useUserSettings(): UseUserSettingsReturn {
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const { setMode } = useThemeContext();
+  const isMounted = useIsMounted();
 
   const fetchSettings = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
       const data = await api.get<UserSettings>('/user-settings');
+      if (!isMounted()) return;
       setSettings(data);
       // Sync theme with settings
       setMode(data.theme);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof ApiError ? err.message : 'Failed to load settings';
       setError(message);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, [setMode]);
+  }, [setMode, isMounted]);
 
   useEffect(() => {
     fetchSettings();
@@ -55,11 +59,13 @@ export function useUserSettings(): UseUserSettingsReturn {
           },
         });
 
-        setSettings(data);
+        if (isMounted()) {
+          setSettings(data);
 
-        // Sync theme if changed
-        if (updates.theme) {
-          setMode(updates.theme);
+          // Sync theme if changed
+          if (updates.theme) {
+            setMode(updates.theme);
+          }
         }
       } catch (err) {
         if (err instanceof ApiError && err.status === 409) {
@@ -68,13 +74,13 @@ export function useUserSettings(): UseUserSettingsReturn {
           throw new Error('Settings were updated elsewhere. Please try again.');
         }
         const message = err instanceof ApiError ? err.message : 'Failed to save settings';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       } finally {
-        setIsSaving(false);
+        if (isMounted()) setIsSaving(false);
       }
     },
-    [settings, setMode, fetchSettings],
+    [settings, setMode, fetchSettings, isMounted],
   );
 
   const updateTheme = useCallback(

--- a/apps/web/src/hooks/useUsers.ts
+++ b/apps/web/src/hooks/useUsers.ts
@@ -5,6 +5,7 @@ import {
   updateUser as updateUserApi,
   updateUserRoles as updateUserRolesApi,
 } from '../services/api';
+import { useIsMounted } from './useIsMounted';
 
 interface UseUsersResult {
   users: UserListItem[];
@@ -36,6 +37,7 @@ export function useUsers(): UseUsersResult {
   const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchUsers = useCallback(
     async (params?: {
@@ -49,20 +51,22 @@ export function useUsers(): UseUsersResult {
       setError(null);
       try {
         const response: UsersResponse = await getUsersApi(params);
+        if (!isMounted()) return;
         setUsers(response.items);
         setTotal(response.total);
         setPage(response.page);
         setPageSize(response.pageSize);
         setTotalPages(response.totalPages);
       } catch (err) {
+        if (!isMounted()) return;
         const message = err instanceof Error ? err.message : 'Failed to fetch users';
         setError(message);
         setUsers([]);
       } finally {
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   const updateUser = useCallback(
@@ -71,16 +75,18 @@ export function useUsers(): UseUsersResult {
       try {
         const updatedUser = await updateUserApi(id, data);
         // Update the user in the list
-        setUsers((prevUsers) =>
-          prevUsers.map((user) => (user.id === id ? updatedUser : user)),
-        );
+        if (isMounted()) {
+          setUsers((prevUsers) =>
+            prevUsers.map((user) => (user.id === id ? updatedUser : user)),
+          );
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to update user';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [],
+    [isMounted],
   );
 
   const updateUserRoles = useCallback(
@@ -89,17 +95,19 @@ export function useUsers(): UseUsersResult {
       try {
         const updatedUser = await updateUserRolesApi(id, roles);
         // Update the user in the list
-        setUsers((prevUsers) =>
-          prevUsers.map((user) => (user.id === id ? updatedUser : user)),
-        );
+        if (isMounted()) {
+          setUsers((prevUsers) =>
+            prevUsers.map((user) => (user.id === id ? updatedUser : user)),
+          );
+        }
       } catch (err) {
         const message =
           err instanceof Error ? err.message : 'Failed to update user roles';
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       }
     },
-    [],
+    [isMounted],
   );
 
   return {

--- a/apps/web/src/hooks/useWorkers.ts
+++ b/apps/web/src/hooks/useWorkers.ts
@@ -3,6 +3,7 @@ import {
   getWorkers,
   deleteWorker as deleteWorkerService,
 } from '../services/workers';
+import { useIsMounted } from './useIsMounted';
 import type { WorkerNodeDto } from '../services/workers';
 
 const POLL_INTERVAL_MS = 5000;
@@ -28,17 +29,20 @@ export function useWorkers(options: UseWorkersOptions = {}): UseWorkersResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(options.autoRefresh ?? true);
+  const isMounted = useIsMounted();
 
   // Silent fetch (no loading spinner) — used by the polling interval.
   const fetchNodes = useCallback(async () => {
     try {
       const data = await getWorkers();
+      if (!isMounted()) return;
       setNodes(data);
       setError(null);
     } catch (err) {
+      if (!isMounted()) return;
       setError(err instanceof Error ? err.message : 'Failed to load worker nodes');
     }
-  }, []);
+  }, [isMounted]);
 
   // Explicit refresh with a loading indicator.
   const refresh = useCallback(async () => {
@@ -46,9 +50,9 @@ export function useWorkers(options: UseWorkersOptions = {}): UseWorkersResult {
     try {
       await fetchNodes();
     } finally {
-      setLoading(false);
+      if (isMounted()) setLoading(false);
     }
-  }, [fetchNodes]);
+  }, [fetchNodes, isMounted]);
 
   // Initial load.
   useEffect(() => {

--- a/apps/web/src/hooks/useWorkflow.ts
+++ b/apps/web/src/hooks/useWorkflow.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { Workflow } from '../types/workflows';
 import { getWorkflow as getWorkflowApi } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 interface UseWorkflowResult {
   workflow: Workflow | null;
@@ -13,21 +14,24 @@ export function useWorkflow(): UseWorkflowResult {
   const [workflow, setWorkflow] = useState<Workflow | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchWorkflow = useCallback(async (id: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await getWorkflowApi(id);
+      if (!isMounted()) return;
       setWorkflow(response);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch workflow';
       setError(message);
       setWorkflow(null);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return { workflow, isLoading, error, fetchWorkflow };
 }

--- a/apps/web/src/hooks/useWorkflowMutations.ts
+++ b/apps/web/src/hooks/useWorkflowMutations.ts
@@ -16,6 +16,7 @@ import {
   cancelWorkflowRun as cancelWorkflowRunApi,
   duplicateWorkflow as duplicateWorkflowApi,
 } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 type RunResult = { runId: string; status: WorkflowRunStatus };
 
@@ -35,6 +36,7 @@ interface UseWorkflowMutationsResult {
 export function useWorkflowMutations(): UseWorkflowMutationsResult {
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const run = useCallback(
     async <T>(fn: () => Promise<T>, fallback: string): Promise<T> => {
@@ -44,13 +46,13 @@ export function useWorkflowMutations(): UseWorkflowMutationsResult {
         return await fn();
       } catch (err) {
         const message = err instanceof Error ? err.message : fallback;
-        setError(message);
+        if (isMounted()) setError(message);
         throw err;
       } finally {
-        setIsSaving(false);
+        if (isMounted()) setIsSaving(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   const createWorkflow = useCallback(

--- a/apps/web/src/hooks/useWorkflowPreview.ts
+++ b/apps/web/src/hooks/useWorkflowPreview.ts
@@ -4,6 +4,7 @@ import type {
   WorkflowPreviewResponse,
 } from '../types/workflows';
 import { previewWorkflow as previewWorkflowApi } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 interface UseWorkflowPreviewResult {
   preview: (body: WorkflowPreviewRequest) => Promise<WorkflowPreviewResponse | null>;
@@ -24,6 +25,7 @@ export function useWorkflowPreview(): UseWorkflowPreviewResult {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const latestRequestId = useRef(0);
+  const isMounted = useIsMounted();
 
   const preview = useCallback(
     async (body: WorkflowPreviewRequest): Promise<WorkflowPreviewResponse | null> => {
@@ -33,13 +35,13 @@ export function useWorkflowPreview(): UseWorkflowPreviewResult {
       try {
         const response = await previewWorkflowApi(body);
         // Only apply if this is still the most recent request.
-        if (requestId === latestRequestId.current) {
+        if (requestId === latestRequestId.current && isMounted()) {
           setData(response);
           setIsLoading(false);
         }
         return response;
       } catch (err) {
-        if (requestId === latestRequestId.current) {
+        if (requestId === latestRequestId.current && isMounted()) {
           const message = err instanceof Error ? err.message : 'Failed to preview workflow';
           setError(message);
           setIsLoading(false);
@@ -47,7 +49,7 @@ export function useWorkflowPreview(): UseWorkflowPreviewResult {
         return null;
       }
     },
-    [],
+    [isMounted],
   );
 
   const reset = useCallback(() => {

--- a/apps/web/src/hooks/useWorkflowRun.ts
+++ b/apps/web/src/hooks/useWorkflowRun.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { WorkflowRunDetail } from '../types/workflows';
 import { getWorkflowRun as getWorkflowRunApi } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 interface UseWorkflowRunResult {
   run: WorkflowRunDetail | null;
@@ -17,21 +18,24 @@ export function useWorkflowRun(): UseWorkflowRunResult {
   const [run, setRun] = useState<WorkflowRunDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchRun = useCallback(async (runId: string) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await getWorkflowRunApi(runId);
+      if (!isMounted()) return;
       setRun(response);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch workflow run';
       setError(message);
       setRun(null);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return { run, isLoading, error, fetchRun };
 }

--- a/apps/web/src/hooks/useWorkflowRunItems.ts
+++ b/apps/web/src/hooks/useWorkflowRunItems.ts
@@ -5,6 +5,7 @@ import type {
   RunItemsQueryParams,
 } from '../types/workflows';
 import { listWorkflowRunItems as listWorkflowRunItemsApi } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 interface UseWorkflowRunItemsResult {
   items: WorkflowRunItem[];
@@ -19,6 +20,7 @@ export function useWorkflowRunItems(): UseWorkflowRunItemsResult {
   const [meta, setMeta] = useState<WorkflowListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchItems = useCallback(
     async (runId: string, params?: RunItemsQueryParams) => {
@@ -26,18 +28,20 @@ export function useWorkflowRunItems(): UseWorkflowRunItemsResult {
       setError(null);
       try {
         const response = await listWorkflowRunItemsApi(runId, params);
+        if (!isMounted()) return;
         setItems(response.items);
         setMeta(response.meta);
       } catch (err) {
+        if (!isMounted()) return;
         const message =
           err instanceof Error ? err.message : 'Failed to fetch workflow run items';
         setError(message);
         setItems([]);
       } finally {
-        setIsLoading(false);
+        if (isMounted()) setIsLoading(false);
       }
     },
-    [],
+    [isMounted],
   );
 
   return { items, meta, isLoading, error, fetchItems };

--- a/apps/web/src/hooks/useWorkflowRuns.ts
+++ b/apps/web/src/hooks/useWorkflowRuns.ts
@@ -5,6 +5,7 @@ import type {
   RunsQueryParams,
 } from '../types/workflows';
 import { listWorkflowRuns as listWorkflowRunsApi } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 interface UseWorkflowRunsResult {
   runs: WorkflowRun[];
@@ -19,22 +20,25 @@ export function useWorkflowRuns(): UseWorkflowRunsResult {
   const [meta, setMeta] = useState<WorkflowListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchRuns = useCallback(async (id: string, params?: RunsQueryParams) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await listWorkflowRunsApi(id, params);
+      if (!isMounted()) return;
       setRuns(response.items);
       setMeta(response.meta);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch workflow runs';
       setError(message);
       setRuns([]);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return { runs, meta, isLoading, error, fetchRuns };
 }

--- a/apps/web/src/hooks/useWorkflows.ts
+++ b/apps/web/src/hooks/useWorkflows.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowsQueryParams,
 } from '../types/workflows';
 import { listWorkflows as listWorkflowsApi } from '../services/workflows';
+import { useIsMounted } from './useIsMounted';
 
 interface UseWorkflowsResult {
   workflows: Workflow[];
@@ -19,22 +20,25 @@ export function useWorkflows(): UseWorkflowsResult {
   const [meta, setMeta] = useState<WorkflowListMeta | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
 
   const fetchWorkflows = useCallback(async (params: WorkflowsQueryParams) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await listWorkflowsApi(params);
+      if (!isMounted()) return;
       setWorkflows(response.items);
       setMeta(response.meta);
     } catch (err) {
+      if (!isMounted()) return;
       const message = err instanceof Error ? err.message : 'Failed to fetch workflows';
       setError(message);
       setWorkflows([]);
     } finally {
-      setIsLoading(false);
+      if (isMounted()) setIsLoading(false);
     }
-  }, []);
+  }, [isMounted]);
 
   return { workflows, meta, isLoading, error, fetchWorkflows };
 }


### PR DESCRIPTION
## Summary

Makes `apps/web`'s CI gate deterministic. The `Build & Test` check intermittently failed with an unhandled `ReferenceError: window is not defined` while every individual assertion passed — so a red run meant nothing and clearing it meant re-running and hoping.

Root cause: data-loading hooks called React state setters after an `await` with no unmount guard. When a fetch was still in flight as a Vitest file finished and unmounted, the continuation fired later — sometimes during a *different, later* file in the same worker, after that worker's `window` was gone — and React's `dispatchSetState → requestUpdateLane → resolveUpdatePriority` threw.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #196

## Changes Made

- **New `src/hooks/useIsMounted.ts`** — a ref-backed `() => boolean`, with a header comment explaining the bug so it isn't later deleted as ceremony. The ref starts `true` *and* is re-set `true` on mount, so React 18/19 StrictMode's mount→unmount→remount cycle doesn't leave it permanently reporting "unmounted".
- **Applied across 52 hooks** — the issue listed the 20 observed firing, but `grep "finally {"` found 51 guard sites; all were audited, since the list was "the ones that happened to fire", not the complete set. `useDashboard` had the identical shape and wasn't on the list either.
- **Polling paths handled specifically**, not mechanically: an interval's `.then` now stops the poll on unmount rather than just skipping the setter.
- **Test-side half of the leak closed** — the three `MediaDetailDrawer` specs now mock the tagging/metadata services their hooks fetch on mount, and drain pending continuations before teardown via a new `flushPendingAsyncWork` helper. `MediaDetailDrawerOrigin.test.tsx` is the file CI kept attributing the error to.

Behaviour for a *mounted* component is unchanged — this is purely "don't touch state after teardown". No hook's return value, fetch timing, or error text changed.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

**Five consecutive CI-equivalent runs: 179 files / 3443 tests, all passing, zero errors every time.** A single green run proves nothing for a flake, which is why this was repeated.

### Test Instructions

1. `cd apps/web && for i in 1 2 3 4 5; do npm run test:ci; done` — every run should report zero `Errors`. Before this change, `Errors 1` / `Errors 4` / `Errors 0` across identical runs was the observed pattern.
2. To confirm the regression test earns its keep: remove the `isMounted()` guards from `src/hooks/useMediaTags.ts` and run `npx vitest run src/__tests__/hooks/useMediaTags.test.ts` — it fails with the exact `ReferenceError: window is not defined` unhandled rejection from the issue.

## Additional Notes

**The regression test needed care to be worth anything.** The obvious version — render, unmount, resolve — *passes even with the guard removed*, because React 18+ silently no-ops a post-unmount state update on a function component with no warning and no throw. The test therefore also removes the global `window` binding around the resolve, faithfully reproducing the real cross-file condition. That was verified empirically by reverting the guard and watching it fail; the transcript is kept in the test file so nobody later "simplifies" it back into uselessness.

One related note on StrictMode: the double-effect-invocation only triggers via RTL's `reactStrictMode` render option, not by manually wrapping the wrapper in `<React.StrictMode>` (verified under RTL 16 / React 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpUS8iDyPjqfKsch8W2Yuv)_