### PR TITLE
test(api): make the OCR soft-timeout test deterministic

### DIFF
--- a/apps/api/src/social-media/social-media-ocr.service.spec.ts
+++ b/apps/api/src/social-media/social-media-ocr.service.spec.ts
@@ -29,6 +29,11 @@ jest.mock('tesseract.js', () => ({
   createWorker: (...args: unknown[]) => mockCreateWorker(...args),
 }));
 
+// Captured before any test calls jest.useFakeTimers() so it always resolves to
+// the genuine, non-faked setTimeout implementation regardless of which timer
+// mode is currently active in a given test.
+const realSetTimeout = setTimeout;
+
 /** Fake already-materialized video path — VideoFrameExtractionService is mocked via DI. */
 const FAKE_VIDEO_PATH = '/tmp/fake-video-input.mp4';
 
@@ -183,6 +188,12 @@ describe('SocialMediaOcrService', () => {
   // recognizeVideo — timeout returns partial texts
   // -------------------------------------------------------------------------
   describe('recognizeVideo — soft timeout returns partial results', () => {
+    afterEach(() => {
+      // Runs even if an assertion above throws, so fake timers never leak
+      // into sibling tests/files.
+      jest.useRealTimers();
+    });
+
     it('returns collected text from completed frames and stops waiting on the budget elapsing', async () => {
       const recognize = jest
         .fn()
@@ -191,7 +202,10 @@ describe('SocialMediaOcrService', () => {
           async () =>
             ({ data: makeFakePage([{ text: 'PARTIAL1', confidence: 90 }]) }) as any,
         )
-        // Second frame hangs well beyond the timeout budget.
+        // Second frame hangs well beyond the timeout budget. Under fake
+        // timers this setTimeout is also frozen, so this mock can never
+        // resolve on its own — a second guarantee (on top of the service's
+        // own `cancelled` flag) that 'TOO_LATE' can never leak in.
         .mockImplementationOnce(
           () =>
             new Promise((resolve) =>
@@ -208,17 +222,42 @@ describe('SocialMediaOcrService', () => {
         { timestampMs: 100, buffer: Buffer.from('frame1') },
       ]);
 
-      const result = await service.recognizeVideo(FAKE_VIDEO_PATH, {
+      jest.useFakeTimers();
+
+      // Don't await yet — the service's internal soft-timeout setTimeout is
+      // now frozen and cannot fire until we explicitly advance the fake
+      // clock below, so however long the real (unmocked) fs.mkdir + sharp
+      // preprocessing work underneath actually takes, there is no race.
+      const resultPromise = service.recognizeVideo(FAKE_VIDEO_PATH, {
         durationMs: 5000,
         maxFrames: 4,
         languages: ['eng'],
         timeoutMs: 40,
       });
 
+      // Flush the real, non-fake-timer async work (fs.mkdir, createWorker
+      // resolution, extractFramesAt resolution, the sharp preprocessing
+      // attempt/catch on frame 1, and frame 1's mocked recognize() call)
+      // via real ticks, using the genuine setTimeout captured before fake
+      // timers were installed. Polling on an event-driven condition (both
+      // recognize() calls having started) rather than a guessed iteration
+      // count keeps this safe to be generous without reintroducing flakiness,
+      // since the fake soft-timeout cannot fire spontaneously in the meantime.
+      for (let i = 0; i < 50 && recognize.mock.calls.length < 2; i++) {
+        await new Promise<void>((resolve) => realSetTimeout(resolve, 1));
+      }
+      expect(recognize.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      // Deterministically fire the service's internal soft timeout: past the
+      // 40ms budget, well short of frame 2's 300ms mock delay.
+      await jest.advanceTimersByTimeAsync(40);
+
+      const result = await resultPromise;
+
       expect(result.available).toBe(true);
       expect(result.texts).toEqual(['PARTIAL1']);
       expect(result.texts).not.toContain('TOO_LATE');
-    }, 10000);
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`SocialMediaOcrService › recognizeVideo — soft timeout returns partial results` failed non-deterministically and, unlike every other flaky suite in this repo, was **not** excluded from `test:ci` — so it could turn `Build & Test` red on a PR that changed nothing related.

The test gave `recognizeVideo` a **40 ms real wall-clock budget** and asserted the first frame's text survived. That required frame 1's entire async chain — engine init, frame extraction, sharp preprocessing, the mocked `recognize` — to complete inside 40 ms of real time. On a contended machine it didn't, the service's soft-timeout timer won the race, and `texts` came back empty.

**The failure was `Received: []`, not a leaked `'TOO_LATE'`** — the service was behaving *correctly* under load. Only the test's timing assumption was wrong, so `social-media-ocr.service.ts` is untouched.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Fixes #210

## Changes Made

The ordering is now **caused rather than hoped for**:

- **Fake timers freeze the service's internal `setTimeout`**, so the soft timeout cannot fire until the test explicitly advances the clock. However long the real work underneath actually takes, there is no race.
- **The test polls for an event-driven condition, not a duration** — `recognize()` having been called twice. The service's loop awaits each frame in turn (`for (const frame of frames) { ...await engine.recognizeFrame(...); texts.push(text) }`), so a second call can only happen *after* frame 1's text was pushed. That makes the condition causal rather than a guess.
- **Frame 2's own 300 ms mock delay is frozen too**, so `'TOO_LATE'` cannot leak in even in principle — a second guarantee on top of the service's `cancelled` flag.
- **`useRealTimers()` runs in `afterEach`**, not at the end of the test body, so fake timers cannot escape into sibling tests or later files if an assertion throws.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

A green run proves nothing here — the test already passed most of the time. So the load condition was reproduced first, then the fix measured against it:

| | old test | new test |
|---|---|---|
| Idle | (1 failure in 6, previously measured) | **20 / 20 pass** |
| Under 6 busy-loops on a 4-core box | **3 / 12 FAIL** | **12 / 12 pass** |

That's ~150% CPU oversubscription — harsher than a GitHub Actions runner. Confirming the old test still fails under that exact harness is what makes the new test's 12/12 meaningful, rather than just "it passed again".

Full API `test:ci` unchanged: **225 suites / 5489 tests**, `tsc` clean.

### Test Instructions

```bash
cd apps/api
# hammer it; should be 20/20
for i in $(seq 1 20); do npx jest --config ./test/jest.config.js \
  src/social-media/social-media-ocr.service.spec.ts -t "soft timeout"; done
```
To see the original failure, revert this commit and re-run the same loop with a few `while :; do :; done &` background processes.

## Additional Notes

**Sibling audit:** every other `recognizeVideo` case in the file uses a 1000–5000 ms budget where the work completes normally, so none of them shares this tight-budget assumption. Nothing else needed changing.

**One residual bound, stated honestly:** the poll loop caps at 50 real-timer yields before asserting the condition was met. That is not a wall-clock duration and it fails loudly rather than silently if exceeded, but it is technically still a bound. It held under the oversubscribed load above; if it ever trips, raising the cap is free, since the loop exits as soon as the condition is satisfied.

This is the same lesson already recorded in `docs/ci-known-failing-tests.md` for the CLI TUI suites — a fixed sleep is a race a fast machine happens to win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpUS8iDyPjqfKsch8W2Yuv)_