### PR TITLE
fix(web): remove the invisible favorite hit-target from gallery tiles

### DIFF
--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -1,6 +1,9 @@
 /**
  * MediaGallery — canonical day-grouped infinite grid with multi-select,
- * lightbox, properties drawer, favorite toggle, and bulk actions.
+ * lightbox, properties drawer, and bulk actions.
+ *
+ * Tiles carry a static favorite badge only; favoriting is done through
+ * selection + BulkActionToolbar (or the lightbox), never from the tile itself.
  *
  * Two data-source modes:
  *   FEED mode   (queryParams provided): calls useInfiniteMedia internally,
@@ -21,7 +24,6 @@ import {
   IconButton,
   Tooltip,
   ImageListItem,
-  ImageListItemBar,
   CircularProgress,
   Stack,
   Snackbar,
@@ -33,7 +35,6 @@ import {
   BrokenImage as BrokenImageIcon,
   PlayCircleOutlined as PlayCircleOutlinedIcon,
   Star as StarIcon,
-  StarBorder as StarBorderIcon,
   BurstMode as BurstModeIcon,
   ContentCopy as ContentCopyIcon,
 } from '@mui/icons-material';
@@ -60,7 +61,7 @@ import { BulkDateDialog } from './BulkDateDialog';
 import { BulkTagsDialog } from './BulkTagsDialog';
 import { AddToAlbumDialog } from '../album/AddToAlbumDialog';
 import { TimelineScrubber } from './TimelineScrubber';
-import { patchMedia as patchMediaApi, removeAlbumItem } from '../../services/media';
+import { removeAlbumItem } from '../../services/media';
 import type { MediaItem, MediaQueryParams } from '../../types/media';
 import type { CircleRole } from '../../types/circles';
 
@@ -77,7 +78,6 @@ const APP_BAR_HEIGHT = 64;
 interface GalleryTileProps {
   item: MediaItem;
   onSelect: (item: MediaItem) => void;
-  onToggleFavorite: (item: MediaItem) => void;
   isSelected: boolean;
   anySelected: boolean;
   onToggleSelect: (id: string) => void;
@@ -95,7 +95,6 @@ interface GalleryTileProps {
 const GalleryTile = memo(function GalleryTile({
   item,
   onSelect,
-  onToggleFavorite,
   isSelected,
   anySelected,
   onToggleSelect,
@@ -104,6 +103,9 @@ const GalleryTile = memo(function GalleryTile({
 }: GalleryTileProps) {
   const theme = useTheme();
   const isMobileDevice = useMediaQuery(theme.breakpoints.down('sm'));
+  // Any pointer without hover (phones, tablets) never fires :hover, so
+  // hover-revealed controls must be shown outright there instead.
+  const isTouchDevice = useMediaQuery('(hover: none)');
   const [imgError, setImgError] = useState(false);
   const { getPreview } = useMediaPreview();
   const navigate = useNavigate();
@@ -116,6 +118,12 @@ const GalleryTile = memo(function GalleryTile({
       ? 'duplicate'
       : null;
   const showBadge = showOriginBadge && originType !== null;
+
+  // The selection checkbox is hover-revealed on pointers that have hover, and
+  // permanently visible everywhere else — a hover-only reveal would otherwise
+  // leave an invisible tap target on touch devices.
+  const checkboxAlwaysVisible =
+    isMobileDevice || isTouchDevice || selectionMode || anySelected || isSelected;
 
   // Instant local upload preview (object URL) shown while the server thumbnail
   // is still being generated. Only consulted when there is no server thumbnail
@@ -144,7 +152,6 @@ const GalleryTile = memo(function GalleryTile({
         opacity: isSelected ? 0.85 : 1,
         transition: 'outline 0.1s, opacity 0.1s',
         '&:hover .gallery-tile-overlay': { opacity: 1 },
-        '&:hover .gallery-tile-fav': { opacity: 1 },
       }}
     >
       {item.thumbnailUrl && !imgError ? (
@@ -246,9 +253,14 @@ const GalleryTile = memo(function GalleryTile({
           top: 4,
           left: 4,
           zIndex: 2,
-          opacity: isMobileDevice || selectionMode || anySelected || isSelected ? 1 : 0,
+          opacity: checkboxAlwaysVisible ? 1 : 0,
           transition: 'opacity 0.15s',
-          '.MuiImageListItem-root:hover &': { opacity: 1 },
+          // Reveal on hover only where hover genuinely exists (issue #243) —
+          // a bare :hover rule would leave this invisible yet tappable on any
+          // hover-less pointer; those get the always-visible branch above.
+          '@media (hover: hover)': {
+            '.MuiImageListItem-root:hover &': { opacity: 1 },
+          },
         }}
       >
         <MediaSelectionCheckbox
@@ -271,34 +283,28 @@ const GalleryTile = memo(function GalleryTile({
         }}
       />
 
-      {/* Favorite toggle */}
-      <ImageListItemBar
-        className="gallery-tile-fav"
-        sx={{
-          background: 'transparent',
-          opacity: item.favorite ? 1 : 0,
-          transition: 'opacity 0.2s',
-          '& .MuiImageListItemBar-titleWrap': { display: 'none' },
-          '.MuiImageListItem-root:hover &': { opacity: 1 },
-        }}
-        actionIcon={
-          <Tooltip title={item.favorite ? 'Remove from favorites' : 'Add to favorites'}>
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleFavorite(item);
-              }}
-              aria-label={item.favorite ? 'Remove from favorites' : 'Add to favorites'}
-              sx={{ color: item.favorite ? 'warning.main' : 'white', p: { xs: 1, sm: 0.5 } }}
-            >
-              {item.favorite ? <StarIcon /> : <StarBorderIcon />}
-            </IconButton>
-          </Tooltip>
-        }
-        position="top"
-        actionPosition="right"
-      />
+      {/* Favorite badge — static status indicator, NOT a control (issue #243).
+          A hover-revealed toggle here was invisible yet fully tappable on touch
+          devices, silently starring photos. Favoriting is done from selection +
+          BulkActionToolbar, or from the lightbox. */}
+      {item.favorite && (
+        <Box
+          role="img"
+          aria-label="Favorite"
+          sx={{
+            position: 'absolute',
+            top: 6,
+            right: 6,
+            zIndex: 2,
+            display: 'flex',
+            pointerEvents: 'none',
+            color: 'warning.main',
+            filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))',
+          }}
+        >
+          <StarIcon fontSize="small" />
+        </Box>
+      )}
 
       {/* Origin badge — Archive/Trash only; links to the resolved burst or
           duplicate review group this item's non-kept copy came from. */}
@@ -468,7 +474,7 @@ export function MediaGallery({
   const error: string | null = isFeedMode ? feedError : null;
 
   // -------------------------------------------------------------------------
-  // Optimistic patches for favorite toggles
+  // Optimistic patches (thumbnail reconcile, lightbox/drawer item updates)
   // -------------------------------------------------------------------------
 
   const [localPatches, setLocalPatches] = useState<Record<string, Partial<MediaItem>>>({});
@@ -544,25 +550,6 @@ export function MediaGallery({
     },
     [indexById],
   );
-
-  // -------------------------------------------------------------------------
-  // Favorite toggle (optimistic)
-  // -------------------------------------------------------------------------
-
-  const handleToggleFavorite = useCallback(async (item: MediaItem) => {
-    const next = !item.favorite;
-    setLocalPatches((prev) => ({ ...prev, [item.id]: { favorite: next } }));
-    try {
-      await patchMediaApi(item.id, { favorite: next });
-    } catch {
-      // Rollback
-      setLocalPatches((prev) => {
-        const copy = { ...prev };
-        delete copy[item.id];
-        return copy;
-      });
-    }
-  }, []);
 
   // -------------------------------------------------------------------------
   // Selection
@@ -882,7 +869,6 @@ export function MediaGallery({
                     key={item.id}
                     item={item}
                     onSelect={handleSelectTile}
-                    onToggleFavorite={handleToggleFavorite}
                     isSelected={selected.has(item.id)}
                     anySelected={selected.size > 0}
                     onToggleSelect={handleToggleSelect}

--- a/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
@@ -542,6 +542,63 @@ describe('MediaGallery', () => {
   });
 
   // -------------------------------------------------------------------------
+  // (e) Favorite badge is static — guards against reintroducing the
+  // hover-revealed favorite toggle removed by issue #243 (invisible yet
+  // fully tappable on touch devices, silently starring photos).
+  // -------------------------------------------------------------------------
+  describe('favorite badge (issue #243 regression guard)', () => {
+    it('shows a static favorite badge and no favorite toggle button for a favorited item', () => {
+      const items = [
+        makeItem('fav-1', { favorite: true, originalFilename: 'starred-photo.jpg' }),
+      ];
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      // Exact-match the accessible name — the tile's own alt text
+      // ("starred-photo.jpg") must never accidentally satisfy this query.
+      expect(screen.getByRole('img', { name: /^favorite$/i })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /add to favorites|remove from favorites/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows no favorite badge and no favorite toggle button for a non-favorited item', () => {
+      const items = [
+        makeItem('fav-2', { favorite: false, originalFilename: 'unstarred-photo.jpg' }),
+      ];
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      expect(screen.queryByRole('img', { name: /^favorite$/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /add to favorites|remove from favorites/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('clicking a non-favorited tile still opens the lightbox (click is not swallowed)', async () => {
+      const user = userEvent.setup();
+      const items = [
+        makeItem('fav-3', { favorite: false, originalFilename: 'clickable.jpg' }),
+      ];
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      const tile = screen.getByAltText('clickable.jpg');
+      await user.click(tile);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('media-lightbox')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // (d) Feed mode — infinite scroll
   // -------------------------------------------------------------------------
   describe('feed mode', () => {


### PR DESCRIPTION
## Summary

Every gallery tile carried a favorite (star) toggle inside a hover-revealed `ImageListItemBar` — `opacity: 0` with a bare `.MuiImageListItem-root:hover &` reveal, and `pointer-events` never disabled. `:hover` does not exist on touch devices, so on a phone the control was invisible but fully hit-testable, and its deliberately enlarged mobile padding (`p: { xs: 1, sm: 0.5 }`) made the invisible target *bigger* exactly where it could not be seen. Its `onClick` called `stopPropagation()`, so a tap near the top-right of a thumbnail silently starred the photo instead of opening it, with no feedback.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #243
Relates to #234

## Changes Made

- Deleted the `ImageListItemBar` favorite action and the `onToggleFavorite` prop from `GalleryTile`, along with the now-dead plumbing: the parent's optimistic `handleToggleFavorite`, the `patchMedia` import, the `ImageListItemBar`/`StarBorderIcon` imports, and the orphaned `.gallery-tile-fav` hover rule.
- Favorite status is still visible on the tile: the existing gradient overlay stays, plus a new **static, non-interactive** star badge (`pointerEvents: 'none'`, `role="img" aria-label="Favorite"`) rendered only when the item is favorited.
- Favoriting from the gallery now goes through selection + the existing star action in `BulkActionToolbar` (which already supports add and remove) or the lightbox toggle — both unchanged, no API work needed.
- **Second offender found during the opacity audit:** the selection checkbox had the same defect. It was `opacity: 0` with a bare `:hover` reveal, forced visible only when `theme.breakpoints.down('sm')` matched — so on a tablet or any hover-less pointer at ≥600 px it was invisible yet fully tappable. Its reveal is now scoped to `@media (hover: hover)`, and a new `useMediaQuery('(hover: none)')` check keeps it permanently visible on any hover-less pointer.

Audited the rest of the tile: the burst/duplicate origin badge is unconditionally visible, and the video play icon and favorite gradient overlay already carry `pointerEvents: 'none'`. No other offenders.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

- `npx vitest run src/__tests__/components/media/ src/components/media/__tests__/` → **26 files / 460 tests passing**. No existing test asserted the per-tile favorite button, so nothing had to be weakened or deleted; `BulkActionToolbar.test.tsx` already covers the add and remove favorite paths and passes unchanged.
- Added a 3-case regression guard in `MediaGallery.test.tsx` (file now 24/24): favorited tile renders the static badge and **no** favorite button; non-favorited tile renders neither; a tile click still opens the lightbox rather than being swallowed.
- `npx tsc --noEmit` → clean.

### Test Instructions

1. On a phone, tap a gallery tile near its top-right corner — it opens (or toggles selection) instead of starring the photo.
2. Favorite an item from the lightbox and return to the gallery — the star badge is visible on the tile, and tapping it does nothing.
3. On a tablet, long-press/select an item — the selection checkbox is visible without needing hover.

## Additional Notes

Child 2 of 7 in epic #234. Forward-looking note from the issue, now enforced in this file: a control hidden with `opacity: 0` must also set `pointerEvents: 'none'`, or gate its reveal on a real hover capability (`@media (hover: hover)`) — never on `:hover` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_