### PR TITLE
fix(web): make burst, duplicate and location review layouts fit a phone

### DIFF
--- a/apps/web/src/__tests__/pages/DuplicateGroupPage.test.tsx
+++ b/apps/web/src/__tests__/pages/DuplicateGroupPage.test.tsx
@@ -438,6 +438,89 @@ describe('DuplicateGroupPage', () => {
     });
   });
 
+  // Issue #239: the comparison is transposed below `md` so a phone never has to
+  // scroll sideways through one column per group member. Both orientations are
+  // fed from the same derived model (deriveComparisonRows), so the labels and
+  // values must match whichever way it renders.
+  describe('responsive comparison layout (issue #239)', () => {
+    it('renders one stacked card per member, with its attributes, on narrow viewports', async () => {
+      // The jsdom matchMedia mock reports `matches: false` for every query, so
+      // the md-and-up matrix is not selected — this is the phone rendering.
+      render(<DuplicateGroupPage />);
+
+      await waitFor(() => expect(screen.getByText('Duplicate Group')).toBeInTheDocument());
+
+      // No attribute matrix at this width — nothing to scroll sideways.
+      expect(screen.queryByRole('table')).toBeNull();
+
+      // One card per member, titled Photo 1..3.
+      const cardTitles = screen.getAllByRole('heading', { level: 3 });
+      expect(cardTitles.map((h) => h.textContent)).toEqual(['Photo 1', 'Photo 2', 'Photo 3']);
+
+      // Each card carries the full attribute list as label/value rows.
+      const attributeLabels = [
+        'Dimensions',
+        'File size',
+        'Captured at',
+        'Camera',
+        'GPS',
+        'Hash prefix',
+        'Sharpness',
+        'Similarity to best',
+        'Quality score',
+      ];
+      attributeLabels.forEach((label) => {
+        expect(screen.getAllByText(label)).toHaveLength(3);
+      });
+
+      // Values are rendered per card too (3 members share dimensions/camera).
+      expect(screen.getAllByText('4032×3024')).toHaveLength(3);
+      expect(screen.getAllByText('Apple iPhone 14')).toHaveLength(3);
+    });
+
+    it('renders the side-by-side attribute matrix on wide viewports', async () => {
+      const originalMatchMedia = window.matchMedia;
+      // Report a wide viewport so MUI's useMediaQuery selects the md+ matrix.
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: query.includes('min-width'),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+
+      try {
+        render(<DuplicateGroupPage />);
+
+        await waitFor(() => expect(screen.getByText('Duplicate Group')).toBeInTheDocument());
+
+        const table = await screen.findByRole('table');
+        // One header per member plus the leading attribute-label column.
+        const headers = within(table).getAllByRole('columnheader');
+        expect(headers.map((th) => th.textContent?.trim())).toEqual([
+          'Attribute',
+          'Photo 1',
+          'Photo 2',
+          'Photo 3',
+        ]);
+        // Attribute labels appear once each — as row headers, not per member.
+        expect(within(table).getAllByText('Dimensions')).toHaveLength(1);
+        expect(within(table).getAllByText('Quality score')).toHaveLength(1);
+      } finally {
+        Object.defineProperty(window, 'matchMedia', {
+          writable: true,
+          value: originalMatchMedia,
+        });
+      }
+    });
+  });
+
   describe('dismiss flow', () => {
     it('opens a confirm dialog when the dismiss button is clicked', async () => {
       const user = userEvent.setup();

--- a/apps/web/src/components/review/MemberComparison.tsx
+++ b/apps/web/src/components/review/MemberComparison.tsx
@@ -1,0 +1,232 @@
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { Star as StarIcon } from '@mui/icons-material';
+
+/**
+ * Member comparison matrix for the review screens (duplicate group detail today,
+ * any future keep/discard comparison tomorrow).
+ *
+ * This is deliberately NOT a generic data table: it is a *member* comparison
+ * whose column count grows with the group size, which is exactly the dimension a
+ * phone does not have. So it renders in two orientations from ONE derived model
+ * (see `deriveComparisonRows`):
+ *
+ *  - `md` and up: the classic attribute matrix — one column per member.
+ *  - below `md`: one card per member, attributes stacked as label/value rows.
+ *
+ * Difference highlighting (amber emphasis on attributes whose values are not
+ * identical across every member) is computed once and applied in both
+ * orientations.
+ */
+
+export interface ComparisonColumn {
+  /** Stable key — the member id. */
+  id: string;
+  /** Column header / card title, e.g. "Photo 2". */
+  label: string;
+  /** Renders the suggested-best star next to the label. */
+  isSuggestedBest?: boolean;
+}
+
+export interface ComparisonCell {
+  /** Plain-text value; drives difference detection and is the default display. */
+  text: string;
+  /** Optional richer rendering (icon, progress bar) shown instead of `text`. */
+  content?: ReactNode;
+}
+
+export interface ComparisonRow {
+  key: string;
+  label: string;
+  /** True when the members do not all share the same value for this attribute. */
+  differs: boolean;
+  /** One cell per column, index-aligned with `columns`. */
+  cells: ComparisonCell[];
+}
+
+export interface ComparisonRowDef<T> {
+  key: string;
+  label: string;
+  /** Plain-text value used for display and for the "differs" computation. */
+  value: (member: T) => string;
+  /** Optional richer rendering; falls back to `value`. */
+  render?: (member: T) => ReactNode;
+  /** Set false to opt out of difference highlighting (e.g. per-member scores). */
+  compare?: boolean;
+}
+
+/**
+ * Derive the per-member attribute rows and their "differs" flags ONCE, so the
+ * mobile and desktop renderings can never drift apart.
+ */
+export function deriveComparisonRows<T>(
+  members: T[],
+  defs: ComparisonRowDef<T>[],
+): ComparisonRow[] {
+  return defs.map((def) => {
+    const cells: ComparisonCell[] = members.map((m) => ({
+      text: def.value(m),
+      content: def.render?.(m),
+    }));
+    const differs =
+      def.compare === false ? false : new Set(cells.map((c) => c.text)).size > 1;
+    return { key: def.key, label: def.label, differs, cells };
+  });
+}
+
+const DIFF_SX = {
+  bgcolor: 'warning.main',
+  color: 'warning.contrastText',
+  opacity: 0.85,
+} as const;
+
+interface MemberComparisonProps {
+  columns: ComparisonColumn[];
+  rows: ComparisonRow[];
+  /** Header for the attribute-label column (desktop matrix only). */
+  attributeLabel?: string;
+}
+
+export function MemberComparison({
+  columns,
+  rows,
+  attributeLabel = 'Attribute',
+}: MemberComparisonProps) {
+  const theme = useTheme();
+  const isWide = useMediaQuery(theme.breakpoints.up('md'));
+
+  if (!isWide) {
+    return <StackedComparison columns={columns} rows={rows} />;
+  }
+
+  return (
+    <TableContainer component={Paper} variant="outlined" sx={{ mb: 3, overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 600 }}>{attributeLabel}</TableCell>
+            {columns.map((col) => (
+              <TableCell key={col.id} align="center" sx={{ fontWeight: 600, minWidth: 140 }}>
+                <Box
+                  sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}
+                >
+                  {col.isSuggestedBest && (
+                    <Tooltip title="Suggested best copy">
+                      <StarIcon fontSize="small" sx={{ color: 'warning.main' }} />
+                    </Tooltip>
+                  )}
+                  {col.label}
+                </Box>
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.key}>
+              <TableCell sx={{ fontWeight: 500 }}>{row.label}</TableCell>
+              {columns.map((col, idx) => {
+                const cell = row.cells[idx];
+                return (
+                  <TableCell
+                    key={col.id}
+                    align="center"
+                    sx={row.differs ? DIFF_SX : undefined}
+                  >
+                    {cell?.content ?? cell?.text ?? '—'}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+/**
+ * Transposed rendering for phones/tablets: one card per member so width stays
+ * constant no matter how many members the group has.
+ */
+function StackedComparison({ columns, rows }: { columns: ComparisonColumn[]; rows: ComparisonRow[] }) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mb: 3 }}>
+      {columns.map((col, idx) => (
+        <Paper key={col.id} variant="outlined" sx={{ p: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+            {col.isSuggestedBest && (
+              <Tooltip title="Suggested best copy">
+                <StarIcon fontSize="small" sx={{ color: 'warning.main' }} />
+              </Tooltip>
+            )}
+            <Typography variant="subtitle2" component="h3">
+              {col.label}
+            </Typography>
+          </Box>
+          <Box
+            component="dl"
+            sx={{
+              m: 0,
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 8rem) minmax(0, 1fr)',
+              columnGap: 1.5,
+              rowGap: 0.75,
+              alignItems: 'center',
+            }}
+          >
+            {rows.map((row) => {
+              const cell = row.cells[idx];
+              return (
+                <Fragment key={row.key}>
+                  <Typography
+                    component="dt"
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ minWidth: 0, overflowWrap: 'anywhere' }}
+                  >
+                    {row.label}
+                  </Typography>
+                  <Box
+                    component="dd"
+                    sx={{
+                      m: 0,
+                      minWidth: 0,
+                      overflowWrap: 'anywhere',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      ...(row.differs
+                        ? { ...DIFF_SX, borderRadius: 0.5, px: 0.75, py: 0.25 }
+                        : {}),
+                    }}
+                  >
+                    {cell?.content ?? (
+                      <Typography variant="body2" component="span" sx={{ color: 'inherit' }}>
+                        {cell?.text ?? '—'}
+                      </Typography>
+                    )}
+                  </Box>
+                </Fragment>
+              );
+            })}
+          </Box>
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Bursts/BurstGroupPage.tsx
+++ b/apps/web/src/pages/Bursts/BurstGroupPage.tsx
@@ -65,8 +65,10 @@ function MemberCard({ member, selected, onToggle }: MemberCardProps) {
         userSelect: 'none',
         transition: 'border-color 0.15s',
         bgcolor: 'background.paper',
-        minWidth: 200,
-        flexShrink: 0,
+        // Below `md` the strip is a wrapping grid, so the card must be free to
+        // shrink to its cell; the fixed width only applies to the md+ strip.
+        minWidth: { xs: 0, md: 200 },
+        flexShrink: { xs: 1, md: 0 },
       }}
     >
       {/* Thumbnail */}
@@ -283,10 +285,14 @@ export default function BurstGroupPage() {
         pre-selected.
       </Alert>
 
-      {/* Photo grid */}
+      {/* Photo grid — 2-up / 3-up below md so the whole burst fits the viewport */}
       <Box
         sx={{
-          display: 'flex',
+          display: { xs: 'grid', md: 'flex' },
+          gridTemplateColumns: {
+            xs: 'repeat(2, minmax(0, 1fr))',
+            sm: 'repeat(3, minmax(0, 1fr))',
+          },
           flexWrap: 'wrap',
           gap: 2,
           mb: 3,

--- a/apps/web/src/pages/Duplicates/DuplicateGroupPage.tsx
+++ b/apps/web/src/pages/Duplicates/DuplicateGroupPage.tsx
@@ -16,13 +16,6 @@ import {
   DialogActions,
   LinearProgress,
   Tooltip,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
 } from '@mui/material';
 import {
   ArrowBack as BackIcon,
@@ -37,6 +30,11 @@ import { useDuplicateGroupDetail } from '../../hooks/useDuplicates';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useCircle } from '../../hooks/useCircle';
 import { SelectionCheckboxOverlay } from '../../components/review/SelectionCheckboxOverlay';
+import {
+  MemberComparison,
+  deriveComparisonRows,
+} from '../../components/review/MemberComparison';
+import type { ComparisonRowDef } from '../../components/review/MemberComparison';
 import { formatBytes } from '../../utils/formatBytes';
 import type { DuplicateGroupKind, DuplicateGroupMember, DuplicateResolveAction } from '../../services/duplicates';
 
@@ -77,8 +75,10 @@ function FilmstripItem({ member, selected, isLeft, isRight, onToggleKeep, onAssi
         userSelect: 'none',
         transition: 'border-color 0.15s',
         bgcolor: 'background.paper',
-        minWidth: 160,
-        flexShrink: 0,
+        // Below `md` the strip is a wrapping grid, so the tile must be free to
+        // shrink to its cell; the fixed width only applies to the md+ scroller.
+        minWidth: { xs: 0, md: 160 },
+        flexShrink: { xs: 1, md: 0 },
       }}
     >
       <Box sx={{ position: 'relative', width: '100%', paddingBottom: '75%', bgcolor: 'action.hover' }}>
@@ -186,11 +186,79 @@ function humanDims(m: DuplicateGroupMember): string | null {
   return `${m.width}×${m.height}`;
 }
 
-interface DiffRow {
-  label: string;
-  render: (m: DuplicateGroupMember) => string;
-  differs: boolean;
-}
+/**
+ * Attribute catalog for the member comparison. Derived ONCE (below) and fed to
+ * both the md+ matrix and the stacked mobile cards — see MemberComparison.
+ */
+const COMPARISON_ROW_DEFS: ComparisonRowDef<DuplicateGroupMember>[] = [
+  { key: 'dimensions', label: 'Dimensions', value: (m) => humanDims(m) ?? '—' },
+  {
+    key: 'fileSize',
+    label: 'File size',
+    value: (m) => (m.fileSize != null ? formatBytes(String(m.fileSize)) : '—'),
+  },
+  {
+    key: 'capturedAt',
+    label: 'Captured at',
+    value: (m) =>
+      m.capturedAt
+        ? new Date(m.capturedAt).toLocaleString(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+          })
+        : '—',
+  },
+  {
+    key: 'camera',
+    label: 'Camera',
+    value: (m) => [m.cameraMake, m.cameraModel].filter(Boolean).join(' ') || '—',
+  },
+  {
+    key: 'gps',
+    label: 'GPS',
+    value: (m) => (m.hasGps ? 'Yes' : 'No'),
+    render: (m) =>
+      m.hasGps ? (
+        <CheckCircleIcon fontSize="small" color="success" />
+      ) : (
+        <CancelIcon fontSize="small" color="disabled" />
+      ),
+  },
+  { key: 'hash', label: 'Hash prefix', value: (m) => m.contentHash ?? '—' },
+  {
+    key: 'sharpness',
+    label: 'Sharpness',
+    value: (m) => (m.sharpnessScore != null ? m.sharpnessScore.toFixed(1) : '—'),
+  },
+  {
+    key: 'similarity',
+    label: 'Similarity to best',
+    value: (m) =>
+      m.similarityToBest != null ? `${Math.round(m.similarityToBest * 100)}%` : '—',
+  },
+  {
+    key: 'quality',
+    label: 'Quality score',
+    // Per-member score — never a "difference" to flag.
+    compare: false,
+    value: (m) => (m.qualityScore != null ? `${Math.round(m.qualityScore * 100)}%` : '—'),
+    render: (m) => {
+      const pct = m.qualityScore != null ? Math.round(m.qualityScore * 100) : null;
+      if (pct == null) return '—';
+      return (
+        <Box sx={{ minWidth: 80, width: '100%' }}>
+          <LinearProgress
+            variant="determinate"
+            value={pct}
+            sx={{ height: 6, borderRadius: 3, mb: 0.5 }}
+            color={pct >= 70 ? 'success' : pct >= 40 ? 'warning' : 'error'}
+          />
+          <Typography variant="caption">{pct}%</Typography>
+        </Box>
+      );
+    },
+  },
+];
 
 export default function DuplicateGroupPage() {
   const { id } = useParams<{ id: string }>();
@@ -318,36 +386,13 @@ export default function DuplicateGroupPage() {
   const leftMember = leftId ? membersById.get(leftId) ?? null : null;
   const rightMember = rightId ? membersById.get(rightId) ?? null : null;
 
-  // Build metadata diff rows
-  const diffRowDefs: Array<{
-    label: string;
-    values: (m: DuplicateGroupMember) => string;
-  }> = [
-    { label: 'Dimensions', values: (m) => humanDims(m) ?? '—' },
-    { label: 'File size', values: (m) => (m.fileSize != null ? formatBytes(String(m.fileSize)) : '—') },
-    {
-      label: 'Captured at',
-      values: (m) =>
-        m.capturedAt ? new Date(m.capturedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }) : '—',
-    },
-    {
-      label: 'Camera',
-      values: (m) => [m.cameraMake, m.cameraModel].filter(Boolean).join(' ') || '—',
-    },
-    { label: 'GPS', values: () => '' },
-    { label: 'Hash prefix', values: (m) => m.contentHash ?? '—' },
-    { label: 'Sharpness', values: (m) => (m.sharpnessScore != null ? m.sharpnessScore.toFixed(1) : '—') },
-    {
-      label: 'Similarity to best',
-      values: (m) => (m.similarityToBest != null ? `${Math.round(m.similarityToBest * 100)}%` : '—'),
-    },
-  ];
-
-  const diffRows: DiffRow[] = diffRowDefs.map((def) => {
-    const rendered = group.members.map((m) => def.values(m));
-    const differs = new Set(rendered).size > 1;
-    return { label: def.label, render: def.values, differs };
-  });
+  // Build the comparison model once; both orientations render from it.
+  const comparisonColumns = group.members.map((m, index) => ({
+    id: m.id,
+    label: `Photo ${index + 1}`,
+    isSuggestedBest: m.isSuggestedBest,
+  }));
+  const comparisonRows = deriveComparisonRows(group.members, COMPARISON_ROW_DEFS);
 
   return (
     <Box sx={{ p: { xs: 2, md: 3 } }}>
@@ -402,7 +447,21 @@ export default function DuplicateGroupPage() {
       <Typography variant="subtitle2" sx={{ mb: 1 }}>
         All members — click to compare, checkbox to keep
       </Typography>
-      <Box sx={{ display: 'flex', gap: 2, overflowX: 'auto', pb: 1, mb: 3 }}>
+      <Box
+        sx={{
+          // Below `md` the whole group must be visible at once, so the strip
+          // wraps into a 2-up / 3-up grid instead of scrolling sideways.
+          display: { xs: 'grid', md: 'flex' },
+          gridTemplateColumns: {
+            xs: 'repeat(2, minmax(0, 1fr))',
+            sm: 'repeat(3, minmax(0, 1fr))',
+          },
+          gap: 2,
+          overflowX: { xs: 'visible', md: 'auto' },
+          pb: 1,
+          mb: 3,
+        }}
+      >
         {group.members.map((member) => (
           <FilmstripItem
             key={member.id}
@@ -416,88 +475,8 @@ export default function DuplicateGroupPage() {
         ))}
       </Box>
 
-      {/* Metadata diff table */}
-      <TableContainer component={Paper} variant="outlined" sx={{ mb: 3, overflowX: 'auto' }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>Attribute</TableCell>
-              {group.members.map((m) => (
-                <TableCell key={m.id} align="center" sx={{ fontWeight: 600, minWidth: 140 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
-                    {m.isSuggestedBest && (
-                      <Tooltip title="Suggested best copy">
-                        <StarIcon fontSize="small" sx={{ color: 'warning.main' }} />
-                      </Tooltip>
-                    )}
-                    Photo {group.members.indexOf(m) + 1}
-                  </Box>
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {diffRows.map((row) => (
-              <TableRow key={row.label}>
-                <TableCell sx={{ fontWeight: 500 }}>{row.label}</TableCell>
-                {group.members.map((m) => {
-                  if (row.label === 'GPS') {
-                    return (
-                      <TableCell
-                        key={m.id}
-                        align="center"
-                        sx={row.differs ? { bgcolor: 'warning.main', opacity: 0.85 } : undefined}
-                      >
-                        {m.hasGps ? (
-                          <CheckCircleIcon fontSize="small" color="success" />
-                        ) : (
-                          <CancelIcon fontSize="small" color="disabled" />
-                        )}
-                      </TableCell>
-                    );
-                  }
-                  return (
-                    <TableCell
-                      key={m.id}
-                      align="center"
-                      sx={
-                        row.differs
-                          ? { bgcolor: 'warning.main', color: 'warning.contrastText', opacity: 0.85 }
-                          : undefined
-                      }
-                    >
-                      {row.render(m)}
-                    </TableCell>
-                  );
-                })}
-              </TableRow>
-            ))}
-            <TableRow>
-              <TableCell sx={{ fontWeight: 500 }}>Quality score</TableCell>
-              {group.members.map((m) => {
-                const pct = m.qualityScore != null ? Math.round(m.qualityScore * 100) : null;
-                return (
-                  <TableCell key={m.id} align="center">
-                    {pct != null ? (
-                      <Box sx={{ minWidth: 80 }}>
-                        <LinearProgress
-                          variant="determinate"
-                          value={pct}
-                          sx={{ height: 6, borderRadius: 3, mb: 0.5 }}
-                          color={pct >= 70 ? 'success' : pct >= 40 ? 'warning' : 'error'}
-                        />
-                        <Typography variant="caption">{pct}%</Typography>
-                      </Box>
-                    ) : (
-                      '—'
-                    )}
-                  </TableCell>
-                );
-              })}
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      {/* Member comparison — attribute matrix at md+, stacked cards below */}
+      <MemberComparison columns={comparisonColumns} rows={comparisonRows} />
 
       {/* Action bar */}
       {canAct && (

--- a/apps/web/src/pages/LocationSuggestions/LocationSuggestionsPage.tsx
+++ b/apps/web/src/pages/LocationSuggestions/LocationSuggestionsPage.tsx
@@ -133,8 +133,8 @@ function SuggestionRow({ suggestion, acting, onAccept, onReject, onAdjust }: Sug
 
   return (
     <Card variant="outlined">
-      <CardContent>
-        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', md: 'row' } }}>
+      <CardContent sx={{ px: { xs: 1.5, sm: 2 } }}>
+        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', md: 'row' }, minWidth: 0 }}>
           {/* Thumbnail */}
           <Box
             sx={{
@@ -187,16 +187,22 @@ function SuggestionRow({ suggestion, acting, onAccept, onReject, onAdjust }: Sug
             </Typography>
             <SpeedWarning impliedSpeedKmh={suggestion.impliedSpeedKmh} />
 
-            <Box sx={{ mt: 1.5, maxWidth: 320 }}>
+            <Box sx={{ mt: 1.5, width: '100%', maxWidth: 320 }}>
               <LocationMiniMap lat={suggestion.lat} lng={suggestion.lng} />
             </Box>
           </Box>
 
-          {/* Actions */}
+          {/* Actions — stacked full-width on phones, side by side from sm up */}
           <Stack
-            direction={{ xs: 'row', md: 'column' }}
+            direction={{ xs: 'column', sm: 'row', md: 'column' }}
             spacing={1}
-            sx={{ flexShrink: 0, justifyContent: { xs: 'flex-start', md: 'center' } }}
+            useFlexGap
+            sx={{
+              flexShrink: 0,
+              flexWrap: 'wrap',
+              width: { xs: '100%', md: 'auto' },
+              justifyContent: { xs: 'flex-start', md: 'center' },
+            }}
           >
             <Button
               variant="contained"


### PR DESCRIPTION
## Summary

The review detail screens are where a user makes irreversible keep/archive/delete decisions, so every piece of comparison data has to be readable — and on a phone it was not. The duplicate-group comparison was transposed the wrong way for mobile: one column per group member, each pinned to `minWidth: 140`, so with the Attribute label column a 3-member group already exceeded a 360 px viewport and a 4th member was entirely off-screen. The member filmstrips were one-line `overflowX: 'auto'` scrollers on both the duplicate and burst pages.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #239
Relates to #234

## Changes Made

- **New `components/review/MemberComparison.tsx`** — a bespoke review component that derives the per-member attribute rows and their "differs" flags **once** (`deriveComparisonRows`) and renders two orientations from that single model, so the two layouts cannot drift:
  - `md+`: the existing side-by-side attribute matrix, unchanged.
  - below `md`: one card per member with its attributes as label/value rows, stacked vertically.
  - The amber difference highlighting is preserved in both orientations.
- **Member strips wrap below `md`** on both the duplicate and burst detail pages — a 2-up (`xs`) / 3-up (`sm`) CSS grid instead of a horizontal scroller, so the whole group is visible at once. The strip stays at `md+`, and the fixed tile `minWidth` (160 / 200) now applies only from `md` up.
- **Location suggestions**: the review rows stack their action buttons full-width at `xs`.
- Checkbox-to-keep and click-to-compare use the identical handlers and state in both layouts — this is layout-only.

Per the issue, the `md+` matrix stays a bespoke member-comparison component and takes **no** dependency on the DataTable from epic #238. The list views (`/bursts`, `/duplicates`, `/location-suggestions` index) already worked on a phone and are untouched.

**One incidental correctness fix:** the GPS row's difference flag was computed from a constant empty string, so it could never highlight. It now compares actual `hasGps` values.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

`npx vitest run src/__tests__/pages src/__tests__/components/review` → **55 files / 1146 tests passing** on the rebased branch, no regressions (covers the existing `DuplicateGroupPage`, `BurstsPage`, `DuplicatesPage`, `LocationSuggestionsPage`, `Reviews/ReviewRunPage` and `components/review/*` suites).

Two new tests in `DuplicateGroupPage.test.tsx`. The shared jsdom `matchMedia` mock reports `matches: false` for every query, so the default render *is* the phone rendering: one asserts no `table` role exists and that three `Photo 1..3` cards each carry all nine attribute labels and values; the other temporarily swaps in a `min-width`-matching `matchMedia` and asserts the `md+` matrix still renders one column header per member with each attribute label appearing exactly once.

`npx tsc --noEmit` → clean. (`noUnusedLocals` is on, which confirms the removed `Table`/`TableContainer`/`Paper` imports are actually gone.)

### Test Instructions

1. On a 360 px viewport open `/duplicates` and tap into a group with 3+ members — no horizontal document scroll, one card per member, all attributes readable.
2. Repeat at `/bursts/:id` — the member strip wraps to a grid instead of running off the edge.
3. Check `/location-suggestions` at `xs` — action buttons stack full-width.
4. At `md+`, all three screens look exactly as before.

## Additional Notes

Child 4 of 7 in epic #234. Fully self-contained — no dependency on #238 or #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_