### PR TITLE
fix(web): clear the upload queue whenever the upload dialog opens

### DIFF
--- a/apps/web/src/__tests__/components/media/MediaUploadDialog.test.tsx
+++ b/apps/web/src/__tests__/components/media/MediaUploadDialog.test.tsx
@@ -716,4 +716,112 @@ describe('MediaUploadDialog', () => {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Reopen reset (issue #241)
+  //
+  // The dialog is permanently mounted in AppBar and only toggled via `open`,
+  // so its fileStates survive between runs unless explicitly reset on the
+  // next false -> true transition.
+  // -------------------------------------------------------------------------
+
+  describe('reopen reset (issue #241)', () => {
+    it('should call onSuccess and request close once every file succeeds', async () => {
+      const onSuccess = vi.fn();
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <MediaUploadDialog {...defaultProps} onSuccess={onSuccess} onClose={onClose} />,
+      );
+      const input = getFileInput();
+      fireEvent.change(input, { target: { files: [makeImageFile('done.jpg')] } });
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /upload \d+ file/i })).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole('button', { name: /upload \d+ file/i }));
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+      // The success path routes through handleClose, so the parent is asked
+      // to close the dialog exactly like the Cancel/X paths do.
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not show a leftover completed file when the dialog is reopened', async () => {
+      // NOTE: a run where every file ends success/duplicate makes handleUploadAll
+      // call handleClose() (-> resetQueue()) synchronously, so a fully-successful
+      // run's file list never actually persists in the DOM even without a
+      // reopen. To exercise the reopen-reset mechanism itself (rather than that
+      // auto-close side effect), use a mixed run: one file succeeds, one fails,
+      // so `allTerminal` is false, the run does NOT auto-close, and the
+      // succeeded file's list entry stays on screen — exactly the shape of
+      // leftover state issue #241 was about.
+      // uploadFileWithRetry retries a failed part up to MAX_RETRIES (3) times
+      // internally, so bad.jpg's part must reject on every attempt — not just
+      // once — or the internal retry silently recovers it into 'success' too.
+      mockUploadPart
+        .mockResolvedValueOnce('"etag-001"')
+        .mockRejectedValue(new Error('network drop'));
+
+      const user = userEvent.setup();
+      const { rerender } = render(<MediaUploadDialog {...defaultProps} />);
+      const input = getFileInput();
+      fireEvent.change(input, {
+        target: { files: [makeImageFile('ok.jpg'), makeImageFile('bad.jpg')] },
+      });
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /upload 2 file/i })).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole('button', { name: /upload 2 file/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /retry uploading bad.jpg/i }),
+        ).toBeInTheDocument();
+      });
+      // ok.jpg reached the success state and is still visible because the run
+      // as a whole didn't fully terminate (bad.jpg errored, so no auto-close).
+      expect(screen.getByText('ok.jpg')).toBeInTheDocument();
+      expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument();
+
+      // Parent closes then reopens the (permanently mounted) dialog.
+      rerender(<MediaUploadDialog {...defaultProps} open={false} />);
+      rerender(<MediaUploadDialog {...defaultProps} open={true} />);
+
+      expect(screen.queryByText('ok.jpg')).not.toBeInTheDocument();
+      expect(screen.queryByText('bad.jpg')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('CheckCircleIcon')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /retry uploading bad.jpg/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show a leftover errored file when the dialog is reopened', async () => {
+      mockUploadPart.mockRejectedValue(new Error('boom'));
+      const user = userEvent.setup();
+      const { rerender } = render(<MediaUploadDialog {...defaultProps} />);
+      const input = getFileInput();
+      fireEvent.change(input, { target: { files: [makeImageFile('failed.jpg')] } });
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /upload \d+ file/i })).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole('button', { name: /upload \d+ file/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /retry uploading failed.jpg/i }),
+        ).toBeInTheDocument();
+      });
+
+      rerender(<MediaUploadDialog {...defaultProps} open={false} />);
+      rerender(<MediaUploadDialog {...defaultProps} open={true} />);
+
+      expect(screen.queryByText('failed.jpg')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /retry uploading failed.jpg/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/components/media/MediaUploadDialog.tsx
+++ b/apps/web/src/components/media/MediaUploadDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -167,6 +167,28 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
   const [fileStates, setFileStates] = useState<FileState[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  // Mirrors `isUploading` so the close guard never reads a stale closure when
+  // it is invoked programmatically at the end of a run.
+  const isUploadingRef = useRef(false);
+
+  const resetQueue = useCallback(() => {
+    isUploadingRef.current = false;
+    setIsUploading(false);
+    setFileStates([]);
+    setValidationError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, []);
+
+  // The dialog is permanently mounted (see AppBar) and only toggled via `open`,
+  // so its state survives between runs. Reset on every false -> true transition
+  // to make a clean queue an invariant of opening, however the last run ended.
+  useEffect(() => {
+    if (open) {
+      resetQueue();
+    }
+  }, [open, resetQueue]);
 
   const updateFileState = useCallback((index: number, patch: Partial<FileState>) => {
     setFileStates((prev) =>
@@ -212,11 +234,22 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
     [],
   );
 
+  const handleClose = useCallback(() => {
+    if (isUploadingRef.current) return;
+    resetQueue();
+    onClose();
+  }, [onClose, resetQueue]);
+
   const handleUploadAll = useCallback(async () => {
     const pending = fileStates.filter((fs) => fs.status === 'pending');
     if (pending.length === 0) return;
 
+    isUploadingRef.current = true;
     setIsUploading(true);
+
+    // Mirrors the terminal status of each file so the end-of-run check does not
+    // have to reach back into `fileStates` (which is stale inside this closure).
+    const finalStatuses: FileStatus[] = fileStates.map((fs) => fs.status);
 
     for (let i = 0; i < fileStates.length; i++) {
       if (fileStates[i].status !== 'pending') continue;
@@ -242,6 +275,7 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
           if (existing.items.length > 0) {
             // Already in the library — skip the upload entirely.
             updateFileState(i, { status: 'duplicate', progress: 100 });
+            finalStatuses[i] = 'duplicate';
             continue;
           }
         }
@@ -260,6 +294,7 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
         // Server dedup race: another session registered the same hash first.
         if (deduplicated) {
           updateFileState(i, { status: 'duplicate', progress: 100 });
+          finalStatuses[i] = 'duplicate';
         } else {
           // Capture an instant local preview from the uploaded bytes so the new
           // gallery tile renders immediately instead of a "Processing…" spinner
@@ -269,26 +304,29 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
             addPreview(mediaItemId, file);
           }
           updateFileState(i, { status: 'success', progress: 100 });
+          finalStatuses[i] = 'success';
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Upload failed';
         updateFileState(i, { status: 'error', error: message });
+        finalStatuses[i] = 'error';
       }
     }
 
+    isUploadingRef.current = false;
     setIsUploading(false);
 
-    // Notify parent if every file is either success or duplicate (no errors, no pending)
-    setFileStates((current) => {
-      const allTerminal = current.every(
-        (fs) => fs.status === 'success' || fs.status === 'duplicate',
-      );
-      if (allTerminal && current.length > 0) {
-        onSuccess();
-      }
-      return current;
-    });
-  }, [fileStates, onSuccess, updateFileState, addPreview]);
+    // Notify parent if every file is either success or duplicate (no errors, no pending),
+    // then close through handleClose so the success and cancel paths cannot diverge.
+    const allTerminal =
+      finalStatuses.length > 0 &&
+      finalStatuses.every((status) => status === 'success' || status === 'duplicate');
+
+    if (allTerminal) {
+      onSuccess();
+      handleClose();
+    }
+  }, [fileStates, onSuccess, updateFileState, addPreview, handleClose]);
 
   const handleRetry = useCallback(
     async (index: number) => {
@@ -300,13 +338,6 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
   const handleRemove = useCallback((index: number) => {
     setFileStates((prev) => prev.filter((_, i) => i !== index));
   }, []);
-
-  const handleClose = useCallback(() => {
-    if (isUploading) return;
-    setFileStates([]);
-    setValidationError(null);
-    onClose();
-  }, [isUploading, onClose]);
 
   // ---------------------------------------------------------------------------
   // Derived state

--- a/apps/web/src/components/media/MediaUploadDialog.tsx
+++ b/apps/web/src/components/media/MediaUploadDialog.tsx
@@ -182,8 +182,11 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
   }, []);
 
   // The dialog is permanently mounted (see AppBar) and only toggled via `open`,
-  // so its state survives between runs. Reset on every false -> true transition
-  // to make a clean queue an invariant of opening, however the last run ended.
+  // so its state survives between runs. This effect is the SINGLE owner of queue
+  // clearing: it resets on every false -> true transition, making a clean queue an
+  // invariant of opening however the last run ended. Closing intentionally leaves
+  // the queue intact so the last run's result stays rendered until the dialog is
+  // actually hidden (nothing is user-visible between close and the next open).
   useEffect(() => {
     if (open) {
       resetQueue();
@@ -234,11 +237,14 @@ export function MediaUploadDialog({ open, onClose, onSuccess, circleId }: MediaU
     [],
   );
 
+  // Deliberately does NOT reset the queue: clearing `fileStates` here would land in
+  // the same React commit as the final `updateFileState(..., 'success')` of a
+  // successful run, so the completion summary and Close button would never render.
+  // The reset-on-open effect above is the single owner of queue clearing.
   const handleClose = useCallback(() => {
     if (isUploadingRef.current) return;
-    resetQueue();
     onClose();
-  }, [onClose, resetQueue]);
+  }, [onClose]);
 
   const handleUploadAll = useCallback(async () => {
     const pending = fileStates.filter((fs) => fs.status === 'pending');


### PR DESCRIPTION
## Summary

`MediaUploadDialog` is permanently mounted in `AppBar` and only toggled via the `open` prop, so its `fileStates` were never discarded between runs. State was cleared only in `handleClose`, which the success path bypassed — `handleUploadAll` called `onSuccess()` and the parent closed the dialog directly — leaving the previous batch's completed files (green checks, 100% bars) visible the next time the dialog was opened.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #241
Relates to #234

## Changes Made

- Added a `useEffect` keyed on `open` that resets `fileStates`, `validationError`, `isUploading` and the file `<input>` value on every `false -> true` transition, making a clean queue an invariant of opening regardless of how the previous run ended. Files in `error` state are cleared too, per the issue's decision.
- Routed the success path through `handleClose` so the success and cancel paths cannot diverge again.
- Made the open-effect the single owner of queue clearing — `handleClose` deliberately does **not** reset. Clearing on close would batch `setFileStates([])` with the run's final `updateFileState(..., 'success')` in the same React commit, so the completion summary and Close button would never render. Nothing is user-visible between close and the next open, since the dialog stays mounted.
- Added an `isUploadingRef` mirror so the close guard cannot be blocked by a stale closure when close is invoked programmatically at end-of-run, and replaced the `onSuccess()`-inside-a-`setFileStates`-updater side effect with a local `finalStatuses` array.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)

`npx vitest run src/__tests__/components/media/MediaUploadDialog.test.tsx` → **35 passed / 35**, including three new `reopen reset (issue #241)` cases:

1. `onSuccess` fires once and the dialog requests close when every file succeeds.
2. A completed file is gone after toggling `open` false → true.
3. An errored file is gone after the same toggle.

`npx tsc --noEmit` in `apps/web` → clean.

### Test Instructions

1. Upload a batch of files and let every one complete successfully.
2. Reopen the upload dialog from the top bar.
3. The queue is empty — no leftover rows from the previous run.

## Additional Notes

This is child 1 of 7 in epic #234. Behaviour is pure state management, so it is platform-independent (phone, tablet and desktop alike).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_