### PR TITLE
test(api): pin sharp module resolution so one jest.mock covers both call sites

### DIFF
--- a/apps/api/test/jest.config.js
+++ b/apps/api/test/jest.config.js
@@ -38,6 +38,18 @@ module.exports = {
     // make a real network call. Force every 'openai' import to the single
     // copy this app resolves so one mock covers both call sites.
     '^openai$': require.resolve('openai'),
+    // Same nesting problem, same fix, different package: the root
+    // package.json pins `overrides.sharp` (exact, for server/worker compute
+    // parity) while apps/api, apps/cli and packages/enrichment-compute each
+    // declare their own sharp spec. npm resolves that by giving each
+    // workspace its OWN nested copy instead of one hoisted one, so
+    // jest.mock('sharp') in a spec only mocked the copy apps/api resolves —
+    // the shared package's dhash compute (`await import('sharp')` inside
+    // packages/enrichment-compute) picked up its own nested copy, ran REAL
+    // sharp against a fake test buffer, threw "unsupported image format",
+    // and computeVisualHash swallowed it into null. Pin every 'sharp'
+    // specifier to one copy so a single mock covers both call sites.
+    '^sharp$': require.resolve('sharp'),
   },
   setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   globalTeardown: '<rootDir>/test/teardown.ts',


### PR DESCRIPTION
## Summary

`apps/api` specs mock sharp with a bare `jest.mock('sharp')`, which only mocks the copy **`apps/api` itself resolves**. The dHash/sharpness compute lives in `@memoriahub/enrichment-compute` and does its own `await import('sharp')` — so the moment npm gives that package a nested `node_modules/sharp`, the shared package resolves an unmocked, **real** sharp, runs it against a fake test buffer, throws `Input buffer contains unsupported image format`, and `computeVisualHash` swallows it into `null`.

main currently hoists a single `node_modules/sharp`, so the mock happens to work. That's luck, not design — it flips whenever the dependency tree changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #212
Unblocks #177 (the dependabot npm-minor group, whose `Build & Test` failure this explains)

## Changes Made

- Add `'^sharp$': require.resolve('sharp')` to `moduleNameMapper` in `apps/api/test/jest.config.js`, pinning every `sharp` specifier to one resolved path so a single mock is authoritative for both call sites.
- Comment the reasoning inline, mirroring the existing `openai` entry directly above it — that one exists for exactly this reason (enrichment-compute exact-pins `openai`, npm nests a second copy, and without the mapping a spec's `jest.mock('openai')` would let the shared package make a **real network call**). sharp is the same trap with a quieter failure mode.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

Verified against **both** tree layouts:

| Layout | Before | After |
|---|---|---|
| main (single hoisted `node_modules/sharp`) | 225/225 suites, 5489/5489 | 225/225 suites, 5489/5489 — no-op |
| #177 (nested per-workspace sharp) | **7 suites / 61 tests failing** | 225/225 suites, 5489/5489 |

So it fixes the nested case without perturbing the hoisted one.

### Test Instructions

1. `npm ci && npm run build --workspace=@memoriahub/enrichment-compute && npx prisma generate` (in `apps/api`)
2. `npm run test:ci --workspace=api` → 225 suites pass.
3. To see the bug it prevents, check out #177's lockfile so npm nests sharp per-workspace, then run step 2 without this change: `visual-hash.util.spec.ts` and 6 sibling suites fail with `Received: null`.

## Additional Notes

Worth landing independently of #177. The failure mode is the dangerous part: it surfaces as a `null` from `computeVisualHash`, which reads as a compute/decode bug rather than a module-resolution artifact, so it costs real time to diagnose. Any future lockfile churn can spring it again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpUS8iDyPjqfKsch8W2Yuv)_