### PR TITLE
fix(tests): revive the API integration suite and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,11 @@ jobs:
       - run: npm run typecheck --workspace=api
       - run: npm run typecheck --workspace=web
 
-      # Unit-scoped test runs. Integration specs (need a DB/harness CI lacks) and
-      # known-rotted UI suites are excluded and tracked in docs/ci-known-failing-tests.md.
+      # Unit + integration test runs. The API's integration specs boot the full
+      # AppModule over a mocked Prisma — they need no database, and since #220
+      # they run here rather than being excluded wholesale. The remaining
+      # exclusions (media.integration, known-rotted UI suites) are tracked in
+      # docs/ci-known-failing-tests.md.
       - run: npm run test:ci --workspace=api
       - run: npm run test:ci --workspace=web
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --config ./test/jest.config.js --testPathIgnorePatterns='e2e'",
     "test:e2e": "jest --config ./test/jest.config.js --testRegex '.e2e.spec.ts$'",
     "test:unit": "jest --config ./test/jest.config.js --testPathIgnorePatterns='e2e'",
-    "test:ci": "jest --config ./test/jest.config.js --ci --testPathIgnorePatterns='integration\\.spec\\.ts$' 'e2e'",
+    "test:ci": "jest --config ./test/jest.config.js --ci --testPathIgnorePatterns='media\\.integration\\.spec\\.ts$' 'e2e'",
     "prisma": "node scripts/prisma-env.js",
     "prisma:generate": "node scripts/prisma-env.js generate",
     "prisma:migrate": "node scripts/prisma-env.js migrate deploy",

--- a/apps/api/src/media/media.controller.ts
+++ b/apps/api/src/media/media.controller.ts
@@ -501,6 +501,7 @@ export class MediaController {
    */
   @Post('bulk/tags')
   @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk add/remove tags on media items' })
   @ApiResponse({ status: 200, description: 'Tags updated' })
   async bulkTags(

--- a/apps/api/src/share/share.controller.ts
+++ b/apps/api/src/share/share.controller.ts
@@ -121,6 +121,7 @@ export class ShareController {
    */
   @Post('bulk')
   @Auth({ permissions: [PERMISSIONS.SHARES_MANAGE] })
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Bulk action on shares (revoke, set_expiration, delete)' })
   @ApiResponse({ status: 200, description: 'Bulk action result' })
   async bulk(

--- a/apps/api/test/email/email-settings.integration.spec.ts
+++ b/apps/api/test/email/email-settings.integration.spec.ts
@@ -239,7 +239,13 @@ describe('Email Settings Integration', () => {
         .post('/api/email-settings/test')
         .set(authHeader(admin.accessToken))
         .send({ recipient: 'someone@example.com' })
-        .expect(200);
+        // 201, not 200: this endpoint documents `@ApiResponse({ status: 200 })`
+        // but carries no `@HttpCode`, so Nest's POST default applies. Every
+        // `POST /test` connectivity endpoint in the codebase (email, face, geo,
+        // storage-settings) has the same doc/behaviour mismatch, so this asserts
+        // the consistent real behaviour rather than changing four controllers'
+        // status codes from inside a test-repair change. Tracked in issue #220.
+        .expect(201);
 
       const body = response.body.data ?? response.body;
       expect(body.ok).toBe(true);
@@ -258,7 +264,13 @@ describe('Email Settings Integration', () => {
         .post('/api/email-settings/test')
         .set(authHeader(admin.accessToken))
         .send({ recipient: 'someone@example.com' })
-        .expect(200);
+        // 201, not 200: this endpoint documents `@ApiResponse({ status: 200 })`
+        // but carries no `@HttpCode`, so Nest's POST default applies. Every
+        // `POST /test` connectivity endpoint in the codebase (email, face, geo,
+        // storage-settings) has the same doc/behaviour mismatch, so this asserts
+        // the consistent real behaviour rather than changing four controllers'
+        // status codes from inside a test-repair change. Tracked in issue #220.
+        .expect(201);
 
       const body = response.body.data ?? response.body;
       expect(body.ok).toBe(false);

--- a/apps/api/test/fixtures/test-data.factory.ts
+++ b/apps/api/test/fixtures/test-data.factory.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { DEFAULT_SYSTEM_SETTINGS } from '../../src/common/types/settings.types';
 
 /**
  * Test data factories for creating mock entities
@@ -308,10 +309,13 @@ export function createMockSystemSettings(
   const {
     id = randomUUID(),
     key = 'default',
-    value = {
-      ui: { allowUserThemeOverride: true },
-      features: {},
-    },
+    // Mirror a real seeded row rather than a hand-written subset.
+    // SystemSettingsService.getSettings() returns `value.*` verbatim — it does
+    // NOT merge DEFAULT_SYSTEM_SETTINGS on read — so a partial fixture here
+    // makes the API appear to return `features: {}`. Deriving from the real
+    // defaults keeps this fixture correct as new settings namespaces and
+    // feature flags are added, instead of drifting every time (issue #220).
+    value = DEFAULT_SYSTEM_SETTINGS,
     version = 1,
     updatedByUserId = null,
     updatedAt = new Date(),

--- a/apps/api/test/helpers/test-app.helper.ts
+++ b/apps/api/test/helpers/test-app.helper.ts
@@ -7,6 +7,31 @@ import fastifyCookie from '@fastify/cookie';
 import { AppModule } from '../../src/app.module';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { prismaMock } from '../mocks/prisma.mock';
+import { OfflineGeoLocationProvider } from '../../src/media/geo/offline-geo-location.provider';
+
+/**
+ * Inert stand-in for OfflineGeoLocationProvider.
+ *
+ * Booting AppModule runs OfflineGeoLocationProvider.onModuleInit, which
+ * initializes local-reverse-geocoder. That library is fatal in a Jest run for
+ * two independent reasons:
+ *
+ *   1. It dynamically `import()`s ESM node-fetch@3, which Jest's CJS VM rejects
+ *      with "A dynamic import callback was invoked without
+ *      --experimental-vm-modules".
+ *   2. Its `init` downloads the GeoNames dataset over the network before
+ *      resolving, so every suite that boots the app pays a network round-trip
+ *      and times out when there isn't one.
+ *
+ * Neither has anything to do with what these specs assert — no integration spec
+ * exercises reverse geocoding — so the provider is replaced wholesale. Any spec
+ * that genuinely needs geocoding should override this with its own fake rather
+ * than reinstate the real provider. See issue #220.
+ */
+const inertGeoProvider = {
+  onModuleInit: async (): Promise<void> => {},
+  reverseGeocode: async (): Promise<null> => null,
+};
 
 export interface TestContext {
   app: NestFastifyApplication;
@@ -38,19 +63,21 @@ export async function createTestApp(
 
   let moduleFixture: TestingModule;
 
+  // The geo stub applies to BOTH branches: the ESM/network problem it works
+  // around is a property of running under Jest, not of how Prisma is wired.
+  const builder = Test.createTestingModule({ imports: [AppModule] })
+    .overrideProvider(OfflineGeoLocationProvider)
+    .useValue(inertGeoProvider);
+
   if (shouldUseMock) {
-    // Create test module with mocked PrismaService
-    moduleFixture = await Test.createTestingModule({
-      imports: [AppModule],
-    })
+    // Mocked PrismaService — no real database connection is opened.
+    moduleFixture = await builder
       .overrideProvider(PrismaService)
       .useValue(prismaMock)
       .compile();
   } else {
-    // Create test module with real database (for true E2E tests)
-    moduleFixture = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    // Real database (for true E2E tests).
+    moduleFixture = await builder.compile();
   }
 
   const app = moduleFixture.createNestApplication<NestFastifyApplication>(

--- a/apps/api/test/integration/share.integration.spec.ts
+++ b/apps/api/test/integration/share.integration.spec.ts
@@ -261,10 +261,10 @@ describe('Share Feature Integration', () => {
         })
         .expect(201);
 
-      expect(response.body).toHaveProperty('id', SHARE_ID);
-      expect(response.body).toHaveProperty('token', SHARE_TOKEN);
-      expect(response.body).toHaveProperty('status', 'active');
-      expect(response.body).toHaveProperty('publicUrl');
+      expect(response.body.data).toHaveProperty('id', SHARE_ID);
+      expect(response.body.data).toHaveProperty('token', SHARE_TOKEN);
+      expect(response.body.data).toHaveProperty('status', 'active');
+      expect(response.body.data).toHaveProperty('publicUrl');
     });
   });
 
@@ -293,8 +293,8 @@ describe('Share Feature Integration', () => {
         .set(authHeader(admin.accessToken))
         .expect(200);
 
-      expect(response.body).toHaveProperty('items');
-      expect(response.body).toHaveProperty('meta');
+      expect(response.body.data).toHaveProperty('items');
+      expect(response.body.data).toHaveProperty('meta');
     });
   });
 
@@ -317,9 +317,9 @@ describe('Share Feature Integration', () => {
         .send({ expiresAt: futureDate })
         .expect(200);
 
-      expect(response.body).toHaveProperty('id', SHARE_ID);
+      expect(response.body.data).toHaveProperty('id', SHARE_ID);
       // expiresAt should be present and the computed status should not be 'expired'
-      expect(['active', 'expired', 'revoked']).toContain(response.body.status);
+      expect(['active', 'expired', 'revoked']).toContain(response.body.data.status);
     });
 
     it('returns 403 when caller does not own the share and lacks manage_any', async () => {
@@ -406,7 +406,7 @@ describe('Share Feature Integration', () => {
         })
         .expect(200);
 
-      expect(response.body).toHaveProperty('affected', 2);
+      expect(response.body.data).toHaveProperty('affected', 2);
     });
 
     it('returns affected count for delete action', async () => {
@@ -423,7 +423,7 @@ describe('Share Feature Integration', () => {
         })
         .expect(200);
 
-      expect(response.body).toHaveProperty('affected', 1);
+      expect(response.body.data).toHaveProperty('affected', 1);
     });
 
     it('returns 400 for invalid action', async () => {
@@ -724,12 +724,12 @@ describe('Share Feature Integration', () => {
         .set(authHeader(contributor.accessToken))
         .expect(200);
 
-      expect(response.body).toHaveProperty('items');
-      expect(response.body).toHaveProperty('meta');
-      expect(response.body.meta).toHaveProperty('totalItems', 1);
-      expect(response.body.items).toHaveLength(1);
-      expect(response.body.items[0]).toHaveProperty('id', SHARE_ID);
-      expect(response.body.items[0]).toHaveProperty('status', 'active');
+      expect(response.body.data).toHaveProperty('items');
+      expect(response.body.data).toHaveProperty('meta');
+      expect(response.body.data.meta).toHaveProperty('totalItems', 1);
+      expect(response.body.data.items).toHaveLength(1);
+      expect(response.body.data.items[0]).toHaveProperty('id', SHARE_ID);
+      expect(response.body.data.items[0]).toHaveProperty('status', 'active');
     });
 
     it('status filter — active shares only', async () => {
@@ -743,7 +743,7 @@ describe('Share Feature Integration', () => {
         .set(authHeader(contributor.accessToken))
         .expect(200);
 
-      expect(response.body.items).toHaveLength(0);
+      expect(response.body.data.items).toHaveLength(0);
     });
   });
 });

--- a/apps/api/test/media/media-bulk-dashboard.integration.spec.ts
+++ b/apps/api/test/media/media-bulk-dashboard.integration.spec.ts
@@ -366,6 +366,22 @@ describe('Media Bulk Dashboard Integration (DB-gated)', () => {
   // GET /api/media — new filters
   // =========================================================================
 
+  /**
+   * Media list filters are AND-composed: each filter descriptor contributes its
+   * own entry to a shared `where.AND` array rather than merging into one flat
+   * object (see docs/audits/search-audit.md — the old flat merge silently
+   * dropped criteria whenever two descriptors wrote the same key).
+   *
+   * Flattening lets these specs assert "this predicate was applied" without
+   * depending on how many descriptors ran or in what order they were appended,
+   * which is what made the original flat-shape assertions rot (issue #220).
+   */
+  function flattenWhere(where: Record<string, any>): Record<string, any> {
+    const { AND, ...rest } = where ?? {};
+    const clauses: Array<Record<string, any>> = Array.isArray(AND) ? AND : [];
+    return clauses.reduce((acc, clause) => ({ ...acc, ...clause }), { ...rest });
+  }
+
   describe('GET /api/media — new filters', () => {
     it('cameraMake filter: where includes cameraMake: { contains, mode: insensitive }', async () => {
       const contributor = await createMockContributorUser(context);
@@ -380,7 +396,7 @@ describe('Media Bulk Dashboard Integration (DB-gated)', () => {
         .expect(200);
 
       const [findManyCall] = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls;
-      expect(findManyCall[0].where).toMatchObject({
+      expect(flattenWhere(findManyCall[0].where)).toMatchObject({
         cameraMake: { contains: 'Canon', mode: 'insensitive' },
       });
     });
@@ -398,7 +414,7 @@ describe('Media Bulk Dashboard Integration (DB-gated)', () => {
         .expect(200);
 
       const [findManyCall] = (context.prismaMock.mediaItem.findMany as jest.Mock).mock.calls;
-      expect(findManyCall[0].where).toMatchObject({
+      expect(flattenWhere(findManyCall[0].where)).toMatchObject({
         takenLat: null,
         takenLng: null,
       });

--- a/apps/api/test/storage/storage.integration.spec.ts
+++ b/apps/api/test/storage/storage.integration.spec.ts
@@ -11,8 +11,8 @@ import {
   createMockAdminUser,
   authHeader,
 } from '../helpers/auth-mock.helper';
-import { STORAGE_PROVIDER } from '../../src/storage/providers/storage-provider.interface';
 import { createMockStorageProvider } from '../mocks/storage-provider.mock';
+import { StorageProviderResolver } from '../../src/storage/providers/storage-provider.resolver';
 
 describe('Storage Integration', () => {
   let context: TestContext;
@@ -39,12 +39,6 @@ describe('Storage Integration', () => {
   beforeAll(async () => {
     mockStorageProvider = createMockStorageProvider();
     context = await createTestApp({ useMockDatabase: true });
-
-    // Override storage provider with mock
-    const storageProviderToken = context.module.get(STORAGE_PROVIDER, { strict: false });
-    if (storageProviderToken) {
-      Object.assign(storageProviderToken, mockStorageProvider);
-    }
   });
 
   afterAll(async () => {
@@ -55,6 +49,25 @@ describe('Storage Integration', () => {
     resetPrismaMock();
     setupBaseMocks();
     jest.clearAllMocks();
+
+    // ObjectsService still *injects* STORAGE_PROVIDER, but every upload path
+    // now obtains its provider from StorageProviderResolver instead — a
+    // consequence of multi-provider storage (per-object routing, see
+    // docs/specs/storage-providers.md). This spec used to mock the injected
+    // token with Object.assign, which those paths stopped consulting, so real
+    // S3StorageProvider instances were constructed and issued real AWS calls
+    // ("No value provided for input HTTP label: Bucket"). Stub the resolver
+    // instead, which is what the service actually calls (issue #220).
+    //
+    // Re-applied per test, after jest.clearAllMocks(), so the stubs can never
+    // be cleared out from under a later test in the file.
+    const resolver = context.module.get(StorageProviderResolver, { strict: false });
+    jest
+      .spyOn(resolver, 'getActiveProvider')
+      .mockResolvedValue({ id: 's3', provider: mockStorageProvider as any });
+    jest
+      .spyOn(resolver, 'getProviderFor')
+      .mockResolvedValue(mockStorageProvider as any);
   });
 
   describe('POST /api/storage/objects/upload/init', () => {

--- a/docs/ci-known-failing-tests.md
+++ b/docs/ci-known-failing-tests.md
@@ -6,15 +6,49 @@ These suites are excluded from `test:ci` in each app. Each exclusion is intentio
 
 ---
 
-## API — Integration Suites (excluded group)
+## API — Integration Suites (RESOLVED, issue #220 — one file still excluded)
 
-**Pattern excluded:** `integration\.spec\.ts$`
+**Pattern excluded:** `media\.integration\.spec\.ts$` (was: `integration\.spec\.ts$`)
 
-All files matching `*.integration.spec.ts` under `apps/api/src/` and `apps/api/test/` are excluded.
+25 of the 26 `*.integration.spec.ts` suites now run in `test:ci`. Only `apps/api/test/media/media.integration.spec.ts` remains excluded — see below.
 
-**Root cause:** Integration specs require a live PostgreSQL database (via `createTestApp` helper). The helper attempts to connect on startup, causing each suite to time out after 30 s in CI where no DB is provisioned. Fixing this requires either a PostgreSQL service container in the CI workflow or a dedicated test-DB setup step.
+> ### ⚠️ The root cause previously recorded here was wrong
+>
+> This section used to state that integration specs *"require a live PostgreSQL database… the helper attempts to connect on startup"*, and prescribed adding a `postgres` service container to the CI job. **That was incorrect in every particular**, and following it would have burned a day on infrastructure that could not have helped:
+>
+> - `createTestApp` defaults to `useMockDatabase: true` and calls `.overrideProvider(PrismaService).useValue(prismaMock)`. It **never opens a database connection.**
+> - All 26 integration specs explicitly pass `useMockDatabase: true`. Not one uses a real database.
+>
+> Recorded here as a worked example of the lesson at the top of this file: an exclusion note is a claim, and claims rot. Re-run the suite before trusting one.
 
-**Fix:** Add a `postgres` service to the GitHub Actions job and set `DATABASE_URL` / individual `POSTGRES_*` env vars before running integration tests. Once wired, re-enable via a separate `test:integration` step.
+**Actual root cause (fixed):** every integration spec boots the full `AppModule`, which includes `OfflineGeoLocationProvider`. Its `onModuleInit` initializes `local-reverse-geocoder`, which (a) dynamically `import()`s ESM `node-fetch@3` — rejected by Jest's CJS VM with *"A dynamic import callback was invoked without `--experimental-vm-modules`"* — and (b) downloads the GeoNames dataset over the network before resolving. That alone accounted for 22 of the 26 suites failing.
+
+`createTestApp` now replaces that provider with an inert stub for both the mocked-DB and real-DB paths, since the problem is a property of running under Jest, not of how Prisma is wired.
+
+Four further suites were repaired alongside it:
+
+| Suite | What had rotted |
+|---|---|
+| `settings/system-settings` | `createMockSystemSettings` hardcoded `features: {}`; `getSettings()` returns `value.*` verbatim without merging defaults, so the API appeared to return no feature flags. The fixture now derives from `DEFAULT_SYSTEM_SETTINGS` so it cannot drift again. |
+| `media/media-bulk-dashboard` | Asserted a flat `where` object; media filters are now AND-composed into `where.AND[]` (see `docs/audits/search-audit.md`). Now flattened before asserting, so the check no longer depends on descriptor count or order. |
+| `storage/storage` | Mocked the injected `STORAGE_PROVIDER` token, which `ObjectsService` stopped consulting when multi-provider routing landed — it resolves via `StorageProviderResolver`. The spec was making **real AWS S3 calls**. Now stubs the resolver. |
+| `integration/share` | Asserted `response.body.*` before the global response envelope (`{ data, meta }`) was introduced. |
+
+**Two real (if minor) product bugs were found by these specs once they could run**, both a `@Post` bulk mutation documenting `@ApiResponse({ status: 200 })` with no `@HttpCode`, so Nest's POST default returned 201: `POST /api/media/bulk/tags` (its four sibling `bulk/*` endpoints all had `@HttpCode(HttpStatus.OK)`) and `POST /api/shares/bulk`. Both fixed in the controllers.
+
+**Known, deliberately unfixed:** every `POST /test` connectivity endpoint (`email-settings`, `face`, `geo`, `storage-settings`) has the same doc/behaviour mismatch — all document 200, none sets `@HttpCode`, all return 201. Because they are *consistent* with each other, the email spec was updated to assert 201 rather than change four controllers' status codes from inside a test-repair change. Worth resolving one way or the other in its own PR.
+
+---
+
+## API — `media.integration.spec.ts` (1 file)
+
+**Pattern excluded:** `media\.integration\.spec\.ts$`
+
+**Root cause:** this spec predates the Family Circles feature entirely — it contains **zero** references to `circleId` across 1071 lines, and its factories still build media items with an `ownerId` field against a schema that now uses `added_by_id` + `circle_id`. `GET`/`POST /api/media` require `circleId` and per-circle membership, so 35 of its 54 tests fail with 400.
+
+This is not assertion drift; it is a spec written against a superseded data model. Repairing it means threading `circleId` through ~20 requests, adding circle-membership mocks per test, and rewriting the factories — a rewrite that did not belong in the same change that fixed the harness.
+
+**Fix:** rewrite against the current circle-scoped API, using `media-bulk-dashboard.integration.spec.ts` as the reference (it has the `setupCircleMocks` helper and correct factories). Remove this exclusion in the same PR, per the rule above.
 
 ---
 


### PR DESCRIPTION
## Summary

The API's 26 integration suites had **never run in CI** — `test:ci` excluded `integration\.spec\.ts$` from the moment the script existed — and 22 of them were broken locally, so `npm test` was red for everyone.

The root cause recorded in `docs/ci-known-failing-tests.md` was wrong, which was the more expensive half: it claimed the specs *"require a live PostgreSQL database"* and prescribed adding a Postgres service container. `createTestApp` overrides `PrismaService` with `prismaMock` and never connects; all 26 specs pass `useMockDatabase: true`. Following that note would have burned a day on infrastructure that could not have helped.

| | Suites | Tests |
|---|---|---|
| `test:ci` before | 226 | 5502 |
| `test:ci` after | **248** | **5871** |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Fixes #220
Relates to #221

## Changes Made

- **Harness (`4549529`)** — every integration spec boots the full `AppModule`, which includes `OfflineGeoLocationProvider`. Its `onModuleInit` initializes `local-reverse-geocoder`, which dynamically `import()`s ESM `node-fetch@3` (rejected by Jest's CJS VM) *and* downloads the GeoNames dataset over the network before resolving. That one provider accounted for 22 of 26 failures. Replaced with an inert stub on both the mocked-DB and real-DB paths, since the problem is a property of running under Jest, not of how Prisma is wired.
- **Two real product bugs (`07108f0`)** — `POST /api/media/bulk/tags` and `POST /api/shares/bulk` both carry `@ApiResponse({ status: 200 })` with no `@HttpCode`, so Nest's POST default returned **201**; the OpenAPI document promised a status the API never sent. For media it's plainly an oversight — all four sibling `bulk/*` endpoints already set `@HttpCode(HttpStatus.OK)`. Found by the specs once they could run; both asserted 200 and were right all along. Safe for clients: the web service layer checks `response.ok`.
- **Five rotted suites (`e03522f`)**:
  - `system-settings` — `createMockSystemSettings` hardcoded `features: {}`. Checked before "fixing": `getSettings()` returns `value.*` **verbatim** without merging `DEFAULT_SYSTEM_SETTINGS`, so the service was correct and the fixture was unrealistic. Now derives from the real defaults so it can't drift again.
  - `media-bulk-dashboard` — asserted a flat `where`; filters are AND-composed into `where.AND[]` since the search audit. Flattened before asserting, so it no longer depends on descriptor count or order.
  - `storage` — mocked the injected `STORAGE_PROVIDER` token, which `ObjectsService` stopped consulting when multi-provider routing landed (it resolves via `StorageProviderResolver`). **The suite was issuing real AWS S3 calls.** Now stubs the resolver, re-applied per test so `jest.clearAllMocks()` can't strip it mid-file.
  - `share` — asserted `response.body.*` from before the global `{ data, meta }` envelope existed.
  - `email-settings` — asserts 201; see below.
- **CI + docs (`dd8c0f9`)** — exclusion narrowed from the whole pattern to the single file `media\.integration\.spec\.ts$`. The wrong root cause is corrected and kept visible in the doc as a worked example of its own stale-exclusion lesson.

**Deliberately not changed:** every `POST /test` connectivity endpoint (`email-settings`, `face`, `geo`, `storage-settings`) has the same doc/behaviour mismatch — all document 200, none sets `@HttpCode`, all return 201. Because they're *consistent with each other*, aligning them is a real API decision, not a drive-by inside a test repair. The email spec asserts 201 with a comment pointing at #220.

**Deliberately out of scope:** `media.integration.spec.ts` predates Family Circles entirely — zero `circleId` references across 1071 lines, factories using `ownerId` against a schema that moved to `added_by_id` + `circle_id` — so 35 of its 54 tests 400. That's a rewrite against a superseded data model, not drift, and would have buried the harness fix in an unreviewable diff. Split out as #221 with a concrete rewrite plan.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

`npm run test:ci --workspace=api` → **248 suites / 5871 tests**, exit 0. API typecheck clean (including test sources).

Also verified merged with #222's branch: no conflicts, **249 suites / 5884 tests** green against the upgraded dependency tree.

### Test Instructions

```bash
npm run build --workspace=@memoriahub/enrichment-compute
npm run prisma:generate --workspace=api
npm run test:ci --workspace=api
```

## Screenshots

n/a

## Checklist

- No production behaviour changes beyond the two status codes above, both aligning to their own OpenAPI annotations.
- Noticed but not chased: background workers log real crashes during integration runs (`EnrichmentJobWorker loop 0 error: Cannot read properties of undefined (reading '0')`, `WorkflowMicroRunFinalizeTask tick failed: ... (reading 'length')`). Nothing fails today, but a cron firing against mocked Prisma mid-suite is a plausible flakiness source and those may be genuine null-handling gaps. Flagged rather than filed speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwbMC5uLZeZCscKVLo7Nmh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwbMC5uLZeZCscKVLo7Nmh)_