### PR TITLE
fix(web): stabilise gallery vertical scrolling on mobile

### DIFF
--- a/apps/web/src/components/common/Layout.tsx
+++ b/apps/web/src/components/common/Layout.tsx
@@ -36,7 +36,15 @@ export function Layout({ fullBleed = false }: LayoutProps) {
           sx={{
             display: 'flex',
             flexDirection: 'column',
+            // The shell is the ONLY owner of viewport height — pages must not
+            // nest their own 100vh inside it (issue #237), or the document is
+            // always at least 100vh + AppBar + padding tall and scrolls even
+            // when the content fits. `100dvh` tracks mobile browser chrome;
+            // `100vh` measures against the LARGEST viewport, so a collapsing
+            // URL bar adds jitter. The plain 100vh below is the fallback for
+            // browsers without dvh support (same lesson as MediaMapPage).
             minHeight: '100vh',
+            '@supports (min-height: 100dvh)': { minHeight: '100dvh' },
             backgroundColor: theme.palette.background.default,
           }}
         >

--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -66,10 +66,59 @@ import type { MediaItem, MediaQueryParams } from '../../types/media';
 import type { CircleRole } from '../../types/circles';
 
 // ---------------------------------------------------------------------------
-// AppBar height constant for sticky day-header offset
+// Grid geometry — ONE source of truth for the column count
 // ---------------------------------------------------------------------------
 
-const APP_BAR_HEIGHT = 64;
+/**
+ * Column count per breakpoint. Consumed by BOTH `gridTemplateColumns` and the
+ * `content-visibility` placeholder math below — they must never drift. Issue
+ * #237: the placeholder used to hard-code the desktop `/ 6`, so on a phone
+ * (3 columns) every group reserved half the height it actually needed and the
+ * document grew by roughly a group's height each time one scrolled into view.
+ */
+export const GALLERY_COLS = { xs: 3, sm: 4, md: 6 } as const;
+
+/** Inter-tile grid gap, in px. Must match the grid's `gap` value. */
+export const GALLERY_GAP_PX = 2;
+
+/**
+ * Row height assumed before the first ResizeObserver measurement lands. Tiles
+ * are `aspectRatio: '1'`, so the real row height is derived from the measured
+ * container width instead — this is only the pre-measurement estimate.
+ */
+export const GALLERY_FALLBACK_ROW_PX = 120;
+
+const GALLERY_GRID_COLUMNS = {
+  xs: `repeat(${GALLERY_COLS.xs}, 1fr)`,
+  sm: `repeat(${GALLERY_COLS.sm}, 1fr)`,
+  md: `repeat(${GALLERY_COLS.md}, 1fr)`,
+} as const;
+
+/**
+ * Height reserved by `contain-intrinsic-size` for an off-screen day group.
+ *
+ * @param itemCount items in the group
+ * @param cols      columns at the ACTIVE breakpoint (never a hard-coded 6)
+ * @param tileSize  measured square tile edge in px, or null before the first
+ *                  ResizeObserver callback (falls back to the old estimate)
+ */
+export function galleryPlaceholderHeight(
+  itemCount: number,
+  cols: number,
+  tileSize: number | null,
+): number {
+  const rows = Math.ceil(itemCount / cols);
+  const rowHeight =
+    tileSize !== null && tileSize > 0 ? tileSize + GALLERY_GAP_PX : GALLERY_FALLBACK_ROW_PX;
+  return Math.round(rows * rowHeight);
+}
+
+/**
+ * Sticky day-header offset. MUI's Toolbar is 56px below the `sm` breakpoint and
+ * 64px at `sm` and up — a flat 64 left an 8px see-through gap under the AppBar
+ * on phones (issue #237).
+ */
+const DAY_HEADER_TOP = { xs: 56, sm: 64 } as const;
 
 // ---------------------------------------------------------------------------
 // GalleryTile — internal thumbnail tile
@@ -675,6 +724,42 @@ export function MediaGallery({
   }, [queryParams, albumId, circleId]);
 
   // -------------------------------------------------------------------------
+  // Grid measurement — ONE ResizeObserver for the whole gallery (never one per
+  // day group). Feeds the content-visibility placeholder math so an off-screen
+  // group reserves the height it will actually occupy at the current width.
+  // -------------------------------------------------------------------------
+
+  const isSmUp = useMediaQuery(theme.breakpoints.up('sm'));
+  const isMdUp = useMediaQuery(theme.breakpoints.up('md'));
+  const cols = isMdUp ? GALLERY_COLS.md : isSmUp ? GALLERY_COLS.sm : GALLERY_COLS.xs;
+
+  const [gridWidth, setGridWidth] = useState<number | null>(null);
+  const gridObserverRef = useRef<ResizeObserver | null>(null);
+
+  // Callback ref: the grid wrapper mounts/unmounts with the item list, so a
+  // mount-time useEffect would miss it. contentRect excludes the wrapper's own
+  // horizontal padding, which is exactly the width the columns divide up.
+  const gridRootRef = useCallback((el: HTMLDivElement | null) => {
+    gridObserverRef.current?.disconnect();
+    gridObserverRef.current = null;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      setGridWidth(width > 0 ? width : null);
+    });
+    observer.observe(el);
+    gridObserverRef.current = observer;
+  }, []);
+
+  useEffect(() => () => gridObserverRef.current?.disconnect(), []);
+
+  const tileSize = useMemo(() => {
+    if (gridWidth === null) return null;
+    const size = (gridWidth - (cols - 1) * GALLERY_GAP_PX) / cols;
+    return size > 0 ? size : null;
+  }, [gridWidth, cols]);
+
+  // -------------------------------------------------------------------------
   // Derived display flags
   // -------------------------------------------------------------------------
 
@@ -701,12 +786,8 @@ export function MediaGallery({
           <Box
             sx={{
               display: 'grid',
-              gridTemplateColumns: {
-                xs: 'repeat(3, 1fr)',
-                sm: 'repeat(4, 1fr)',
-                md: 'repeat(6, 1fr)',
-              },
-              gap: '2px',
+              gridTemplateColumns: GALLERY_GRID_COLUMNS,
+              gap: `${GALLERY_GAP_PX}px`,
             }}
           >
             {Array.from({ length: 18 }).map((_, i) => (
@@ -785,7 +866,7 @@ export function MediaGallery({
 
       {/* Day-grouped grid */}
       {!showFirstLoad && mergedItems.length > 0 && (
-        <Box sx={{ px: { xs: 1, sm: 2 }, pt: { xs: 1, sm: 2 } }}>
+        <Box ref={gridRootRef} sx={{ px: { xs: 1, sm: 2 }, pt: { xs: 1, sm: 2 } }}>
           {grouped.map((group) => (
             <Box
               key={group.key}
@@ -800,7 +881,7 @@ export function MediaGallery({
               <Box
                 sx={{
                   position: 'sticky',
-                  top: APP_BAR_HEIGHT,
+                  top: DAY_HEADER_TOP,
                   zIndex: 10,
                   py: 0.75,
                   px: 0.5,
@@ -854,14 +935,14 @@ export function MediaGallery({
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: {
-                    xs: 'repeat(3, 1fr)',
-                    sm: 'repeat(4, 1fr)',
-                    md: 'repeat(6, 1fr)',
-                  },
-                  gap: '2px',
+                  gridTemplateColumns: GALLERY_GRID_COLUMNS,
+                  gap: `${GALLERY_GAP_PX}px`,
                   contentVisibility: 'auto',
-                  containIntrinsicSize: `auto ${Math.ceil(group.items.length / 6) * 120}px`,
+                  containIntrinsicSize: `auto ${galleryPlaceholderHeight(
+                    group.items.length,
+                    cols,
+                    tileSize,
+                  )}px`,
                 }}
               >
                 {group.items.map((item) => (

--- a/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
@@ -15,7 +15,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../__tests__/utils/test-utils';
-import { MediaGallery } from '../MediaGallery';
+import {
+  MediaGallery,
+  GALLERY_COLS,
+  GALLERY_GAP_PX,
+  GALLERY_FALLBACK_ROW_PX,
+  galleryPlaceholderHeight,
+} from '../MediaGallery';
 import type { MediaItem } from '../../../types/media';
 
 // ---------------------------------------------------------------------------
@@ -595,6 +601,65 @@ describe('MediaGallery', () => {
       await waitFor(() => {
         expect(screen.getByTestId('media-lightbox')).toBeInTheDocument();
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (f) content-visibility placeholder height (issue #237)
+  //
+  // The reserved height for an off-screen day group must be computed with the
+  // ACTIVE breakpoint's column count. It used to hard-code the desktop `/ 6`,
+  // so a phone (3 columns) reserved half the rows it actually rendered and the
+  // document grew by roughly a group's height as each one scrolled in.
+  // -------------------------------------------------------------------------
+  describe('placeholder height (issue #237)', () => {
+    it('assumes 4 rows for a 12-item group at xs (3 columns), not 2', () => {
+      expect(GALLERY_COLS.xs).toBe(3);
+      // 12 items / 3 columns = 4 rows — NOT the 2 rows the old `/ 6` produced.
+      expect(galleryPlaceholderHeight(12, GALLERY_COLS.xs, null)).toBe(
+        4 * GALLERY_FALLBACK_ROW_PX,
+      );
+      expect(galleryPlaceholderHeight(12, GALLERY_COLS.xs, null)).not.toBe(
+        2 * GALLERY_FALLBACK_ROW_PX,
+      );
+    });
+
+    it('scales rows with the column count at each breakpoint', () => {
+      expect(galleryPlaceholderHeight(12, GALLERY_COLS.sm, null)).toBe(
+        3 * GALLERY_FALLBACK_ROW_PX,
+      );
+      expect(galleryPlaceholderHeight(12, GALLERY_COLS.md, null)).toBe(
+        2 * GALLERY_FALLBACK_ROW_PX,
+      );
+    });
+
+    it('uses the measured tile size once a container width is known', () => {
+      // 360px phone viewport, 3 columns, 2px gaps → tile edge ~118.67px
+      const tile = (360 - (GALLERY_COLS.xs - 1) * GALLERY_GAP_PX) / GALLERY_COLS.xs;
+      expect(galleryPlaceholderHeight(12, GALLERY_COLS.xs, tile)).toBe(
+        Math.round(4 * (tile + GALLERY_GAP_PX)),
+      );
+    });
+
+    it('renders the xs placeholder height into the grid style for a 12-item group', () => {
+      // jsdom's matchMedia mock always reports `matches: false`, so both
+      // breakpoint.up() queries are false → the xs (3-column) branch is active.
+      // ResizeObserver is mocked and never fires → the fallback row height.
+      const items = Array.from({ length: 12 }, (_, i) =>
+        makeItem(`ph-${i}`, { capturedAt: '2024-06-15T10:00:00.000Z' }),
+      );
+
+      render(
+        <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" items={items} />,
+      );
+
+      const css = Array.from(document.querySelectorAll('style'))
+        .map((s) => s.textContent ?? '')
+        .join('');
+
+      expect(css).toMatch(
+        new RegExp(`contain-intrinsic-size:\\s*auto\\s+${4 * GALLERY_FALLBACK_ROW_PX}px`),
+      );
     });
   });
 

--- a/apps/web/src/pages/Albums/AlbumPage.tsx
+++ b/apps/web/src/pages/Albums/AlbumPage.tsx
@@ -195,8 +195,11 @@ export default function AlbumPage() {
 
   const isEmpty = albumItems.length === 0;
 
+  // No minHeight/pb on this Box — the Layout shell owns viewport height and
+  // the BottomNav clearance (issue #237); duplicating either stacks dead
+  // scroll space below the last row.
   return (
-    <Box sx={{ minHeight: '100vh', pb: { xs: 10, sm: 4 } }}>
+    <Box>
       {/* Album chrome */}
       <Box sx={{ px: { xs: 2, md: 3 }, pt: { xs: 2, md: 3 }, pb: 1 }}>
         <Button

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -46,8 +46,11 @@ export default function HomePage() {
     </Box>
   );
 
+  // No minHeight/pb on this Box — the Layout shell owns viewport height and
+  // the BottomNav clearance (issue #237); duplicating either stacks dead
+  // scroll space below the last row.
   return (
-    <Box sx={{ minHeight: '100vh', pb: { xs: 10, sm: 4 } }}>
+    <Box>
       {/* No active circle */}
       {showNoCircle && (
         <Box sx={{ p: { xs: 2, md: 3 } }}>


### PR DESCRIPTION
## Summary

Scrolling the gallery on a phone was positionally unstable: content jumped as day-groups came into view, the scroll thumb resized mid-scroll, the sticky day header floated below the app bar leaving a see-through gap, and a tall empty region sat below the last row. Even a library that fits one screen still scrolled.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #237
Relates to #234

## Changes Made

**1. Breakpoint-correct `content-visibility` placeholders.** Each day group reserved `Math.ceil(items.length / 6) * 120` px — hard-coding the desktop 6-column layout even though the grid is `repeat(3, 1fr)` at `xs` and `repeat(4, 1fr)` at `sm`. On a phone every group reserved roughly half the height it actually rendered, so the document grew by about a group's height each time one scrolled into view. That was the jump. The fixed `120px` row height was also wrong at any width other than the one it was tuned for, since tiles are `aspectRatio: '1'`.

The column counts are now a single source of truth (`GALLERY_COLS = { xs: 3, sm: 4, md: 6 }`) consumed by **both** `gridTemplateColumns` and a new `galleryPlaceholderHeight()` helper, which derives the real row height from a container width measured by **one** `ResizeObserver` at the grid root (never one per group), falling back to the old estimate until the first measurement lands.

Virtualization was deliberately **not** introduced — an accurate placeholder is the fix, per the issue.

**2. Single owner for viewport height.** Removed the nested `minHeight: '100vh'` from `HomePage` and `AlbumPage`; the Layout shell owns it. The shell now prefers `100dvh` (with a `100vh` fallback declaration first), since mobile browsers measure `100vh` against the largest viewport and a collapsing URL bar adds its own jitter — the lesson already documented in `MediaMapPage.tsx`.

**3. Single owner for bottom padding.** Deleted the page-level `pb` from `HomePage`/`AlbumPage`; the Layout container's `pb: { xs: 10, md: 3 }` is now the only BottomNav clearance. Stacked, the two produced ~160 px of guaranteed dead scroll space on a phone.

**4. Breakpoint-correct sticky offset.** `APP_BAR_HEIGHT = 64` became `top: { xs: 56, sm: 64 }`, matching MUI's Toolbar height below `sm` and closing the 8 px gap the day header floated through.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

`npx vitest run src/components/media/__tests__/ src/__tests__/components/media/ src/__tests__/components/common` → **32 files / 667 tests passing** on the rebased branch. In the worktree the wider sweep including `src/__tests__/pages` ran **85 files / 1774 tests, 0 failures**.

New `placeholder height (issue #237)` block (4 tests): a 12-item group at `xs` reserves 4 rows (3 cols) and explicitly *not* 2; row counts scale correctly at `sm` (3 rows) and `md` (2 rows); a measured tile size replaces the fallback; and a render-level check that the emitted `contain-intrinsic-size` is `auto 480px` for a 12-item group at `xs`.

`npx tsc --noEmit` → clean.

*Note:* the render-level test emits a React `act(...)` warning, but that warning is pre-existing on the untouched feed-mode tests in the same file (it originates in `usePendingThumbnails`' async state update) and is not introduced here.

### Test Instructions

1. At 360 px, scroll the Home gallery steadily through several day-groups — no content shift, no scroll-thumb resize.
2. Check the sticky day header at 360 px — flush under the AppBar, no see-through gap.
3. Scroll to the bottom — no tall empty region below "All photos loaded".
4. With a library small enough to fit one screen, the page does not scroll at all.
5. Repeat at 768 px and 1440 px — unchanged behaviour.

## Additional Notes

Child 6 of 7 in epic #234. Issue #242 (feed reset on edit) also perturbs scroll position and lands next, on top of this — they were developed and verified in sequence.

Rebase note from the epic: #250 (in epic #240) also edits `HomePage.tsx` to remove the review-queue banners. This PR touches only that file's `minHeight` and `pb`, so the two should merge cleanly, but whichever lands second should re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_