### PR TITLE
feat(web): DataTable mobile card renderer and tablet intermediate layout

### DIFF
--- a/apps/web/src/components/datatable/DataTable.tsx
+++ b/apps/web/src/components/datatable/DataTable.tsx
@@ -1,58 +1,105 @@
 /**
  * DataTable — public component.
  *
- * A thin renderer-switch shell over one shared column contract. Today the only
- * registered renderer is the DataGrid-backed desktop one; issue #253 registers
- * `mobile/CardListRenderer` beside it and the switch below starts resolving to
- * two different layouts from the *same* `DataTableColumn[]`.
+ * A thin layout-switch shell over one shared column contract. It resolves ONE
+ * of three layouts from the table's own container width and hands the same
+ * `DataTableRendererProps` to whichever renderer serves it:
  *
- * Nothing about a table's declaration changes when that happens — which is the
- * whole point of the contract living in `types.ts` rather than in either
- * renderer.
+ *   | layout    | renderer module              | `detail` columns          |
+ *   | --------- | ---------------------------- | ------------------------- |
+ *   | `mobile`  | `mobile/CardListRenderer`    | collapsed "More details"  |
+ *   | `tablet`  | `desktop/DesktopGridRenderer`| hidden; row expansion     |
+ *   | `desktop` | `desktop/DesktopGridRenderer`| visible                   |
+ *
+ * ## Container width, not viewport width
+ *
+ * The switch measures THIS table's wrapper. A DataTable in a 400px drawer on a
+ * 1440px desktop gets cards; a viewport media query would give it the desktop
+ * grid and it would be unusable. See `useContainerLayout.ts` for the mechanics
+ * and the pre-measurement fallback.
+ *
+ * ## State lives above the renderers
+ *
+ * Selection, pagination and sort are all controlled props owned by the calling
+ * page. Nothing a user chose is stored inside a renderer, so rotating a device,
+ * dragging a drawer wider, or resizing a window swaps the layout without
+ * losing a single selected id, the current page, or the active sort. The only
+ * state a renderer owns is which rows/cards happen to be expanded right now —
+ * pure presentation, and meaningless in the layout being switched to.
  */
 
-import { Box, useMediaQuery, useTheme } from '@mui/material';
-import type { DataTableProps, DataTableRendererMode } from './types';
+import { useRef } from 'react';
+import { Box } from '@mui/material';
+import type {
+  DataTableLayout,
+  DataTableProps,
+  DataTableRendererKind,
+  DataTableRendererMode,
+} from './types';
 import { DesktopGridRenderer } from './desktop/DesktopGridRenderer';
+import { CardListRenderer } from './mobile/CardListRenderer';
+import { useDataTableLayout, useViewportLayout } from './useContainerLayout';
 
 /**
- * Placeholder registration for the card-list renderer.
- *
- * TODO(#253): replace with `mobile/CardListRenderer`. Until then `'mobile'`
- * resolves to the desktop grid so the switch is exercised end to end (the
- * `data-renderer` attribute below reports the *resolved* mode either way) and
- * narrow viewports still get a working table.
+ * The card-list registration. This is the seam #252 left behind; it now points
+ * at the real renderer.
  */
-const MOBILE_RENDERER = DesktopGridRenderer;
+const MOBILE_RENDERER = CardListRenderer;
+
+/** Which renderer module serves a given layout. */
+export function rendererForLayout(layout: DataTableLayout): DataTableRendererKind {
+  return layout === 'mobile' ? 'mobile' : 'desktop';
+}
 
 /**
- * Resolve which renderer to use.
+ * Viewport-based renderer resolution.
  *
- * `'auto'` breaks at the `md` boundary — below it a table cannot show more than
- * about two columns without horizontal scrolling, which is exactly where cards
- * beat rows.
+ * Retained as the public, ref-free helper (and used as the layout hook's
+ * pre-measurement fallback). Prefer `DataTable`'s own container-driven switch:
+ * this one cannot see that its table is inside a narrow drawer.
  */
-export function useDataTableRenderer(mode: DataTableRendererMode = 'auto'): 'desktop' | 'mobile' {
-  const theme = useTheme();
-  const isNarrow = useMediaQuery(theme.breakpoints.down('md'));
-  if (mode !== 'auto') return mode;
-  return isNarrow ? 'mobile' : 'desktop';
+export function useDataTableRenderer(
+  mode: DataTableRendererMode = 'auto',
+): DataTableRendererKind {
+  const viewportLayout = useViewportLayout();
+  if (mode !== 'auto') return rendererForLayout(mode);
+  return rendererForLayout(viewportLayout);
 }
 
 export function DataTable<Row>(props: DataTableProps<Row>) {
-  const { renderer = 'auto', 'data-testid': testId, ...rendererProps } = props;
-  const mode = useDataTableRenderer(renderer);
-  const Renderer = mode === 'mobile' ? MOBILE_RENDERER : DesktopGridRenderer;
+  const {
+    renderer = 'auto',
+    mobileBreakpoint,
+    tabletBreakpoint,
+    'data-testid': testId,
+    ...rendererProps
+  } = props;
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const layout = useDataTableLayout(containerRef, renderer, {
+    mobile: mobileBreakpoint,
+    tablet: tabletBreakpoint,
+  });
+  const mode = rendererForLayout(layout);
 
   return (
     <Box
+      ref={containerRef}
       data-testid={testId ?? 'datatable'}
+      // `data-renderer` is which module drew this (two values); `data-layout`
+      // is which of the three layouts it drew. Both are test hooks and
+      // debugging aids.
       data-renderer={mode}
+      data-layout={layout}
       // The horizontal-containment contract starts here: no DataTable may ever
       // make the document body scroll sideways, at any viewport width.
       sx={{ width: '100%', maxWidth: '100%', minWidth: 0 }}
     >
-      <Renderer {...rendererProps} />
+      {mode === 'mobile' ? (
+        <MOBILE_RENDERER {...rendererProps} />
+      ) : (
+        <DesktopGridRenderer {...rendererProps} variant={layout === 'tablet' ? 'tablet' : 'desktop'} />
+      )}
     </Box>
   );
 }

--- a/apps/web/src/components/datatable/__tests__/ResponsiveDataTable.test.tsx
+++ b/apps/web/src/components/datatable/__tests__/ResponsiveDataTable.test.tsx
@@ -1,0 +1,986 @@
+/**
+ * Component tests — responsive DataTable (issue #253).
+ *
+ * Covers what this issue promises beyond the #252 foundation:
+ *
+ *  1. Three layouts, resolved from the table's **container** width — including
+ *     the case the whole design exists for: a narrow container inside a wide
+ *     viewport (the 400px Workflow runs drawer on a 1440px desktop, issue #261)
+ *     renders cards.
+ *  2. Selection / page / sort survive a layout switch, because they live above
+ *     the renderers.
+ *  3. The card layout: priority-driven headline/body/detail, detail closed by
+ *     default, tap-to-expand truncation, overflow-menu row actions with the
+ *     shared confirm dialog, and the same BulkActionBar as the grid.
+ *  4. The tablet layout: the real grid with `detail` columns hidden but
+ *     reachable through row expansion.
+ *  5. A regression guard for the issue #243 class of bug — no control that is
+ *     invisible (`opacity: 0`) while still being hit-testable.
+ *
+ * ## Test doubles
+ *
+ * jsdom performs no layout, so both the container-width hook and MUI X's
+ * virtualizer would measure 0×0. `installLayoutStubs()` gives every element a
+ * width driven by a module-level `containerWidth`, and a ResizeObserver that
+ * actually fires — and, unlike the #252 recipe, can be re-fired on demand so a
+ * resize is observable mid-test.
+ *
+ * `window.matchMedia` is implemented against a FIXED 1440px viewport. That is
+ * what makes the container-vs-viewport assertions meaningful: every viewport
+ * media query in the tree answers "desktop", so any `mobile` result can only
+ * have come from the container measurement.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { useState } from 'react';
+import { act, screen, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../__tests__/utils/test-utils';
+import { DataTable } from '../DataTable';
+import { layoutForWidth, DEFAULT_BREAKPOINTS } from '../useContainerLayout';
+import type { DataTableColumn, DataTableSortState } from '../types';
+
+// ---------------------------------------------------------------------------
+// Layout stubs
+// ---------------------------------------------------------------------------
+
+/** The (fixed) viewport every media query in these tests sees. */
+const VIEWPORT_WIDTH = 1440;
+const VIEWPORT_HEIGHT = 900;
+
+/** The container width under test. Mutated by `setContainerWidth`. */
+let containerWidth = 1400;
+
+interface FakeObserver {
+  callback: ResizeObserverCallback;
+  targets: Set<Element>;
+  fire: () => void;
+}
+
+const observers = new Set<FakeObserver>();
+
+function installLayoutStubs() {
+  for (const prop of ['clientWidth', 'offsetWidth', 'scrollWidth'] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => containerWidth,
+    });
+  }
+  for (const prop of ['clientHeight', 'offsetHeight', 'scrollHeight'] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => VIEWPORT_HEIGHT,
+    });
+  }
+
+  HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    return {
+      width: containerWidth,
+      height: VIEWPORT_HEIGHT,
+      top: 0,
+      left: 0,
+      right: containerWidth,
+      bottom: VIEWPORT_HEIGHT,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+
+  class ControllableResizeObserver {
+    private readonly entry: FakeObserver;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.entry = {
+        callback,
+        targets: new Set<Element>(),
+        fire: () => {
+          const entries = Array.from(this.entry.targets, (target) => ({
+            target,
+            contentRect: { width: containerWidth, height: VIEWPORT_HEIGHT },
+          })) as unknown as ResizeObserverEntry[];
+          if (entries.length > 0) {
+            this.entry.callback(entries, this as unknown as ResizeObserver);
+          }
+        },
+      };
+      observers.add(this.entry);
+    }
+
+    observe(target: Element) {
+      this.entry.targets.add(target);
+      this.entry.fire();
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target);
+    }
+    disconnect() {
+      this.entry.targets.clear();
+      observers.delete(this.entry);
+    }
+  }
+
+  global.ResizeObserver = ControllableResizeObserver as unknown as typeof ResizeObserver;
+
+  // A fixed 1440px viewport, so a viewport media query never says "mobile".
+  window.matchMedia = vi.fn().mockImplementation((query: string) => {
+    const max = /max-width:\s*([\d.]+)px/.exec(query);
+    const min = /min-width:\s*([\d.]+)px/.exec(query);
+    let matches = true;
+    if (max) matches = matches && VIEWPORT_WIDTH <= Number.parseFloat(max[1]);
+    if (min) matches = matches && VIEWPORT_WIDTH >= Number.parseFloat(min[1]);
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  }) as unknown as typeof window.matchMedia;
+}
+
+/** Resize the container and let every live observer report the new width. */
+function setContainerWidth(width: number) {
+  containerWidth = width;
+  act(() => {
+    observers.forEach((observer) => observer.fire());
+  });
+}
+
+beforeAll(() => {
+  installLayoutStubs();
+});
+
+beforeEach(() => {
+  containerWidth = 1400;
+});
+
+// ---------------------------------------------------------------------------
+// Fixture — deliberately the same shape as the #252 suite's
+// ---------------------------------------------------------------------------
+
+interface Job {
+  id: string;
+  type: string;
+  status: 'pending' | 'running' | 'succeeded' | 'failed';
+  attempts: number;
+  lastError: string | null;
+}
+
+const JOBS: Job[] = [
+  { id: 'job-1', type: 'face_detection', status: 'succeeded', attempts: 1, lastError: null },
+  {
+    id: 'job-2',
+    type: 'auto_tagging',
+    status: 'failed',
+    attempts: 3,
+    lastError: 'rate limited by provider after three consecutive attempts',
+  },
+  { id: 'job-3', type: 'geocode', status: 'pending', attempts: 0, lastError: null },
+];
+
+const COLUMNS: DataTableColumn<Job>[] = [
+  { id: 'type', label: 'Type', priority: 'primary', sortable: true, value: (r) => r.type },
+  {
+    id: 'status',
+    label: 'Status',
+    priority: 'primary',
+    value: (r) => r.status,
+    render: (r) => <span data-testid={`status-chip-${r.id}`}>{r.status.toUpperCase()}</span>,
+  },
+  {
+    id: 'attempts',
+    label: 'Attempts',
+    priority: 'secondary',
+    align: 'right',
+    sortable: true,
+    value: (r) => r.attempts,
+  },
+  {
+    id: 'lastError',
+    label: 'Last error',
+    priority: 'detail',
+    truncate: true,
+    value: (r) => r.lastError,
+  },
+];
+
+const rowId = (job: Job) => job.id;
+
+type TableProps = React.ComponentProps<typeof DataTable<Job>>;
+
+function renderTable(overrides: Partial<TableProps> = {}) {
+  return render(
+    <DataTable<Job>
+      columns={COLUMNS}
+      rows={JOBS}
+      rowId={rowId}
+      ariaLabel="Enrichment jobs"
+      {...overrides}
+    />,
+  );
+}
+
+/** Renders at a given container width without going through a resize. */
+function renderAtWidth(width: number, overrides: Partial<TableProps> = {}) {
+  containerWidth = width;
+  return renderTable(overrides);
+}
+
+const wrapper = () => screen.getByTestId('datatable');
+const layout = () => wrapper().getAttribute('data-layout');
+const renderer = () => wrapper().getAttribute('data-renderer');
+
+// ---------------------------------------------------------------------------
+// 1. Breakpoint mapping (pure)
+// ---------------------------------------------------------------------------
+
+describe('layoutForWidth', () => {
+  it('maps widths onto the three layouts at the documented thresholds', () => {
+    expect(layoutForWidth(320)).toBe('mobile');
+    expect(layoutForWidth(599)).toBe('mobile');
+    expect(layoutForWidth(600)).toBe('tablet');
+    expect(layoutForWidth(1199)).toBe('tablet');
+    expect(layoutForWidth(1200)).toBe('desktop');
+    expect(layoutForWidth(1920)).toBe('desktop');
+  });
+
+  it('honours per-instance breakpoint overrides', () => {
+    expect(layoutForWidth(700, { mobile: 800, tablet: 1400 })).toBe('mobile');
+    expect(layoutForWidth(900, { mobile: 800, tablet: 1400 })).toBe('tablet');
+    expect(layoutForWidth(1500, { mobile: 800, tablet: 1400 })).toBe('desktop');
+  });
+
+  it('publishes the documented default thresholds', () => {
+    expect(DEFAULT_BREAKPOINTS).toEqual({ mobile: 600, tablet: 1200 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Renderer switching, driven by CONTAINER width
+// ---------------------------------------------------------------------------
+
+describe('DataTable — container-driven renderer switching', () => {
+  it('renders the card list in a phone-width container', () => {
+    renderAtWidth(400);
+
+    expect(renderer()).toBe('mobile');
+    expect(layout()).toBe('mobile');
+    expect(screen.getByTestId('datatable-card-list')).toBeInTheDocument();
+    expect(screen.getAllByTestId('datatable-card')).toHaveLength(3);
+    // No grid at all.
+    expect(screen.queryByRole('columnheader', { name: /^type$/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the real grid in a tablet-width container, with detail columns folded away', () => {
+    renderAtWidth(800);
+
+    expect(layout()).toBe('tablet');
+    // Still the grid renderer — tablet is a grid variant, not a third module.
+    expect(renderer()).toBe('desktop');
+    expect(screen.getByRole('columnheader', { name: /^type$/i })).toBeInTheDocument();
+    // `detail` priority is hidden...
+    expect(screen.queryByRole('columnheader', { name: /last error/i })).not.toBeInTheDocument();
+    // ...but reachable, via the row expander.
+    expect(screen.getAllByTestId('datatable-row-expander')).toHaveLength(3);
+    expect(screen.queryByTestId('datatable-card-list')).not.toBeInTheDocument();
+  });
+
+  it('renders the full grid in a desktop-width container, with no expander', () => {
+    renderAtWidth(1400);
+
+    expect(layout()).toBe('desktop');
+    expect(renderer()).toBe('desktop');
+    expect(screen.getByRole('columnheader', { name: /last error/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-row-expander')).not.toBeInTheDocument();
+  });
+
+  /**
+   * The reason the switch measures a container at all — issue #261's acceptance
+   * case. Every media query in this file answers for a 1440px viewport, so a
+   * `mobile` result here can only have come from the 400px container.
+   */
+  it('renders cards for a narrow container inside a WIDE viewport (drawer case)', () => {
+    expect(window.matchMedia('(max-width:899.95px)').matches).toBe(false); // viewport is desktop
+
+    renderAtWidth(400);
+
+    expect(layout()).toBe('mobile');
+    expect(screen.getByTestId('datatable-card-list')).toBeInTheDocument();
+  });
+
+  it('switches layout when the container is resized, viewport untouched', () => {
+    renderAtWidth(1400);
+    expect(layout()).toBe('desktop');
+
+    setContainerWidth(800);
+    expect(layout()).toBe('tablet');
+
+    setContainerWidth(420);
+    expect(layout()).toBe('mobile');
+
+    setContainerWidth(1400);
+    expect(layout()).toBe('desktop');
+  });
+
+  it('honours the per-instance mobileBreakpoint / tabletBreakpoint props', () => {
+    renderAtWidth(800, { mobileBreakpoint: 900, tabletBreakpoint: 1600 });
+    // 800 is normally tablet; this instance says everything under 900 is cards.
+    expect(layout()).toBe('mobile');
+  });
+
+  it('honours a forced renderer regardless of container width', () => {
+    renderAtWidth(1400, { renderer: 'mobile' });
+    expect(layout()).toBe('mobile');
+    expect(screen.getByTestId('datatable-card-list')).toBeInTheDocument();
+  });
+
+  it('honours a forced tablet layout', () => {
+    renderAtWidth(1400, { renderer: 'tablet' });
+    expect(layout()).toBe('tablet');
+    expect(screen.queryByRole('columnheader', { name: /last error/i })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. State preservation across a layout switch
+// ---------------------------------------------------------------------------
+
+/**
+ * A page-shaped harness: it owns selection, pagination and sort exactly the way
+ * a real caller does, so "state survives a resize" is a claim about the
+ * architecture (state above the renderers) rather than about a renderer's
+ * internals.
+ */
+function StatefulTable({ initialSort }: { initialSort?: DataTableSortState | null }) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set(['job-2']));
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [sort, setSort] = useState<DataTableSortState | null>(
+    initialSort ?? { field: 'attempts', direction: 'desc' },
+  );
+
+  return (
+    <>
+      <div data-testid="probe-selection">{Array.from(selectedIds).sort().join(',')}</div>
+      <div data-testid="probe-page">{page}</div>
+      <div data-testid="probe-sort">{sort ? `${sort.field}:${sort.direction}` : 'none'}</div>
+      <DataTable<Job>
+        columns={COLUMNS}
+        rows={JOBS}
+        rowId={rowId}
+        ariaLabel="Enrichment jobs"
+        selection={{ selectedIds, onSelectionChange: setSelectedIds }}
+        sort={{ sort, onSortChange: setSort }}
+        pagination={{
+          page,
+          pageSize,
+          total: 137,
+          onPaginationChange: (next) => {
+            setPage(next.page);
+            setPageSize(next.pageSize);
+          },
+        }}
+      />
+    </>
+  );
+}
+
+describe('DataTable — state survives a layout switch', () => {
+  it('keeps selection, page and sort across desktop -> mobile -> desktop', () => {
+    containerWidth = 1400;
+    render(<StatefulTable />);
+
+    expect(screen.getByTestId('probe-selection')).toHaveTextContent('job-2');
+    expect(screen.getByTestId('probe-page')).toHaveTextContent('1');
+    expect(screen.getByTestId('probe-sort')).toHaveTextContent('attempts:desc');
+    expect(screen.getByRole('columnheader', { name: /attempts/i })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+
+    // --- to the card layout -------------------------------------------------
+    setContainerWidth(400);
+    expect(layout()).toBe('mobile');
+
+    // Selection is intact, and visible in the card layout.
+    expect(screen.getByTestId('probe-selection')).toHaveTextContent('job-2');
+    const selectedCard = screen
+      .getAllByTestId('datatable-card')
+      .find((card) => card.getAttribute('data-row-id') === 'job-2');
+    expect(selectedCard).toHaveAttribute('data-selected', 'true');
+    expect(within(screen.getByTestId('datatable-bulk-action-bar')).getByText('1 selected'))
+      .toBeInTheDocument();
+
+    // Page is intact: page 1 (zero-based) of 25 => rows 26-28 of 137.
+    expect(screen.getByTestId('probe-page')).toHaveTextContent('1');
+    expect(screen.getByTestId('datatable-compact-pagination')).toHaveTextContent('26–28 of 137');
+
+    // Sort is intact and still reachable, via the card sort control.
+    expect(screen.getByTestId('probe-sort')).toHaveTextContent('attempts:desc');
+    expect(within(screen.getByTestId('datatable-card-sort')).getByText('Attempts')).toBeInTheDocument();
+
+    // --- back to the grid ---------------------------------------------------
+    setContainerWidth(1400);
+    expect(layout()).toBe('desktop');
+    expect(screen.getByTestId('probe-selection')).toHaveTextContent('job-2');
+    expect(screen.getByTestId('probe-page')).toHaveTextContent('1');
+    expect(screen.getByRole('columnheader', { name: /attempts/i })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+  });
+
+  it('carries a selection MADE on the card layout back to the grid', () => {
+    containerWidth = 400;
+    render(<StatefulTable />);
+
+    const cards = screen.getAllByTestId('datatable-card');
+    const firstCard = cards.find((card) => card.getAttribute('data-row-id') === 'job-1');
+    fireEvent.click(within(firstCard as HTMLElement).getByRole('checkbox', { name: /select row/i }));
+
+    expect(screen.getByTestId('probe-selection')).toHaveTextContent('job-1,job-2');
+
+    setContainerWidth(1400);
+    expect(screen.getByTestId('probe-selection')).toHaveTextContent('job-1,job-2');
+    expect(within(screen.getByTestId('datatable-bulk-action-bar')).getByText('2 selected'))
+      .toBeInTheDocument();
+  });
+
+  it('keeps pagination controlled from the card layout', () => {
+    containerWidth = 400;
+    render(<StatefulTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /go to next page/i }));
+    expect(screen.getByTestId('probe-page')).toHaveTextContent('2');
+  });
+
+  it('lets the card sort control clear the sort back to the server default', async () => {
+    const user = userEvent.setup();
+    containerWidth = 400;
+    render(<StatefulTable />);
+
+    await user.click(within(screen.getByTestId('datatable-card-sort')).getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: 'Default' }));
+
+    expect(screen.getByTestId('probe-sort')).toHaveTextContent('none');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Card layout — priority mapping and expansion
+// ---------------------------------------------------------------------------
+
+describe('CardListRenderer — priority drives the card', () => {
+  it('puts primary columns in the headline and secondary columns in the body', () => {
+    renderAtWidth(400);
+
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-2') as HTMLElement;
+
+    // primary -> headline
+    expect(within(card).getByTestId('datatable-card-headline-type')).toHaveTextContent(
+      'auto_tagging',
+    );
+    // primary with a `render` keeps its rich cell, unchanged from the grid.
+    expect(within(card).getByTestId('status-chip-job-2')).toHaveTextContent('FAILED');
+    // secondary -> body label/value pair
+    const attempts = within(card).getByTestId('datatable-card-field-attempts');
+    expect(attempts).toHaveTextContent('Attempts');
+    expect(attempts).toHaveTextContent('3');
+  });
+
+  it('renders an em dash for a null scalar, matching the grid', () => {
+    renderAtWidth(400);
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-1') as HTMLElement;
+
+    fireEvent.click(within(card).getByRole('button', { name: /more details/i }));
+    expect(within(card).getByTestId('datatable-card-field-lastError')).toHaveTextContent('—');
+  });
+
+  it('keeps the detail region CLOSED by default', () => {
+    renderAtWidth(400);
+
+    expect(screen.queryByTestId('datatable-card-detail-region')).not.toBeInTheDocument();
+    for (const toggle of screen.getAllByTestId('datatable-card-detail-toggle')) {
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    }
+    // The detail column's value is genuinely not on screen while collapsed.
+    expect(screen.queryByText(/rate limited by provider/)).not.toBeInTheDocument();
+  });
+
+  it('opens the detail region on tap', () => {
+    renderAtWidth(400);
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-2') as HTMLElement;
+
+    fireEvent.click(within(card).getByRole('button', { name: /more details/i }));
+
+    const region = within(card).getByTestId('datatable-card-detail-region');
+    expect(region).toHaveTextContent('Last error');
+    expect(region).toHaveTextContent('rate limited by provider after three consecutive attempts');
+    expect(within(card).getByTestId('datatable-card-detail-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('opens the detail region with Enter and closes it with Space', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(400);
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-2') as HTMLElement;
+
+    const toggle = within(card).getByTestId('datatable-card-detail-toggle');
+    toggle.focus();
+
+    await user.keyboard('{Enter}');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard(' ');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands one card without expanding its siblings', () => {
+    renderAtWidth(400);
+
+    fireEvent.click(screen.getAllByTestId('datatable-card-detail-toggle')[0]);
+    expect(screen.getAllByTestId('datatable-card-detail-region')).toHaveLength(1);
+  });
+
+  it('renders a compact pagination control instead of the desktop footer', () => {
+    renderAtWidth(400, {
+      pagination: { page: 0, pageSize: 25, total: 137, onPaginationChange: vi.fn() },
+    });
+
+    const compact = screen.getByTestId('datatable-compact-pagination');
+    expect(compact).toHaveTextContent('1–3 of 137');
+    // No rows-per-page select — that is the control that overflows a phone.
+    expect(screen.queryByLabelText(/rows per page/i)).not.toBeInTheDocument();
+  });
+
+  it('disables the previous-page control on the first page', () => {
+    renderAtWidth(400, {
+      pagination: { page: 0, pageSize: 25, total: 137, onPaginationChange: vi.fn() },
+    });
+    expect(screen.getByRole('button', { name: /go to previous page/i })).toBeDisabled();
+  });
+
+  it('shows the caller-supplied empty state and the error alert', () => {
+    renderAtWidth(400, {
+      rows: [],
+      emptyState: <span>No jobs match these filters</span>,
+      error: 'Failed to load jobs',
+    });
+
+    expect(
+      within(screen.getByTestId('datatable-empty-overlay')).getByText('No jobs match these filters'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('datatable-error')).toHaveTextContent('Failed to load jobs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Card layout — truncation is tap-to-expand
+// ---------------------------------------------------------------------------
+
+describe('CardListRenderer — truncated values', () => {
+  it('clamps a truncate column and expands it in place on tap', () => {
+    renderAtWidth(400);
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-2') as HTMLElement;
+
+    fireEvent.click(within(card).getByRole('button', { name: /more details/i }));
+
+    const value = within(card).getByTestId('datatable-card-expandable-value');
+    expect(value).toHaveAttribute('data-expanded', 'false');
+    expect(value).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(value);
+    expect(value).toHaveAttribute('data-expanded', 'true');
+    expect(value).toHaveAttribute('aria-expanded', 'true');
+    // The full text was in the DOM all along — the clamp is visual, so the
+    // value can never be lost, only folded.
+    expect(value).toHaveTextContent('rate limited by provider after three consecutive attempts');
+  });
+
+  it('exposes the expander as a real button, so Enter works', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(400);
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-2') as HTMLElement;
+    fireEvent.click(within(card).getByRole('button', { name: /more details/i }));
+
+    const value = within(card).getByTestId('datatable-card-expandable-value');
+    value.focus();
+    await user.keyboard('{Enter}');
+    expect(value).toHaveAttribute('data-expanded', 'true');
+  });
+
+  it('does not make a non-truncate column expandable', () => {
+    renderAtWidth(400);
+    const card = screen
+      .getAllByTestId('datatable-card')
+      .find((c) => c.getAttribute('data-row-id') === 'job-2') as HTMLElement;
+    // Only `lastError` declares truncate, and it is behind the closed detail
+    // region — so no expandable value is on screen yet.
+    expect(within(card).queryByTestId('datatable-card-expandable-value')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Card layout — selection parity with the grid
+// ---------------------------------------------------------------------------
+
+describe('CardListRenderer — selection parity', () => {
+  it('toggles a single row and reports the same id set the grid would', () => {
+    const onSelectionChange = vi.fn();
+    renderAtWidth(400, { selection: { selectedIds: new Set<string>(), onSelectionChange } });
+
+    fireEvent.click(screen.getAllByRole('checkbox', { name: /select row/i })[0]);
+    expect(Array.from(onSelectionChange.mock.calls[0][0] as Set<string>)).toEqual(['job-1']);
+  });
+
+  it('offers the same page-scoped select-all as the grid header checkbox', () => {
+    const onSelectionChange = vi.fn();
+    renderAtWidth(400, { selection: { selectedIds: new Set<string>(), onSelectionChange } });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all rows/i }));
+    expect(Array.from(onSelectionChange.mock.calls[0][0] as Set<string>).sort()).toEqual([
+      'job-1',
+      'job-2',
+      'job-3',
+    ]);
+  });
+
+  it('deselects everything when select-all is toggled off', () => {
+    const onSelectionChange = vi.fn();
+    renderAtWidth(400, {
+      selection: { selectedIds: new Set(['job-1', 'job-2', 'job-3']), onSelectionChange },
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all rows/i }));
+    expect((onSelectionChange.mock.calls[0][0] as Set<string>).size).toBe(0);
+  });
+
+  it('reuses the shared BulkActionBar verbatim', () => {
+    const archive = vi.fn();
+    renderAtWidth(400, {
+      selection: { selectedIds: new Set(['job-1', 'job-2']), onSelectionChange: vi.fn() },
+      bulkActions: [{ id: 'archive', label: 'Archive', onClick: archive }],
+    });
+
+    const bar = screen.getByTestId('datatable-bulk-action-bar');
+    expect(bar).toHaveAttribute('role', 'toolbar');
+    expect(within(bar).getByText('2 selected')).toBeInTheDocument();
+
+    fireEvent.click(within(bar).getByRole('button', { name: 'Archive' }));
+    expect(archive).toHaveBeenCalledWith(['job-1', 'job-2']);
+  });
+
+  it('renders no checkboxes without a selection config', () => {
+    renderAtWidth(400);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-bulk-action-bar')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Card layout — row actions in the header overflow menu
+// ---------------------------------------------------------------------------
+
+describe('CardListRenderer — row actions', () => {
+  it('collapses even a SINGLE action into the card header overflow menu', () => {
+    const retry = vi.fn();
+    renderAtWidth(400, { rowActions: [{ id: 'retry', label: 'Retry', onClick: retry }] });
+
+    // No bare icon button; the affordance is always the same menu.
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions for face_detection' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Retry' }));
+    expect(retry).toHaveBeenCalledWith(JOBS[0]);
+  });
+
+  it('names each card menu button after its row headline', () => {
+    renderAtWidth(400, { rowActions: [{ id: 'retry', label: 'Retry', onClick: vi.fn() }] });
+
+    expect(screen.getByRole('button', { name: 'Row actions for auto_tagging' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Row actions for geocode' })).toBeInTheDocument();
+  });
+
+  it('disables an action per row inside the menu', () => {
+    renderAtWidth(400, {
+      rowActions: [
+        {
+          id: 'retry',
+          label: 'Retry',
+          onClick: vi.fn(),
+          disabled: (row) => row.status === 'pending',
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions for geocode' }));
+    expect(screen.getByRole('menuitem', { name: 'Retry' })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('gates a destructive action behind the SAME confirmation dialog as the grid', () => {
+    const destroy = vi.fn();
+    renderAtWidth(400, {
+      rowActions: [
+        { id: 'retry', label: 'Retry', onClick: vi.fn() },
+        {
+          id: 'delete',
+          label: 'Delete',
+          destructive: true,
+          confirm: { title: 'Delete job?', description: 'This removes the job row permanently.' },
+          onClick: destroy,
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions for auto_tagging' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(destroy).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Delete job?')).toBeInTheDocument();
+    expect(within(dialog).getByText('This removes the job row permanently.')).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    expect(destroy).toHaveBeenCalledWith(JOBS[1]);
+  });
+
+  it('does not run a confirming action when the dialog is cancelled', () => {
+    const destroy = vi.fn();
+    renderAtWidth(400, {
+      rowActions: [
+        { id: 'delete', label: 'Delete', destructive: true, confirm: true, onClick: destroy },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions for face_detection' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' }));
+    expect(destroy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Tablet — hidden detail columns stay reachable
+// ---------------------------------------------------------------------------
+
+describe('DesktopGridRenderer — tablet row expansion', () => {
+  it('reveals the hidden detail columns as label/value pairs', () => {
+    renderAtWidth(800);
+
+    expect(screen.queryByRole('columnheader', { name: /last error/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-row-detail-panel')).not.toBeInTheDocument();
+
+    // Row 2 is `auto_tagging`, the one with a lastError.
+    const expanders = screen.getAllByTestId('datatable-row-expander');
+    expect(expanders[1]).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(expanders[1]);
+
+    const panel = screen.getByTestId('datatable-row-detail-panel');
+    expect(within(panel).getByText('Last error')).toBeInTheDocument();
+    expect(panel).toHaveTextContent('rate limited by provider after three consecutive attempts');
+    expect(screen.getAllByTestId('datatable-row-expander')[1]).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('collapses the row again on a second activation', () => {
+    renderAtWidth(800);
+
+    fireEvent.click(screen.getAllByTestId('datatable-row-expander')[1]);
+    expect(screen.getByTestId('datatable-row-detail-panel')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByTestId('datatable-row-expander')[1]);
+    expect(screen.queryByTestId('datatable-row-detail-panel')).not.toBeInTheDocument();
+  });
+
+  it('keeps the real rows intact and selectable while a row is expanded', () => {
+    const onSelectionChange = vi.fn();
+    renderAtWidth(800, { selection: { selectedIds: new Set<string>(), onSelectionChange } });
+
+    fireEvent.click(screen.getAllByTestId('datatable-row-expander')[0]);
+
+    // The synthetic detail row must not add a selectable row.
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    expect(rowCheckboxes).toHaveLength(3);
+
+    fireEvent.click(rowCheckboxes[0]);
+    expect(Array.from(onSelectionChange.mock.calls[0][0] as Set<string>)).toEqual(['job-1']);
+  });
+
+  it('adds no expander when the table declares no detail columns', () => {
+    const noDetail = COLUMNS.filter((column) => column.priority !== 'detail');
+    renderAtWidth(800, { columns: noDetail });
+
+    expect(layout()).toBe('tablet');
+    expect(screen.queryByTestId('datatable-row-expander')).not.toBeInTheDocument();
+  });
+
+  it('gives the expander a comfortable touch target, except at compact density', () => {
+    // A tablet is a touch device and this is the only route to the hidden
+    // columns — but a `compact` row is 36px tall and cannot hold a 44px target.
+    const { unmount } = renderAtWidth(800);
+    expect(
+      Number.parseFloat(
+        getComputedStyle(screen.getAllByTestId('datatable-row-expander')[0]).minHeight || '0',
+      ),
+    ).toBeGreaterThanOrEqual(44);
+    unmount();
+
+    renderAtWidth(800, { density: 'compact' });
+    expect(
+      getComputedStyle(screen.getAllByTestId('datatable-row-expander')[0]).minHeight,
+    ).not.toBe('44px');
+  });
+
+  it('does not fall back to "phone or desktop" at the sm boundary', () => {
+    // 600px is the first tablet width: it must be the grid, not cards, and it
+    // must not be the unqualified desktop grid either.
+    renderAtWidth(600);
+    expect(layout()).toBe('tablet');
+    expect(screen.queryByTestId('datatable-card-list')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('datatable-row-expander').length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Touch-target rule / issue #243 regression guard
+// ---------------------------------------------------------------------------
+
+/**
+ * The exact bug filed as issue #243: a control revealed on `:hover` sits at
+ * `opacity: 0` on a touch device but stays fully hit-testable, so a user taps
+ * something they cannot see. The rule is therefore not "don't use opacity" but
+ * "invisible implies non-interactive": anything at `opacity: 0` must also carry
+ * `pointer-events: none` (or be gated behind `@media (hover: hover)`, which
+ * never applies on a touch device).
+ */
+
+/**
+ * The *visible* controls, i.e. the ones whose disappearance is a bug.
+ *
+ * Two deliberate exclusions:
+ *
+ *  - Bare `<input>`: MUI's Checkbox/Radio put a transparent native input
+ *    exactly on top of a painted SVG. That is the correct pattern (the
+ *    hit-target coincides with a visible affordance) and is the opposite of
+ *    #243, so the sweep looks at the painted `.MuiCheckbox-root` instead.
+ *  - MUI X's own column-header chrome, whose sort/menu buttons are
+ *    hover-revealed by the library. Not ours to assert on, and reachable by
+ *    keyboard regardless.
+ */
+const VISIBLE_CONTROL_SELECTOR =
+  'button, [role="button"], .MuiCheckbox-root, a[href]';
+const THIRD_PARTY_CHROME = '.MuiDataGrid-columnHeaders, .MuiDataGrid-columnHeader';
+
+function assertNoInvisibleHitTargets(root: HTMLElement) {
+  const controls = Array.from(
+    root.querySelectorAll<HTMLElement>(VISIBLE_CONTROL_SELECTOR),
+  ).filter((control) => !control.closest(THIRD_PARTY_CHROME));
+  expect(controls.length).toBeGreaterThan(0);
+
+  // Report the offenders by name rather than as a bare `false`, so a
+  // regression names the control that reintroduced the bug.
+  const offenders = controls
+    .filter((control) => {
+      const style = getComputedStyle(control);
+      return style.opacity === '0' && style.pointerEvents !== 'none';
+    })
+    .map(describeControl);
+
+  expect(offenders).toEqual([]);
+}
+
+function describeControl(control: HTMLElement) {
+  const label = control.getAttribute('aria-label') ?? control.textContent?.slice(0, 24) ?? '';
+  return `${control.tagName.toLowerCase()}[${label}]`;
+}
+
+describe('DataTable — no invisible-but-tappable controls (issue #243 guard)', () => {
+  it('holds for the card layout, with everything on screen', () => {
+    renderAtWidth(400, {
+      selection: { selectedIds: new Set(['job-1']), onSelectionChange: vi.fn() },
+      bulkActions: [{ id: 'archive', label: 'Archive', onClick: vi.fn() }],
+      rowActions: [{ id: 'retry', label: 'Retry', onClick: vi.fn() }],
+      pagination: { page: 0, pageSize: 25, total: 137, onPaginationChange: vi.fn() },
+      sort: { sort: { field: 'attempts', direction: 'desc' }, onSortChange: vi.fn() },
+    });
+
+    // Open every collapsible region so nothing escapes the sweep.
+    for (const toggle of screen.getAllByTestId('datatable-card-detail-toggle')) {
+      fireEvent.click(toggle);
+    }
+
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable'));
+  });
+
+  it('holds for the tablet layout with a row expanded', () => {
+    renderAtWidth(800, {
+      selection: { selectedIds: new Set(['job-1']), onSelectionChange: vi.fn() },
+      rowActions: [{ id: 'retry', label: 'Retry', onClick: vi.fn() }],
+    });
+
+    fireEvent.click(screen.getAllByTestId('datatable-row-expander')[1]);
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable'));
+  });
+
+  it('gives every card control a >=44px touch target', () => {
+    renderAtWidth(400, {
+      selection: { selectedIds: new Set<string>(), onSelectionChange: vi.fn() },
+      rowActions: [{ id: 'retry', label: 'Retry', onClick: vi.fn() }],
+      pagination: { page: 1, pageSize: 25, total: 137, onPaginationChange: vi.fn() },
+    });
+
+    const mustBeTouchSized = [
+      screen.getAllByRole('checkbox', { name: /select row/i })[0],
+      screen.getByRole('checkbox', { name: /select all rows/i }),
+      screen.getByRole('button', { name: 'Row actions for face_detection' }),
+      screen.getAllByTestId('datatable-card-detail-toggle')[0],
+      screen.getByRole('button', { name: /go to next page/i }),
+      screen.getByRole('button', { name: /go to previous page/i }),
+    ];
+
+    for (const control of mustBeTouchSized) {
+      // The checkbox input is wrapped; the sizing lives on the labelled span.
+      const sized = control.closest<HTMLElement>('[class*="MuiCheckbox-root"]') ?? control;
+      const style = getComputedStyle(sized);
+      expect(Number.parseFloat(style.minHeight || '0')).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  it('shows every card control without any pointer interaction (no hover reveal)', () => {
+    renderAtWidth(400, {
+      selection: { selectedIds: new Set<string>(), onSelectionChange: vi.fn() },
+      rowActions: [{ id: 'retry', label: 'Retry', onClick: vi.fn() }],
+    });
+
+    // MediaGallery's tile checkbox needs a hover to appear; a card's must not —
+    // a card list is a touch surface first.
+    const list = screen.getByTestId('datatable-card-list');
+    const painted = Array.from(
+      list.querySelectorAll<HTMLElement>('.MuiCheckbox-root, button'),
+    );
+    expect(painted.length).toBeGreaterThan(0);
+    for (const control of painted) {
+      expect(getComputedStyle(control).opacity).not.toBe('0');
+    }
+  });
+});

--- a/apps/web/src/components/datatable/desktop/DesktopGridRenderer.tsx
+++ b/apps/web/src/components/datatable/desktop/DesktopGridRenderer.tsx
@@ -1,11 +1,24 @@
 /**
- * DataTable — desktop renderer (MUI X DataGrid).
+ * DataTable — grid renderer (MUI X DataGrid). Serves TWO layouts.
  *
  * Everything is server-driven: pagination, sorting and the row set all come in
  * as controlled props and every user gesture is reported back out. The grid
  * itself never sorts, filters, or paginates a row — it only draws what it is
  * handed. That is what makes the same contract work against a 150k-item
  * library where client-side anything is off the table.
+ *
+ * `variant` selects between the two grid layouts:
+ *
+ *   - `'desktop'` — every column visible.
+ *   - `'tablet'`  — `detail`-priority columns hidden, and a leading expander
+ *     column that reveals them as label/value pairs in an expanded row. This
+ *     is the intermediate case: still a real grid, but nothing it hides becomes
+ *     unreachable. See `./detailRow.tsx` for why expansion is built from
+ *     synthetic rows rather than `getDetailPanelContent` (a Pro-only feature).
+ *
+ * When `variant` is omitted the renderer falls back to its historical
+ * viewport-based behaviour, so using it directly (outside `DataTable`) still
+ * works.
  */
 
 import { useCallback, useMemo, useState } from 'react';
@@ -18,23 +31,28 @@ import {
   type GridSortModel,
   type GridValidRowModel,
 } from '@mui/x-data-grid';
+import { GRID_CHECKBOX_SELECTION_FIELD } from '@mui/x-data-grid';
+import { Alert, Box, IconButton, useMediaQuery, useTheme } from '@mui/material';
 import {
-  Alert,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
-import type { DataTableRendererProps, DataTableRowAction } from '../types';
+  KeyboardArrowDown as KeyboardArrowDownIcon,
+  KeyboardArrowRight as KeyboardArrowRightIcon,
+} from '@mui/icons-material';
+import type { DataTableRendererProps } from '../types';
 import { buildColumnVisibilityModel, toGridColumns } from './columnAdapter';
 import { DataTableEmptyOverlay, DataTableLoadingOverlay } from './cells';
 import { RowActionsCell } from './RowActionsCell';
 import { BulkActionBar } from '../BulkActionBar';
+import { useRowActionConfirm } from '../shared/rowActionConfirm';
+import {
+  DETAIL_ROW_CLASS,
+  DETAIL_ROW_SOURCE,
+  DetailRowPanel,
+  EXPANDER_FIELD,
+  detailRowHeight,
+  detailRowId,
+  isDetailRow,
+  makeDetailRow,
+} from './detailRow';
 
 /** Field name of the synthetic trailing actions column. */
 export const ACTIONS_FIELD = '__datatable_actions__';
@@ -44,26 +62,12 @@ const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 const MAX_UNPAGINATED_ROWS = 100;
 const EMPTY_SELECTION: ReadonlySet<string> = new Set<string>();
 
-interface PendingConfirm<Row> {
-  action: DataTableRowAction<Row>;
-  row: Row;
-}
-
-function confirmCopy<Row>(pending: PendingConfirm<Row>) {
-  const { action, row } = pending;
-  const options = typeof action.confirm === 'object' ? action.confirm : {};
-  const description =
-    typeof options.description === 'function' ? options.description(row) : options.description;
-  return {
-    title: options.title ?? `${action.label}?`,
-    description:
-      description ??
-      (action.destructive
-        ? 'This action cannot be undone.'
-        : `Are you sure you want to ${action.label.toLowerCase()}?`),
-    confirmLabel: options.confirmLabel ?? action.label,
-    cancelLabel: options.cancelLabel ?? 'Cancel',
-  };
+export interface DesktopGridRendererProps<Row> extends DataTableRendererProps<Row> {
+  /**
+   * Which grid layout to draw. Omit to fall back to a viewport media query
+   * (the pre-#253 behaviour) — `DataTable` always passes it explicitly.
+   */
+  variant?: 'desktop' | 'tablet';
 }
 
 export function DesktopGridRenderer<Row>({
@@ -81,62 +85,181 @@ export function DesktopGridRenderer<Row>({
   density = 'standard',
   ariaLabel,
   height,
-}: DataTableRendererProps<Row>) {
+  variant,
+}: DesktopGridRendererProps<Row>) {
   const theme = useTheme();
-  // `detail`-priority columns fold away once the desktop viewport gets tight.
-  const hideDetailColumns = useMediaQuery(theme.breakpoints.down('lg'));
+  // Fallback only: `DataTable` resolves this from the CONTAINER width and
+  // passes `variant` explicitly, so this media query never decides anything
+  // for a table rendered through the public component.
+  const viewportIsNarrow = useMediaQuery(theme.breakpoints.down('lg'));
+  const isTablet = variant ? variant === 'tablet' : viewportIsNarrow;
 
-  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm<Row> | null>(null);
+  const { run: runAction, dialog: confirmDialog } = useRowActionConfirm<Row>();
 
   const selectable = selection ? (selection.selectable ?? true) : false;
   const selectedIds = selection?.selectedIds ?? EMPTY_SELECTION;
 
+  // --- Row expansion (tablet only) ------------------------------------------
+
+  const detailColumns = useMemo(
+    () => columns.filter((column) => column.priority === 'detail'),
+    [columns],
+  );
+  // Nothing is hidden when there are no `detail` columns, so there is nothing
+  // to expand and no expander column is added.
+  const expandable = isTablet && detailColumns.length > 0;
+
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(EMPTY_SELECTION);
+
+  const toggleExpanded = useCallback((id: string) => {
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
   // --- Rows -----------------------------------------------------------------
 
   const rowIds = useMemo(() => rows.map((row) => rowId(row)), [rows, rowId]);
-  const gridRows = rows as unknown as readonly GridValidRowModel[];
-  const getRowId = useCallback((row: GridValidRowModel) => rowId(row as Row), [rowId]);
+
+  const gridRows = useMemo(() => {
+    if (!expandable || expandedIds.size === 0) {
+      return rows as unknown as readonly GridValidRowModel[];
+    }
+    const out: unknown[] = [];
+    rows.forEach((row, index) => {
+      out.push(row);
+      const id = rowIds[index];
+      if (expandedIds.has(id)) out.push(makeDetailRow(id, row));
+    });
+    return out as readonly GridValidRowModel[];
+  }, [rows, rowIds, expandable, expandedIds]);
+
+  const getRowId = useCallback(
+    (row: GridValidRowModel) =>
+      isDetailRow<Row>(row) ? detailRowId(row.__datatableDetailFor) : rowId(row as Row),
+    [rowId],
+  );
+
+  const getRowHeight = useCallback(
+    ({ model }: { model: GridValidRowModel }) =>
+      isDetailRow<Row>(model) ? detailRowHeight(detailColumns.length) : null,
+    [detailColumns.length],
+  );
+
+  // A synthetic row is a presentation artefact, never a selectable entity.
+  const isRowSelectable = useCallback(
+    ({ row }: { row: GridValidRowModel }) => !isDetailRow<Row>(row),
+    [],
+  );
+
+  const getRowClassName = useCallback(
+    ({ row }: { row: GridValidRowModel }) => (isDetailRow<Row>(row) ? DETAIL_ROW_CLASS : ''),
+    [],
+  );
 
   // --- Columns --------------------------------------------------------------
 
-  const runAction = useCallback((action: DataTableRowAction<Row>, row: Row) => {
-    if (action.confirm) {
-      setPendingConfirm({ action, row });
-      return;
-    }
-    action.onClick(row);
-  }, []);
-
   const gridColumns: GridColDef[] = useMemo(() => {
     const mapped = toGridColumns(columns);
-    if (!rowActions || rowActions.length === 0) return mapped;
+    const visibleDataColumnCount = isTablet
+      ? mapped.length - detailColumns.length
+      : mapped.length;
 
-    const actionsColumn: GridColDef = {
-      field: ACTIONS_FIELD,
-      headerName: 'Actions',
-      // Header text is visually redundant next to icon buttons but is what a
-      // screen reader announces when navigating cells, so it stays.
+    const withActions: GridColDef[] = [...mapped];
+    if (rowActions && rowActions.length > 0) {
+      withActions.push({
+        field: ACTIONS_FIELD,
+        headerName: 'Actions',
+        // Header text is visually redundant next to icon buttons but is what a
+        // screen reader announces when navigating cells, so it stays.
+        sortable: false,
+        filterable: false,
+        hideable: false,
+        disableColumnMenu: true,
+        align: 'right',
+        headerAlign: 'right',
+        width: rowActions.length === 1 ? 72 : 64,
+        renderCell: (params) =>
+          isDetailRow<Row>(params.row) ? null : (
+            <RowActionsCell row={params.row as Row} actions={rowActions} onRun={runAction} />
+          ),
+      });
+    }
+
+    if (!expandable) return withActions;
+
+    // Every column the expander's spanned cell must cover: itself, the visible
+    // data columns, and the actions column if present.
+    const spannedColumns = 1 + visibleDataColumnCount + (rowActions?.length ? 1 : 0);
+
+    const expanderColumn: GridColDef = {
+      field: EXPANDER_FIELD,
+      headerName: '',
       sortable: false,
       filterable: false,
       hideable: false,
+      resizable: false,
       disableColumnMenu: true,
-      align: 'right',
-      headerAlign: 'right',
-      width: rowActions.length === 1 ? 72 : 64,
-      renderCell: (params) => (
-        <RowActionsCell
-          row={params.row as Row}
-          actions={rowActions}
-          onRun={runAction}
-        />
-      ),
+      width: 48,
+      align: 'center',
+      headerAlign: 'center',
+      colSpan: (_value, row) => (isDetailRow<Row>(row) ? spannedColumns : 1),
+      renderCell: (params) => {
+        if (isDetailRow<Row>(params.row)) {
+          return (
+            <DetailRowPanel
+              row={params.row[DETAIL_ROW_SOURCE] as Row}
+              columns={detailColumns}
+            />
+          );
+        }
+        const id = String(params.id);
+        const open = expandedIds.has(id);
+        return (
+          <IconButton
+            size="small"
+            aria-label={open ? 'Hide details' : 'Show details'}
+            aria-expanded={open}
+            data-testid="datatable-row-expander"
+            // A tablet is a touch device, and this is the ONLY route to the
+            // hidden `detail` columns — so it gets a comfortable target
+            // wherever the row is tall enough to hold one. `compact` rows are
+            // 36px, so they keep the grid's own density instead.
+            sx={density === 'compact' ? undefined : { minWidth: 44, minHeight: 44 }}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleExpanded(id);
+            }}
+          >
+            {open ? (
+              <KeyboardArrowDownIcon fontSize="small" />
+            ) : (
+              <KeyboardArrowRightIcon fontSize="small" />
+            )}
+          </IconButton>
+        );
+      },
     };
-    return [...mapped, actionsColumn];
-  }, [columns, rowActions, runAction]);
+
+    return [expanderColumn, ...withActions];
+  }, [
+    columns,
+    detailColumns,
+    rowActions,
+    runAction,
+    expandable,
+    expandedIds,
+    toggleExpanded,
+    isTablet,
+    density,
+  ]);
 
   const columnVisibilityModel = useMemo(
-    () => buildColumnVisibilityModel(columns, { hideDetailColumns }),
-    [columns, hideDetailColumns],
+    () => buildColumnVisibilityModel(columns, { hideDetailColumns: isTablet }),
+    [columns, isTablet],
   );
 
   // --- Pagination (server) --------------------------------------------------
@@ -145,8 +268,8 @@ export function DesktopGridRenderer<Row>({
     () =>
       pagination
         ? { page: pagination.page, pageSize: pagination.pageSize }
-        : { page: 0, pageSize: Math.min(Math.max(rows.length, 1), MAX_UNPAGINATED_ROWS) },
-    [pagination, rows.length],
+        : { page: 0, pageSize: Math.min(Math.max(gridRows.length, 1), MAX_UNPAGINATED_ROWS) },
+    [pagination, gridRows.length],
   );
 
   const handlePaginationModelChange = useCallback(
@@ -216,8 +339,6 @@ export function DesktopGridRenderer<Row>({
     [emptyState],
   );
 
-  const confirm = pendingConfirm ? confirmCopy(pendingConfirm) : null;
-
   return (
     <Box sx={{ width: '100%', maxWidth: '100%', minWidth: 0 }}>
       {error && (
@@ -258,6 +379,9 @@ export function DesktopGridRenderer<Row>({
           disableColumnFilter
           disableColumnMenu
           disableRowSelectionOnClick
+          {...(expandable
+            ? { getRowHeight, isRowSelectable, getRowClassName }
+            : {})}
           // Pagination — server-side.
           paginationMode="server"
           rowCount={pagination?.total ?? rows.length}
@@ -281,35 +405,18 @@ export function DesktopGridRenderer<Row>({
             '& .MuiDataGrid-cell:focus, & .MuiDataGrid-cell:focus-within': {
               outlineOffset: -2,
             },
+            // The expanded panel owns its whole cell, with no cell padding.
+            [`& .MuiDataGrid-cell[data-field="${EXPANDER_FIELD}"]`]: { p: 0 },
+            // A detail row is not a row of data: drop the grid's own selection
+            // checkbox from it entirely (see DETAIL_ROW_CLASS for why this is
+            // `display: none` and not `opacity: 0`).
+            [`& .${DETAIL_ROW_CLASS} .MuiDataGrid-cell[data-field="${GRID_CHECKBOX_SELECTION_FIELD}"] .MuiCheckbox-root`]:
+              { display: 'none' },
           }}
         />
       </Box>
 
-      <Dialog
-        open={Boolean(pendingConfirm)}
-        onClose={() => setPendingConfirm(null)}
-        aria-labelledby="datatable-confirm-title"
-      >
-        <DialogTitle id="datatable-confirm-title">{confirm?.title}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>{confirm?.description}</DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setPendingConfirm(null)}>{confirm?.cancelLabel}</Button>
-          <Button
-            variant="contained"
-            color={pendingConfirm?.action.destructive ? 'error' : 'primary'}
-            onClick={() => {
-              if (pendingConfirm) {
-                pendingConfirm.action.onClick(pendingConfirm.row);
-              }
-              setPendingConfirm(null);
-            }}
-          >
-            {confirm?.confirmLabel}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {confirmDialog}
     </Box>
   );
 }

--- a/apps/web/src/components/datatable/desktop/RowActionsCell.tsx
+++ b/apps/web/src/components/datatable/desktop/RowActionsCell.tsx
@@ -5,6 +5,11 @@
  * two or more collapse into an overflow menu, mirroring the hand-rolled
  * `MoreVert` menus in JobsPage / UserList that this component replaces.
  *
+ * Shared by BOTH renderers — the card layout reuses it with `alwaysMenu` (a
+ * card header has room for one trailing control) and `touchTarget` (>=44px).
+ * That is why it lives next to the grid but is not grid-specific: reimplementing
+ * an action menu for cards would guarantee the two drift.
+ *
  * The cell never executes an action itself — it hands the descriptor back to
  * the renderer, which owns the (single, shared) confirmation dialog.
  */
@@ -29,21 +34,55 @@ export interface RowActionsCellProps<Row> {
   /** Label used to disambiguate the menu button for screen readers. */
   rowLabel?: string;
   onRun: (action: DataTableRowAction<Row>, row: Row) => void;
+  /**
+   * Collapse into the overflow menu even for a single action.
+   *
+   * The card renderer sets this: a card header has room for exactly one
+   * trailing control, and a header whose affordance changes shape depending on
+   * how many actions a page happened to declare is worse than one that is
+   * always the same button.
+   */
+  alwaysMenu?: boolean;
+  /**
+   * Enforce a >=44px hit area (WCAG 2.5.8 / the review-queue touch rule).
+   * Off by default so the desktop grid keeps its compact cell density.
+   */
+  touchTarget?: boolean;
 }
 
-export function RowActionsCell<Row>({ row, actions, rowLabel, onRun }: RowActionsCellProps<Row>) {
+/** >=44px in both axes, per the touch-target rule this component must honour. */
+const TOUCH_TARGET_SX = { minWidth: 44, minHeight: 44 } as const;
+
+export function RowActionsCell<Row>({
+  row,
+  actions,
+  rowLabel,
+  onRun,
+  alwaysMenu = false,
+  touchTarget = false,
+}: RowActionsCellProps<Row>) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   if (actions.length === 0) return null;
 
   const suffix = rowLabel ? ` for ${rowLabel}` : '';
+  const sizing = touchTarget ? TOUCH_TARGET_SX : undefined;
+  const menuItemSx = touchTarget ? { minHeight: 44 } : undefined;
+
+  // In a grid cell the wrapper fills the cell and right-aligns its button. In a
+  // card header it is a flex sibling of a `flexGrow: 1` headline, where
+  // `width: 100%` would fight that headline for space — so it sizes to content
+  // and refuses to shrink instead.
+  const wrapperSx = alwaysMenu
+    ? { width: 'auto', flexShrink: 0, justifyContent: 'flex-end' }
+    : { width: '100%', justifyContent: 'flex-end' };
 
   // --- Single action: a plain icon button -----------------------------------
-  if (actions.length === 1) {
+  if (actions.length === 1 && !alwaysMenu) {
     const action = actions[0];
     const disabled = action.disabled?.(row) ?? false;
     return (
-      <Stack direction="row" sx={{ width: "100%", justifyContent: "flex-end" }}>
+      <Stack direction="row" sx={wrapperSx}>
         <Tooltip title={action.label}>
           {/* span keeps the tooltip working while the button is disabled */}
           <span>
@@ -52,6 +91,7 @@ export function RowActionsCell<Row>({ row, actions, rowLabel, onRun }: RowAction
               aria-label={`${action.label}${suffix}`}
               disabled={disabled}
               color={action.destructive ? 'error' : 'default'}
+              sx={sizing}
               onClick={(event: MouseEvent<HTMLElement>) => {
                 event.stopPropagation();
                 onRun(action, row);
@@ -68,12 +108,13 @@ export function RowActionsCell<Row>({ row, actions, rowLabel, onRun }: RowAction
   // --- Multiple actions: overflow menu --------------------------------------
   const open = Boolean(anchorEl);
   return (
-    <Stack direction="row" sx={{ width: "100%", justifyContent: "flex-end" }}>
+    <Stack direction="row" sx={wrapperSx}>
       <IconButton
         size="small"
         aria-label={`Row actions${suffix}`}
         aria-haspopup="menu"
         aria-expanded={open ? true : undefined}
+        sx={sizing}
         onClick={(event: MouseEvent<HTMLElement>) => {
           event.stopPropagation();
           setAnchorEl(event.currentTarget);
@@ -86,7 +127,10 @@ export function RowActionsCell<Row>({ row, actions, rowLabel, onRun }: RowAction
           <MenuItem
             key={action.id}
             disabled={action.disabled?.(row) ?? false}
-            sx={action.destructive ? { color: 'error.main' } : undefined}
+            sx={{
+              ...menuItemSx,
+              ...(action.destructive ? { color: 'error.main' } : {}),
+            }}
             onClick={(event: MouseEvent<HTMLElement>) => {
               event.stopPropagation();
               setAnchorEl(null);

--- a/apps/web/src/components/datatable/desktop/columnAdapter.ts
+++ b/apps/web/src/components/datatable/desktop/columnAdapter.ts
@@ -46,10 +46,19 @@ export function extractColumnValue<Row>(
   return String(raw);
 }
 
-/** The scalar rendered as display text (`null` becomes an em dash). */
-function displayText(value: string | number | null): string {
+/**
+ * The scalar rendered as display text (`null`/empty becomes an em dash).
+ *
+ * Shared with the card renderer so an empty cell reads identically in both
+ * layouts — a blank card field and an em-dashed grid cell would look like two
+ * different states of the data.
+ */
+export function formatColumnValue(value: string | number | null): string {
   return value === null || value === '' ? '—' : String(value);
 }
+
+/** @deprecated internal alias kept for readability inside this module. */
+const displayText = formatColumnValue;
 
 /**
  * Map one {@link DataTableColumn} to a `GridColDef`.

--- a/apps/web/src/components/datatable/desktop/detailRow.tsx
+++ b/apps/web/src/components/datatable/desktop/detailRow.tsx
@@ -1,0 +1,146 @@
+/**
+ * DataTable — tablet row expansion.
+ *
+ * The intermediate case, and the one that is easiest to skip: between the
+ * mobile and desktop breakpoints the grid is still the right control (rows are
+ * scannable at 800px in a way cards are not), but it cannot show every column,
+ * so `detail`-priority columns fold away. Folding them away with no way back
+ * makes them *unreachable* rather than *deprioritised* — which is a data-loss
+ * bug dressed up as responsive design.
+ *
+ * ## Why synthetic rows rather than a detail panel
+ *
+ * MUI X's `getDetailPanelContent` is declared on the community `DataGrid`'s
+ * prop types but is **not implemented** in the MIT package (grep the built
+ * package: the only occurrence is in `propTypes`). It is a Pro feature.
+ *
+ * So expansion is built from two primitives the MIT grid *does* implement:
+ *
+ *   1. A synthetic row is spliced in directly after its parent when that
+ *      parent is expanded. It carries the parent row on a symbol-ish key so
+ *      nothing in the caller's `Row` type can collide with it.
+ *   2. The leading expander column declares `colSpan` covering every visible
+ *      column for that synthetic row, so one cell renders the whole panel.
+ *
+ * `paginationMode="server"` is what makes this safe: the grid never slices the
+ * `rows` array in server mode (`gridPaginationRowRangeSelector` short-circuits
+ * unless client-side pagination is enabled), so injecting a row cannot push a
+ * real row onto a phantom next page.
+ */
+
+import type { ReactNode } from 'react';
+import { Box, Stack, Typography } from '@mui/material';
+import type { DataTableColumn } from '../types';
+import { extractColumnValue, formatColumnValue } from './columnAdapter';
+
+/** Field name of the synthetic leading expander column. */
+export const EXPANDER_FIELD = '__datatable_expander__';
+
+/**
+ * Class applied to a synthetic detail row.
+ *
+ * Used to suppress the grid's own selection checkbox on that row. `colSpan`
+ * only ever spans *forward*, and DataGrid injects `__check__` ahead of every
+ * user column, so the one cell the panel cannot absorb has to be dealt with in
+ * CSS. It is removed with `display: none` — not `opacity: 0` — precisely so it
+ * leaves the accessibility tree and stops being hit-testable, rather than
+ * becoming the invisible-but-tappable control issue #243 was filed about.
+ */
+export const DETAIL_ROW_CLASS = 'datatable-detail-row';
+
+/** Key marking a synthetic detail row; also holds the parent's row id. */
+export const DETAIL_ROW_KEY = '__datatableDetailFor';
+/** Key holding the parent row object on a synthetic detail row. */
+export const DETAIL_ROW_SOURCE = '__datatableDetailSource';
+
+export interface DetailRow<Row> {
+  [DETAIL_ROW_KEY]: string;
+  [DETAIL_ROW_SOURCE]: Row;
+}
+
+export function isDetailRow<Row>(row: unknown): row is DetailRow<Row> {
+  return (
+    typeof row === 'object' &&
+    row !== null &&
+    typeof (row as Record<string, unknown>)[DETAIL_ROW_KEY] === 'string'
+  );
+}
+
+export function makeDetailRow<Row>(parentId: string, row: Row): DetailRow<Row> {
+  return { [DETAIL_ROW_KEY]: parentId, [DETAIL_ROW_SOURCE]: row };
+}
+
+/** The grid row id for a synthetic detail row — namespaced so it cannot clash. */
+export function detailRowId(parentId: string): string {
+  return `__datatable_detail__${parentId}`;
+}
+
+/**
+ * Row height for an expanded detail row.
+ *
+ * Computed rather than `getRowHeight: () => 'auto'` on purpose: auto-height
+ * rows depend on a measurement pass, and a panel that measures 0px in a
+ * layout-free environment (jsdom, a `display: none` ancestor) would clip its
+ * own content. An arithmetic height is deterministic everywhere, and the panel
+ * scrolls internally if a value is longer than the estimate.
+ */
+export function detailRowHeight(fieldCount: number): number {
+  const HEADER_AND_PADDING = 24;
+  const PER_FIELD = 46;
+  return HEADER_AND_PADDING + Math.max(1, fieldCount) * PER_FIELD;
+}
+
+export interface DetailRowPanelProps<Row> {
+  row: Row;
+  columns: DataTableColumn<Row>[];
+}
+
+/**
+ * The expanded region's content: the hidden `detail` columns as label/value
+ * pairs, in declaration order — the same shape the card renderer's collapsed
+ * region uses, so a value looks the same wherever it was folded away to.
+ */
+export function DetailRowPanel<Row>({ row, columns }: DetailRowPanelProps<Row>) {
+  return (
+    <Box
+      data-testid="datatable-row-detail-panel"
+      sx={{
+        width: '100%',
+        height: '100%',
+        minWidth: 0,
+        overflow: 'auto',
+        px: 2,
+        py: 1.5,
+        bgcolor: (theme) =>
+          theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.025)',
+      }}
+    >
+      <Stack spacing={1.25} sx={{ minWidth: 0 }}>
+        {columns.map((column) => {
+          const content: ReactNode = column.render
+            ? column.render(row)
+            : formatColumnValue(extractColumnValue(column, row));
+          return (
+            <Box key={column.id} data-testid={`datatable-detail-field-${column.id}`} sx={{ minWidth: 0 }}>
+              <Typography
+                variant="caption"
+                component="div"
+                color="text.secondary"
+                sx={{ fontWeight: 600 }}
+              >
+                {column.label}
+              </Typography>
+              <Typography
+                variant="body2"
+                component="div"
+                sx={{ minWidth: 0, overflowWrap: 'anywhere' }}
+              >
+                {content}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/index.ts
+++ b/apps/web/src/components/datatable/index.ts
@@ -1,25 +1,58 @@
 /**
  * DataTable — public entry point.
  *
- * Consumers should import from `components/datatable` only; the `desktop/`
- * (and, from #253, `mobile/`) subfolders are implementation detail.
+ * Consumers should import from `components/datatable` only; the `desktop/`,
+ * `mobile/` and `shared/` subfolders are implementation detail.
  */
 
-export { DataTable, useDataTableRenderer } from './DataTable';
+export { DataTable, useDataTableRenderer, rendererForLayout } from './DataTable';
 export { BulkActionBar } from './BulkActionBar';
 export type { BulkActionBarProps } from './BulkActionBar';
 
+// --- Layout resolution -------------------------------------------------------
+export {
+  useDataTableLayout,
+  useContainerWidth,
+  useViewportLayout,
+  layoutForWidth,
+  DEFAULT_BREAKPOINTS,
+  DEFAULT_MOBILE_BREAKPOINT,
+  DEFAULT_TABLET_BREAKPOINT,
+} from './useContainerLayout';
+export type { DataTableBreakpoints } from './useContainerLayout';
+
+// --- Desktop / tablet renderer ----------------------------------------------
 export { DesktopGridRenderer, ACTIONS_FIELD } from './desktop/DesktopGridRenderer';
+export type { DesktopGridRendererProps } from './desktop/DesktopGridRenderer';
 export {
   toGridColDef,
   toGridColumns,
   extractColumnValue,
+  formatColumnValue,
   buildColumnVisibilityModel,
   DEFAULT_COLUMN_MIN_WIDTH,
 } from './desktop/columnAdapter';
 export { TruncatedCell, DataTableEmptyOverlay, DataTableLoadingOverlay } from './desktop/cells';
 export { RowActionsCell } from './desktop/RowActionsCell';
 export type { RowActionsCellProps } from './desktop/RowActionsCell';
+export {
+  DetailRowPanel,
+  EXPANDER_FIELD,
+  detailRowHeight,
+  detailRowId,
+  isDetailRow,
+} from './desktop/detailRow';
+
+// --- Mobile renderer ---------------------------------------------------------
+export { CardListRenderer } from './mobile/CardListRenderer';
+export { DataCard } from './mobile/DataCard';
+export type { DataCardProps } from './mobile/DataCard';
+export { CardField, ExpandableValue, columnContent, columnText } from './mobile/CardField';
+export { CompactPagination } from './mobile/CompactPagination';
+export { CardSortControl } from './mobile/CardSortControl';
+
+// --- Shared ------------------------------------------------------------------
+export { useRowActionConfirm, confirmCopy } from './shared/rowActionConfirm';
 
 export type {
   DataTableColumn,
@@ -36,5 +69,7 @@ export type {
   DataTableProps,
   DataTableRendererProps,
   DataTableRendererMode,
+  DataTableLayout,
+  DataTableRendererKind,
   FilterOperator,
 } from './types';

--- a/apps/web/src/components/datatable/mobile/CardField.tsx
+++ b/apps/web/src/components/datatable/mobile/CardField.tsx
@@ -1,0 +1,158 @@
+/**
+ * DataTable — card field primitives.
+ *
+ * A "field" is one column's contribution to one card: its `label` and whatever
+ * the column's `render`/`value` produces. The two rules that matter:
+ *
+ *  1. A column's `render` is used **verbatim**. A job's `succeeded` chip and a
+ *     share's preview thumbnail must look the same in a card as in a grid cell;
+ *     the card is a different *layout*, not a different *vocabulary*.
+ *  2. `truncate: true` clamps to two lines and becomes tap-to-expand. The grid
+ *     reveals a truncated value in a hover tooltip, which does not exist on a
+ *     touch device — so on a card the value itself is the control.
+ */
+
+import { useId, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Box, ButtonBase, Typography } from '@mui/material';
+import type { DataTableColumn } from '../types';
+import { extractColumnValue, formatColumnValue } from '../desktop/columnAdapter';
+
+/** Lines shown before a `truncate` value is clamped. */
+const CLAMP_LINES = 2;
+
+// ---------------------------------------------------------------------------
+// Expandable (truncated) value
+// ---------------------------------------------------------------------------
+
+export interface ExpandableValueProps {
+  /**
+   * Name of the thing being expanded — the column's `label`, not its value.
+   * Produces `"Expand Last error"` / `"Collapse Last error"`; announcing the
+   * whole (potentially 500-character) value as the button's name would be
+   * unusable.
+   */
+  text: string;
+  children: ReactNode;
+}
+
+/**
+ * A clamped value that expands in place on tap, Enter or Space.
+ *
+ * `ButtonBase` is deliberate: it gives real button semantics (focusable,
+ * Enter/Space activation, `aria-expanded`) with no button chrome, so the value
+ * still reads as text. The 44px floor is the touch-target rule — a two-line
+ * clamp of a short string can otherwise be ~34px tall.
+ */
+export function ExpandableValue({ text, children }: ExpandableValueProps) {
+  const [expanded, setExpanded] = useState(false);
+  const regionId = useId();
+
+  return (
+    <ButtonBase
+      data-testid="datatable-card-expandable-value"
+      data-expanded={expanded ? 'true' : 'false'}
+      aria-expanded={expanded}
+      aria-controls={regionId}
+      aria-label={expanded ? `Collapse ${text}` : `Expand ${text}`}
+      onClick={() => setExpanded((value) => !value)}
+      sx={{
+        display: 'block',
+        width: '100%',
+        minWidth: 0,
+        minHeight: 44,
+        px: 0.5,
+        mx: -0.5,
+        py: 0.5,
+        borderRadius: 1,
+        textAlign: 'left',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <Box
+        id={regionId}
+        sx={{
+          width: '100%',
+          minWidth: 0,
+          // Collapsed: a two-line clamp. Expanded: wrap freely and break long
+          // unbroken tokens (ids, URLs, stack frames) rather than overflow.
+          ...(expanded
+            ? { overflowWrap: 'anywhere', whiteSpace: 'pre-wrap' }
+            : {
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: CLAMP_LINES,
+                overflow: 'hidden',
+                overflowWrap: 'anywhere',
+              }),
+        }}
+      >
+        {children}
+      </Box>
+    </ButtonBase>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field content
+// ---------------------------------------------------------------------------
+
+/** The visual content of one column's cell — `render` wins, `value` is the fallback. */
+export function columnContent<Row>(column: DataTableColumn<Row>, row: Row): ReactNode {
+  if (column.render) return column.render(row);
+  return formatColumnValue(extractColumnValue(column, row));
+}
+
+/** The plain-text form of a column's cell, for aria labels and clamp toggles. */
+export function columnText<Row>(column: DataTableColumn<Row>, row: Row): string {
+  return formatColumnValue(extractColumnValue(column, row));
+}
+
+// ---------------------------------------------------------------------------
+// Label / value pair
+// ---------------------------------------------------------------------------
+
+export interface CardFieldProps<Row> {
+  column: DataTableColumn<Row>;
+  row: Row;
+}
+
+/**
+ * One label/value pair in a card body or detail region.
+ *
+ * Stacked (label above value) rather than side-by-side: at 320px a two-column
+ * layout gives the value ~150px, which re-creates on a card exactly the
+ * truncation problem cards exist to solve.
+ */
+export function CardField<Row>({ column, row }: CardFieldProps<Row>) {
+  const content = columnContent(column, row);
+
+  return (
+    <Box data-testid={`datatable-card-field-${column.id}`} sx={{ minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        component="div"
+        color="text.secondary"
+        sx={{ fontWeight: 600, letterSpacing: 0.2, lineHeight: 1.4 }}
+      >
+        {column.label}
+      </Typography>
+      <Typography
+        variant="body2"
+        component="div"
+        sx={{
+          minWidth: 0,
+          // Never let a long unbroken token push the card past the viewport.
+          overflowWrap: 'anywhere',
+          textAlign: column.align === 'right' || column.align === 'center' ? column.align : 'left',
+        }}
+      >
+        {column.truncate ? (
+          <ExpandableValue text={column.label}>{content}</ExpandableValue>
+        ) : (
+          content
+        )}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/mobile/CardListRenderer.tsx
+++ b/apps/web/src/components/datatable/mobile/CardListRenderer.tsx
@@ -1,0 +1,197 @@
+/**
+ * DataTable — mobile renderer (card list).
+ *
+ * Consumes the exact same `DataTableRendererProps` the desktop grid does, from
+ * the exact same `DataTableColumn[]`. A page never declares a card layout: the
+ * `priority` field it already wrote for the grid is what produces the headline,
+ * the body, and the collapsed detail region.
+ *
+ * What is shared verbatim with the desktop renderer, rather than reimplemented:
+ *   - `BulkActionBar` — identical selection UX at every width.
+ *   - `useRowActionConfirm` — identical confirmation copy and one dialog per
+ *     table, not one per card.
+ *   - `RowActionsCell` — the same overflow menu, in `alwaysMenu` mode.
+ *   - `DataTableEmptyOverlay` / `DataTableLoadingOverlay`.
+ *
+ * What is deliberately different:
+ *   - Pagination is `CompactPagination`, not `TablePagination` (see that file).
+ *   - Truncated values expand on tap rather than on hover — there is no hover.
+ *
+ * All of selection, pagination and sort remain CONTROLLED by the owning page,
+ * so switching to or from this renderer is a pure presentation change: nothing
+ * a user picked survives only in a renderer's own state.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { Alert, Box, Checkbox, FormControlLabel, Stack } from '@mui/material';
+import type { DataTableRendererProps } from '../types';
+import { BulkActionBar } from '../BulkActionBar';
+import { DataTableEmptyOverlay, DataTableLoadingOverlay } from '../desktop/cells';
+import { useRowActionConfirm } from '../shared/rowActionConfirm';
+import { DataCard } from './DataCard';
+import { CompactPagination } from './CompactPagination';
+import { CardSortControl } from './CardSortControl';
+
+const EMPTY_SELECTION: ReadonlySet<string> = new Set<string>();
+
+export function CardListRenderer<Row>({
+  columns,
+  rows,
+  rowId,
+  loading = false,
+  error = null,
+  emptyState,
+  pagination,
+  sort,
+  selection,
+  rowActions,
+  bulkActions,
+  ariaLabel,
+  height,
+}: DataTableRendererProps<Row>) {
+  const selectable = selection ? (selection.selectable ?? true) : false;
+  const selectedIds = selection?.selectedIds ?? EMPTY_SELECTION;
+
+  const { run: runAction, dialog: confirmDialog } = useRowActionConfirm<Row>();
+
+  // --- Columns, split by priority -------------------------------------------
+
+  const { primaryColumns, secondaryColumns, detailColumns } = useMemo(
+    () => ({
+      primaryColumns: columns.filter((column) => column.priority === 'primary'),
+      secondaryColumns: columns.filter((column) => column.priority === 'secondary'),
+      detailColumns: columns.filter((column) => column.priority === 'detail'),
+    }),
+    [columns],
+  );
+
+  // --- Selection ------------------------------------------------------------
+
+  const rowIds = useMemo(() => rows.map((row) => rowId(row)), [rows, rowId]);
+
+  const toggleRow = useCallback(
+    (id: string) => {
+      if (!selection) return;
+      const next = new Set(selection.selectedIds);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      selection.onSelectionChange(next);
+    },
+    [selection],
+  );
+
+  const selectedOnPage = rowIds.filter((id) => selectedIds.has(id)).length;
+  const allSelected = rowIds.length > 0 && selectedOnPage === rowIds.length;
+  const someSelected = selectedOnPage > 0 && !allSelected;
+
+  const toggleAll = useCallback(() => {
+    if (!selection) return;
+    // Page-scoped, exactly like the grid's header checkbox: with server-side
+    // pagination "all" can only mean the ids this table has actually loaded.
+    selection.onSelectionChange(allSelected ? new Set<string>() : new Set(rowIds));
+  }, [selection, allSelected, rowIds]);
+
+  const clearSelection = useCallback(() => {
+    selection?.onSelectionChange(new Set<string>());
+  }, [selection]);
+
+  const selectedIdList = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+  // --- Render ---------------------------------------------------------------
+
+  const showEmpty = !loading && rows.length === 0;
+
+  return (
+    <Box
+      data-testid="datatable-card-list"
+      sx={{
+        width: '100%',
+        maxWidth: '100%',
+        minWidth: 0,
+        ...(height != null ? { height, overflowY: 'auto' } : {}),
+      }}
+    >
+      {error && (
+        <Alert severity="error" sx={{ mb: 1 }} data-testid="datatable-error">
+          {error}
+        </Alert>
+      )}
+
+      {sort && <CardSortControl columns={columns} sort={sort} />}
+
+      {selectable && (
+        <>
+          <BulkActionBar ids={selectedIdList} actions={bulkActions} onClear={clearSelection} />
+          <FormControlLabel
+            sx={{ ml: 0, mb: 0.5, minHeight: 44 }}
+            control={
+              <Checkbox
+                checked={allSelected}
+                indeterminate={someSelected}
+                disabled={rowIds.length === 0}
+                onChange={toggleAll}
+                slotProps={{ input: { 'aria-label': 'Select all rows' } }}
+                sx={{ minWidth: 44, minHeight: 44 }}
+              />
+            }
+            // Visible text matches the accessible name (WCAG 2.5.3 "Label in
+            // Name") AND matches the grid header checkbox's name verbatim, so
+            // the two layouts are queryable — and speakable — identically.
+            label="Select all rows"
+          />
+        </>
+      )}
+
+      {loading && rows.length === 0 && (
+        <Box sx={{ height: 120, position: 'relative' }}>
+          <DataTableLoadingOverlay />
+        </Box>
+      )}
+
+      {showEmpty && <DataTableEmptyOverlay>{emptyState}</DataTableEmptyOverlay>}
+
+      {rows.length > 0 && (
+        <Box sx={{ position: 'relative', minWidth: 0 }}>
+          <Stack
+            component="ul"
+            role="list"
+            aria-label={ariaLabel}
+            spacing={1.5}
+            sx={{ listStyle: 'none', m: 0, p: 0, minWidth: 0 }}
+          >
+            {rows.map((row, index) => {
+              const id = rowIds[index];
+              return (
+                <DataCard
+                  key={id}
+                  row={row}
+                  id={id}
+                  primaryColumns={primaryColumns}
+                  secondaryColumns={secondaryColumns}
+                  detailColumns={detailColumns}
+                  selectable={selectable}
+                  selected={selectedIds.has(id)}
+                  onToggleSelect={toggleRow}
+                  rowActions={rowActions}
+                  onRunAction={runAction}
+                />
+              );
+            })}
+          </Stack>
+
+          {/* A refetch dims the current cards rather than blanking the list —
+              same promise the grid's loading overlay makes. */}
+          {loading && (
+            <Box sx={{ position: 'absolute', inset: 0, zIndex: 1 }}>
+              <DataTableLoadingOverlay />
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {pagination && <CompactPagination pagination={pagination} loadedRows={rows.length} />}
+
+      {confirmDialog}
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/mobile/CardSortControl.tsx
+++ b/apps/web/src/components/datatable/mobile/CardSortControl.tsx
@@ -1,0 +1,87 @@
+/**
+ * DataTable — card-layout sort control.
+ *
+ * A card has no column header to click, so without this the sort a page
+ * declares would be *held* correctly across a layout switch (it lives above the
+ * renderers) but would be unreachable while the phone layout is active. That is
+ * a worse outcome than the grid's, so the card list gets an explicit control:
+ * a field picker plus a direction toggle.
+ *
+ * Only columns declaring `sortable: true` appear — same rule as the grid, where
+ * a non-sortable header is inert. "Default" maps to `onSortChange(null)`, the
+ * contract's "back to the server's own order".
+ */
+
+import { Box, IconButton, MenuItem, TextField, Tooltip } from '@mui/material';
+import {
+  ArrowUpward as ArrowUpwardIcon,
+  ArrowDownward as ArrowDownwardIcon,
+} from '@mui/icons-material';
+import type { DataTableColumn, DataTableSortConfig } from '../types';
+
+const DEFAULT_VALUE = '__default__';
+
+export interface CardSortControlProps<Row> {
+  columns: DataTableColumn<Row>[];
+  sort: DataTableSortConfig;
+}
+
+export function CardSortControl<Row>({ columns, sort }: CardSortControlProps<Row>) {
+  const sortable = columns.filter((column) => column.sortable);
+  if (sortable.length === 0) return null;
+
+  const current = sort.sort;
+  const direction = current?.direction ?? 'asc';
+
+  return (
+    <Box
+      data-testid="datatable-card-sort"
+      sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5, minWidth: 0 }}
+    >
+      <TextField
+        select
+        size="small"
+        label="Sort by"
+        value={current?.field ?? DEFAULT_VALUE}
+        onChange={(event) => {
+          const value = event.target.value;
+          if (value === DEFAULT_VALUE) {
+            sort.onSortChange(null);
+            return;
+          }
+          sort.onSortChange({ field: value, direction });
+        }}
+        sx={{ flexGrow: 1, minWidth: 0 }}
+        slotProps={{ htmlInput: { 'aria-label': 'Sort by' } }}
+      >
+        <MenuItem value={DEFAULT_VALUE}>Default</MenuItem>
+        {sortable.map((column) => (
+          <MenuItem key={column.id} value={column.id}>
+            {column.label}
+          </MenuItem>
+        ))}
+      </TextField>
+
+      <Tooltip title={direction === 'asc' ? 'Sort ascending' : 'Sort descending'}>
+        <span>
+          <IconButton
+            aria-label={
+              direction === 'asc' ? 'Sorted ascending, switch to descending' : 'Sorted descending, switch to ascending'
+            }
+            disabled={!current}
+            onClick={() =>
+              current &&
+              sort.onSortChange({
+                field: current.field,
+                direction: current.direction === 'asc' ? 'desc' : 'asc',
+              })
+            }
+            sx={{ minWidth: 44, minHeight: 44 }}
+          >
+            {direction === 'asc' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/mobile/CompactPagination.tsx
+++ b/apps/web/src/components/datatable/mobile/CompactPagination.tsx
@@ -1,0 +1,84 @@
+/**
+ * DataTable — compact pagination (card layout).
+ *
+ * `TablePagination` is the wrong control on a phone: rows-per-page select +
+ * "1–25 of 137" + two arrows + the grid's own footer padding come to roughly
+ * 420px of intrinsic width, so on a 360px screen it either overflows the card
+ * column or forces the whole table into a horizontal scroller — which is
+ * precisely the failure the card layout exists to remove.
+ *
+ * This replaces it with prev / range / next. Page size is not adjustable here:
+ * it is a desktop-scale concern (nobody sets 100-per-page on a phone) and the
+ * owning page can still change it programmatically, since pagination stays
+ * fully controlled.
+ */
+
+import { Box, IconButton, Typography } from '@mui/material';
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+} from '@mui/icons-material';
+import type { DataTablePaginationConfig } from '../types';
+
+export interface CompactPaginationProps {
+  pagination: DataTablePaginationConfig;
+  /** Rows actually rendered on this page, used to close the displayed range. */
+  loadedRows: number;
+}
+
+export function CompactPagination({ pagination, loadedRows }: CompactPaginationProps) {
+  const { page, pageSize, total, onPaginationChange } = pagination;
+
+  const pageCount = pageSize > 0 ? Math.max(1, Math.ceil(total / pageSize)) : 1;
+  const first = total === 0 ? 0 : page * pageSize + 1;
+  // Trust the row count we actually have over arithmetic on a possibly-stale
+  // `total` — a short final page must not claim rows it never rendered.
+  const last = total === 0 ? 0 : page * pageSize + Math.min(loadedRows || pageSize, pageSize);
+
+  const atStart = page <= 0;
+  const atEnd = page >= pageCount - 1;
+
+  const go = (next: number) => onPaginationChange({ page: next, pageSize });
+
+  return (
+    <Box
+      data-testid="datatable-compact-pagination"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 1,
+        mt: 1.5,
+        minWidth: 0,
+        maxWidth: '100%',
+      }}
+    >
+      <IconButton
+        aria-label="Go to previous page"
+        disabled={atStart}
+        onClick={() => go(page - 1)}
+        sx={{ minWidth: 44, minHeight: 44 }}
+      >
+        <ChevronLeftIcon />
+      </IconButton>
+
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        aria-live="polite"
+        sx={{ textAlign: 'center', minWidth: 0, overflowWrap: 'anywhere' }}
+      >
+        {total === 0 ? 'No results' : `${first}–${last} of ${total}`}
+      </Typography>
+
+      <IconButton
+        aria-label="Go to next page"
+        disabled={atEnd}
+        onClick={() => go(page + 1)}
+        sx={{ minWidth: 44, minHeight: 44 }}
+      >
+        <ChevronRightIcon />
+      </IconButton>
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/mobile/DataCard.tsx
+++ b/apps/web/src/components/datatable/mobile/DataCard.tsx
@@ -1,0 +1,219 @@
+/**
+ * DataTable — one row, as a card.
+ *
+ * Layout is driven entirely by `priority`, never by column order or by any
+ * mobile-specific declaration on the column:
+ *
+ *   primary   → card headline (the thing you scan a list for)
+ *   secondary → card body, as stacked label/value pairs
+ *   detail    → collapsed behind "More details", CLOSED by default
+ *
+ * Visual language follows the burst/duplicate/location review queues, which are
+ * the surfaces in this app that already work well on a phone: an outlined
+ * `Card`, a checkbox at the leading edge, a single trailing overflow control,
+ * and body text at `body2` / `text.secondary`.
+ *
+ * Touch-target rule (issue #243): every control here is >=44px and none of them
+ * is hidden with `opacity: 0` while staying clickable. There are no
+ * hover-revealed affordances on a card at all — a card list is a touch surface
+ * first, and an invisible-but-tappable control is the exact bug #243 filed.
+ */
+
+import { useId, useState } from 'react';
+import {
+  Box,
+  Card,
+  Checkbox,
+  Collapse,
+  Divider,
+  Stack,
+  Typography,
+  ButtonBase,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  ExpandLess as ExpandLessIcon,
+} from '@mui/icons-material';
+import type { DataTableColumn, DataTableRowAction } from '../types';
+import { RowActionsCell } from '../desktop/RowActionsCell';
+import { CardField, columnContent, columnText } from './CardField';
+
+export interface DataCardProps<Row> {
+  row: Row;
+  id: string;
+  primaryColumns: DataTableColumn<Row>[];
+  secondaryColumns: DataTableColumn<Row>[];
+  detailColumns: DataTableColumn<Row>[];
+  selectable: boolean;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
+  rowActions?: DataTableRowAction<Row>[];
+  onRunAction: (action: DataTableRowAction<Row>, row: Row) => void;
+}
+
+export function DataCard<Row>({
+  row,
+  id,
+  primaryColumns,
+  secondaryColumns,
+  detailColumns,
+  selectable,
+  selected,
+  onToggleSelect,
+  rowActions,
+  onRunAction,
+}: DataCardProps<Row>) {
+  const [expanded, setExpanded] = useState(false);
+  const detailRegionId = useId();
+
+  const hasDetail = detailColumns.length > 0;
+  const hasActions = Boolean(rowActions && rowActions.length > 0);
+
+  // The first `primary` column doubles as the card's accessible name and as the
+  // disambiguator on the actions menu ("Row actions for face_detection").
+  const headlineText = primaryColumns.length > 0 ? columnText(primaryColumns[0], row) : id;
+
+  return (
+    <Card
+      variant="outlined"
+      component="li"
+      data-testid="datatable-card"
+      data-row-id={id}
+      data-selected={selected ? 'true' : 'false'}
+      sx={{
+        listStyle: 'none',
+        minWidth: 0,
+        maxWidth: '100%',
+        overflow: 'hidden',
+        ...(selected
+          ? {
+              borderColor: 'primary.main',
+              bgcolor: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? 'rgba(144, 202, 249, 0.10)'
+                  : 'rgba(25, 118, 210, 0.06)',
+            }
+          : {}),
+      }}
+    >
+      {/* --- Header: selection, headline, actions ---------------------------- */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+          px: 1.5,
+          py: 1.25,
+          minWidth: 0,
+        }}
+      >
+        {selectable && (
+          <Checkbox
+            checked={selected}
+            onChange={() => onToggleSelect(id)}
+            slotProps={{ input: { 'aria-label': 'Select row' } }}
+            sx={{ minWidth: 44, minHeight: 44, mt: -0.5, ml: -0.5 }}
+          />
+        )}
+
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          {primaryColumns.map((column, index) => (
+            <Typography
+              key={column.id}
+              data-testid={`datatable-card-headline-${column.id}`}
+              variant={index === 0 ? 'subtitle2' : 'body2'}
+              component="div"
+              color={index === 0 ? 'text.primary' : 'text.secondary'}
+              sx={{
+                fontWeight: index === 0 ? 700 : 400,
+                minWidth: 0,
+                overflowWrap: 'anywhere',
+              }}
+            >
+              {columnContent(column, row)}
+            </Typography>
+          ))}
+        </Box>
+
+        {hasActions && (
+          <RowActionsCell
+            row={row}
+            actions={rowActions ?? []}
+            rowLabel={headlineText}
+            onRun={onRunAction}
+            alwaysMenu
+            touchTarget
+          />
+        )}
+      </Box>
+
+      {/* --- Body: secondary fields ----------------------------------------- */}
+      {secondaryColumns.length > 0 && (
+        <>
+          <Divider />
+          <Stack spacing={1.25} sx={{ px: 1.5, py: 1.25, minWidth: 0 }}>
+            {secondaryColumns.map((column) => (
+              <CardField key={column.id} column={column} row={row} />
+            ))}
+          </Stack>
+        </>
+      )}
+
+      {/* --- Detail: collapsed by default ------------------------------------ */}
+      {hasDetail && (
+        <>
+          <Divider />
+          <ButtonBase
+            data-testid="datatable-card-detail-toggle"
+            aria-expanded={expanded}
+            aria-controls={detailRegionId}
+            aria-label={`${expanded ? 'Hide' : 'More'} details for ${headlineText}`}
+            onClick={() => setExpanded((value) => !value)}
+            sx={{
+              display: 'flex',
+              width: '100%',
+              minHeight: 44,
+              px: 1.5,
+              py: 1,
+              gap: 0.5,
+              justifyContent: 'flex-start',
+              alignItems: 'center',
+              color: 'primary.main',
+              typography: 'body2',
+              fontWeight: 600,
+            }}
+          >
+            {expanded ? (
+              <ExpandLessIcon fontSize="small" />
+            ) : (
+              <ExpandMoreIcon fontSize="small" />
+            )}
+            {expanded ? 'Fewer details' : 'More details'}
+          </ButtonBase>
+
+          <Collapse in={expanded} unmountOnExit>
+            <Box
+              id={detailRegionId}
+              data-testid="datatable-card-detail-region"
+              sx={{
+                px: 1.5,
+                pb: 1.5,
+                minWidth: 0,
+                bgcolor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(255, 255, 255, 0.03)'
+                    : 'rgba(0, 0, 0, 0.02)',
+              }}
+            >
+              <Stack spacing={1.25} sx={{ pt: 1.25, minWidth: 0 }}>
+                {detailColumns.map((column) => (
+                  <CardField key={column.id} column={column} row={row} />
+                ))}
+              </Stack>
+            </Box>
+          </Collapse>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/components/datatable/shared/rowActionConfirm.tsx
+++ b/apps/web/src/components/datatable/shared/rowActionConfirm.tsx
@@ -1,0 +1,92 @@
+/**
+ * DataTable — shared row-action confirmation.
+ *
+ * Extracted from `DesktopGridRenderer` in #253 so the card renderer gets the
+ * *same* confirmation behaviour rather than a lookalike: identical default
+ * copy, identical destructive palette, and — the important part — exactly ONE
+ * dialog per table rather than one per row.
+ *
+ * The contract both renderers follow: a row-action control never executes an
+ * action, it hands the descriptor to `run()`. `run()` either invokes it
+ * immediately or parks it behind the dialog.
+ */
+
+import { useCallback, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import type { DataTableRowAction } from '../types';
+
+interface PendingConfirm<Row> {
+  action: DataTableRowAction<Row>;
+  row: Row;
+}
+
+/** Resolve the four dialog strings, filling in defaults. */
+export function confirmCopy<Row>(action: DataTableRowAction<Row>, row: Row) {
+  const options = typeof action.confirm === 'object' ? action.confirm : {};
+  const description =
+    typeof options.description === 'function' ? options.description(row) : options.description;
+  return {
+    title: options.title ?? `${action.label}?`,
+    description:
+      description ??
+      (action.destructive
+        ? 'This action cannot be undone.'
+        : `Are you sure you want to ${action.label.toLowerCase()}?`),
+    confirmLabel: options.confirmLabel ?? action.label,
+    cancelLabel: options.cancelLabel ?? 'Cancel',
+  };
+}
+
+export interface RowActionConfirm<Row> {
+  /** Run an action, routing it through the dialog when it declares `confirm`. */
+  run: (action: DataTableRowAction<Row>, row: Row) => void;
+  /** The single dialog element. Render it once, anywhere in the renderer. */
+  dialog: React.ReactElement;
+}
+
+export function useRowActionConfirm<Row>(): RowActionConfirm<Row> {
+  const [pending, setPending] = useState<PendingConfirm<Row> | null>(null);
+
+  const run = useCallback((action: DataTableRowAction<Row>, row: Row) => {
+    if (action.confirm) {
+      setPending({ action, row });
+      return;
+    }
+    action.onClick(row);
+  }, []);
+
+  const close = useCallback(() => setPending(null), []);
+
+  const copy = pending ? confirmCopy(pending.action, pending.row) : null;
+
+  const dialog = (
+    <Dialog open={Boolean(pending)} onClose={close} aria-labelledby="datatable-confirm-title">
+      <DialogTitle id="datatable-confirm-title">{copy?.title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{copy?.description}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={close}>{copy?.cancelLabel}</Button>
+        <Button
+          variant="contained"
+          color={pending?.action.destructive ? 'error' : 'primary'}
+          onClick={() => {
+            if (pending) pending.action.onClick(pending.row);
+            close();
+          }}
+        >
+          {copy?.confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+
+  return { run, dialog };
+}

--- a/apps/web/src/components/datatable/types.ts
+++ b/apps/web/src/components/datatable/types.ts
@@ -222,13 +222,26 @@ export interface DataTableSelectionConfig {
 // ---------------------------------------------------------------------------
 
 /**
- * Which renderer to use. `'auto'` (default) picks by viewport width; the
- * explicit values exist for tests, Storybook-style previews, and pages that
- * genuinely want one layout at every width.
+ * Which layout to use.
  *
- * `'mobile'` resolves to the desktop renderer until issue #253 lands.
+ * `'auto'` (default) picks by the table's own **container** width — not the
+ * viewport — so a table inside a 400px drawer on a 1440px desktop still gets
+ * cards. The explicit values exist for tests, Storybook-style previews, and
+ * pages that genuinely want one layout at every width.
+ *
+ * The three layouts map onto two renderer modules:
+ *   - `'mobile'`  → `mobile/CardListRenderer`
+ *   - `'tablet'`  → `desktop/DesktopGridRenderer` with `variant="tablet"`
+ *     (the real grid, `detail` columns folded into an expandable row)
+ *   - `'desktop'` → `desktop/DesktopGridRenderer` with `variant="desktop"`
  */
-export type DataTableRendererMode = 'auto' | 'desktop' | 'mobile';
+export type DataTableRendererMode = 'auto' | 'desktop' | 'tablet' | 'mobile';
+
+/** The resolved layout. Reported as `data-layout` on the table wrapper. */
+export type DataTableLayout = 'mobile' | 'tablet' | 'desktop';
+
+/** The resolved renderer module. Reported as `data-renderer` on the wrapper. */
+export type DataTableRendererKind = 'mobile' | 'desktop';
 
 export interface DataTableProps<Row> {
   columns: DataTableColumn<Row>[];
@@ -260,14 +273,36 @@ export interface DataTableProps<Row> {
    * scrolling table body instead.
    */
   height?: number | string;
-  /** Force a renderer. Default `'auto'`. */
+  /** Force a layout. Default `'auto'` (container-width driven). */
   renderer?: DataTableRendererMode;
+
+  /**
+   * Container width (px) below which the card list is used.
+   * Default {@link DEFAULT_MOBILE_BREAKPOINT} (600).
+   *
+   * This is a **container** measurement, not a viewport one: overriding it is
+   * how a host that knows something the table cannot measure (a chrome-heavy
+   * panel, a table of unusually wide cells) shifts the pivot for one instance
+   * without touching the global default.
+   */
+  mobileBreakpoint?: number;
+  /**
+   * Container width (px) below which the grid runs in its tablet variant
+   * (`detail` columns hidden, reachable via row expansion) and at or above
+   * which the full desktop grid is used.
+   * Default {@link DEFAULT_TABLET_BREAKPOINT} (1200).
+   */
+  tabletBreakpoint?: number;
+
   /** Forwarded to the outermost wrapper for test targeting. */
   'data-testid'?: string;
 }
 
 /**
- * Props handed to a concrete renderer. Identical to {@link DataTableProps}
- * minus the renderer switch itself — every renderer consumes the same contract.
+ * Props handed to a concrete renderer. {@link DataTableProps} minus the layout
+ * switch itself — every renderer consumes the same contract.
  */
-export type DataTableRendererProps<Row> = Omit<DataTableProps<Row>, 'renderer'>;
+export type DataTableRendererProps<Row> = Omit<
+  DataTableProps<Row>,
+  'renderer' | 'mobileBreakpoint' | 'tabletBreakpoint'
+>;

--- a/apps/web/src/components/datatable/useContainerLayout.ts
+++ b/apps/web/src/components/datatable/useContainerLayout.ts
@@ -1,0 +1,175 @@
+/**
+ * DataTable — container-driven layout resolution.
+ *
+ * The renderer switch is driven by the width of the table's OWN container, not
+ * by the viewport. That distinction is the entire point of this module:
+ *
+ *   A DataTable inside the Workflow runs drawer is 400px wide on a 1440px
+ *   desktop. A viewport-based `useMediaQuery` would hand that drawer the full
+ *   desktop grid and it would be unusable; a ResizeObserver on the wrapper
+ *   hands it cards, which is correct.
+ *
+ * Container queries would express this natively, but CSS container queries
+ * cannot change *which component tree renders* — only how an already-rendered
+ * one is styled. A card list and a DataGrid are genuinely different trees, so
+ * measurement has to reach JavaScript, and `ResizeObserver` is the cheapest way
+ * to get there.
+ *
+ * ## Before the first measurement
+ *
+ * `ResizeObserver` reports nothing during SSR and nothing on the very first
+ * paint. Rather than flash the wrong renderer (or worse, mount a DataGrid and
+ * immediately throw it away), the hook falls back to a viewport `useMediaQuery`
+ * until a real, non-zero width arrives. On a normal page the viewport and the
+ * container agree, so the fallback is right; in a drawer it is wrong for
+ * exactly one frame, which is strictly better than being wrong forever.
+ *
+ * A measured width of `0` is treated as "not measured yet" — that is what a
+ * `display: none` ancestor, a not-yet-laid-out node, and jsdom's layout-free
+ * DOM all report, and none of them mean "this table is 0px wide".
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import type { RefObject } from 'react';
+import { useMediaQuery, useTheme } from '@mui/material';
+import type { DataTableLayout, DataTableRendererMode } from './types';
+
+// ---------------------------------------------------------------------------
+// Breakpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Below 600px a table cannot show a headline plus one supporting column
+ * without either horizontal scrolling or unreadable truncation — that is where
+ * cards win. 600 is also MUI's `sm`, so a container that happens to match the
+ * viewport lands on the same pivot the rest of the app uses.
+ */
+export const DEFAULT_MOBILE_BREAKPOINT = 600;
+
+/**
+ * 1200px (MUI's `lg`) is where the grid stops having to hide anything. It is
+ * deliberately the SAME threshold the desktop renderer already used to fold
+ * `detail` columns away, so the tablet band is exactly "the widths at which
+ * columns are being hidden" — and therefore exactly the band that needs a row
+ * expander to make them reachable again.
+ */
+export const DEFAULT_TABLET_BREAKPOINT = 1200;
+
+export interface DataTableBreakpoints {
+  /** Below this container width, render cards. */
+  mobile: number;
+  /** Below this container width (and at/above `mobile`), run the tablet grid. */
+  tablet: number;
+}
+
+export const DEFAULT_BREAKPOINTS: DataTableBreakpoints = {
+  mobile: DEFAULT_MOBILE_BREAKPOINT,
+  tablet: DEFAULT_TABLET_BREAKPOINT,
+};
+
+/**
+ * Pure width → layout mapping. Exported so it can be unit-tested without a DOM
+ * and reused by anything that already knows its width.
+ */
+export function layoutForWidth(
+  width: number,
+  breakpoints: DataTableBreakpoints = DEFAULT_BREAKPOINTS,
+): DataTableLayout {
+  if (width < breakpoints.mobile) return 'mobile';
+  if (width < breakpoints.tablet) return 'tablet';
+  return 'desktop';
+}
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
+
+/**
+ * Observe an element's inline size.
+ *
+ * Returns `null` until a real (non-zero) width has been observed, which is the
+ * caller's signal to use a viewport fallback instead of guessing.
+ */
+export function useContainerWidth(ref: RefObject<HTMLElement | null>): number | null {
+  const [width, setWidth] = useState<number | null>(null);
+
+  // Ignore a 0/absent measurement rather than resolving to `mobile` for a
+  // hidden or not-yet-laid-out container.
+  const record = useCallback((next: number | undefined) => {
+    if (typeof next !== 'number' || !Number.isFinite(next) || next <= 0) return;
+    setWidth((current) => (current === next ? current : next));
+  }, []);
+
+  // Layout effect: measure before paint so a correctly-sized container never
+  // shows a frame of the fallback layout.
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    record(element.getBoundingClientRect().width);
+  }, [ref, record]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[entries.length - 1];
+      if (!entry) return;
+      // `contentBoxSize` is the spec'd field; `contentRect` is the older one
+      // and is what most test doubles provide.
+      const inline = Array.isArray(entry.contentBoxSize)
+        ? entry.contentBoxSize[0]?.inlineSize
+        : undefined;
+      record(inline ?? entry.contentRect?.width);
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref, record]);
+
+  return width;
+}
+
+// ---------------------------------------------------------------------------
+// Layout resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Viewport-based layout — the pre-measurement fallback only.
+ *
+ * Mirrors {@link layoutForWidth}'s thresholds using MUI's own breakpoints so
+ * the fallback and the measured answer agree whenever the container happens to
+ * be the full viewport.
+ */
+export function useViewportLayout(): DataTableLayout {
+  const theme = useTheme();
+  const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const isBelowDesktop = useMediaQuery(theme.breakpoints.down('lg'));
+  if (isPhone) return 'mobile';
+  return isBelowDesktop ? 'tablet' : 'desktop';
+}
+
+/**
+ * Resolve the layout for one DataTable instance.
+ *
+ * @param ref         wrapper element to measure
+ * @param mode        `'auto'` measures; anything else is returned verbatim
+ * @param breakpoints per-instance overrides (`undefined` entries keep defaults)
+ */
+export function useDataTableLayout(
+  ref: RefObject<HTMLElement | null>,
+  mode: DataTableRendererMode = 'auto',
+  breakpoints?: Partial<DataTableBreakpoints>,
+): DataTableLayout {
+  const width = useContainerWidth(ref);
+  const viewportLayout = useViewportLayout();
+
+  const mobile = breakpoints?.mobile ?? DEFAULT_MOBILE_BREAKPOINT;
+  const tablet = breakpoints?.tablet ?? DEFAULT_TABLET_BREAKPOINT;
+
+  if (mode !== 'auto') return mode;
+  if (width === null) return viewportLayout;
+  // A caller that sets `mobile` above `tablet` gets mobile-wins rather than an
+  // unreachable band; clamping here keeps `layoutForWidth` a total function.
+  return layoutForWidth(width, { mobile, tablet: Math.max(mobile, tablet) });
+}

--- a/docs/specs/datatable.md
+++ b/docs/specs/datatable.md
@@ -1,6 +1,6 @@
 # DataTable — Shared Column Contract & Renderers
 
-**Status:** foundation shipped (issue #252 of epic #238)
+**Status:** foundation shipped (issue #252); mobile + tablet layouts shipped (issue #253) — both of epic #238
 **Location:** `apps/web/src/components/datatable/`
 **Spec owner:** frontend
 
@@ -15,11 +15,12 @@ checkboxes, a `MoreVert` menu, an empty/loading/error state) with slightly
 different behaviour, slightly different accessibility, and no mobile story at
 all beyond "scroll sideways and hope".
 
-The DataTable replaces that with **one contract and two renderers**. A page
-declares *what* its columns are and *how important* each one is; the renderers
-decide how that becomes pixels — a MUI X DataGrid on desktop, a card list on
-mobile (issue #253). A column declaration is written once and never edited when
-a new renderer, filter UI, or export path arrives.
+The DataTable replaces that with **one contract, two renderers, three
+layouts**. A page declares *what* its columns are and *how important* each one
+is; the renderers decide how that becomes pixels — a MUI X DataGrid on desktop,
+the same grid with row expansion on a tablet, a card list on a phone. A column
+declaration is written once and never edited when a new renderer, filter UI, or
+export path arrives.
 
 The contract lives in `types.ts` and is intentionally free of any DataGrid type.
 `desktop/columnAdapter.ts` is the only module in the codebase that knows
@@ -27,18 +28,19 @@ The contract lives in `types.ts` and is intentionally free of any DataGrid type.
 
 ### Scope of this document
 
-This spec documents the contract as of #252. Fields that exist in the contract
+This spec documents the contract as of #253. Fields that exist in the contract
 but are **not yet consumed** are marked *reserved* and name the issue that will
 consume them, so column authors can declare them today without churn later:
 
 | Field / concept              | Consumed by                            |
 | ---------------------------- | -------------------------------------- |
-| `priority` (card layout half)| #253 — mobile `CardListRenderer`       |
 | `filterable`                 | #254 — server-backed filter UI         |
 | `hideable`                   | #255 — column visibility / saved views |
 | `exportable`                 | #256 — CSV/export + virtualization     |
 
-Everything else on this page is live behaviour today.
+Everything else on this page is live behaviour today. `priority` is now fully
+consumed: it drives column visibility on the grid *and* the card's
+headline/body/detail split (§3).
 
 ---
 
@@ -48,18 +50,29 @@ Everything else on this page is live behaviour today.
 apps/web/src/components/datatable/
   index.ts                        # public entry point — import from here
   types.ts                        # THE contract (renderer-agnostic)
-  DataTable.tsx                   # renderer-switch shell + shared wrapper
-  BulkActionBar.tsx               # selection toolbar (shared by both renderers)
+  DataTable.tsx                   # layout-switch shell + shared wrapper
+  useContainerLayout.ts           # ResizeObserver width -> layout resolution
+  BulkActionBar.tsx               # selection toolbar (shared by all layouts)
+  shared/
+    rowActionConfirm.tsx          # one confirm dialog, shared by both renderers
   desktop/
-    DesktopGridRenderer.tsx       # MUI X DataGrid renderer
+    DesktopGridRenderer.tsx       # MUI X DataGrid renderer (desktop + tablet)
     columnAdapter.ts              # DataTableColumn -> GridColDef
     cells.tsx                     # TruncatedCell + empty/loading overlays
     RowActionsCell.tsx            # per-row icon button / overflow menu
-  __tests__/DataTable.test.tsx
+    detailRow.tsx                 # tablet row expansion (synthetic detail rows)
+  mobile/
+    CardListRenderer.tsx          # card list renderer
+    DataCard.tsx                  # one row, as a card
+    CardField.tsx                 # label/value pair + tap-to-expand value
+    CardSortControl.tsx           # sort picker (no headers to click on a card)
+    CompactPagination.tsx         # prev / range / next
+  __tests__/DataTable.test.tsx            # #252 foundation
+  __tests__/ResponsiveDataTable.test.tsx  # #253 layouts
 ```
 
-Consumers import from `components/datatable` only. `desktop/` (and, from #253,
-`mobile/`) are implementation detail.
+Consumers import from `components/datatable` only. `desktop/`, `mobile/` and
+`shared/` are implementation detail.
 
 ---
 
@@ -69,17 +82,30 @@ Consumers import from `components/datatable` only. `desktop/` (and, from #253,
 different layouts. It expresses **importance**, never geometry — a column author
 never writes "hide below 1200px" or "show on mobile".
 
-| `priority`  | Desktop (wide ≥ `lg`) | Desktop (narrow < `lg`) | Mobile card (#253)      |
-| ----------- | --------------------- | ----------------------- | ----------------------- |
-| `primary`   | visible               | visible                 | card **headline**       |
-| `secondary` | visible               | visible                 | card **body**           |
-| `detail`    | visible               | **hidden by default**   | card **expandable area**|
+| `priority`  | Desktop (≥ 1200px)  | Tablet (600–1199px)                  | Mobile card (< 600px)          |
+| ----------- | ------------------- | ------------------------------------ | ------------------------------ |
+| `primary`   | visible column      | visible column                       | card **headline**              |
+| `secondary` | visible column      | visible column                       | card **body** (label/value)    |
+| `detail`    | visible column      | **hidden**, reachable via row expand | card **"More details"**, closed |
 
-The desktop baseline is computed by `buildColumnVisibilityModel(columns, {
-hideDetailColumns })`, where `hideDetailColumns` is
-`useMediaQuery(theme.breakpoints.down('lg'))`. Issue #255 layers explicit user
-overrides and saved views *on top of* this baseline rather than replacing it, so
-a fresh table always opens in a sane state.
+Three consequences worth stating explicitly:
+
+- **A `detail` column is never lost, only folded.** On tablet it moves into an
+  expandable row; on a card it moves behind a collapsed region. Hiding a column
+  with no route back would be data loss dressed as responsive design.
+- **A column's `render` is used verbatim in every layout.** A job's `succeeded`
+  chip and a share's preview thumbnail look the same inside a card as inside a
+  grid cell. A card is a different *layout*, not a different *vocabulary*.
+- **Card order follows priority, then declaration order** — `primary` columns in
+  the header (the first one is the card's accessible name), then `secondary`,
+  then `detail`. Column order within a priority band is preserved.
+
+The grid's own visibility baseline is computed by
+`buildColumnVisibilityModel(columns, { hideDetailColumns })`, where
+`hideDetailColumns` is now the resolved layout being `tablet` (§7), not a
+viewport media query. Issue #255 layers explicit user overrides and saved views
+*on top of* this baseline rather than replacing it, so a fresh table always
+opens in a sane state.
 
 **Rule of thumb:** one or two `primary` columns (the thing you scan for), the
 rest `secondary`, and anything diagnostic (ids, error text, timestamps nobody
@@ -228,7 +254,11 @@ interface DataTableProps<Row> {
   density?: 'compact' | 'standard' | 'comfortable';
   ariaLabel?: string;
   height?: number | string;
-  renderer?: 'auto' | 'desktop' | 'mobile';
+
+  renderer?: 'auto' | 'desktop' | 'tablet' | 'mobile';
+  mobileBreakpoint?: number;   // container px, default 600
+  tabletBreakpoint?: number;   // container px, default 1200
+
   'data-testid'?: string;
 }
 ```
@@ -243,7 +273,8 @@ interface DataTableProps<Row> {
 | `density`    | Maps straight to DataGrid row density. |
 | `ariaLabel`  | Accessible name of the grid. Strongly recommended — a table with no name is an unnavigable blob to a screen reader. |
 | `height`     | Omit for **auto-height**: the table grows with its rows and the page scrolls vertically. Supply a value to get a fixed-height, internally scrolling table body. |
-| `renderer`   | `'auto'` (default) picks by viewport; `'desktop'`/`'mobile'` force one. Until #253, `'mobile'` resolves to the desktop grid. |
+| `renderer`   | `'auto'` (default) picks by **container** width; `'desktop'`/`'tablet'`/`'mobile'` force one layout at every width. |
+| `mobileBreakpoint` / `tabletBreakpoint` | Per-instance container-width thresholds, in px. See §7. |
 
 ### 5.1 Server-side pagination
 
@@ -283,6 +314,12 @@ header past `desc` emits `null`, meaning "back to the server's default order" �
 handle that case rather than treating `null` as "no change".
 
 `sort.field` is a column `id`, sent to the API verbatim.
+
+On the grid the control is the column header. A card has no header, so the card
+layout renders `CardSortControl` instead — a field picker over the `sortable`
+columns plus a direction toggle (§8.4). Both write the same
+`DataTableSortConfig`, so the active sort survives a layout switch in either
+direction.
 
 ### 5.3 Selection
 
@@ -372,8 +409,11 @@ region (so the count is announced as it changes), a **Clear** button, and one
 button per bulk action. The bar itself is `role="toolbar"` with
 `aria-label="Bulk actions"`.
 
-The bar is renderer-agnostic and is reused verbatim by the mobile card renderer
-in #253, so selection UX is identical at every width.
+The bar is renderer-agnostic and is reused **verbatim** by the mobile card
+renderer, so selection UX is identical at every width. The card layout's
+select-all checkbox carries the same accessible name as the grid's header
+checkbox (`"Select all rows"`) and the same page-scoped semantics, so a test —
+or a screen-reader user — meets the same control in both.
 
 ---
 
@@ -398,28 +438,217 @@ that flex child — the table cannot fix a parent that refuses to shrink.
 
 ---
 
-## 7. Renderer switch
+## 7. Layout switch — container width, not viewport width
+
+### 7.1 The three layouts
+
+| Layout    | Container width | Renderer module               | `data-renderer` | `data-layout` |
+| --------- | --------------- | ----------------------------- | --------------- | ------------- |
+| `mobile`  | `< 600px`       | `mobile/CardListRenderer`     | `mobile`        | `mobile`      |
+| `tablet`  | `600–1199px`    | `desktop/DesktopGridRenderer` (`variant="tablet"`) | `desktop` | `tablet` |
+| `desktop` | `≥ 1200px`      | `desktop/DesktopGridRenderer` (`variant="desktop"`) | `desktop` | `desktop` |
+
+Two attributes, not one, because they answer different questions.
+`data-renderer` is *which component module drew this* (two values — the seam
+#252 left behind); `data-layout` is *which of the three layouts it drew*. Tablet
+is a variant of the grid, not a third renderer.
+
+### 7.2 Why the container, not the viewport
+
+The switch measures the table's **own wrapper** with a `ResizeObserver`:
+
+> A DataTable inside the Workflow runs drawer is 400px wide on a 1440px
+> desktop. A viewport media query hands that drawer the full desktop grid and it
+> is unusable. Container measurement hands it cards, which is correct.
+
+This is issue #261's acceptance case, and it is why a bare `useMediaQuery` is
+not sufficient. CSS container queries can't help either: they change how an
+already-rendered tree is *styled*, and a card list versus a DataGrid are
+genuinely different trees, so the measurement has to reach JavaScript.
+
+**Before the first measurement** (SSR, first paint) the hook falls back to a
+viewport `useMediaQuery` using the same thresholds — `down('sm')` → mobile,
+`down('lg')` → tablet. On an ordinary page the container and the viewport agree,
+so the fallback is right; in a drawer it is wrong for exactly one frame, which
+beats being wrong forever or flashing an empty table.
+
+A measured width of **`0` is treated as "not measured yet"**, not as "0px wide".
+That is what a `display: none` ancestor, a not-yet-laid-out node, and jsdom's
+layout-free DOM all report, and none of them means the table is a phone.
+
+### 7.3 Why 600 and 1200
+
+- **600px (`sm`)** — below this a grid cannot show a headline plus one
+  supporting column without horizontal scrolling or unreadable truncation.
+- **1200px (`lg`)** — this is *already* the threshold at which `detail` columns
+  folded away (#252's `hideDetailColumns`). Reusing it makes the tablet band
+  exactly "the widths at which the grid is hiding something", which is exactly
+  the band that needs a row expander to make it reachable again.
+
+Both are per-instance overridable, because a host sometimes knows something the
+table cannot measure — a chrome-heavy panel, or a table whose cells are
+unusually wide:
 
 ```tsx
-export function useDataTableRenderer(mode = 'auto'): 'desktop' | 'mobile' {
-  const isNarrow = useMediaQuery(theme.breakpoints.down('md'));
-  if (mode !== 'auto') return mode;
-  return isNarrow ? 'mobile' : 'desktop';
-}
+<DataTable {...props} mobileBreakpoint={720} tabletBreakpoint={1440} />
 ```
 
-The `md` breakpoint (900px) is where a table stops being able to show more than
-about two columns without horizontal scrolling — exactly where cards beat rows.
+### 7.4 State lives above the renderers
 
-The resolved mode is exposed as `data-renderer` on the wrapper element, which is
-both a test hook and a debugging aid. Until #253 lands, `'mobile'` resolves to
-`DesktopGridRenderer` through a single named constant (`MOBILE_RENDERER`) — that
-constant is the whole seam, and #253's change to this file is one import and one
-assignment.
+Selection, pagination, sort (and, from #254, filters) are **controlled props
+owned by the calling page**. No renderer stores any of them. Rotating a device,
+dragging a drawer wider, or resizing a window therefore swaps the layout without
+losing a single selected id, the current page, or the active sort — the switch
+is a pure presentation change.
+
+The only state a renderer owns is which rows/cards are currently expanded, which
+is meaningless in the layout being switched to and is deliberately not carried
+across.
 
 ---
 
-## 8. Worked example
+## 8. Mobile layout — the card list
+
+One card per row, built entirely from `priority` (§3). Nothing about a table's
+declaration changes to get it.
+
+### 8.1 Card anatomy
+
+```
+┌─────────────────────────────────────────────┐
+│ [✓]  auto_tagging            FAILED     [⋮] │  header: selection,
+│                                             │          primary columns,
+├─────────────────────────────────────────────┤          row-actions menu
+│ Attempts                                    │
+│ 3                                           │  body: secondary columns
+├─────────────────────────────────────────────┤        as stacked pairs
+│ ⌄ More details                              │  detail: CLOSED by default
+└─────────────────────────────────────────────┘
+```
+
+Label/value pairs are **stacked**, not side by side: at 320px a two-column field
+layout leaves the value ~150px, which recreates on a card the exact truncation
+problem cards exist to solve.
+
+The visual language follows the burst/duplicate/location review queues (outlined
+`Card`, `body2` / `text.secondary` body text, leading checkbox), which are the
+surfaces in this app that already work well on a phone. Both themes are styled;
+selection tint and the detail region's background are derived from
+`theme.palette.mode`.
+
+### 8.2 Row actions
+
+Row actions collapse into an overflow menu in the **card header — always, even
+for a single action** (`RowActionsCell` gains an `alwaysMenu` prop). A header has
+room for exactly one trailing control, and an affordance that changes shape
+depending on how many actions a page happened to declare is worse than one that
+is always the same button.
+
+The menu button is named after the row: `"Row actions for auto_tagging"`, using
+the first `primary` column's scalar.
+
+Confirmation is not reimplemented — both renderers call the shared
+`useRowActionConfirm()` (`shared/rowActionConfirm.tsx`), so the copy, the
+destructive palette, and the one-dialog-per-table rule are identical in both.
+
+### 8.3 Truncation is tap-to-expand
+
+The grid reveals a `truncate` value in a hover tooltip. **A touch device has no
+hover**, so on a card the value itself becomes the control: a `ButtonBase`
+clamped to two lines that expands in place, with `aria-expanded` and real
+Enter/Space activation. The full text is always in the DOM — the clamp is purely
+visual, so a value can be folded but never lost.
+
+### 8.4 Pagination and sort
+
+`TablePagination` is the wrong control on a phone: rows-per-page select +
+"1–25 of 137" + two arrows comes to roughly 420px of intrinsic width, so on a
+360px screen it overflows or forces the table into a horizontal scroller — the
+exact failure cards exist to remove. `CompactPagination` replaces it with
+prev / range / next. Page size is not adjustable from a card list (nobody sets
+100-per-page on a phone); it stays a controlled prop the page can still change.
+
+A card has no column header to click, so sort would otherwise be *held*
+correctly across a layout switch but *unreachable* while the card layout is
+active. `CardSortControl` fixes that: a field picker listing only
+`sortable: true` columns, plus a direction toggle. "Default" emits
+`onSortChange(null)`, the contract's "back to the server's own order".
+
+### 8.5 Touch and keyboard rules (hard requirements)
+
+1. **Every interactive element is ≥44px** in both axes (WCAG 2.5.8).
+2. **Nothing is hidden with `opacity: 0` while remaining clickable.** This is the
+   exact bug filed as issue #243 — a hover-revealed control on `MediaGallery`
+   tiles was invisible yet fully tappable on touch, silently starring photos. A
+   hover-only affordance must be gated on `@media (hover: hover)` or carry
+   `pointer-events: none`. The card layout has **no** hover-revealed
+   affordances at all.
+   *(MUI's Checkbox puts a transparent native `<input>` exactly on top of a
+   painted SVG. That is the opposite pattern — the hit target coincides with a
+   visible affordance — and is fine.)*
+3. Every collapsible region is a real `button` with `aria-expanded` and
+   `aria-controls`, so Enter/Space work without a keydown handler.
+4. The card list is a `ul role="list"` labelled with `ariaLabel`; each card is
+   an `li`.
+
+---
+
+## 9. Tablet layout — the real grid, with row expansion
+
+The intermediate case, and the one most likely to be skipped. Between 600px and
+1200px the grid is still the right control — rows are scannable at 800px in a
+way cards are not — but it cannot show every column. So `detail` columns are
+hidden **and a leading expander column is added** that reveals them as
+label/value pairs in an expanded row.
+
+The switch is deliberately *not* "phone layout or desktop layout at the `sm`
+boundary". At 600px you get the grid; at 599px you get cards; at neither width do
+you get a grid that has silently dropped a column.
+
+### 9.1 Implementation: synthetic detail rows
+
+MUI X's `getDetailPanelContent` is declared on the community `DataGrid`'s prop
+types but is **not implemented** in the MIT package — grep the built package and
+its only occurrence is in `propTypes`. It is a Pro feature.
+
+So expansion is built from two primitives the MIT grid *does* implement
+(`desktop/detailRow.tsx`):
+
+1. A **synthetic row** is spliced in directly after its parent when that parent
+   is expanded, carrying the parent row under namespaced keys
+   (`__datatableDetailFor` / `__datatableDetailSource`) that no caller `Row`
+   type can collide with. Its grid id is `__datatable_detail__<parentId>`.
+2. The expander column declares **`colSpan`** covering every visible column for
+   that synthetic row, so one cell renders the whole panel.
+
+Three details make this safe:
+
+- **`paginationMode="server"` never slices `rows`** (`gridPaginationRowRangeSelector`
+  short-circuits unless client-side pagination is on), so injecting a row cannot
+  push a real row onto a phantom next page.
+- **`isRowSelectable`** rejects detail rows, and the grid's `__check__` cell —
+  which `colSpan` cannot absorb, since spanning only ever runs *forward* — has
+  its checkbox removed with `display: none`, not `opacity: 0`, so it leaves the
+  accessibility tree instead of becoming an invisible hit target (§8.5 rule 2).
+- **Row height is arithmetic** (`detailRowHeight(fieldCount)`), not
+  `getRowHeight: () => 'auto'`. Auto height depends on a measurement pass, and a
+  panel that measures 0px in a layout-free environment would clip its own
+  content; the panel scrolls internally if a value exceeds the estimate.
+
+No expander column is added when a table declares no `detail` columns — nothing
+is hidden, so there is nothing to reach.
+
+### 9.2 Touch target
+
+A tablet is a touch device, and the expander is the *only* route to the hidden
+columns, so it gets the same ≥44px target the card layout uses — except at
+`density="compact"`, where the row itself is only 36px tall and the button keeps
+the grid's own density. Every other control in the grid follows the grid's
+density contract, unchanged from #252.
+
+---
+
+## 10. Worked example
 
 A jobs table with all four states, server pagination and sorting, selection with
 a bulk retry, and per-row actions including a confirming destructive one:
@@ -562,7 +791,7 @@ export function JobsTable() {
 
 ---
 
-## 9. Testing notes
+## 11. Testing notes
 
 `apps/web/src/components/datatable/__tests__/DataTable.test.tsx` covers the
 rendered shell, the four states, pagination/sort/selection round-trips, row and
@@ -579,9 +808,34 @@ needs the same stubs — the project-wide `ResizeObserver` mock in
 Containment is asserted through computed styles (`overflow-x`, `max-width`,
 `min-width`) rather than measured geometry, since jsdom reports no real layout.
 
+*(Note that because the layout switch is now container-driven, that file's
+800px stub container puts it in the **tablet** layout. It passes unchanged,
+which is the point: tablet is a drop-in variant of the same grid.)*
+
+### 11.1 Testing the responsive layouts
+
+`__tests__/ResponsiveDataTable.test.tsx` covers #253 and needs two things the
+#252 recipe does not:
+
+1. **A re-fireable `ResizeObserver`.** `installLayoutStubs()` there drives every
+   width getter from a module-level `containerWidth`, and keeps a registry of
+   live observers so `setContainerWidth(px)` can re-invoke their callbacks
+   inside `act()`. That is what makes a *resize* — and therefore
+   state-preservation across a layout switch — observable in a test.
+2. **A `window.matchMedia` implemented against a FIXED 1440px viewport.** Every
+   viewport media query in the tree then answers "desktop", so a `mobile`
+   result can only have come from the container measurement. This is what makes
+   the drawer assertion (#261) meaningful rather than accidental.
+
+The suite also carries a **regression guard for the issue #243 class of bug**:
+it sweeps every painted control (`button`, `[role="button"]`, `.MuiCheckbox-root`,
+`a[href]`) and fails, naming the offender, if any is `opacity: 0` while its
+`pointer-events` is not `none`. Bare `<input>` and MUI X's own hover-revealed
+column-header chrome are excluded, for the reasons given in §8.5.
+
 ---
 
-## 10. Migration path
+## 12. Migration path
 
 The foundation is additive — no existing table changed in #252. Tables migrate
 one at a time, roughly in ascending order of weirdness:


### PR DESCRIPTION
## Summary

The half MUI does not provide. DataGrid has no card or stacked mode at any tier, so on a phone it is a horizontally scrolling grid — precisely the defect epic #238 exists to fix. This adds the card renderer, the tablet intermediate layout, and the container-driven switch between all three.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Relates to #238
Fixes #253

## Changes Made

**Phone — card list.** One card per row driven entirely by the contract's `priority` field: `primary` becomes the headline, `secondary` renders as label/value pairs in the body, `detail` collapses into a "More details" region closed by default. Rich cells keep their `render` function, so a status chip looks the same as on desktop. Row actions collapse into a card-header overflow menu; selection is a card checkbox feeding the same `BulkActionBar` as desktop. Long values truncate with tap-to-expand. Pagination is a compact control, not the desktop `TablePagination` row that itself overflows on a phone.

**Tablet — the intermediate case.** The real grid, with `detail`-priority columns hidden and reachable through row expansion. Not "phone layout or desktop layout picked at the `sm` boundary".

**Container-driven breakpoints.** `useContainerLayout` measures the container with a `ResizeObserver`, falling back to viewport `useMediaQuery` before first measurement so the wrong renderer never flashes. Overridable per instance via `mobileBreakpoint` / `tabletBreakpoint`. This is what makes #261's Workflow runs drawer — a 400 px drawer on a 1440 px desktop — render cards.

**State.** Selection, page, and sort live above the renderers, so a resize or rotation is a pure presentation change.

**Touch targets.** Every interactive element ≥ 44 px, and no control is hidden with `opacity: 0` while staying clickable — the #243 bug is guarded by a test.

### Breakpoints chosen

**mobile < 600 px · tablet 600–1199 px · desktop ≥ 1200 px**, measured on the container.

- **600 (`sm`)** — below this a grid cannot show a headline plus one supporting column without horizontal scroll or unreadable truncation.
- **1200 (`lg`)** — deliberately the *same* threshold #252 already uses to fold `detail` columns away, so the tablet band is exactly "the widths at which the grid is hiding something", which is exactly the band that needs an expander. A different number would create a dead zone where columns vanish with no route back.

### Decisions worth a reviewer's attention

- **`getDetailPanelContent` is Pro-only.** It is declared on the community `DataGrid`'s prop types but not implemented in the MIT package. Row expansion is built from two MIT primitives instead: a synthetic detail row spliced after its parent, plus `colSpan` on a leading expander column. Safe because `paginationMode="server"` never slices `rows`, so injection cannot push a real row onto a phantom page. `isRowSelectable` rejects detail rows, and the `__check__` cell — which `colSpan` cannot absorb, since spanning only runs forward — has its checkbox removed with `display: none`, **not** `opacity: 0`, specifically to avoid re-creating #243.
- **Detail-row height is arithmetic, not `getRowHeight: () => 'auto'`** — auto height needs a measurement pass, and a panel measuring 0 px in a layout-free environment would clip itself.
- **Added a card sort control** (not in the issue). Without it sort is correctly *held* across a switch but *unreachable* while cards are active, which is worse than the grid.
- **Row actions always collapse to a menu on cards, even for a single action** — an affordance that changes shape based on how many actions a page declared is worse than a constant one.
- **The #243 guard is deliberately narrowed** to painted controls, excluding bare `<input>` and MUI X's hover-revealed header chrome. MUI's Checkbox puts a transparent native input exactly on top of a painted SVG — the hit target coincides with a visible affordance, which is the *opposite* of #243; flagging it would make the guard useless.
- **`data-renderer` (2 values) + `data-layout` (3 values)**, because tablet is a variant of the grid, not a third module. The 32 tests from #252 pass untouched.
- **Card expansion state is intentionally not carried across a switch** — it is pure presentation and meaningless in the layout being switched to.
- **A measured width of `0` means "not measured yet", not "0 px"** — that is what a `display: none` ancestor and jsdom both report, and treating it literally would render cards inside every hidden panel in the app.

## Testing

- [x] Unit tests pass (`npm test`) — **79 passed** in the datatable suite (the 32 from #252 unmodified, 47 new)
- [x] Type checks pass (`npm run typecheck`) — zero errors
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

New tests cover renderer switching at each breakpoint driven by container width (including narrow-container-on-wide-viewport), state preservation across a switch, card expansion, selection parity between layouts, row actions and destructive confirmation in the card menu, tap-to-expand truncation, tablet detail-column reachability, and the opacity-0-hit-test guard.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

No page is migrated yet — `components/datatable` still has zero importers elsewhere in the app, so the `useDataTableRenderer` semantics change from `down('md')` to the tablet-aware mapping affects nothing outside the folder.

Next: #254 (per-column filtering + quick search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE)_