### PR TITLE
feat(web): add a centered play button to the video player

### DIFF
--- a/apps/web/src/__tests__/components/media/VideoPlayer.test.tsx
+++ b/apps/web/src/__tests__/components/media/VideoPlayer.test.tsx
@@ -6,16 +6,27 @@
  *   - src / poster / title props are forwarded to the player
  *   - Both seek Gesture zones render with the correct action attributes
  *   - The layout component renders
+ *   - The centered play/pause control (issue #236) renders, is labelled for
+ *     the current playback state, fades out while playing, and is clickable
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
 
 // ---------------------------------------------------------------------------
 // Mock @vidstack/react — replace heavy browser-media implementation with
 // lightweight stubs that emit testable markup.
+//
+// `paused` drives the mocked `useMediaState('paused')` so tests can render the
+// player in either playback state. Hoisted so the vi.mock factory can see it.
 // ---------------------------------------------------------------------------
+
+const vds = vi.hoisted(() => ({
+  paused: true,
+  playButtonClick: vi.fn(),
+}));
 
 vi.mock('@vidstack/react', () => {
   const MediaPlayer = ({ src, poster, title, children, ...rest }: any) => (
@@ -41,12 +52,24 @@ vi.mock('@vidstack/react', () => {
     />
   );
 
-  return { MediaPlayer, MediaProvider, Gesture };
+  // Vidstack's PlayButton renders a real <button> and toggles playback
+  // internally. The stub keeps the <button> (so role/label/keyboard queries
+  // behave the same) and records clicks, which is what lets us assert that our
+  // centered element really is the hit target.
+  const PlayButton = ({ children, ...rest }: any) => (
+    <button type="button" onClick={vds.playButtonClick} {...rest}>
+      {children}
+    </button>
+  );
+
+  const useMediaState = (prop: string) => (prop === 'paused' ? vds.paused : undefined);
+
+  return { MediaPlayer, MediaProvider, Gesture, PlayButton, useMediaState };
 });
 
 // Mock the layout + icons sub-package (separate deep import path)
 vi.mock('@vidstack/react/player/layouts/default', () => {
-  const DefaultVideoLayout = ({ icons: _icons }: any) => (
+  const DefaultVideoLayout = ({ icons: _icons, slots: _slots }: any) => (
     <div data-testid="default-video-layout" />
   );
   const defaultLayoutIcons = {};
@@ -66,6 +89,7 @@ import { VideoPlayer } from '../../../components/media/VideoPlayer';
 describe('VideoPlayer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vds.paused = true;
   });
 
   describe('prop forwarding', () => {
@@ -152,6 +176,89 @@ describe('VideoPlayer', () => {
       gestures.forEach((g) => {
         expect(g.classList.contains('vds-gesture')).toBe(true);
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Centered play/pause control (issue #236)
+  // -------------------------------------------------------------------------
+
+  describe('centered play button', () => {
+    it('renders a labelled Play button while paused', () => {
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      const button = screen.getByRole('button', { name: 'Play video' });
+      expect(button).toBeInTheDocument();
+      expect(button.tagName).toBe('BUTTON');
+    });
+
+    it('switches the accessible label to Pause while playing', () => {
+      vds.paused = false;
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      expect(screen.getByRole('button', { name: 'Pause video' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+    });
+
+    it('marks the overlay as paused so the control is shown', () => {
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      expect(screen.getByTestId('center-play-overlay')).toHaveAttribute('data-paused', 'true');
+    });
+
+    it('marks the overlay as playing so the control is faded out', () => {
+      vds.paused = false;
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      expect(screen.getByTestId('center-play-overlay')).toHaveAttribute('data-paused', 'false');
+    });
+
+    it('renders the control inside the player, not as a detached overlay', () => {
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      const player = screen.getByTestId('media-player');
+      expect(player).toContainElement(screen.getByTestId('center-play-overlay'));
+    });
+
+    it('toggles playback when clicked', async () => {
+      const user = userEvent.setup();
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      await user.click(screen.getByRole('button', { name: 'Play video' }));
+      expect(vds.playButtonClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('is reachable with the keyboard', async () => {
+      const user = userEvent.setup();
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      const button = screen.getByRole('button', { name: 'Play video' });
+      await user.tab();
+      expect(button).toHaveFocus();
+    });
+
+    it('does not replace the double-tap seek zones', () => {
+      render(<VideoPlayer src="https://example.com/video.mp4" />);
+      // The centered target and both ±10 s zones coexist.
+      expect(screen.getByRole('button', { name: 'Play video' })).toBeInTheDocument();
+      const actions = screen
+        .getAllByTestId('gesture')
+        .map((g) => g.getAttribute('data-action'));
+      expect(actions).toEqual(expect.arrayContaining(['seek:-10', 'seek:10']));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sizing
+  // -------------------------------------------------------------------------
+
+  describe('wrapper sizing', () => {
+    // jsdom normalises `aspect-ratio` to an unspaced ratio, so these read the
+    // computed value rather than going through toHaveStyle.
+    it('defaults to a 16:9 wrapper', () => {
+      const { container } = render(<VideoPlayer src="https://example.com/video.mp4" />);
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(getComputedStyle(wrapper).aspectRatio).toBe('16/9');
+    });
+
+    it('fills the container instead of forcing 16:9 when `fill` is set', () => {
+      const { container } = render(<VideoPlayer src="https://example.com/video.mp4" fill />);
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(getComputedStyle(wrapper).height).toBe('100%');
+      expect(getComputedStyle(wrapper).aspectRatio).not.toBe('16/9');
     });
   });
 });

--- a/apps/web/src/components/media/MediaLightbox.tsx
+++ b/apps/web/src/components/media/MediaLightbox.tsx
@@ -722,11 +722,15 @@ export function MediaLightbox({
             {item.type === 'video' ? (
               /* Video branch: show spinner while downloading URL, then VideoPlayer */
               downloadUrl ? (
-                <Box sx={{ width: '100%', backgroundColor: 'black' }}>
+                /* `fill` lets a portrait clip use the full viewer height
+                   instead of being pillarboxed inside a short 16:9 box; it
+                   needs a definite height on this wrapper to resolve. */
+                <Box sx={{ width: '100%', height: '100%', backgroundColor: 'black' }}>
                   <VideoPlayer
                     src={downloadUrl}
                     poster={thumbnailUrl}
                     title={item.originalFilename}
+                    fill
                   />
                 </Box>
               ) : (

--- a/apps/web/src/components/media/VideoPlayer.tsx
+++ b/apps/web/src/components/media/VideoPlayer.tsx
@@ -4,17 +4,22 @@
  * Features:
  * - Polished controls via DefaultVideoLayout (playback speed, scrubber, time, volume, fullscreen)
  * - Keyboard shortcuts handled by Vidstack out-of-the-box
+ * - Large YouTube-style centered play/pause button (issue #236)
  * - Double-tap seek zones: left half = −10 s, right half = +10 s
- * - Responsive 16:9 wrapper that fits the containing column width
+ * - Responsive wrapper: 16:9 by default, or `fill` to use the whole container
  */
 
 import '@vidstack/react/player/styles/default/theme.css';
 import '@vidstack/react/player/styles/default/layouts/video.css';
 
-import { MediaPlayer, MediaProvider, Gesture } from '@vidstack/react';
+import { MediaPlayer, MediaProvider, Gesture, PlayButton, useMediaState } from '@vidstack/react';
 import type { MediaPlayerInstance } from '@vidstack/react';
 import { defaultLayoutIcons, DefaultVideoLayout } from '@vidstack/react/player/layouts/default';
 import { Box } from '@mui/material';
+import {
+  PlayArrowRounded as PlayArrowRoundedIcon,
+  PauseRounded as PauseRoundedIcon,
+} from '@mui/icons-material';
 import type React from 'react';
 
 // ---------------------------------------------------------------------------
@@ -30,23 +35,147 @@ interface VideoPlayerProps {
    * The parent can call `playerRef.current.currentTime = seconds` to seek.
    */
   playerRef?: React.Ref<MediaPlayerInstance>;
+  /**
+   * Fill the containing block instead of forcing a 16:9 box.
+   *
+   * Only safe where the parent has a definite height (the full-screen
+   * lightbox). Everywhere else the default 16:9 wrapper is what gives the
+   * player a height at all.
+   */
+  fill?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Centered play/pause overlay (issue #236)
+// ---------------------------------------------------------------------------
+
+/**
+ * YouTube-style centered play affordance.
+ *
+ * Implemented with Vidstack's own `<PlayButton>` rather than a hand-rolled
+ * overlay, so the toggle is wired by the player itself and the rendered
+ * element is a real `<button>` — reachable with Tab, operable with
+ * Enter/Space, and carrying an `aria-label` that tracks playback state.
+ *
+ * Interaction contract with the surrounding gesture layers:
+ *
+ * - Vidstack attaches its gesture listeners to the `[data-media-provider]`
+ *   element (see `Gesture#attachListener`). This button is a *sibling* of
+ *   `<MediaProvider>`, so a click here is never also seen by the gesture
+ *   layer — no double toggle.
+ * - `DefaultVideoLayout`'s ±10 s double-tap seek zones occupy only the outer
+ *   20% of the left and right edges (`--video-gesture-seek-width`), so this
+ *   centered target cannot swallow them.
+ * - On touch devices Vidstack disables its own single-tap `toggle:paused`
+ *   gesture entirely (`@media (pointer: coarse)` in its layout CSS), which is
+ *   exactly why a phone had no reliable tap-to-play target before this.
+ * - `MediaLightbox` already suppresses its own tap-to-toggle handler for
+ *   video items (issue #235), so nothing at the lightbox level competes here.
+ *
+ * The overlay spans the whole player box, but only the button itself accepts
+ * pointer events — the rest of the frame keeps its normal Vidstack behaviour.
+ * Because the `<video>` is laid out with `object-fit: contain`, its centre
+ * always coincides with the centre of the player box, so this button sits on
+ * the middle of the *picture* even when the frame is letterboxed.
+ */
+function CenterPlayButton() {
+  const paused = useMediaState('paused');
+
+  return (
+    <Box
+      data-testid="center-play-overlay"
+      data-paused={paused ? 'true' : 'false'}
+      sx={(theme) => ({
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        // Above the poster (z-index 1) and the gesture layers (0–1), below
+        // Vidstack's control bar (10) and its menus.
+        zIndex: 2,
+        '& .mh-center-play-button': {
+          pointerEvents: 'auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 0,
+          border: 0,
+          cursor: 'pointer',
+          borderRadius: '50%',
+          color: '#fff',
+          backgroundColor: 'rgba(0, 0, 0, 0.55)',
+          // Touch target: comfortably above the 56–64 px minimum on phones,
+          // scaled up on tablet and desktop.
+          width: 64,
+          height: 64,
+          [theme.breakpoints.up('sm')]: { width: 76, height: 76 },
+          [theme.breakpoints.up('md')]: { width: 88, height: 88 },
+          // Fade out on play, fade back in on pause.
+          opacity: paused ? 1 : 0,
+          transform: paused ? 'scale(1)' : 'scale(0.85)',
+          transition: theme.transitions.create(['opacity', 'transform', 'background-color'], {
+            duration: theme.transitions.duration.shorter,
+          }),
+          '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.75)' },
+          // Keep the control discoverable for keyboard users while playing,
+          // when it is otherwise faded out.
+          '&:focus-visible': {
+            opacity: 1,
+            transform: 'scale(1)',
+            outline: '2px solid #fff',
+            outlineOffset: 2,
+          },
+        },
+        '& .mh-center-play-button svg': {
+          fontSize: 36,
+          [theme.breakpoints.up('sm')]: { fontSize: 42 },
+          [theme.breakpoints.up('md')]: { fontSize: 48 },
+        },
+      })}
+    >
+      <PlayButton
+        className="mh-center-play-button"
+        aria-label={paused ? 'Play video' : 'Pause video'}
+      >
+        {paused ? <PlayArrowRoundedIcon /> : <PauseRoundedIcon />}
+      </PlayButton>
+    </Box>
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-export function VideoPlayer({ src, poster, title, playerRef }: VideoPlayerProps) {
+export function VideoPlayer({ src, poster, title, playerRef, fill = false }: VideoPlayerProps) {
   return (
     /*
-     * Aspect-ratio box — 16:9 ratio, width 100% of the containing block.
-     * The Vidstack player fills this box.
+     * Player wrapper.
+     *
+     * Default: a 16:9 aspect-ratio box at 100% of the containing block width —
+     * the only thing giving the player a height in flow layouts such as the
+     * detail drawer.
+     *
+     * `fill`: take the container's full width AND height and let the video's
+     * own `object-fit: contain` size the picture. This is what stops a portrait
+     * phone clip from being pillarboxed inside a short 16:9 letterbox in the
+     * full-screen lightbox. Vidstack's defaults (`aspect-ratio: 16 / 9` on the
+     * player, `height: auto` on the video) are declared with `:where(...)`, so
+     * these overrides win on specificity without `!important`.
      */
     <Box
       sx={{
         position: 'relative',
         width: '100%',
-        aspectRatio: '16 / 9',
+        ...(fill
+          ? {
+              height: '100%',
+              '& [data-media-player]': { height: '100%', aspectRatio: 'auto' },
+              '& video': { height: '100%' },
+            }
+          : { aspectRatio: '16 / 9' }),
         backgroundColor: 'black',
         borderRadius: 1,
         overflow: 'hidden',
@@ -87,6 +216,9 @@ export function VideoPlayer({ src, poster, title, playerRef }: VideoPlayerProps)
           action="seek:10"
         />
 
+        {/* Large centered play/pause target — see CenterPlayButton above. */}
+        <CenterPlayButton />
+
         {/*
          * DefaultVideoLayout wires up:
          *   - Play/pause, mute, volume, fullscreen, PiP buttons
@@ -94,8 +226,15 @@ export function VideoPlayer({ src, poster, title, playerRef }: VideoPlayerProps)
          *   - Playback-speed menu
          *   - Single-tap toggle-paused gesture (via its own DefaultVideoGestures)
          *   - Keyboard shortcuts (space, arrows, f, m, …)
+         *
+         * The small (phone) layout's own centre play button is suppressed: it
+         * lives inside the auto-hiding control bar and would otherwise stack
+         * on top of our persistent centered button.
          */}
-        <DefaultVideoLayout icons={defaultLayoutIcons} />
+        <DefaultVideoLayout
+          icons={defaultLayoutIcons}
+          slots={{ smallLayout: { playButton: null } }}
+        />
       </MediaPlayer>
     </Box>
   );


### PR DESCRIPTION
## Summary

Adds a YouTube-style centered play/pause control to the video viewer. This closes a real gap rather than duplicating an affordance: Vidstack disables its own single-tap `toggle:paused` gesture under `@media (pointer: coarse)`, so on a phone there was **no** tap-to-play target at all — the only play control was the small, auto-hiding bottom control bar.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #236
Relates to #234, builds on #235

## Changes Made

- **Centered control built on Vidstack's own `<PlayButton>`** driven by `useMediaState('paused')`, rather than a hand-rolled overlay. It renders a real `<button>`: Tab-reachable, Enter/Space-operable, with an `aria-label` that tracks state ("Play video" / "Pause video").
- 64 px on phones, scaling to 76 / 88 px on tablet and desktop. Sits over the poster before first play; fades and shrinks out on play, fades back in on pause — and on `:focus-visible`, so keyboard users can still find it mid-playback.
- **Double-tap ±10 s seek zones are untouched.** `DefaultVideoLayout` renders them at the outer 20% of the left/right edges, nowhere near the centre, and Vidstack binds gesture listeners to `[data-media-provider]` while this button is a sibling of `<MediaProvider>` — so a click here can never also fire a gesture.
- Passed `slots={{ smallLayout: { playButton: null } }}` to `DefaultVideoLayout`, since the phone layout renders its own small centre play button inside the auto-hiding control bar which would otherwise stack on top of the new persistent one.

### Aspect-ratio handling — changed, opt-in

The button is centered on the player box, and Vidstack lays the `<video>` out with `object-fit: contain`, so the video's centre always coincides with the box's centre. But the letterboxing the issue flagged was a real, separate problem: with a hard `aspectRatio: '16 / 9'` on the wrapper, a portrait phone clip in the full-screen lightbox was pillarboxed inside a short, wide box using only `viewportWidth / 1.78` of the available height.

Rather than change the default, this adds an opt-in `fill` prop: the wrapper takes the container's full width **and** height and lets `object-fit: contain` size the picture, so a portrait clip uses the full viewer height. Two targeted overrides make that work — `aspect-ratio: auto` on `[data-media-player]` and `height: 100%` on the `video` — both of which beat Vidstack's defaults on specificity because Vidstack declares them inside `:where(...)`; the `height: 100%` is the same rule Vidstack itself applies in fullscreen. `MediaLightbox` is the only caller passing `fill`. `MediaDetailDrawer` keeps the 16:9 path unchanged, since that column has no definite height and the ratio box is what gives the player one.

One visible consequence: a full-height video now runs under the pinned translucent toolbar at the top, which matches standard full-screen-viewer behaviour.

### Coordination with #235

No new tap handler at the lightbox level. `MediaLightbox` already skips its tap-to-toggle for video items and pins the toolbar for video; both are left alone. The play/pause target belongs entirely to the player, and that contract is documented in a comment on `CenterPlayButton` so the two changes don't drift.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

`npx vitest run src/components/media/__tests__/ src/__tests__/components/media/` → **26 files / 480 tests passing** on the rebased branch. 10 new: button present and labelled "Play video" when paused; label flips to "Pause video" when playing; overlay `data-paused` reflects state both ways; control renders inside the player; click reaches the underlying Vidstack `PlayButton`; reachable as the first Tab stop; both `seek:-10` / `seek:10` zones still present; and two sizing tests covering the default 16:9 box and the `fill` path.

`npx tsc --noEmit` → clean.

### Test Instructions

1. On a phone, open a video from the gallery — a large play button sits in the centre over the poster. Tap it to play.
2. It fades out during playback and reappears on pause.
3. Double-tap the far left/right edges — ±10 s seek still works.
4. Open a portrait phone video in the lightbox — it now fills the viewer height instead of being pillarboxed into a 16:9 box.
5. Tab to the button and press Enter — playback toggles.

## Additional Notes

Child 5 of 7 in epic #234.

**Incidental finding, deliberately not changed (out of scope):** the two hand-declared `<Gesture>` elements in `VideoPlayer.tsx` appear to be dead code. `.vds-gesture` is `position: absolute` with no box set, and is only given `top/left/width/height` by the `:where(.vds-video-layout .vds-gesture)` rule — which these two don't match, since they sit outside `.vds-video-layout`. Their `getBoundingClientRect()` is therefore zero-sized and `Gesture#inBounds` rejects essentially every pointer event. They duplicate the `seek:-10` / `seek:10` gestures `DefaultVideoGestures` already renders (properly positioned), which is what actually delivers the working double-tap seek. Left in place because existing tests assert on them; removing them would be a separate change with no behavioural loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_