### PR TITLE
fix(web): pin the lightbox toolbar over video and close the viewer on Back

### DIFF
--- a/apps/web/src/components/media/MediaLightbox.tsx
+++ b/apps/web/src/components/media/MediaLightbox.tsx
@@ -107,6 +107,14 @@ export function MediaLightbox({
   const enhanceEnabled = Boolean(pictureEnhancement?.enabled);
 
   const item = index !== null ? items[index] ?? null : null;
+  const isOpen = index !== null;
+  /**
+   * Videos pin the control bar. The Vidstack player installs its own pointer /
+   * gesture handling and does not reliably propagate the events the auto-hide
+   * restore paths rely on, so once the bar hid over a video it was
+   * unrecoverable (issue #235).
+   */
+  const isVideo = item?.type === 'video';
 
   // Full item (with downloadUrl) fetched from API
   const [fullItem, setFullItem] = useState<MediaItem | null>(null);
@@ -137,6 +145,8 @@ export function MediaLightbox({
   } | null>(null);
 
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** True while this lightbox owns a pushed history entry. */
+  const historyPushedRef = useRef(false);
   const swipeRef = useRef<{
     startX: number;
     startY: number;
@@ -145,23 +155,74 @@ export function MediaLightbox({
     swiping: boolean;
   }>({ startX: 0, startY: 0, deltaX: 0, deltaY: 0, swiping: false });
 
-  // --- Mobile auto-hide controls ---
+  // --- Mobile auto-hide controls (photos only — videos keep the bar pinned) ---
   const resetHideTimer = useCallback(() => {
-    if (!isMobile) return;
+    if (!isMobile || isVideo) return;
     setControlsVisible(true);
     if (hideTimerRef.current !== null) clearTimeout(hideTimerRef.current);
     hideTimerRef.current = setTimeout(() => setControlsVisible(false), 3000);
-  }, [isMobile]);
+  }, [isMobile, isVideo]);
 
-  // Start auto-hide on mobile when lightbox opens
+  // Start auto-hide on mobile when the lightbox opens; on a video, cancel any
+  // pending hide and force the bar back on so navigating photo -> video always
+  // leaves the user a way out of the viewer.
   useEffect(() => {
-    if (isMobile && index !== null) {
-      resetHideTimer();
+    if (index !== null) {
+      if (isVideo) {
+        if (hideTimerRef.current !== null) {
+          clearTimeout(hideTimerRef.current);
+          hideTimerRef.current = null;
+        }
+        setControlsVisible(true);
+      } else if (isMobile) {
+        resetHideTimer();
+      }
     }
     return () => {
       if (hideTimerRef.current !== null) clearTimeout(hideTimerRef.current);
     };
-  }, [isMobile, index, resetHideTimer]);
+  }, [isMobile, isVideo, index, resetHideTimer]);
+
+  // --- Browser history integration ---
+  // The lightbox is component state rendered into a Modal, so without a history
+  // entry the browser Back button popped the underlying route and left the
+  // gallery entirely (issue #235). One entry is pushed per open; Back pops it
+  // and closes the viewer instead.
+  useEffect(() => {
+    if (!isOpen) {
+      historyPushedRef.current = false;
+      return;
+    }
+
+    // Guarded by a ref so React 18 StrictMode's double-invoked effect cannot
+    // push twice; keyed on open/closed only so item navigation never pushes.
+    if (!historyPushedRef.current) {
+      historyPushedRef.current = true;
+      window.history.pushState({ mhLightbox: true }, '');
+    }
+
+    const handlePopState = () => {
+      historyPushedRef.current = false;
+      onClose();
+    };
+    window.addEventListener('popstate', handlePopState);
+    // On unmount while open we only detach the listener — never history.back().
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [isOpen, onClose]);
+
+  /**
+   * Close path for every UI affordance (Close button, Escape, backdrop, delete).
+   * When our own history entry is on top, go back and let the popstate handler
+   * do the closing, so the stack stays balanced whichever way the user exits.
+   */
+  const requestClose = useCallback(() => {
+    const state = window.history.state as { mhLightbox?: boolean } | null;
+    if (state?.mhLightbox) {
+      window.history.back();
+      return;
+    }
+    onClose();
+  }, [onClose]);
 
   // --- Favorite toggle ---
   const handleToggleFavorite = useCallback(async () => {
@@ -247,7 +308,7 @@ export function MediaLightbox({
     setDeleteLoading(true);
     try {
       await bulkDelete({ circleId: item.circleId, ids: [item.id] });
-      onClose();
+      requestClose();
     } catch (err) {
       setSnack({
         message: err instanceof Error ? err.message : 'Failed to move item to Trash',
@@ -256,7 +317,7 @@ export function MediaLightbox({
     } finally {
       setDeleteLoading(false);
     }
-  }, [item, onClose]);
+  }, [item, requestClose]);
 
   // --- Overflow: refresh faces (async job — no polling) ---
   const handleRefreshFaces = useCallback(async () => {
@@ -333,13 +394,13 @@ export function MediaLightbox({
         setPlaying(false);
         onIndexChange(index + 1);
       } else if (e.key === 'Escape') {
-        onClose();
+        requestClose();
       }
     };
 
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [index, items.length, onIndexChange, onClose]);
+  }, [index, items.length, onIndexChange, requestClose]);
 
   // --- Swipe handlers ---
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
@@ -450,7 +511,7 @@ export function MediaLightbox({
           display: 'flex',
           flexDirection: 'column',
         }}
-        onClick={onClose}
+        onClick={requestClose}
         onPointerMove={isMobile ? resetHideTimer : undefined}
       >
         {/* Inner content — stop propagation so clicks on controls don't close */}
@@ -479,7 +540,7 @@ export function MediaLightbox({
             <Tooltip title="Close">
               <IconButton
                 aria-label="Close lightbox"
-                onClick={onClose}
+                onClick={requestClose}
                 sx={{ color: 'white' }}
               >
                 <CloseIcon />
@@ -653,7 +714,9 @@ export function MediaLightbox({
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}
             onPointerCancel={handlePointerUp}
-            onClick={isMobile ? () => setControlsVisible((v) => !v) : undefined}
+            onClick={
+              isMobile && !isVideo ? () => setControlsVisible((v) => !v) : undefined
+            }
             onDoubleClick={() => setZoomed((z) => !z)}
           >
             {item.type === 'video' ? (

--- a/apps/web/src/components/media/__tests__/MediaLightbox.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaLightbox.test.tsx
@@ -19,7 +19,7 @@
  *   6. Video item — video player rendered instead of <img>
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../__tests__/utils/test-utils';
@@ -262,13 +262,15 @@ describe('close behaviour', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onClose when the Escape key is pressed', () => {
+  // Escape (like the Close button) unwinds the pushed history entry and lets
+  // the popstate handler close, so the close is asynchronous.
+  it('calls onClose when the Escape key is pressed', async () => {
     const onClose = vi.fn();
     renderLightbox({ onClose });
 
     fireEvent.keyDown(window, { key: 'Escape' });
 
-    expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });
 
   it('does not call onClose for Escape when index is null', () => {
@@ -472,5 +474,153 @@ describe('video item', () => {
         (el as HTMLImageElement).src === 'https://cdn.example.com/full-vid-3.mp4',
     );
     expect(fullResImg).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Mobile control-bar auto-hide (issue #235)
+// ---------------------------------------------------------------------------
+
+describe('mobile control bar auto-hide', () => {
+  /** Force MUI's `useMediaQuery(theme.breakpoints.down('sm'))` to report mobile. */
+  function forceMobileViewport() {
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes('max-width'),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+  }
+
+  /** The control bar is the Box wrapping the Close button. */
+  function controlBar(): HTMLElement {
+    return screen.getByRole('button', { name: /close lightbox/i })
+      .parentElement as HTMLElement;
+  }
+
+  // Restore the default (desktop) matchMedia stub for the rest of the file.
+  afterEach(() => {
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+  });
+
+  it('hides the control bar on a photo after the idle timeout', async () => {
+    forceMobileViewport();
+    renderLightbox({ items: [makeMediaItem('mob-photo')], index: 0 });
+
+    await waitFor(
+      () => expect(window.getComputedStyle(controlBar()).opacity).toBe('0'),
+      { timeout: 5000 },
+    );
+  }, 10000);
+
+  it('keeps the control bar pinned on a video', async () => {
+    forceMobileViewport();
+    const videoItem = makeMediaItem('mob-video', {
+      type: 'video',
+      downloadUrl: null,
+    });
+    mockGetMedia.mockResolvedValue({
+      ...videoItem,
+      downloadUrl: 'https://cdn.example.com/full-mob-video.mp4',
+    });
+
+    renderLightbox({ items: [videoItem], index: 0 });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('video-player')).toBeInTheDocument(),
+    );
+
+    // Well past the 3 s photo auto-hide window — the bar must still be
+    // visible and tappable, since Vidstack swallows the restore gestures.
+    await new Promise((resolve) => setTimeout(resolve, 3200));
+
+    const style = window.getComputedStyle(controlBar());
+    expect(style.opacity).toBe('1');
+    expect(style.pointerEvents).toBe('auto');
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// 8. Browser history integration (issue #235)
+// ---------------------------------------------------------------------------
+
+describe('browser history integration', () => {
+  it('pushes exactly one history entry when the lightbox opens', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    renderLightbox({ items: [makeMediaItem('hist-1')], index: 0 });
+
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    expect(pushSpy.mock.calls[0][0]).toEqual({ mhLightbox: true });
+    pushSpy.mockRestore();
+  });
+
+  it('does not push a history entry while closed', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    renderLightbox({ items: [makeMediaItem('hist-2')], index: null });
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
+  });
+
+  it('does not push another entry when navigating between items', () => {
+    const items = [makeMediaItem('hist-3a'), makeMediaItem('hist-3b')];
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    const { rerender } = renderLightbox({ items, index: 0 });
+
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MediaLightbox
+        items={items}
+        index={1}
+        onIndexChange={vi.fn()}
+        onClose={vi.fn()}
+        onOpenProperties={vi.fn()}
+      />,
+    );
+
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    pushSpy.mockRestore();
+  });
+
+  it('closes the lightbox when the browser Back button fires popstate', () => {
+    const onClose = vi.fn();
+    renderLightbox({ items: [makeMediaItem('hist-4')], index: 0, onClose });
+
+    fireEvent.popState(window);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('unwinds its own history entry when closed from the UI', async () => {
+    const backSpy = vi.spyOn(window.history, 'back');
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderLightbox({ items: [makeMediaItem('hist-5')], index: 0, onClose });
+
+    await user.click(screen.getByRole('button', { name: /close lightbox/i }));
+
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    backSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

The video lightbox could strand the user with no way back to the gallery. On mobile a 3-second timer set `controlsVisible = false`, which also drops `pointerEvents` on the control bar. The only restore paths — `onPointerMove` on the outer wrapper and the tap-to-toggle handler on the media area — are swallowed by the Vidstack player's own pointer/gesture handling, so over a video the toolbar hid permanently. That explains the intermittency: interact inside the 3-second window and the toolbar stays; miss it and it is unrecoverable.

The lightbox is also pure component state rendered into a MUI `Modal` with no history entry, so the browser Back button popped the *route* the gallery was reached from and left the app entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #235
Relates to #234

## Changes Made

**Toolbar pinned for videos**
- `resetHideTimer` is a no-op when the current item is a video, alongside the existing `!isMobile` guard.
- Navigating onto a video clears any pending hide timer and forces `controlsVisible` back to `true`.
- Tap-to-toggle on the media area is disabled for videos, so the pinned bar cannot be dismissed into an unrecoverable state.
- Photos keep the existing 3-second auto-hide and tap-to-toggle behaviour completely unchanged.

**History integration**
- Exactly one `{ mhLightbox: true }` entry is pushed per open — ref-guarded so React 18 StrictMode's double-invoked effect cannot double-push, and keyed on open/closed so navigating between items never adds entries.
- A `popstate` listener closes the lightbox while it is open.
- Every UI close path (Close button, Escape, backdrop, post-delete) routes through a `requestClose` helper that calls `history.back()` when our entry is on top, letting the `popstate` handler perform the close so the stack stays balanced however the user exits.
- Unmounting while open only detaches the listener and never calls `history.back()`.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

`npx vitest run src/components/media/__tests__/ src/__tests__/components/media/` → **26 files / 470 tests passing** on top of the just-merged #243 change. Seven new cases:

- mobile control bar: a photo hides after the idle timeout; a video stays at `opacity: 1` / `pointerEvents: auto` past 3 s
- history: single push on open, no push while closed, no extra push on item navigation, `popstate` closes, and a UI close calls `history.back()`

One existing test (`calls onClose when the Escape key is pressed`) now awaits, because Escape intentionally unwinds the history entry and closes via the async `popstate` handler rather than calling `onClose` synchronously. No other existing assertion was changed.

`npx tsc --noEmit` → clean.

### Test Instructions

1. On a phone, open a video from the gallery and leave it untouched for more than 3 seconds — the toolbar is still there and still tappable.
2. Press the browser Back button — the viewer closes and you are back on the gallery, not on the landing page.
3. Open and close the viewer via the Close button several times — Back still returns to wherever you were before opening the gallery (the history stack stays balanced).
4. Open a photo — the toolbar still auto-hides after 3 s and a tap still toggles it.

## Additional Notes

Child 3 of 7 in epic #234. Issue #236 (centered play button) also touches tap handling over the player and lands next, on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_