### PR TITLE
fix(web): keep the loaded gallery feed when editing an item

### DIFF
--- a/apps/web/src/__tests__/components/media/BulkActionToolbar.test.tsx
+++ b/apps/web/src/__tests__/components/media/BulkActionToolbar.test.tsx
@@ -327,8 +327,10 @@ describe('BulkActionToolbar', () => {
       await user.click(confirmBtn);
 
       await waitFor(() => {
+        // 'membership': the items leave the current view (issue #242).
         expect(defaultProps.onSuccess).toHaveBeenCalledWith(
           expect.stringMatching(/moved 2 items to trash/i),
+          'membership',
         );
       });
     });

--- a/apps/web/src/__tests__/components/media/BulkActionToolbarArchive.test.tsx
+++ b/apps/web/src/__tests__/components/media/BulkActionToolbarArchive.test.tsx
@@ -109,8 +109,11 @@ describe('BulkActionToolbar — archive/trash actions', () => {
       await user.click(screen.getByText(/^archive$/i));
 
       await waitFor(() => {
+        // The second argument classifies the action for MediaGallery: archive
+        // takes the items out of the current view (issue #242).
         expect(baseProps.onSuccess).toHaveBeenCalledWith(
           expect.stringMatching(/archived 2 items/i),
+          'membership',
         );
       });
     });
@@ -174,6 +177,7 @@ describe('BulkActionToolbar — archive/trash actions', () => {
       await waitFor(() => {
         expect(baseProps.onSuccess).toHaveBeenCalledWith(
           expect.stringMatching(/unarchived 2 items/i),
+          'membership',
         );
       });
     });

--- a/apps/web/src/__tests__/components/media/TrashBulkToolbar.test.tsx
+++ b/apps/web/src/__tests__/components/media/TrashBulkToolbar.test.tsx
@@ -121,6 +121,7 @@ describe('TrashBulkToolbar', () => {
       await waitFor(() => {
         expect(defaultProps.onSuccess).toHaveBeenCalledWith(
           expect.stringMatching(/restored 2 items/i),
+          { retainedIds: [] },
         );
       });
     });
@@ -135,6 +136,24 @@ describe('TrashBulkToolbar', () => {
       await waitFor(() => {
         expect(defaultProps.onSuccess).toHaveBeenCalledWith(
           expect.stringMatching(/1 item.* could not be restored/i),
+          { retainedIds: ['item-2'] },
+        );
+      });
+    });
+
+    it('reports conflicted ids as retainedIds so the gallery keeps them listed', async () => {
+      // Conflicted items were NOT restored — they are still in Trash and must
+      // stay in the list (issue #242).
+      mockRestoreFromTrash.mockResolvedValue({ restored: 1, conflicts: ['item-2'] });
+      const user = userEvent.setup();
+      render(<TrashBulkToolbar {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /restore selected/i }));
+
+      await waitFor(() => {
+        expect(defaultProps.onSuccess).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ retainedIds: ['item-2'] }),
         );
       });
     });

--- a/apps/web/src/components/media/BulkActionToolbar.tsx
+++ b/apps/web/src/components/media/BulkActionToolbar.tsx
@@ -54,6 +54,35 @@ import {
  */
 export type BulkActionMode = 'home' | 'archive' | 'trash';
 
+/**
+ * How a completed bulk action affects the list the user is looking at
+ * (issue #242 — MediaGallery consumes this to decide between an in-place
+ * refresh and an in-place removal, never a feed reset):
+ *
+ *   'metadata'   — the items stay in the current view, only their fields
+ *                  changed (location, date, tags, favorite, album membership,
+ *                  enrichment reruns).
+ *   'membership' — the items leave the current view (archive, unarchive,
+ *                  move to Trash, restore, delete forever).
+ */
+export type BulkEffect = 'metadata' | 'membership';
+
+/**
+ * Extra detail a bulk action can report about its own outcome.
+ *
+ * A membership action is not always all-or-nothing: `POST /api/media/trash/restore`
+ * deliberately leaves behind items whose `content_hash` collides with an active
+ * item and returns them in `conflicts[]`. Those ids must stay rendered — dropping
+ * them would tell the user the opposite of what the server did.
+ */
+export interface BulkSuccessOptions {
+  /**
+   * Selected ids that did NOT leave the view despite the action succeeding.
+   * They are excluded from the in-place removal.
+   */
+  retainedIds?: string[];
+}
+
 interface BulkActionToolbarProps {
   selected: Set<string>;
   circleId: string;
@@ -63,7 +92,12 @@ interface BulkActionToolbarProps {
   onOpenLocation: () => void;
   onOpenDate: () => void;
   onOpenTags: () => void;
-  onSuccess: (message: string) => void;
+  /**
+   * Called after a successful bulk action. `effect` tells the gallery whether
+   * the items stayed in the current view or left it; it defaults to 'metadata'
+   * so a caller that ignores it still gets the non-destructive path.
+   */
+  onSuccess: (message: string, effect?: BulkEffect) => void;
   onError: (message: string) => void;
   onOpenAlbum?: () => void;
   albumMode?: boolean;
@@ -134,7 +168,7 @@ export function BulkActionToolbar({
     setLoading(true);
     try {
       const result = await bulkDelete({ circleId, ids });
-      onSuccess(`Moved ${result.deleted} item${result.deleted !== 1 ? 's' : ''} to Trash`);
+      onSuccess(`Moved ${result.deleted} item${result.deleted !== 1 ? 's' : ''} to Trash`, 'membership');
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to move items to Trash');
     } finally {
@@ -147,7 +181,7 @@ export function BulkActionToolbar({
     setLoading(true);
     try {
       const result = await bulkArchive({ circleId, ids });
-      onSuccess(`Archived ${result.archived} item${result.archived !== 1 ? 's' : ''}`);
+      onSuccess(`Archived ${result.archived} item${result.archived !== 1 ? 's' : ''}`, 'membership');
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to archive items');
     } finally {
@@ -160,7 +194,7 @@ export function BulkActionToolbar({
     setLoading(true);
     try {
       const result = await bulkUnarchive({ circleId, ids });
-      onSuccess(`Unarchived ${result.unarchived} item${result.unarchived !== 1 ? 's' : ''}`);
+      onSuccess(`Unarchived ${result.unarchived} item${result.unarchived !== 1 ? 's' : ''}`, 'membership');
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to unarchive items');
     } finally {

--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -6,13 +6,43 @@
  * selection + BulkActionToolbar (or the lightbox), never from the tile itself.
  *
  * Two data-source modes:
- *   FEED mode   (queryParams provided): calls useInfiniteMedia internally,
- *               renders an infinite-scroll sentinel, and resets on bulk success.
+ *   FEED mode   (queryParams provided): calls useInfiniteMedia internally and
+ *               renders an infinite-scroll sentinel.
  *   CONTROLLED  (items provided): renders the supplied array, no fetching;
  *               uses isLoading for a spinner; calls onChange on bulk success.
  *
  * Album mode is activated by passing albumId.  It adds "Remove from Album"
  * to the BulkActionToolbar and wires onRemoveFromAlbum accordingly.
+ *
+ * BULK SUCCESS AND THE LOADED FEED (issue #242)
+ * ---------------------------------------------
+ * `handleBulkSuccess` used to `feedReset()` after EVERY bulk action. A reset
+ * bumps useInfiniteMedia's generation counter, empties the item list and
+ * refetches page 1 — so a user who had scrolled through ten pages to edit one
+ * photo's date lost all ten and was clamped back to the top of the document.
+ *
+ * Bulk actions are therefore classified by their effect on the CURRENT view:
+ *
+ *   'metadata'   — the item stays in the feed (location, date taken, tags,
+ *                  favorite, add to album, thumbnail/face/tag reruns, and the
+ *                  AI-enhance *replace* decision, which keeps the same item id
+ *                  and only swaps its bytes). The affected ids are refetched
+ *                  with `getMedia` and merged into `localPatches`, exactly the
+ *                  targeted in-place merge the single-item drawer already used
+ *                  via `handleItemUpdated`. No reset, no scroll jump.
+ *
+ *   'membership' — the item leaves the current view (archive, unarchive,
+ *                  trash, restore, delete forever, remove from album). The ids
+ *                  are added to `removedIds` and filtered out of the rendered
+ *                  list in place. Still no reset. An action that only partly
+ *                  succeeded reports the ids it left behind as
+ *                  `options.retainedIds` (Trash restore returns `conflicts[]`
+ *                  for items whose content hash collides with an active item —
+ *                  those are NOT restored and must stay on screen).
+ *
+ * `feedReset()` now survives ONLY for genuine feed changes: a query/circle
+ * change (handled inside useInfiniteMedia via its queryKey) and the upload
+ * `triggerRefresh` path.
  */
 
 import { useState, useRef, useMemo, useCallback, useEffect, memo } from 'react';
@@ -43,6 +73,7 @@ import { useNavigate } from 'react-router-dom';
 import { useInfiniteMedia } from '../../hooks/useInfiniteMedia';
 import type { InfiniteMediaFetcher } from '../../hooks/useInfiniteMedia';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
+import { useIsMounted } from '../../hooks/useIsMounted';
 import { useMediaRefresh } from '../../contexts/MediaRefreshContext';
 import { useMediaPreview } from '../../contexts/MediaPreviewContext';
 import { usePendingThumbnails } from '../../hooks/usePendingThumbnails';
@@ -53,6 +84,7 @@ import { MediaSelectionCheckbox } from './MediaSelectionCheckbox';
 import { MediaLightbox } from './MediaLightbox';
 import { MediaEnhancementDrawer } from './MediaEnhancementDrawer';
 import { BulkActionToolbar } from './BulkActionToolbar';
+import type { BulkEffect, BulkSuccessOptions } from './BulkActionToolbar';
 import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { TrashBulkToolbar } from './TrashBulkToolbar';
 import { ArchiveBulkToolbar } from './ArchiveBulkToolbar';
@@ -61,7 +93,7 @@ import { BulkDateDialog } from './BulkDateDialog';
 import { BulkTagsDialog } from './BulkTagsDialog';
 import { AddToAlbumDialog } from '../album/AddToAlbumDialog';
 import { TimelineScrubber } from './TimelineScrubber';
-import { removeAlbumItem } from '../../services/media';
+import { getMedia, removeAlbumItem } from '../../services/media';
 import type { MediaItem, MediaQueryParams } from '../../types/media';
 import type { CircleRole } from '../../types/circles';
 
@@ -119,6 +151,14 @@ export function galleryPlaceholderHeight(
  * on phones (issue #237).
  */
 const DAY_HEADER_TOP = { xs: 56, sm: 64 } as const;
+
+/**
+ * How many `getMedia` refetches are issued concurrently after a metadata bulk
+ * action (issue #242). A bulk action accepts up to 500 ids; firing 500 parallel
+ * requests would be worse than the reset it replaces, so the ids are walked in
+ * chunks of this size, one chunk at a time.
+ */
+export const BULK_REFRESH_CHUNK_SIZE = 25;
 
 // ---------------------------------------------------------------------------
 // GalleryTile — internal thumbnail tile
@@ -500,6 +540,34 @@ export function MediaGallery({
     disabled: !isFeedMode || !feedHasMore || feedIsLoading || !circleId,
   });
 
+  // -------------------------------------------------------------------------
+  // Locally-removed ids (membership bulk actions — issue #242)
+  //
+  // Archive/trash/restore/… remove an item from THIS view but must not throw
+  // away the pages already loaded. The ids are filtered out of the rendered
+  // list instead, and the set is cleared whenever the feed genuinely resets.
+  // -------------------------------------------------------------------------
+
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set());
+
+  const markRemoved = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    setRemovedIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+  }, []);
+
+  // Mirror of the key useInfiniteMedia resets on, so a query/circle change
+  // drops the stale removal set along with the stale items.
+  const feedResetKey = queryKey ?? JSON.stringify(queryParams ?? {});
+  useEffect(() => {
+    // Identity-stable when already empty, so the mount-time run is a no-op
+    // rather than an extra render.
+    setRemovedIds((prev) => (prev.size === 0 ? prev : new Set()));
+  }, [feedResetKey]);
+
   // Feed-mode refresh: reset to page 1 whenever a new upload completes.
   // The context has a safe default (refreshToken:0, triggerRefresh:noop) so
   // this is harmless when no MediaRefreshProvider is mounted.
@@ -509,6 +577,7 @@ export function MediaGallery({
     // Skip the initial mount — only react to increments.
     if (refreshToken === refreshTokenRef.current) return;
     refreshTokenRef.current = refreshToken;
+    setRemovedIds((prev) => (prev.size === 0 ? prev : new Set()));
     if (isFeedMode) {
       feedReset();
     }
@@ -530,10 +599,12 @@ export function MediaGallery({
 
   const mergedItems = useMemo(
     () =>
-      baseItems.map((item) =>
-        localPatches[item.id] ? { ...item, ...localPatches[item.id] } : item,
-      ),
-    [baseItems, localPatches],
+      baseItems
+        .filter((item) => !removedIds.has(item.id))
+        .map((item) =>
+          localPatches[item.id] ? { ...item, ...localPatches[item.id] } : item,
+        ),
+    [baseItems, localPatches, removedIds],
   );
 
   // -------------------------------------------------------------------------
@@ -661,20 +732,79 @@ export function MediaGallery({
   // Bulk success handler
   // -------------------------------------------------------------------------
 
+  const isMounted = useIsMounted();
+
+  /**
+   * Refetch the given items and merge them into `localPatches` — the same
+   * targeted in-place merge `handleItemUpdated` performs for the drawer, just
+   * for many ids at once. Requests are issued `BULK_REFRESH_CHUNK_SIZE` at a
+   * time; a single failed id is dropped so the rest of the merge still lands.
+   */
+  const refreshItemsById = useCallback(
+    async (ids: string[]) => {
+      if (ids.length === 0) return;
+      const patches: Record<string, Partial<MediaItem>> = {};
+      for (let i = 0; i < ids.length; i += BULK_REFRESH_CHUNK_SIZE) {
+        const chunk = ids.slice(i, i + BULK_REFRESH_CHUNK_SIZE);
+        const results = await Promise.all(
+          chunk.map((id) => getMedia(id).catch(() => null)),
+        );
+        for (const item of results) {
+          if (item) patches[item.id] = item;
+        }
+        if (!isMounted()) return;
+      }
+      if (!isMounted()) return;
+      if (Object.keys(patches).length === 0) return;
+      setLocalPatches((prev) => ({ ...prev, ...patches }));
+    },
+    [isMounted],
+  );
+
+  /**
+   * Shared completion handler for every bulk action. `effect` decides whether
+   * the affected items are refetched in place ('metadata', the default) or
+   * filtered out of the current view ('membership') — see the file header for
+   * why neither path may reset the feed (issue #242).
+   *
+   * A membership action may report `options.retainedIds` for selected items the
+   * server left behind (Trash restore conflicts); those keep their place in the
+   * list so it agrees with the message the user is being shown.
+   */
   const handleBulkSuccess = useCallback(
-    (message: string) => {
+    (message: string, effect: BulkEffect = 'metadata', options?: BulkSuccessOptions) => {
+      // Capture BEFORE clearing the selection — the ids are the payload.
+      const ids = Array.from(selected);
       setSnackbar({ message, severity: 'success' });
       setSelected(new Set());
       setSelectionMode(false);
-      setLocalPatches({});
-      if (isFeedMode) {
-        feedReset();
+      if (effect === 'membership') {
+        const retained = new Set(options?.retainedIds ?? []);
+        markRemoved(ids.filter((id) => !retained.has(id)));
       } else {
+        void refreshItemsById(ids);
+      }
+      if (!isFeedMode) {
+        // Controlled mode owns its item array, so the parent has to refetch.
+        // Feed mode deliberately does NOT call onChange — some callers wire it
+        // to state changes (e.g. SearchPage's clearSearch) that assume the
+        // controlled-mode contract.
         onChange?.();
       }
       onBulkSuccess?.(message);
     },
-    [isFeedMode, feedReset, onChange, onBulkSuccess],
+    [selected, markRemoved, refreshItemsById, isFeedMode, onChange, onBulkSuccess],
+  );
+
+  /**
+   * Convenience wrapper for toolbars whose every action is membership-changing.
+   * `options` is forwarded so a partial outcome (e.g. Trash restore conflicts)
+   * can keep the items it left behind on screen.
+   */
+  const handleMembershipSuccess = useCallback(
+    (message: string, options?: BulkSuccessOptions) =>
+      handleBulkSuccess(message, 'membership', options),
+    [handleBulkSuccess],
   );
 
   // -------------------------------------------------------------------------
@@ -690,10 +820,11 @@ export function MediaGallery({
       setSnackbar({ message, severity: 'success' });
       setSelected(new Set());
       setSelectionMode(false);
-      setLocalPatches({});
-      if (isFeedMode) {
-        feedReset();
-      }
+      // Membership-changing: the items leave this album's view but the rest of
+      // the loaded feed stays exactly where it is (issue #242).
+      markRemoved(ids);
+      // Unlike handleBulkSuccess, onChange fires in both modes here — album
+      // pages rely on it to refresh the header item count.
       onChange?.();
     } catch (err) {
       setSnackbar({
@@ -701,7 +832,7 @@ export function MediaGallery({
         severity: 'error',
       });
     }
-  }, [albumId, selected, isFeedMode, feedReset, onChange]);
+  }, [albumId, selected, markRemoved, onChange]);
 
   // -------------------------------------------------------------------------
   // AddToAlbum filters — strip pagination/sort from queryParams;
@@ -830,7 +961,9 @@ export function MediaGallery({
           activeCircleRole={activeCircleRole}
           onClear={handleClearSelection}
           onSelectAll={handleSelectAll}
-          onSuccess={handleBulkSuccess}
+          // Restore / delete-forever both take the item out of Trash's view —
+          // except restore conflicts, reported back via options.retainedIds.
+          onSuccess={handleMembershipSuccess}
           onError={(msg) => setSnackbar({ message: msg, severity: 'error' })}
         />
       ) : mode === 'archive' ? (
@@ -840,7 +973,8 @@ export function MediaGallery({
           activeCircleRole={activeCircleRole}
           onClear={handleClearSelection}
           onSelectAll={handleSelectAll}
-          onSuccess={handleBulkSuccess}
+          // Unarchive / move-to-Trash both take the item out of Archive's view.
+          onSuccess={handleMembershipSuccess}
           onError={(msg) => setSnackbar({ message: msg, severity: 'error' })}
         />
       ) : (
@@ -1086,10 +1220,16 @@ export function MediaGallery({
                 }
               : undefined
           }
+          // Replace keeps the same item id and only swaps its bytes, so it is a
+          // metadata refresh of the selected item — never a feed reset (#242).
           onReplaced={() => {
             setEnhanceOpen(false);
             handleBulkSuccess('Photo replaced with the enhanced version');
           }}
+          // Keep-both leaves the source item untouched and creates a second
+          // one; the source is refreshed in place and the new item appears on
+          // the next natural feed load rather than costing the user their
+          // scroll position.
           onKeptBoth={(msg) => {
             setEnhanceOpen(false);
             handleBulkSuccess(msg);

--- a/apps/web/src/components/media/TrashBulkToolbar.tsx
+++ b/apps/web/src/components/media/TrashBulkToolbar.tsx
@@ -29,6 +29,7 @@ import {
   RestoreFromTrash as RestoreIcon,
 } from '@mui/icons-material';
 import type { CircleRole } from '../../types/circles';
+import type { BulkSuccessOptions } from './BulkActionToolbar';
 import { restoreFromTrash, deleteForever } from '../../services/media';
 
 interface TrashBulkToolbarProps {
@@ -37,7 +38,12 @@ interface TrashBulkToolbarProps {
   activeCircleRole: CircleRole | null;
   onClear: () => void;
   onSelectAll: () => void;
-  onSuccess: (message: string) => void;
+  /**
+   * Called after a successful bulk action. Every action here is
+   * membership-changing, so the gallery removes the selected ids in place —
+   * except any reported back in `options.retainedIds` (issue #242).
+   */
+  onSuccess: (message: string, options?: BulkSuccessOptions) => void;
   onError: (message: string) => void;
 }
 
@@ -68,7 +74,10 @@ export function TrashBulkToolbar({
       const msg = result.conflicts.length > 0
         ? `Restored ${result.restored} item${result.restored !== 1 ? 's' : ''}. ${result.conflicts.length} item${result.conflicts.length !== 1 ? 's' : ''} could not be restored (duplicate already exists).`
         : `Restored ${result.restored} item${result.restored !== 1 ? 's' : ''}`;
-      onSuccess(msg);
+      // Conflicted items were NOT restored and are still in Trash, so they must
+      // stay in the list — otherwise the message says "could not be restored"
+      // while the row it refers to disappears (issue #242).
+      onSuccess(msg, { retainedIds: result.conflicts });
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to restore items');
     } finally {

--- a/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGallery.test.tsx
@@ -73,6 +73,8 @@ vi.mock('../../../services/media', () => ({
   removeAlbumItem: vi.fn().mockResolvedValue(undefined),
   listMedia: vi.fn(),
   getThumbnails: vi.fn().mockResolvedValue([]),
+  // Used by the post-bulk-action in-place refresh (issue #242).
+  getMedia: vi.fn(),
 }));
 
 // Mock useIntersectionObserver so the infinite-scroll sentinel never triggers.

--- a/apps/web/src/components/media/__tests__/MediaGalleryFeedState.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGalleryFeedState.test.tsx
@@ -1,0 +1,426 @@
+/**
+ * Component tests — MediaGallery bulk-success feed handling (issue #242)
+ *
+ * Regression guard for "editing a media item from the gallery discards the
+ * loaded feed and jumps back to the top". `handleBulkSuccess` used to call
+ * `feedReset()` for EVERY bulk action, which emptied the item list, refetched
+ * page 1 and collapsed the document so the browser clamped scroll to the top.
+ *
+ * The contract these tests pin down:
+ *   - a METADATA bulk success (location/date/tags/favorite/album/reruns) never
+ *     empties the list, never remounts the grid, refetches only the affected
+ *     ids via getMedia, and leaves unaffected items object-identical;
+ *   - a MEMBERSHIP bulk success (archive/trash/restore/…) removes exactly the
+ *     affected ids in place, with no page-1 refetch;
+ *   - the getMedia refresh is chunked, so a 500-id selection cannot fire 500
+ *     parallel requests.
+ *
+ * Scroll position itself is not asserted directly (jsdom has no layout); it is
+ * a consequence of the document not collapsing, which the "list is intact +
+ * grid not remounted + no refetch" assertions below stand in for.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../__tests__/utils/test-utils';
+import { BULK_REFRESH_CHUNK_SIZE, MediaGallery } from '../MediaGallery';
+import type { BulkEffect, BulkSuccessOptions } from '../BulkActionToolbar';
+import type { MediaItem } from '../../../types/media';
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared before any imports of the mocked modules
+// ---------------------------------------------------------------------------
+
+// Capture the item list the gallery hands downstream, so object identity of
+// unaffected items can be asserted across a bulk success.
+const lightboxItems: MediaItem[][] = [];
+vi.mock('../MediaLightbox', () => ({
+  MediaLightbox: vi.fn(({ items }: { items: MediaItem[] }) => {
+    lightboxItems.push(items);
+    return null;
+  }),
+}));
+
+vi.mock('../MediaDetailDrawer', () => ({ MediaDetailDrawer: vi.fn(() => null) }));
+vi.mock('../MediaEnhancementDrawer', () => ({ MediaEnhancementDrawer: vi.fn(() => null) }));
+vi.mock('../BulkLocationDialog', () => ({ BulkLocationDialog: vi.fn(() => null) }));
+vi.mock('../BulkDateDialog', () => ({ BulkDateDialog: vi.fn(() => null) }));
+vi.mock('../BulkTagsDialog', () => ({ BulkTagsDialog: vi.fn(() => null) }));
+vi.mock('../../album/AddToAlbumDialog', () => ({ AddToAlbumDialog: vi.fn(() => null) }));
+
+// Test harness toolbar: exposes the two completion paths as plain buttons so a
+// test can fire either one against whatever is currently selected.
+vi.mock('../BulkActionToolbar', () => ({
+  BulkActionToolbar: vi.fn(
+    ({
+      onSelectAll,
+      onSuccess,
+    }: {
+      onSelectAll: () => void;
+      onSuccess: (message: string, effect?: BulkEffect) => void;
+    }) => (
+      <div>
+        <button onClick={onSelectAll}>harness-select-all</button>
+        <button onClick={() => onSuccess('Updated 1 item')}>harness-metadata</button>
+        <button onClick={() => onSuccess('Archived 1 item', 'membership')}>
+          harness-membership
+        </button>
+      </div>
+    ),
+  ),
+}));
+
+// Trash harness toolbar: reports a partial restore — 'restored everything the
+// server accepted', with one id handed back as a conflict.
+vi.mock('../TrashBulkToolbar', () => ({
+  TrashBulkToolbar: vi.fn(
+    ({
+      onSelectAll,
+      onSuccess,
+    }: {
+      onSelectAll: () => void;
+      onSuccess: (message: string, options?: BulkSuccessOptions) => void;
+    }) => (
+      <div>
+        <button onClick={onSelectAll}>harness-trash-select-all</button>
+        <button
+          onClick={() =>
+            onSuccess(
+              'Restored 2 items. 1 item could not be restored (duplicate already exists).',
+              { retainedIds: ['t2'] },
+            )
+          }
+        >
+          harness-restore-with-conflict
+        </button>
+      </div>
+    ),
+  ),
+}));
+
+vi.mock('../../../services/media', () => ({
+  listMedia: vi.fn(),
+  getMedia: vi.fn(),
+  getThumbnails: vi.fn().mockResolvedValue([]),
+  patchMedia: vi.fn().mockResolvedValue({}),
+  removeAlbumItem: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../hooks/useIntersectionObserver', () => ({
+  useIntersectionObserver: vi.fn(),
+}));
+
+vi.mock('../../../contexts/MediaPreviewContext', () => ({
+  useMediaPreview: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(() => ({
+    features: null,
+    pictureEnhancement: null,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { getMedia, listMedia } from '../../../services/media';
+import { useMediaPreview } from '../../../contexts/MediaPreviewContext';
+
+const mockListMedia = vi.mocked(listMedia);
+const mockGetMedia = vi.mocked(getMedia);
+const mockUseMediaPreview = vi.mocked(useMediaPreview);
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeItem(id: string, overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    id,
+    storageObjectId: `storage-${id}`,
+    addedById: 'user-001',
+    circleId: 'circle-1',
+    type: 'photo',
+    capturedAt: '2024-06-15T10:00:00.000Z',
+    capturedAtOffset: null,
+    importedAt: null,
+    source: 'web',
+    contentHash: null,
+    width: 1920,
+    height: 1080,
+    durationMs: null,
+    orientation: null,
+    takenLat: null,
+    takenLng: null,
+    takenAltitude: null,
+    cameraMake: null,
+    cameraModel: null,
+    originalFilename: `file-${id}.jpg`,
+    description: null,
+    favorite: false,
+    geoCountry: null,
+    geoCountryCode: null,
+    geoAdmin1: null,
+    geoAdmin2: null,
+    geoLocality: null,
+    geoPlaceName: null,
+    geoSource: null,
+    geocodedAt: null,
+    createdAt: '2024-06-15T10:00:00.000Z',
+    updatedAt: '2024-06-15T10:00:00.000Z',
+    deletedAt: null,
+    metadata: null,
+    thumbnailUrl: `https://cdn.example.com/${id}.jpg`,
+    downloadUrl: null,
+    ...overrides,
+  };
+}
+
+/** Render the gallery in FEED mode seeded with a single page of `items`. */
+async function renderFeed(items: MediaItem[], mode: 'home' | 'trash' | 'archive' = 'home') {
+  mockListMedia.mockResolvedValue({
+    items,
+    meta: { pageSize: 50, nextCursor: null, hasMore: false },
+  });
+
+  const result = render(
+    <MediaGallery
+      circleId="circle-1"
+      activeCircleRole="circle_admin"
+      mode={mode}
+      queryParams={{ circleId: 'circle-1' }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByAltText(items[0].originalFilename!)).toBeInTheDocument();
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MediaGallery bulk success — loaded feed is preserved (issue #242)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lightboxItems.length = 0;
+    mockGetMedia.mockImplementation((id: string) =>
+      Promise.resolve(makeItem(id, { favorite: true })),
+    );
+    mockUseMediaPreview.mockReturnValue({
+      addPreview: vi.fn(),
+      getPreview: vi.fn(() => undefined),
+      removePreview: vi.fn(),
+      version: 0,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata path
+  // -------------------------------------------------------------------------
+
+  it('keeps the loaded items and does not refetch page 1 after a metadata bulk success', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    await renderFeed(items);
+
+    expect(mockListMedia).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByText('harness-select-all'));
+    await user.click(screen.getByText('harness-metadata'));
+
+    // Every affected id is refreshed in place...
+    await waitFor(() => {
+      expect(mockGetMedia).toHaveBeenCalledTimes(3);
+    });
+    expect(mockGetMedia.mock.calls.map((c) => c[0]).sort()).toEqual(['a', 'b', 'c']);
+
+    // ...the list is never emptied...
+    expect(screen.getByAltText('file-a.jpg')).toBeInTheDocument();
+    expect(screen.getByAltText('file-b.jpg')).toBeInTheDocument();
+    expect(screen.getByAltText('file-c.jpg')).toBeInTheDocument();
+
+    // ...and the feed is never reset (a reset refetches page 1).
+    expect(mockListMedia).toHaveBeenCalledTimes(1);
+
+    // The refetched values actually land (favorite: true → the static badge).
+    await waitFor(() => {
+      expect(screen.getAllByRole('img', { name: /^favorite$/i })).toHaveLength(3);
+    });
+  });
+
+  it('does not remount the day-group grid on a metadata bulk success', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('a'), makeItem('b')];
+    const { container } = await renderFeed(items);
+
+    const groupBefore = container.querySelector('[id^="group-"]');
+    expect(groupBefore).not.toBeNull();
+
+    await user.click(screen.getByText('harness-select-all'));
+    await user.click(screen.getByText('harness-metadata'));
+    await waitFor(() => {
+      expect(mockGetMedia).toHaveBeenCalledTimes(2);
+    });
+
+    // Same DOM node — React reconciled in place rather than tearing the grid
+    // down and rebuilding it from an empty list.
+    expect(container.querySelector('[id^="group-"]')).toBe(groupBefore);
+  });
+
+  it('leaves unaffected items object-identical across a metadata bulk success', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('a'), makeItem('kept')];
+    await renderFeed(items);
+
+    const before = lightboxItems[lightboxItems.length - 1];
+    const keptBefore = before.find((i) => i.id === 'kept');
+    const affectedBefore = before.find((i) => i.id === 'a');
+
+    // Select only 'a' via its tile checkbox, then complete a metadata action.
+    const checkboxes = screen.getAllByRole('button', { name: /select item/i });
+    await user.click(checkboxes[0]);
+    await user.click(screen.getByText('harness-metadata'));
+
+    await waitFor(() => {
+      expect(mockGetMedia).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      const after = lightboxItems[lightboxItems.length - 1];
+      expect(after.find((i) => i.id === 'a')).not.toBe(affectedBefore);
+    });
+
+    const after = lightboxItems[lightboxItems.length - 1];
+    expect(after.find((i) => i.id === 'kept')).toBe(keptBefore);
+  });
+
+  it('still merges the successful refetches when one id fails', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('ok'), makeItem('boom')];
+    mockGetMedia.mockImplementation((id: string) =>
+      id === 'boom'
+        ? Promise.reject(new Error('nope'))
+        : Promise.resolve(makeItem(id, { favorite: true })),
+    );
+
+    await renderFeed(items);
+    await user.click(screen.getByText('harness-select-all'));
+    await user.click(screen.getByText('harness-metadata'));
+
+    // The successful id is patched; the failed one is left as it was, and
+    // neither the list nor the feed is thrown away.
+    await waitFor(() => {
+      expect(screen.getAllByRole('img', { name: /^favorite$/i })).toHaveLength(1);
+    });
+    expect(screen.getByAltText('file-ok.jpg')).toBeInTheDocument();
+    expect(screen.getByAltText('file-boom.jpg')).toBeInTheDocument();
+    expect(mockListMedia).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Membership path
+  // -------------------------------------------------------------------------
+
+  it('removes exactly the affected ids on a membership bulk success, without a page-1 refetch', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('m1'), makeItem('m2'), makeItem('m3')];
+    await renderFeed(items);
+
+    // Select only the middle item.
+    const checkboxes = screen.getAllByRole('button', { name: /select item/i });
+    await user.click(checkboxes[1]);
+    await user.click(screen.getByText('harness-membership'));
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('file-m2.jpg')).not.toBeInTheDocument();
+    });
+    expect(screen.getByAltText('file-m1.jpg')).toBeInTheDocument();
+    expect(screen.getByAltText('file-m3.jpg')).toBeInTheDocument();
+
+    // No reset, and no pointless per-item refetch of items that just left.
+    expect(mockListMedia).toHaveBeenCalledTimes(1);
+    expect(mockGetMedia).not.toHaveBeenCalled();
+  });
+
+  it('removes every selected id on a bulk membership action', async () => {
+    const user = userEvent.setup();
+    await renderFeed([makeItem('x1'), makeItem('x2')]);
+
+    await user.click(screen.getByText('harness-select-all'));
+    await user.click(screen.getByText('harness-membership'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/no media found/i)).toBeInTheDocument();
+    });
+    expect(mockListMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a conflicted Trash restore visible and removes only the restored ids', async () => {
+    const user = userEvent.setup();
+    // The server restores t1 and t3 but hands t2 back in conflicts[]: its
+    // content hash collides with an active item, so it is still in Trash.
+    await renderFeed([makeItem('t1'), makeItem('t2'), makeItem('t3')], 'trash');
+
+    await user.click(screen.getByText('harness-trash-select-all'));
+    await user.click(screen.getByText('harness-restore-with-conflict'));
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('file-t1.jpg')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByAltText('file-t3.jpg')).not.toBeInTheDocument();
+
+    // The item the server refused to restore stays exactly where it was, so the
+    // list agrees with the "1 item could not be restored" message.
+    expect(screen.getByAltText('file-t2.jpg')).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 item could not be restored \(duplicate already exists\)/i),
+    ).toBeInTheDocument();
+
+    expect(mockListMedia).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Chunking
+  // -------------------------------------------------------------------------
+
+  it('chunks the getMedia refresh — 60 ids issue 3 batches, never 60 parallel calls', async () => {
+    const user = userEvent.setup();
+    const items = Array.from({ length: 60 }, (_, i) => makeItem(`chunk-${i}`));
+
+    // Count concurrency: each call increments on entry and decrements after a
+    // microtask, so a chunk's calls all overlap and chunks never do.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let batches = 0;
+    mockGetMedia.mockImplementation(async (id: string) => {
+      inFlight += 1;
+      if (inFlight === 1) batches += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return makeItem(id);
+    });
+
+    await renderFeed(items);
+    await user.click(screen.getByText('harness-select-all'));
+    await user.click(screen.getByText('harness-metadata'));
+
+    await waitFor(() => {
+      expect(mockGetMedia).toHaveBeenCalledTimes(60);
+    });
+
+    expect(BULK_REFRESH_CHUNK_SIZE).toBe(25);
+    expect(maxInFlight).toBe(BULK_REFRESH_CHUNK_SIZE);
+    // ceil(60 / 25) = 3
+    expect(batches).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

`MediaGallery.handleBulkSuccess` was the shared completion handler for **every** bulk action — location, date, tags, album, archive, trash, enhancement — and it unconditionally called `feedReset()`. That bumps `useInfiniteMedia`'s generation counter, empties the item list, resets the cursor and refetches page 1. A user who had scrolled ten pages to fix one photo's date lost all ten and was clamped back to the top, because the scroll position was now beyond the collapsed document height. Every single edit cost the user their place.

That reset is correct only for actions that remove items from the current view. The single-item drawer path was already right — `MediaDetailDrawer` → `onItemUpdated` → `setLocalPatches`, a targeted in-place merge — the bulk path just did not use it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #242
Relates to #234, builds on #237

## Changes Made

Bulk actions are now classified by their effect on the current view, carried as an optional argument on `BulkActionToolbar`'s `onSuccess` (`(message, effect?: BulkEffect, options?: BulkSuccessOptions)`), defaulting to `'metadata'` so any caller that ignores it still gets the non-destructive path.

**Metadata path — no reset.** `handleBulkSuccess` captures `Array.from(selected)` *before* clearing the selection, refetches only those ids with the existing single-item `getMedia`, chunked 25 at a time via `Promise.all` per chunk, and merges the results into `localPatches`. A failed id is dropped so the rest still merges. `localPatches` is no longer cleared wholesale.

**Membership path — remove in place.** A new `removedIds: Set<string>` is filtered out in the `mergedItems` memo. No refetch at all.

`feedReset()` now survives only for query/circle changes (inside the hook), the upload `triggerRefresh` path, and an explicit user-initiated refresh; `removedIds` is cleared alongside each of those. No manual scroll restoration was added — the document no longer collapses, so the browser keeps scroll position on its own.

**A membership action is not all-or-nothing.** `POST /api/media/trash/restore` returns `conflicts[]` — items whose `content_hash` collided with an active item and deliberately stayed in Trash. `TrashBulkToolbar` forwards those as `retainedIds`, and the membership branch removes `ids − retainedIds`, so a conflicted item stays visible alongside the "1 item could not be restored" message instead of vanishing and reappearing on the next load.

| Action | Effect |
|---|---|
| Set location / date taken / edit tags | metadata |
| Add / remove favorite | metadata |
| Add to album | metadata |
| Refresh thumbnails / re-run faces / re-run AI tagging | metadata |
| AI enhance — replace | metadata (same id, new bytes) |
| AI enhance — keep both | metadata refresh of the source item; the new item appears on the next natural feed load rather than costing the user their scroll position |
| Archive / unarchive / move to Trash | membership |
| Restore (minus conflicts) / delete forever | membership |
| Remove from album | membership |

Out of scope per the issue: changing the upload `triggerRefresh` full reset to a prepend.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

`npx vitest run src/components/media/__tests__/ src/__tests__/components/media/ src/__tests__/hooks` → **54 files / 1075 tests passing** on the rebased branch.

New `MediaGalleryFeedState.test.tsx` covers: a metadata success keeps all items and refetches exactly the selected ids with no page-1 refetch; the day-group DOM node is the identical element afterwards (no remount); an unaffected item stays object-identical while the affected one does not; a failing `getMedia` still merges the rest; a membership success removes exactly the affected id from a partial selection with zero `getMedia` calls and no refetch; 60 ids produce 3 batches with at most 25 in flight; and a restore of 3 selected ids returning 1 conflict removes exactly 2 while the conflicted one stays visible. `TrashBulkToolbar.test.tsx` additionally asserts the `retainedIds` plumbing in both the conflict and no-conflict cases.

`npx tsc --noEmit` → clean.

### Test Instructions

1. Open the Home gallery on a library large enough to need several pages and scroll well down.
2. Select an item, Set location (or Set date taken, or Edit tags), save — the item updates in place, the feed keeps every loaded page, and you stay exactly where you were.
3. Select an item and Archive it — it disappears from the list with no reload and no scroll jump.
4. In Trash, restore a selection containing a duplicate-conflict item — the conflicted item stays listed, matching the message.

## Additional Notes

Child 7 of 7 in epic #234 — this completes the epic.

One deliberate behaviour worth a reviewer's eye: in controlled mode `removedIds` is **not** cleared when the parent supplies a fresh `items` array. Some parents pass inline literals, so clearing on identity change would instantly undo the optimistic removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvVL9La79GdCSVuS8j2wGg)_