### PR TITLE
feat(web): DataTable per-column filtering and global quick search

### DIFF
--- a/apps/web/src/components/datatable/DataTable.tsx
+++ b/apps/web/src/components/datatable/DataTable.tsx
@@ -20,17 +20,27 @@
  *
  * ## State lives above the renderers
  *
- * Selection, pagination and sort are all controlled props owned by the calling
- * page. Nothing a user chose is stored inside a renderer, so rotating a device,
- * dragging a drawer wider, or resizing a window swaps the layout without
- * losing a single selected id, the current page, or the active sort. The only
- * state a renderer owns is which rows/cards happen to be expanded right now —
- * pure presentation, and meaningless in the layout being switched to.
+ * Selection, pagination, sort and filters are all controlled props owned by the
+ * calling page. Nothing a user chose is stored inside a renderer, so rotating a
+ * device, dragging a drawer wider, or resizing a window swaps the layout without
+ * losing a single selected id, the current page, the active sort, or an applied
+ * filter. The only state a renderer owns is which rows/cards happen to be
+ * expanded right now — pure presentation, and meaningless in the layout being
+ * switched to.
+ *
+ * ## The filter surface belongs here, not to a renderer
+ *
+ * `DataTableFilterBar` is drawn by this component, above whichever renderer is
+ * active, because filtering is the one control whose SHAPE is decided by the
+ * layout (a row / a collapsed panel / a full-screen sheet) rather than by how
+ * rows are presented — and because a renderer owning the panel's open state
+ * would discard it on every resize.
  */
 
 import { useRef } from 'react';
 import { Box } from '@mui/material';
 import type {
+  DataTableFilterModel,
   DataTableLayout,
   DataTableProps,
   DataTableRendererKind,
@@ -38,7 +48,11 @@ import type {
 } from './types';
 import { DesktopGridRenderer } from './desktop/DesktopGridRenderer';
 import { CardListRenderer } from './mobile/CardListRenderer';
+import { DataTableFilterBar } from './filter/DataTableFilterBar';
 import { useDataTableLayout, useViewportLayout } from './useContainerLayout';
+
+/** Stable identity so an unfiltered table never re-renders the bar needlessly. */
+const NO_FILTERS: DataTableFilterModel = [];
 
 /**
  * The card-list registration. This is the seam #252 left behind; it now points
@@ -71,6 +85,9 @@ export function DataTable<Row>(props: DataTableProps<Row>) {
     renderer = 'auto',
     mobileBreakpoint,
     tabletBreakpoint,
+    filters,
+    onFiltersChange,
+    quickSearch,
     'data-testid': testId,
     ...rendererProps
   } = props;
@@ -95,6 +112,14 @@ export function DataTable<Row>(props: DataTableProps<Row>) {
       // make the document body scroll sideways, at any viewport width.
       sx={{ width: '100%', maxWidth: '100%', minWidth: 0 }}
     >
+      <DataTableFilterBar
+        columns={props.columns}
+        layout={layout}
+        filters={filters ?? NO_FILTERS}
+        onFiltersChange={onFiltersChange}
+        quickSearch={quickSearch}
+      />
+
       {mode === 'mobile' ? (
         <MOBILE_RENDERER {...rendererProps} />
       ) : (

--- a/apps/web/src/components/datatable/__tests__/DataTableFilters.test.tsx
+++ b/apps/web/src/components/datatable/__tests__/DataTableFilters.test.tsx
@@ -1,0 +1,1256 @@
+/**
+ * Component tests — DataTable per-column filtering & global quick search (#254).
+ *
+ * What this suite is actually asserting:
+ *
+ *  1. The **operator catalog** — the right operators per declared value type,
+ *     both as a pure function and as the options a user is offered.
+ *  2. The **debounce contract** — the quick-search box repaints per keystroke
+ *     while `onChange` fires ONCE, after the pause. This is the one behaviour
+ *     the component exists to provide; a naive debounce would fail it.
+ *  3. **Server-side by construction** — adding, editing and removing a filter
+ *     emits a normalized model, and the table never drops a row of its own
+ *     accord. A test that only checked the emission would still pass if the
+ *     component secretly filtered `rows`, so both halves are asserted.
+ *  4. The **three filter surfaces**: an inline row on desktop, a collapsed panel
+ *     with an active count on tablet, a full-screen focus-trapping sheet plus a
+ *     scrollable chip strip on a phone.
+ *  5. The **URL helper** round-trips, including the cases that break a naive
+ *     `split(':')`: values containing the delimiter, multi-value operands, and
+ *     operators with no operand at all.
+ *  6. The issue **#243 guard**, extended to every control this issue adds.
+ *
+ * Test doubles mirror `ResponsiveDataTable.test.tsx`: a container width driven
+ * by a controllable ResizeObserver, and a `matchMedia` pinned to a 1440px
+ * viewport so a `mobile` result can only have come from the container.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
+import { act, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../__tests__/utils/test-utils';
+import { DataTable } from '../DataTable';
+import { FILTER_COUNT_CLASS } from '../filter/DataTableFilterBar';
+import {
+  OPERATORS_BY_FILTER_TYPE,
+  operatorArity,
+  operatorLabel,
+  operatorsForColumn,
+  isFilterableColumn,
+  filterableColumns,
+  searchableColumns,
+} from '../filter/operators';
+import {
+  addFilter,
+  containsFilter,
+  filterChipLabel,
+  isFilterComplete,
+  draftFilterFor,
+  removeFilterAt,
+} from '../filter/filterModel';
+import {
+  decodeFilter,
+  encodeFilter,
+  readDataTableUrlState,
+  writeDataTableUrlState,
+} from '../filter/filterUrl';
+import type { DataTableColumn, DataTableFilterModel } from '../types';
+
+// ---------------------------------------------------------------------------
+// Layout stubs (same recipe as the #253 suite)
+// ---------------------------------------------------------------------------
+
+const VIEWPORT_WIDTH = 1440;
+const VIEWPORT_HEIGHT = 900;
+
+let containerWidth = 1400;
+
+interface FakeObserver {
+  callback: ResizeObserverCallback;
+  targets: Set<Element>;
+  fire: () => void;
+}
+
+const observers = new Set<FakeObserver>();
+
+function installLayoutStubs() {
+  for (const prop of ['clientWidth', 'offsetWidth', 'scrollWidth'] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => containerWidth,
+    });
+  }
+  for (const prop of ['clientHeight', 'offsetHeight', 'scrollHeight'] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => VIEWPORT_HEIGHT,
+    });
+  }
+
+  HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    return {
+      width: containerWidth,
+      height: VIEWPORT_HEIGHT,
+      top: 0,
+      left: 0,
+      right: containerWidth,
+      bottom: VIEWPORT_HEIGHT,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+
+  class ControllableResizeObserver {
+    private readonly entry: FakeObserver;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.entry = {
+        callback,
+        targets: new Set<Element>(),
+        fire: () => {
+          const entries = Array.from(this.entry.targets, (target) => ({
+            target,
+            contentRect: { width: containerWidth, height: VIEWPORT_HEIGHT },
+          })) as unknown as ResizeObserverEntry[];
+          if (entries.length > 0) {
+            this.entry.callback(entries, this as unknown as ResizeObserver);
+          }
+        },
+      };
+      observers.add(this.entry);
+    }
+
+    observe(target: Element) {
+      this.entry.targets.add(target);
+      this.entry.fire();
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target);
+    }
+    disconnect() {
+      this.entry.targets.clear();
+      observers.delete(this.entry);
+    }
+  }
+
+  global.ResizeObserver = ControllableResizeObserver as unknown as typeof ResizeObserver;
+
+  window.matchMedia = vi.fn().mockImplementation((query: string) => {
+    const max = /max-width:\s*([\d.]+)px/.exec(query);
+    const min = /min-width:\s*([\d.]+)px/.exec(query);
+    let matches = true;
+    if (max) matches = matches && VIEWPORT_WIDTH <= Number.parseFloat(max[1]);
+    if (min) matches = matches && VIEWPORT_WIDTH >= Number.parseFloat(min[1]);
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  }) as unknown as typeof window.matchMedia;
+}
+
+beforeAll(() => {
+  installLayoutStubs();
+});
+
+beforeEach(() => {
+  containerWidth = 1400;
+});
+
+// ---------------------------------------------------------------------------
+// Fixture — one column per filter type
+// ---------------------------------------------------------------------------
+
+interface Job {
+  id: string;
+  type: string;
+  status: 'pending' | 'running' | 'succeeded' | 'failed';
+  attempts: number;
+  createdAt: string;
+  favorite: boolean;
+  lastError: string | null;
+}
+
+const JOBS: Job[] = [
+  {
+    id: 'job-1',
+    type: 'face_detection',
+    status: 'succeeded',
+    attempts: 1,
+    createdAt: '2026-01-04',
+    favorite: true,
+    lastError: null,
+  },
+  {
+    id: 'job-2',
+    type: 'auto_tagging',
+    status: 'failed',
+    attempts: 3,
+    createdAt: '2026-02-11',
+    favorite: false,
+    lastError: 'rate limited by provider',
+  },
+  {
+    id: 'job-3',
+    type: 'geocode',
+    status: 'pending',
+    attempts: 0,
+    createdAt: '2026-03-19',
+    favorite: false,
+    lastError: null,
+  },
+];
+
+const STATUS_VALUES = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'running', label: 'Running' },
+  { value: 'succeeded', label: 'Succeeded' },
+  { value: 'failed', label: 'Failed' },
+];
+
+const COLUMNS: DataTableColumn<Job>[] = [
+  {
+    id: 'type',
+    label: 'Type',
+    priority: 'primary',
+    value: (r) => r.type,
+    filterable: true,
+    filterType: 'text',
+    searchable: true,
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    priority: 'primary',
+    value: (r) => r.status,
+    filterable: true,
+    filterType: 'enum',
+    enumValues: STATUS_VALUES,
+    searchable: true,
+  },
+  {
+    id: 'attempts',
+    label: 'Attempts',
+    priority: 'secondary',
+    align: 'right',
+    value: (r) => r.attempts,
+    filterable: true,
+    filterType: 'number',
+  },
+  {
+    id: 'createdAt',
+    label: 'Created',
+    priority: 'secondary',
+    value: (r) => r.createdAt,
+    filterable: true,
+    filterType: 'date',
+  },
+  {
+    id: 'favorite',
+    label: 'Favorite',
+    priority: 'detail',
+    value: (r) => String(r.favorite),
+    filterable: true,
+    filterType: 'boolean',
+  },
+  {
+    id: 'lastError',
+    label: 'Last error',
+    priority: 'detail',
+    truncate: true,
+    value: (r) => r.lastError,
+    // Explicitly pinned — narrower AND wider than the text default.
+    filterable: ['contains', 'isEmpty', 'isNotEmpty'],
+    searchable: true,
+  },
+  // Deliberately NOT filterable, to prove the column picker is a subset.
+  { id: 'id', label: 'Job ID', priority: 'detail', value: (r) => r.id },
+];
+
+const rowId = (job: Job) => job.id;
+
+type TableProps = React.ComponentProps<typeof DataTable<Job>>;
+
+function renderAtWidth(width: number, overrides: Partial<TableProps> = {}) {
+  containerWidth = width;
+  return render(
+    <DataTable<Job>
+      columns={COLUMNS}
+      rows={JOBS}
+      rowId={rowId}
+      ariaLabel="Enrichment jobs"
+      {...overrides}
+    />,
+  );
+}
+
+/** Open a MUI Select by its visible label and pick an option by name. */
+async function pickOption(user: ReturnType<typeof userEvent.setup>, label: string, option: string) {
+  await user.click(screen.getByRole('combobox', { name: label }));
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByRole('option', { name: option }));
+}
+
+/** The option NAMES currently offered by a select, without choosing one. */
+async function optionsOf(user: ReturnType<typeof userEvent.setup>, label: string) {
+  await user.click(screen.getByRole('combobox', { name: label }));
+  const listbox = await screen.findByRole('listbox');
+  const names = within(listbox)
+    .getAllByRole('option')
+    .map((option) => option.textContent ?? '');
+  await user.keyboard('{Escape}');
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// 1. The operator catalog (pure)
+// ---------------------------------------------------------------------------
+
+describe('filter operators — per value type', () => {
+  it('publishes issue #254\'s operator sets verbatim', () => {
+    expect(OPERATORS_BY_FILTER_TYPE).toEqual({
+      text: ['contains', 'equals', 'startsWith', 'isEmpty'],
+      number: ['equals', 'gt', 'lt', 'between'],
+      date: ['before', 'after', 'between'],
+      enum: ['is', 'isNot', 'isAnyOf'],
+      boolean: ['is'],
+    });
+  });
+
+  it('resolves a column to the operator set for its declared type', () => {
+    const byId = (id: string) => COLUMNS.find((column) => column.id === id)!;
+
+    expect(operatorsForColumn(byId('type'))).toEqual([
+      'contains',
+      'equals',
+      'startsWith',
+      'isEmpty',
+    ]);
+    expect(operatorsForColumn(byId('attempts'))).toEqual(['equals', 'gt', 'lt', 'between']);
+    expect(operatorsForColumn(byId('createdAt'))).toEqual(['before', 'after', 'between']);
+    expect(operatorsForColumn(byId('status'))).toEqual(['is', 'isNot', 'isAnyOf']);
+    expect(operatorsForColumn(byId('favorite'))).toEqual(['is']);
+  });
+
+  it('defaults an undeclared filterType to text', () => {
+    expect(operatorsForColumn({ id: 'x', label: 'X', priority: 'primary', filterable: true })).toEqual(
+      OPERATORS_BY_FILTER_TYPE.text,
+    );
+  });
+
+  it('lets an explicit array pin the operators, in the order given', () => {
+    const byId = COLUMNS.find((column) => column.id === 'lastError')!;
+    expect(operatorsForColumn(byId)).toEqual(['contains', 'isEmpty', 'isNotEmpty']);
+  });
+
+  it('labels numeric comparisons as symbols, everything else as words', () => {
+    expect(operatorLabel('equals', 'number')).toBe('=');
+    expect(operatorLabel('gt', 'number')).toBe('>');
+    expect(operatorLabel('lt', 'number')).toBe('<');
+    expect(operatorLabel('equals', 'text')).toBe('equals');
+    expect(operatorLabel('before', 'date')).toBe('is before');
+    expect(operatorLabel('isAnyOf', 'enum')).toBe('is any of');
+  });
+
+  it('knows how many operands each operator takes', () => {
+    expect(operatorArity('contains')).toBe(1);
+    expect(operatorArity('is')).toBe(1);
+    expect(operatorArity('between')).toBe(2);
+    expect(operatorArity('isAnyOf')).toBe('many');
+    expect(operatorArity('in')).toBe('many');
+    expect(operatorArity('isEmpty')).toBe(0);
+    expect(operatorArity('isNotEmpty')).toBe(0);
+  });
+
+  it('treats an enum column with no enumValues as not filterable', () => {
+    expect(
+      isFilterableColumn({
+        id: 'status',
+        label: 'Status',
+        priority: 'primary',
+        filterable: true,
+        filterType: 'enum',
+      }),
+    ).toBe(false);
+
+    expect(isFilterableColumn(COLUMNS.find((c) => c.id === 'status')!)).toBe(true);
+    expect(isFilterableColumn(COLUMNS.find((c) => c.id === 'id')!)).toBe(false);
+  });
+
+  it('selects the filterable and searchable subsets of a column set', () => {
+    expect(filterableColumns(COLUMNS).map((c) => c.id)).toEqual([
+      'type',
+      'status',
+      'attempts',
+      'createdAt',
+      'favorite',
+      'lastError',
+    ]);
+    expect(searchableColumns(COLUMNS).map((c) => c.id)).toEqual(['type', 'status', 'lastError']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The operators a user is actually offered
+// ---------------------------------------------------------------------------
+
+describe('DataTable — operators offered in the filter UI', () => {
+  it('offers only the filterable columns in the column picker', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(1400, { filters: [], onFiltersChange: vi.fn() });
+
+    expect(await optionsOf(user, 'Column')).toEqual([
+      'Type',
+      'Status',
+      'Attempts',
+      'Created',
+      'Favorite',
+      'Last error',
+    ]);
+  });
+
+  it('swaps the operator set when the column type changes', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(1400, { filters: [], onFiltersChange: vi.fn() });
+
+    // text (the first filterable column, so the default draft)
+    expect(await optionsOf(user, 'Operator')).toEqual([
+      'contains',
+      'equals',
+      'starts with',
+      'is empty',
+    ]);
+
+    await pickOption(user, 'Column', 'Attempts');
+    expect(await optionsOf(user, 'Operator')).toEqual(['=', '>', '<', 'is between']);
+
+    await pickOption(user, 'Column', 'Created');
+    expect(await optionsOf(user, 'Operator')).toEqual(['is before', 'is after', 'is between']);
+
+    await pickOption(user, 'Column', 'Status');
+    expect(await optionsOf(user, 'Operator')).toEqual(['is', 'is not', 'is any of']);
+
+    await pickOption(user, 'Column', 'Favorite');
+    expect(await optionsOf(user, 'Operator')).toEqual(['is']);
+  });
+
+  it('draws the operand control the value type calls for', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(1400, { filters: [], onFiltersChange: vi.fn() });
+
+    // text -> free text
+    expect(screen.getByRole('textbox', { name: 'Value' })).toBeInTheDocument();
+
+    // number -> a spinbutton
+    await pickOption(user, 'Column', 'Attempts');
+    expect(screen.getByRole('spinbutton', { name: 'Value' })).toBeInTheDocument();
+
+    // enum -> a select over enumValues, using the LABELS not the raw values
+    await pickOption(user, 'Column', 'Status');
+    expect(await optionsOf(user, 'Value')).toEqual([
+      'Pending',
+      'Running',
+      'Succeeded',
+      'Failed',
+    ]);
+
+    // boolean -> Yes / No
+    await pickOption(user, 'Column', 'Favorite');
+    expect(await optionsOf(user, 'Value')).toEqual(['Yes', 'No']);
+  });
+
+  it('replaces the single operand with a From/To pair for `between`', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(1400, { filters: [], onFiltersChange: vi.fn() });
+
+    await pickOption(user, 'Column', 'Attempts');
+    await pickOption(user, 'Operator', 'is between');
+
+    expect(screen.getByRole('spinbutton', { name: 'From' })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: 'To' })).toBeInTheDocument();
+    expect(screen.queryByRole('spinbutton', { name: 'Value' })).not.toBeInTheDocument();
+  });
+
+  it('drops the operand control entirely for a 0-arity operator', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(1400, { filters: [], onFiltersChange: vi.fn() });
+
+    await pickOption(user, 'Operator', 'is empty');
+
+    expect(screen.queryByRole('textbox', { name: 'Value' })).not.toBeInTheDocument();
+    // ...and "is empty" is complete on its own, so Add is live immediately.
+    expect(screen.getByTestId('datatable-filter-apply')).toBeEnabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Quick search — the debounce is on the EMISSION
+// ---------------------------------------------------------------------------
+
+describe('DataTable — quick search debounce', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits once after the pause, not once per keystroke', () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    renderAtWidth(1400, { quickSearch: { value: '', onChange } });
+
+    const box = screen.getByRole('searchbox', { name: 'Search' });
+
+    fireEvent.change(box, { target: { value: 'f' } });
+    fireEvent.change(box, { target: { value: 'fa' } });
+    fireEvent.change(box, { target: { value: 'fac' } });
+
+    // The INPUT keeps up with the typist...
+    expect(box).toHaveValue('fac');
+    // ...while nothing has gone to the server yet.
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('fac');
+  });
+
+  it('restarts the window on each keystroke rather than emitting a prefix', () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    renderAtWidth(1400, { quickSearch: { value: '', onChange } });
+
+    const box = screen.getByRole('searchbox', { name: 'Search' });
+
+    fireEvent.change(box, { target: { value: 'ge' } });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    fireEvent.change(box, { target: { value: 'geo' } });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('geo');
+  });
+
+  it('honours a per-instance debounceMs', () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    renderAtWidth(1400, { quickSearch: { value: '', onChange, debounceMs: 1000 } });
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: 'x' },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(onChange).toHaveBeenCalledWith('x');
+  });
+
+  it('clears immediately — an explicit gesture has nothing to debounce', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderAtWidth(1400, { quickSearch: { value: 'geocode', onChange } });
+
+    await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('names the searchable columns in the default placeholder', () => {
+    renderAtWidth(1400, { quickSearch: { value: '', onChange: vi.fn() } });
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveAttribute(
+      'placeholder',
+      'Search Type, Status or Last error',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Filter state round-trips, and NOTHING is filtered locally
+// ---------------------------------------------------------------------------
+
+describe('DataTable — filter model round-trip', () => {
+  it('emits a normalized filter when one is added', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderAtWidth(1400, { filters: [], onFiltersChange });
+
+    // Add is inert until the draft is complete — a half-built filter must never
+    // reach the page and trigger a refetch.
+    expect(screen.getByTestId('datatable-filter-apply')).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox', { name: 'Value' }), 'geo');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+
+    expect(onFiltersChange).toHaveBeenCalledTimes(1);
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { columnId: 'type', operator: 'contains', value: 'geo' },
+    ]);
+  });
+
+  it('emits enum, number and 0-arity filters in the same normalized shape', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderAtWidth(1400, { filters: [], onFiltersChange });
+
+    await pickOption(user, 'Column', 'Status');
+    await pickOption(user, 'Value', 'Failed');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+    expect(onFiltersChange).toHaveBeenLastCalledWith([
+      { columnId: 'status', operator: 'is', value: 'failed' },
+    ]);
+
+    await pickOption(user, 'Column', 'Attempts');
+    await pickOption(user, 'Operator', '>');
+    await user.type(screen.getByRole('spinbutton', { name: 'Value' }), '2');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+    // Number columns emit a real number, not the input's string.
+    expect(onFiltersChange).toHaveBeenLastCalledWith([
+      { columnId: 'attempts', operator: 'gt', value: 2 },
+    ]);
+
+    await pickOption(user, 'Column', 'Last error');
+    await pickOption(user, 'Operator', 'is empty');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+    expect(onFiltersChange).toHaveBeenLastCalledWith([
+      { columnId: 'lastError', operator: 'isEmpty', value: null },
+    ]);
+  });
+
+  it('emits a [from, to] pair for `between`', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderAtWidth(1400, { filters: [], onFiltersChange });
+
+    await pickOption(user, 'Column', 'Attempts');
+    await pickOption(user, 'Operator', 'is between');
+    await user.type(screen.getByRole('spinbutton', { name: 'From' }), '1');
+    // Half a pair is not a filter.
+    expect(screen.getByTestId('datatable-filter-apply')).toBeDisabled();
+
+    await user.type(screen.getByRole('spinbutton', { name: 'To' }), '5');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+
+    expect(onFiltersChange).toHaveBeenLastCalledWith([
+      { columnId: 'attempts', operator: 'between', value: [1, 5] },
+    ]);
+  });
+
+  it('appends to the existing model rather than replacing it', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    const existing: DataTableFilterModel = [
+      { columnId: 'status', operator: 'is', value: 'failed' },
+    ];
+    renderAtWidth(1400, { filters: existing, onFiltersChange });
+
+    await user.type(screen.getByRole('textbox', { name: 'Value' }), 'geo');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { columnId: 'status', operator: 'is', value: 'failed' },
+      { columnId: 'type', operator: 'contains', value: 'geo' },
+    ]);
+  });
+
+  /**
+   * The load-bearing negative. Every assertion above would still pass if the
+   * component quietly filtered `rows` itself — which would be wrong, because
+   * with server-side pagination it would only ever filter the CURRENT PAGE.
+   */
+  it('never filters rows itself — the row set is exactly what it was handed', () => {
+    renderAtWidth(1400, {
+      filters: [
+        { columnId: 'status', operator: 'is', value: 'failed' },
+        { columnId: 'type', operator: 'contains', value: 'nothing-matches-this' },
+      ],
+      onFiltersChange: vi.fn(),
+    });
+
+    // All three rows are still drawn, filters notwithstanding.
+    expect(screen.getByText('face_detection')).toBeInTheDocument();
+    expect(screen.getByText('auto_tagging')).toBeInTheDocument();
+    expect(screen.getByText('geocode')).toBeInTheDocument();
+  });
+
+  it('is fully controlled — a page that ignores the emission sees no change', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(1400, { filters: [], onFiltersChange: vi.fn() });
+
+    await user.type(screen.getByRole('textbox', { name: 'Value' }), 'geo');
+    await user.click(screen.getByTestId('datatable-filter-apply'));
+
+    // The page never fed a new model back, so no chip appeared.
+    expect(screen.queryByTestId('datatable-filter-chip')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Chips
+// ---------------------------------------------------------------------------
+
+describe('DataTable — active filter chips', () => {
+  const FILTERS: DataTableFilterModel = [
+    { columnId: 'status', operator: 'is', value: 'failed' },
+    { columnId: 'attempts', operator: 'gt', value: 2 },
+    { columnId: 'lastError', operator: 'isEmpty', value: null },
+  ];
+
+  it('describes each filter with the column label and the enum LABEL', () => {
+    renderAtWidth(1400, { filters: FILTERS, onFiltersChange: vi.fn() });
+
+    const chips = screen.getAllByTestId('datatable-filter-chip');
+    expect(chips.map((chip) => chip.textContent)).toEqual([
+      'Status is Failed',
+      'Attempts > 2',
+      'Last error is empty',
+    ]);
+  });
+
+  it('removes exactly the chip that was clicked', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderAtWidth(1400, { filters: FILTERS, onFiltersChange });
+
+    await user.click(screen.getByLabelText('Remove filter: Attempts > 2'));
+
+    expect(onFiltersChange).toHaveBeenCalledTimes(1);
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { columnId: 'status', operator: 'is', value: 'failed' },
+      { columnId: 'lastError', operator: 'isEmpty', value: null },
+    ]);
+  });
+
+  it('clears the whole model from "Clear all"', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderAtWidth(1400, { filters: FILTERS, onFiltersChange });
+
+    await user.click(screen.getByTestId('datatable-filter-clear-all'));
+    expect(onFiltersChange).toHaveBeenCalledWith([]);
+  });
+
+  it('offers no "Clear all" for a single filter — the chip already is one', () => {
+    renderAtWidth(1400, { filters: [FILTERS[0]], onFiltersChange: vi.fn() });
+    expect(screen.queryByTestId('datatable-filter-clear-all')).not.toBeInTheDocument();
+  });
+
+  it('still renders a removable chip for a column the table no longer declares', () => {
+    renderAtWidth(1400, {
+      filters: [{ columnId: 'ghostColumn', operator: 'contains', value: 'x' }],
+      onFiltersChange: vi.fn(),
+    });
+    // Falls back to the raw columnId rather than crashing on a URL-restored
+    // filter whose column was renamed.
+    expect(screen.getByTestId('datatable-filter-chip')).toHaveTextContent('ghostColumn contains x');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. The three filter surfaces
+// ---------------------------------------------------------------------------
+
+describe('DataTable — filter surface per layout', () => {
+  const FILTERS: DataTableFilterModel = [
+    { columnId: 'status', operator: 'is', value: 'failed' },
+    { columnId: 'attempts', operator: 'gt', value: 2 },
+  ];
+
+  it('desktop: the filter row is on screen, with no Filters button', () => {
+    renderAtWidth(1400, { filters: FILTERS, onFiltersChange: vi.fn() });
+
+    expect(screen.getByTestId('datatable-filter-bar')).toHaveAttribute(
+      'data-filter-surface',
+      'desktop',
+    );
+    expect(screen.getByTestId('datatable-filter-editor')).toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-filter-toggle')).not.toBeInTheDocument();
+    // Chips wrap; no sideways scroller on a wide layout.
+    expect(screen.getByTestId('datatable-filter-chips')).toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-filter-chip-strip')).not.toBeInTheDocument();
+  });
+
+  it('tablet: the panel is collapsed behind a Filters button carrying the count', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(800, { filters: FILTERS, onFiltersChange: vi.fn() });
+
+    expect(screen.getByTestId('datatable-filter-bar')).toHaveAttribute(
+      'data-filter-surface',
+      'tablet',
+    );
+
+    const toggle = screen.getByTestId('datatable-filter-toggle');
+    // The count is visible as a badge...
+    expect(document.querySelector(`.${FILTER_COUNT_CLASS}`)).toHaveTextContent('2');
+    // ...and spoken, since a badge bubble is invisible to a screen reader.
+    expect(toggle).toHaveAccessibleName('Filters (2 active)');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    // Collapsed: no editor until asked for.
+    expect(screen.queryByTestId('datatable-filter-editor')).not.toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.getByTestId('datatable-filter-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('datatable-filter-editor')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(toggle);
+    expect(screen.queryByTestId('datatable-filter-editor')).not.toBeInTheDocument();
+  });
+
+  it('tablet: the Filters button reads plainly when nothing is applied', () => {
+    renderAtWidth(800, { filters: [], onFiltersChange: vi.fn() });
+    expect(screen.getByTestId('datatable-filter-toggle')).toHaveAccessibleName('Filters');
+  });
+
+  it('phone: filters open in a full-screen sheet that traps focus', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(400, { filters: FILTERS, onFiltersChange: vi.fn() });
+
+    expect(screen.getByTestId('datatable-filter-bar')).toHaveAttribute(
+      'data-filter-surface',
+      'mobile',
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('datatable-filter-toggle'));
+
+    const sheet = await screen.findByRole('dialog');
+    expect(sheet).toHaveAccessibleName('Filters');
+    // MUI's modal marks everything outside inert; focus is inside the sheet.
+    expect(sheet).toContainElement(document.activeElement as HTMLElement);
+    expect(within(sheet).getByTestId('datatable-filter-editor')).toBeInTheDocument();
+
+    await user.click(within(sheet).getByRole('button', { name: 'Close filters' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('phone: Escape closes the sheet', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(400, { filters: [], onFiltersChange: vi.fn() });
+
+    await user.click(screen.getByTestId('datatable-filter-toggle'));
+    await screen.findByRole('dialog');
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('phone: active filters are a horizontally scrollable chip strip', () => {
+    renderAtWidth(400, { filters: FILTERS, onFiltersChange: vi.fn() });
+
+    const strip = screen.getByTestId('datatable-filter-chip-strip');
+    const style = getComputedStyle(strip);
+    // The one place a horizontal scroller is correct: an explicit control that
+    // owns its own overflow, not the document scrolling sideways.
+    expect(style.overflowX).toBe('auto');
+    expect(style.flexWrap).toBe('nowrap');
+    expect(style.maxWidth).toBe('100%');
+    expect(within(strip).getAllByTestId('datatable-filter-chip')).toHaveLength(2);
+  });
+
+  it('renders no filter bar at all when neither filtering nor search is configured', () => {
+    renderAtWidth(1400);
+    expect(screen.queryByTestId('datatable-filter-bar')).not.toBeInTheDocument();
+  });
+
+  it('renders search alone when no column is filterable', () => {
+    containerWidth = 1400;
+    render(
+      <DataTable<Job>
+        columns={COLUMNS.map(({ filterable: _filterable, ...rest }) => rest)}
+        rows={JOBS}
+        rowId={rowId}
+        ariaLabel="Enrichment jobs"
+        filters={[]}
+        onFiltersChange={vi.fn()}
+        quickSearch={{ value: '', onChange: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByTestId('datatable-quick-search')).toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-filter-editor')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('datatable-filter-toggle')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Filters survive a layout switch (state lives above the renderers)
+// ---------------------------------------------------------------------------
+
+function StatefulFilteredTable() {
+  const [filters, setFilters] = useState<DataTableFilterModel>([
+    { columnId: 'status', operator: 'is', value: 'failed' },
+  ]);
+  const [search, setSearch] = useState('tagging');
+
+  return (
+    <>
+      <div data-testid="probe-filters">{JSON.stringify(filters)}</div>
+      <div data-testid="probe-search">{search}</div>
+      <DataTable<Job>
+        columns={COLUMNS}
+        rows={JOBS}
+        rowId={rowId}
+        ariaLabel="Enrichment jobs"
+        filters={filters}
+        onFiltersChange={setFilters}
+        quickSearch={{ value: search, onChange: setSearch }}
+      />
+    </>
+  );
+}
+
+describe('DataTable — filters survive a layout switch', () => {
+  it('keeps the model and the search term across desktop -> mobile -> desktop', () => {
+    containerWidth = 1400;
+    render(<StatefulFilteredTable />);
+
+    const expected = '[{"columnId":"status","operator":"is","value":"failed"}]';
+    expect(screen.getByTestId('probe-filters')).toHaveTextContent(expected);
+    expect(screen.getByTestId('datatable-filter-chips')).toBeInTheDocument();
+
+    act(() => {
+      containerWidth = 400;
+      observers.forEach((observer) => observer.fire());
+    });
+
+    // Same state, different surface.
+    expect(screen.getByTestId('probe-filters')).toHaveTextContent(expected);
+    expect(screen.getByTestId('probe-search')).toHaveTextContent('tagging');
+    expect(screen.getByTestId('datatable-filter-chip-strip')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('tagging');
+
+    act(() => {
+      containerWidth = 1400;
+      observers.forEach((observer) => observer.fire());
+    });
+
+    expect(screen.getByTestId('probe-filters')).toHaveTextContent(expected);
+    expect(screen.getByTestId('datatable-filter-chips')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Model helpers (pure)
+// ---------------------------------------------------------------------------
+
+describe('filter model helpers', () => {
+  it('recognises an incomplete draft', () => {
+    expect(isFilterComplete({ columnId: 'type', operator: 'contains', value: '' })).toBe(false);
+    expect(isFilterComplete({ columnId: 'type', operator: 'contains', value: '   ' })).toBe(false);
+    expect(isFilterComplete({ columnId: 'type', operator: 'contains', value: 'geo' })).toBe(true);
+    expect(isFilterComplete({ columnId: 'a', operator: 'between', value: [1, ''] })).toBe(false);
+    expect(isFilterComplete({ columnId: 'a', operator: 'between', value: [1, 5] })).toBe(true);
+    expect(isFilterComplete({ columnId: 'a', operator: 'isAnyOf', value: [] })).toBe(false);
+    expect(isFilterComplete({ columnId: 'a', operator: 'isAnyOf', value: ['x'] })).toBe(true);
+    expect(isFilterComplete({ columnId: 'a', operator: 'isEmpty', value: null })).toBe(true);
+    // A boolean `false` is a real operand, not an empty one.
+    expect(isFilterComplete({ columnId: 'a', operator: 'is', value: false })).toBe(true);
+    // Zero likewise.
+    expect(isFilterComplete({ columnId: 'a', operator: 'equals', value: 0 })).toBe(true);
+  });
+
+  it('opens a boolean draft on Yes rather than on nothing', () => {
+    const column = COLUMNS.find((c) => c.id === 'favorite')!;
+    expect(draftFilterFor(column)).toEqual({
+      columnId: 'favorite',
+      operator: 'is',
+      value: true,
+    });
+  });
+
+  it('rejects an exact duplicate instead of stacking identical filters', () => {
+    const model: DataTableFilterModel = [
+      { columnId: 'status', operator: 'is', value: 'failed' },
+    ];
+    const duplicate = { columnId: 'status', operator: 'is' as const, value: 'failed' };
+    expect(containsFilter(model, duplicate)).toBe(true);
+    expect(addFilter(model, duplicate)).toBe(model);
+    // A different operand on the same column is NOT a duplicate.
+    expect(addFilter(model, { columnId: 'status', operator: 'is', value: 'pending' })).toHaveLength(
+      2,
+    );
+  });
+
+  it('returns a new array from every transition', () => {
+    const model: DataTableFilterModel = [
+      { columnId: 'a', operator: 'contains', value: '1' },
+      { columnId: 'b', operator: 'contains', value: '2' },
+    ];
+    const next = removeFilterAt(model, 0);
+    expect(next).not.toBe(model);
+    expect(model).toHaveLength(2);
+    expect(next).toEqual([{ columnId: 'b', operator: 'contains', value: '2' }]);
+  });
+
+  it('builds a chip label from labels, not raw ids or values', () => {
+    expect(
+      filterChipLabel({ columnId: 'status', operator: 'isAnyOf', value: ['failed', 'pending'] }, COLUMNS),
+    ).toBe('Status is any of Failed, Pending');
+    expect(
+      filterChipLabel({ columnId: 'attempts', operator: 'between', value: [1, 5] }, COLUMNS),
+    ).toBe('Attempts is between 1 and 5');
+    expect(filterChipLabel({ columnId: 'favorite', operator: 'is', value: true }, COLUMNS)).toBe(
+      'Favorite is Yes',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. URL serialization
+// ---------------------------------------------------------------------------
+
+describe('filter URL helper', () => {
+  const MODEL: DataTableFilterModel = [
+    { columnId: 'status', operator: 'is', value: 'failed' },
+    { columnId: 'attempts', operator: 'between', value: [1, 5] },
+    { columnId: 'lastError', operator: 'isEmpty', value: null },
+    { columnId: 'favorite', operator: 'is', value: true },
+  ];
+
+  it('round-trips a whole model, types included', () => {
+    const written = writeDataTableUrlState(new URLSearchParams(), {
+      filters: MODEL,
+      search: 'geo',
+    });
+    const read = readDataTableUrlState(written, { columns: COLUMNS });
+
+    expect(read.filters).toEqual(MODEL);
+    expect(read.search).toBe('geo');
+  });
+
+  it('survives a trip through a real query STRING, not just the object', () => {
+    const written = writeDataTableUrlState(new URLSearchParams(), { filters: MODEL });
+    // toString() re-encodes our percent escapes; parsing undoes it symmetrically.
+    const reparsed = new URLSearchParams(written.toString());
+
+    expect(readDataTableUrlState(reparsed, { columns: COLUMNS }).filters).toEqual(MODEL);
+  });
+
+  it('survives values containing the delimiters', () => {
+    const awkward: DataTableFilterModel = [
+      { columnId: 'lastError', operator: 'contains', value: 'rate: limited, twice' },
+      { columnId: 'type', operator: 'equals', value: 'a:b,c' },
+    ];
+    const written = writeDataTableUrlState(new URLSearchParams(), { filters: awkward });
+
+    expect(readDataTableUrlState(new URLSearchParams(written.toString()), { columns: COLUMNS }).filters).toEqual(
+      awkward,
+    );
+  });
+
+  it('keeps unrelated params untouched and does not mutate the input', () => {
+    const params = new URLSearchParams('page=3&tab=runs');
+    const written = writeDataTableUrlState(params, { filters: MODEL, search: 'geo' });
+
+    expect(written.get('page')).toBe('3');
+    expect(written.get('tab')).toBe('runs');
+    // The original is untouched — the caller decides push vs. replace.
+    expect(params.getAll('filter')).toEqual([]);
+    expect(written.getAll('filter')).toHaveLength(4);
+  });
+
+  it('removes its params entirely when the model and search are empty', () => {
+    const params = new URLSearchParams('page=3');
+    const seeded = writeDataTableUrlState(params, { filters: MODEL, search: 'geo' });
+    const cleared = writeDataTableUrlState(seeded, { filters: [], search: '' });
+
+    expect(cleared.toString()).toBe('page=3');
+  });
+
+  it('reads scalars as strings when no columns are supplied', () => {
+    const written = writeDataTableUrlState(new URLSearchParams(), {
+      filters: [{ columnId: 'attempts', operator: 'gt', value: 2 }],
+    });
+    // Documented limitation: a URL cannot say "this 2 is a number".
+    expect(readDataTableUrlState(written).filters).toEqual([
+      { columnId: 'attempts', operator: 'gt', value: '2' },
+    ]);
+  });
+
+  it('drops a malformed filter param instead of throwing', () => {
+    const params = new URLSearchParams('filter=nonsense&filter=status:is:failed&filter=');
+    expect(readDataTableUrlState(params, { columns: COLUMNS }).filters).toEqual([
+      { columnId: 'status', operator: 'is', value: 'failed' },
+    ]);
+  });
+
+  it('honours custom param names', () => {
+    const written = writeDataTableUrlState(
+      new URLSearchParams(),
+      { filters: [MODEL[0]], search: 'geo' },
+      { filterParam: 'f', searchParam: 'search' },
+    );
+    expect(written.getAll('f')).toHaveLength(1);
+    expect(written.get('search')).toBe('geo');
+    expect(
+      readDataTableUrlState(written, { filterParam: 'f', searchParam: 'search', columns: COLUMNS })
+        .filters,
+    ).toEqual([MODEL[0]]);
+  });
+
+  it('encodes one filter to the documented shape', () => {
+    expect(encodeFilter({ columnId: 'status', operator: 'is', value: 'failed' })).toBe(
+      'status:is:failed',
+    );
+    expect(encodeFilter({ columnId: 'attempts', operator: 'between', value: [1, 5] })).toBe(
+      'attempts:between:1,5',
+    );
+    expect(encodeFilter({ columnId: 'lastError', operator: 'isEmpty', value: null })).toBe(
+      'lastError:isEmpty',
+    );
+    expect(decodeFilter('lastError:isEmpty')).toEqual({
+      columnId: 'lastError',
+      operator: 'isEmpty',
+      value: null,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Issue #243 guard, extended to the filter controls
+// ---------------------------------------------------------------------------
+
+const VISIBLE_CONTROL_SELECTOR = 'button, [role="button"], .MuiCheckbox-root, a[href]';
+const THIRD_PARTY_CHROME = '.MuiDataGrid-columnHeaders, .MuiDataGrid-columnHeader';
+
+function describeControl(control: HTMLElement) {
+  const label = control.getAttribute('aria-label') ?? control.textContent?.slice(0, 24) ?? '';
+  return `${control.tagName.toLowerCase()}[${label}]`;
+}
+
+function assertNoInvisibleHitTargets(root: HTMLElement) {
+  const controls = Array.from(
+    root.querySelectorAll<HTMLElement>(VISIBLE_CONTROL_SELECTOR),
+  ).filter((control) => !control.closest(THIRD_PARTY_CHROME));
+  expect(controls.length).toBeGreaterThan(0);
+
+  const offenders = controls
+    .filter((control) => {
+      const style = getComputedStyle(control);
+      return style.opacity === '0' && style.pointerEvents !== 'none';
+    })
+    .map(describeControl);
+
+  expect(offenders).toEqual([]);
+}
+
+describe('DataTable filter surface — no invisible-but-tappable controls (#243 guard)', () => {
+  const FILTERS: DataTableFilterModel = [
+    { columnId: 'status', operator: 'is', value: 'failed' },
+    { columnId: 'attempts', operator: 'gt', value: 2 },
+  ];
+
+  it('holds for the desktop filter row', () => {
+    renderAtWidth(1400, {
+      filters: FILTERS,
+      onFiltersChange: vi.fn(),
+      quickSearch: { value: 'geo', onChange: vi.fn() },
+    });
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable-filter-bar'));
+  });
+
+  it('holds for the tablet panel, opened', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(800, {
+      filters: FILTERS,
+      onFiltersChange: vi.fn(),
+      quickSearch: { value: 'geo', onChange: vi.fn() },
+    });
+
+    await user.click(screen.getByTestId('datatable-filter-toggle'));
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable-filter-bar'));
+  });
+
+  it('holds for the phone sheet, opened', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(400, {
+      filters: FILTERS,
+      onFiltersChange: vi.fn(),
+      quickSearch: { value: 'geo', onChange: vi.fn() },
+    });
+
+    await user.click(screen.getByTestId('datatable-filter-toggle'));
+    const sheet = await screen.findByRole('dialog');
+    assertNoInvisibleHitTargets(sheet);
+  });
+
+  it('gives every filter control a >=44px touch target', async () => {
+    const user = userEvent.setup();
+    renderAtWidth(400, {
+      filters: FILTERS,
+      onFiltersChange: vi.fn(),
+      quickSearch: { value: 'geo', onChange: vi.fn() },
+    });
+
+    const mustBeTouchSized: HTMLElement[] = [
+      screen.getByTestId('datatable-filter-toggle'),
+      screen.getByRole('button', { name: 'Clear search' }),
+      ...screen.getAllByTestId('datatable-filter-chip'),
+    ];
+
+    await user.click(screen.getByTestId('datatable-filter-toggle'));
+    const sheet = await screen.findByRole('dialog');
+    mustBeTouchSized.push(
+      within(sheet).getByRole('button', { name: 'Close filters' }),
+      within(sheet).getByTestId('datatable-filter-apply'),
+      within(sheet).getByRole('combobox', { name: 'Column' }),
+    );
+
+    for (const control of mustBeTouchSized) {
+      // A select's sizing lives on its InputBase wrapper, not the combobox div.
+      const sized = control.closest<HTMLElement>('.MuiInputBase-root') ?? control;
+      const style = getComputedStyle(sized);
+      // `height: auto` parses to NaN, which would poison a bare Math.max.
+      const px = (raw: string) => {
+        const parsed = Number.parseFloat(raw);
+        return Number.isFinite(parsed) ? parsed : 0;
+      };
+      const min = Math.max(px(style.minHeight), px(style.height));
+      expect(min, describeControl(control)).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  it('reveals every filter control without a hover', () => {
+    renderAtWidth(400, {
+      filters: FILTERS,
+      onFiltersChange: vi.fn(),
+      quickSearch: { value: 'geo', onChange: vi.fn() },
+    });
+
+    const bar = screen.getByTestId('datatable-filter-bar');
+    const painted = Array.from(bar.querySelectorAll<HTMLElement>('button, .MuiChip-root'));
+    expect(painted.length).toBeGreaterThan(0);
+    for (const control of painted) {
+      expect(getComputedStyle(control).opacity).not.toBe('0');
+    }
+  });
+});

--- a/apps/web/src/components/datatable/filter/DataTableFilterBar.tsx
+++ b/apps/web/src/components/datatable/filter/DataTableFilterBar.tsx
@@ -1,0 +1,255 @@
+/**
+ * DataTable — the filter surface, one component per layout.
+ *
+ * Drawn by `DataTable` itself, above whichever renderer is active, for two
+ * reasons: the shape of this control is decided by the LAYOUT rather than by
+ * how rows are presented, and a renderer that owned the open/draft state would
+ * throw it away on every resize (§7.4 — state lives above the renderers).
+ *
+ * | layout    | filter surface                                              |
+ * | --------- | ----------------------------------------------------------- |
+ * | `desktop` | an always-visible filter ROW above the grid                  |
+ * | `tablet`  | the same row, collapsed behind a "Filters" button + count    |
+ * | `mobile`  | a FULL-SCREEN sheet; chips become a scrollable strip         |
+ *
+ * The phone case is a sheet rather than a squeezed-down inline row for the same
+ * reason the card list exists at all: a three-control form at 360px is either
+ * unusable or pushes the page sideways. A sheet gets the full screen, the
+ * stacked form, and a real focus trap.
+ *
+ * Filtering is SERVER-SIDE, always. Nothing here touches `rows`; every gesture
+ * produces a new normalized model and hands it to the page.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+  AppBar,
+  Badge,
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  Divider,
+  IconButton,
+  Stack,
+  Toolbar,
+  Typography,
+} from '@mui/material';
+import {
+  FilterList as FilterListIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import type {
+  DataTableColumn,
+  DataTableFilter,
+  DataTableFilterModel,
+  DataTableLayout,
+  DataTableQuickSearchConfig,
+} from '../types';
+import { filterableColumns } from './operators';
+import { addFilter, draftFilterFor, removeFilterAt } from './filterModel';
+import { FilterEditor } from './FilterEditor';
+import { FilterChips } from './FilterChips';
+import { QuickSearchField } from './QuickSearchField';
+
+/** Class on the tablet/phone "Filters" badge, so its count is assertable. */
+export const FILTER_COUNT_CLASS = 'datatable-filter-count';
+
+export interface DataTableFilterBarProps<Row> {
+  columns: DataTableColumn<Row>[];
+  layout: DataTableLayout;
+  filters: DataTableFilterModel;
+  onFiltersChange?: (next: DataTableFilterModel) => void;
+  quickSearch?: DataTableQuickSearchConfig;
+}
+
+export function DataTableFilterBar<Row>({
+  columns,
+  layout,
+  filters,
+  onFiltersChange,
+  quickSearch,
+}: DataTableFilterBarProps<Row>) {
+  const filterable = useMemo(() => filterableColumns(columns), [columns]);
+  const filteringEnabled = filterable.length > 0 && Boolean(onFiltersChange);
+
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<DataTableFilter | null>(null);
+
+  // A draft whose column has disappeared (columns are a prop and can change)
+  // would render an editor pointed at nothing, so it is re-seeded rather than
+  // trusted.
+  const activeDraft = useMemo<DataTableFilter | null>(() => {
+    if (filterable.length === 0) return null;
+    if (draft && filterable.some((column) => column.id === draft.columnId)) return draft;
+    return draftFilterFor(filterable[0]);
+  }, [draft, filterable]);
+
+  if (!filteringEnabled && !quickSearch) return null;
+
+  const emit = (next: DataTableFilterModel) => onFiltersChange?.(next);
+
+  const commitDraft = (filter: DataTableFilter) => {
+    emit(addFilter(filters, filter));
+    // Reset to a blank draft so the form is immediately ready for the next
+    // filter instead of re-offering the one just applied.
+    setDraft(draftFilterFor(filterable[0]));
+  };
+
+  const removeAt = (index: number) => emit(removeFilterAt(filters, index));
+  const clearAll = () => emit([]);
+
+  const editor = activeDraft ? (
+    <FilterEditor
+      columns={filterable}
+      draft={activeDraft}
+      onDraftChange={setDraft}
+      onCommit={commitDraft}
+      orientation={layout === 'mobile' ? 'stacked' : 'row'}
+    />
+  ) : null;
+
+  const filtersButton = (
+    <Badge
+      color="primary"
+      badgeContent={filters.length}
+      // MUI's slot props are strictly typed and reject `data-*`; `className` is
+      // a first-class slot prop, so the count bubble stays queryable without a
+      // cast. The button's accessible name carries the same count in words.
+      slotProps={{ badge: { className: FILTER_COUNT_CLASS } }}
+      sx={{ flex: '0 0 auto' }}
+    >
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<FilterListIcon />}
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        aria-haspopup={layout === 'mobile' ? 'dialog' : undefined}
+        // The visible word "Filters" is preserved inside the accessible name
+        // (WCAG 2.5.3), with the badge's count spelled out for screen readers,
+        // which cannot see a superscript bubble.
+        aria-label={filters.length > 0 ? `Filters (${filters.length} active)` : 'Filters'}
+        data-testid="datatable-filter-toggle"
+        sx={{ minHeight: 44 }}
+      >
+        Filters
+      </Button>
+    </Badge>
+  );
+
+  return (
+    <Box
+      data-testid="datatable-filter-bar"
+      data-filter-surface={layout}
+      sx={{ width: '100%', maxWidth: '100%', minWidth: 0, mb: 1.5 }}
+    >
+      <Stack
+        direction={layout === 'mobile' ? 'column' : 'row'}
+        spacing={1}
+        useFlexGap
+        sx={{
+          alignItems: layout === 'mobile' ? 'stretch' : 'center',
+          flexWrap: 'wrap',
+          minWidth: 0,
+        }}
+      >
+        {quickSearch && (
+          <QuickSearchField
+            config={quickSearch}
+            columns={columns}
+            fullWidth={layout !== 'desktop'}
+          />
+        )}
+
+        {/* Desktop keeps the whole form on screen; the narrower layouts put it
+            behind a button so the table itself stays the page's subject. */}
+        {filteringEnabled && layout === 'desktop' && editor}
+        {filteringEnabled && layout !== 'desktop' && filtersButton}
+      </Stack>
+
+      {/* Tablet: the same row, revealed in place. */}
+      {filteringEnabled && layout === 'tablet' && open && (
+        <Box sx={{ mt: 1.5 }} data-testid="datatable-filter-panel">
+          {editor}
+        </Box>
+      )}
+
+      {filteringEnabled && (
+        <FilterChips
+          filters={filters}
+          columns={columns}
+          onRemove={removeAt}
+          onClearAll={clearAll}
+          variant={layout === 'mobile' ? 'strip' : 'wrap'}
+        />
+      )}
+
+      {/* Phone: a real sheet. MUI's Dialog gives the focus trap, the Escape
+          handling and the aria-modal semantics for free — reimplementing any of
+          those by hand is how a "custom sheet" ends up unusable by keyboard. */}
+      {filteringEnabled && layout === 'mobile' && (
+        <Dialog
+          fullScreen
+          open={open}
+          onClose={() => setOpen(false)}
+          aria-labelledby="datatable-filter-sheet-title"
+        >
+          <AppBar position="relative" color="default" elevation={0}>
+            <Toolbar sx={{ gap: 1 }}>
+              <Typography
+                id="datatable-filter-sheet-title"
+                variant="h6"
+                component="h2"
+                sx={{ flexGrow: 1 }}
+              >
+                Filters
+              </Typography>
+              <IconButton
+                edge="end"
+                aria-label="Close filters"
+                onClick={() => setOpen(false)}
+                sx={{ minWidth: 44, minHeight: 44 }}
+              >
+                <CloseIcon />
+              </IconButton>
+            </Toolbar>
+          </AppBar>
+          <Divider />
+
+          <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {editor}
+
+            {filters.length > 0 && (
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                  Active filters
+                </Typography>
+                {/* Inside the sheet there is vertical room, so chips wrap
+                    rather than hiding themselves behind a sideways scroll. */}
+                <FilterChips
+                  filters={filters}
+                  columns={columns}
+                  onRemove={removeAt}
+                  onClearAll={clearAll}
+                  variant="wrap"
+                />
+              </Box>
+            )}
+
+            <Box sx={{ flexGrow: 1 }} />
+
+            <Button
+              variant="contained"
+              fullWidth
+              onClick={() => setOpen(false)}
+              sx={{ minHeight: 44 }}
+            >
+              Done
+            </Button>
+          </DialogContent>
+        </Dialog>
+      )}
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/filter/FilterChips.tsx
+++ b/apps/web/src/components/datatable/filter/FilterChips.tsx
@@ -1,0 +1,120 @@
+/**
+ * DataTable — active filters, as removable chips.
+ *
+ * The chip strip is the only always-visible statement of *why* the table shows
+ * what it shows. It is present in all three layouts because a filtered table
+ * with no visible filter is the single most common way a user concludes their
+ * data is missing.
+ *
+ * ## The one place a horizontal scroller is correct
+ *
+ * On a phone the strip scrolls sideways (`variant="strip"`) rather than
+ * wrapping onto four lines above a card list. That does not contradict §6's
+ * "the document must never scroll horizontally" rule — §6 is about a table
+ * accidentally pushing the BODY wide. This is an explicit, discoverable,
+ * self-contained control that owns its own overflow, and it is exactly what
+ * issue #254 asks for.
+ *
+ * ## Chip keyboard semantics
+ *
+ * A MUI `Chip` with `onDelete` is itself focusable and responds to
+ * Backspace/Delete — that is the library's a11y contract and the reason the
+ * delete icon is not separately tabbable (it would double every tab stop). The
+ * icon still carries an `aria-label` so the pointer target has a name.
+ */
+
+import { Box, Button, Chip } from '@mui/material';
+import { Cancel as CancelIcon } from '@mui/icons-material';
+import type { DataTableColumn, DataTableFilterModel } from '../types';
+import { filterChipLabel, filterKey } from './filterModel';
+
+export interface FilterChipsProps<Row> {
+  filters: DataTableFilterModel;
+  columns: DataTableColumn<Row>[];
+  onRemove: (index: number) => void;
+  onClearAll?: () => void;
+  /**
+   * `'wrap'` — chips flow onto multiple lines (desktop / tablet).
+   * `'strip'` — one line, horizontally scrollable (phone).
+   */
+  variant?: 'wrap' | 'strip';
+}
+
+export function FilterChips<Row>({
+  filters,
+  columns,
+  onRemove,
+  onClearAll,
+  variant = 'wrap',
+}: FilterChipsProps<Row>) {
+  if (filters.length === 0) return null;
+
+  const strip = variant === 'strip';
+
+  return (
+    <Box
+      data-testid={strip ? 'datatable-filter-chip-strip' : 'datatable-filter-chips'}
+      role="list"
+      aria-label="Active filters"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        minWidth: 0,
+        maxWidth: '100%',
+        mt: 1,
+        ...(strip
+          ? {
+              flexWrap: 'nowrap',
+              overflowX: 'auto',
+              // Scrolling is the point here; keep the momentum feel on iOS and
+              // stop the strip from stealing vertical scroll.
+              WebkitOverflowScrolling: 'touch',
+              overscrollBehaviorX: 'contain',
+              pb: 0.5,
+            }
+          : { flexWrap: 'wrap' }),
+      }}
+    >
+      {filters.map((filter, index) => {
+        const label = filterChipLabel(filter, columns);
+        return (
+          <Chip
+            key={`${filterKey(filter)}#${index}`}
+            role="listitem"
+            label={label}
+            size="medium"
+            variant="outlined"
+            color="primary"
+            data-testid="datatable-filter-chip"
+            onDelete={() => onRemove(index)}
+            deleteIcon={
+              <CancelIcon
+                aria-label={`Remove filter: ${label}`}
+                data-testid="datatable-filter-chip-remove"
+              />
+            }
+            sx={{
+              minHeight: 44,
+              maxWidth: '100%',
+              ...(strip ? { flex: '0 0 auto' } : {}),
+              // The delete icon is the pointer target; give it a real one.
+              '& .MuiChip-deleteIcon': { fontSize: 22, mr: 0.5 },
+            }}
+          />
+        );
+      })}
+
+      {onClearAll && filters.length > 1 && (
+        <Button
+          size="small"
+          onClick={onClearAll}
+          data-testid="datatable-filter-clear-all"
+          sx={{ minHeight: 44, flex: '0 0 auto' }}
+        >
+          Clear all
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/apps/web/src/components/datatable/filter/FilterEditor.tsx
+++ b/apps/web/src/components/datatable/filter/FilterEditor.tsx
@@ -1,0 +1,303 @@
+/**
+ * DataTable — the add-a-filter form.
+ *
+ * Three controls in a row (or stacked, on a phone): **column → operator →
+ * value**, plus an Add button. The same component serves every layout; only
+ * `orientation` changes.
+ *
+ * ## Why the draft is local and only committed filters are emitted
+ *
+ * The form owns an incomplete `DataTableFilter` — the user has picked a column
+ * but not yet typed a value. That draft is NEVER emitted: `onCommit` fires once
+ * `isFilterComplete()` holds. If a half-built filter reached the page, the very
+ * first click of "Add filter" would trigger a refetch with a meaningless param,
+ * and every keystroke after it another one. The chip strip and the emitted
+ * model therefore always describe a real, applied query.
+ *
+ * ## Value control by declared type
+ *
+ * | `filterType` | operand control                                    |
+ * | ------------ | -------------------------------------------------- |
+ * | `text`       | text field                                         |
+ * | `number`     | number field (two, for `between`)                  |
+ * | `date`       | native date field (two, for `between`)             |
+ * | `enum`       | select over `enumValues`; multi-select for `isAnyOf`|
+ * | `boolean`    | Yes / No select                                    |
+ *
+ * A 0-arity operator (`isEmpty`) draws no operand control at all.
+ */
+
+import { Box, Button, MenuItem, Stack, TextField } from '@mui/material';
+import { Add as AddIcon } from '@mui/icons-material';
+import type { DataTableColumn, DataTableFilter, DataTableFilterValue } from '../types';
+import {
+  filterTypeOf,
+  operatorArity,
+  operatorLabel,
+  operatorsForColumn,
+} from './operators';
+import { blankValueFor, columnForFilter, draftFilterFor, isFilterComplete } from './filterModel';
+
+export interface FilterEditorProps<Row> {
+  /** Filterable columns only. */
+  columns: DataTableColumn<Row>[];
+  draft: DataTableFilter;
+  onDraftChange: (next: DataTableFilter) => void;
+  onCommit: (filter: DataTableFilter) => void;
+  /** `'row'` on desktop/tablet, `'stacked'` in the phone sheet. */
+  orientation?: 'row' | 'stacked';
+}
+
+/** Shared sizing so every control in the form is a legal touch target. */
+const CONTROL_SX = { '& .MuiInputBase-root': { minHeight: 44 } } as const;
+
+export function FilterEditor<Row>({
+  columns,
+  draft,
+  onDraftChange,
+  onCommit,
+  orientation = 'row',
+}: FilterEditorProps<Row>) {
+  const column = columnForFilter(columns, draft) ?? columns[0];
+  if (!column) return null;
+
+  const filterType = filterTypeOf(column);
+  const operators = operatorsForColumn(column);
+  const arity = operatorArity(draft.operator);
+  const complete = isFilterComplete(draft);
+  const stacked = orientation === 'stacked';
+
+  // Switching column invalidates both the operator and the operand: `contains`
+  // is meaningless on a boolean, and `'failed'` on an `attempts` column.
+  const changeColumn = (columnId: string) => {
+    const next = columns.find((entry) => entry.id === columnId);
+    if (next) onDraftChange(draftFilterFor(next));
+  };
+
+  // Switching operator keeps the column but resets the operand whenever the
+  // arity changes — a `between` pair cannot be reinterpreted as a scalar.
+  const changeOperator = (operator: string) => {
+    const nextArity = operatorArity(operator as DataTableFilter['operator']);
+    const keepValue = nextArity === arity;
+    onDraftChange({
+      ...draft,
+      operator: operator as DataTableFilter['operator'],
+      value: keepValue ? draft.value : blankValueFor(nextArity),
+    });
+  };
+
+  const changeValue = (value: DataTableFilterValue) => onDraftChange({ ...draft, value });
+
+  const changePairEntry = (index: 0 | 1, raw: string) => {
+    const pair = Array.isArray(draft.value) ? [...draft.value] : ['', ''];
+    pair[index] = filterType === 'number' && raw !== '' ? Number(raw) : raw;
+    changeValue(pair as (string | number)[]);
+  };
+
+  const pairValue = (index: 0 | 1): string => {
+    if (!Array.isArray(draft.value)) return '';
+    const entry = draft.value[index];
+    return entry === undefined || entry === null ? '' : String(entry);
+  };
+
+  const scalarValue = (): string => {
+    if (draft.value === null || Array.isArray(draft.value)) return '';
+    return String(draft.value);
+  };
+
+  const commit = () => {
+    if (complete) onCommit(draft);
+  };
+
+  return (
+    <Box
+      data-testid="datatable-filter-editor"
+      component="form"
+      onSubmit={(event) => {
+        event.preventDefault();
+        commit();
+      }}
+      sx={{ minWidth: 0, maxWidth: '100%' }}
+    >
+      <Stack
+        direction={stacked ? 'column' : 'row'}
+        spacing={1}
+        useFlexGap
+        sx={{ flexWrap: stacked ? 'nowrap' : 'wrap', alignItems: stacked ? 'stretch' : 'center' }}
+      >
+        <TextField
+          select
+          size="small"
+          label="Column"
+          value={column.id}
+          onChange={(event) => changeColumn(event.target.value)}
+          sx={{ minWidth: 160, ...(stacked ? {} : { flex: '0 1 200px' }), ...CONTROL_SX }}
+        >
+          {columns.map((entry) => (
+            <MenuItem key={entry.id} value={entry.id}>
+              {entry.label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        <TextField
+          select
+          size="small"
+          label="Operator"
+          value={draft.operator}
+          onChange={(event) => changeOperator(event.target.value)}
+          sx={{ minWidth: 150, ...(stacked ? {} : { flex: '0 1 180px' }), ...CONTROL_SX }}
+        >
+          {operators.map((operator) => (
+            <MenuItem key={operator} value={operator} data-operator={operator}>
+              {operatorLabel(operator, filterType)}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        {arity === 2 ? (
+          <>
+            <ValueField
+              label="From"
+              filterType={filterType}
+              column={column}
+              value={pairValue(0)}
+              onChange={(raw) => changePairEntry(0, raw)}
+              stacked={stacked}
+            />
+            <ValueField
+              label="To"
+              filterType={filterType}
+              column={column}
+              value={pairValue(1)}
+              onChange={(raw) => changePairEntry(1, raw)}
+              stacked={stacked}
+            />
+          </>
+        ) : arity === 'many' ? (
+          <TextField
+            select
+            size="small"
+            label="Value"
+            value={Array.isArray(draft.value) ? draft.value.map(String) : []}
+            onChange={(event) => {
+              const raw = event.target.value;
+              changeValue(
+                (typeof raw === 'string' ? raw.split(',') : (raw as unknown as string[])).filter(
+                  Boolean,
+                ),
+              );
+            }}
+            slotProps={{ select: { multiple: true } }}
+            sx={{ minWidth: 180, ...(stacked ? {} : { flex: '1 1 220px' }), ...CONTROL_SX }}
+          >
+            {(column.enumValues ?? []).map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        ) : arity === 1 ? (
+          <ValueField
+            label="Value"
+            filterType={filterType}
+            column={column}
+            value={scalarValue()}
+            onChange={(raw) =>
+              changeValue(
+                filterType === 'number'
+                  ? raw === ''
+                    ? ''
+                    : Number(raw)
+                  : filterType === 'boolean'
+                    ? raw === 'true'
+                    : raw,
+              )
+            }
+            stacked={stacked}
+          />
+        ) : null}
+
+        <Button
+          type="submit"
+          variant="contained"
+          size="small"
+          startIcon={<AddIcon />}
+          disabled={!complete}
+          data-testid="datatable-filter-apply"
+          sx={{ minHeight: 44, flex: '0 0 auto' }}
+        >
+          Add
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Operand control
+// ---------------------------------------------------------------------------
+
+interface ValueFieldProps<Row> {
+  label: string;
+  filterType: ReturnType<typeof filterTypeOf>;
+  column: DataTableColumn<Row>;
+  value: string;
+  onChange: (raw: string) => void;
+  stacked: boolean;
+}
+
+function ValueField<Row>({
+  label,
+  filterType,
+  column,
+  value,
+  onChange,
+  stacked,
+}: ValueFieldProps<Row>) {
+  const sx = {
+    minWidth: 140,
+    ...(stacked ? {} : { flex: '1 1 180px' }),
+    ...CONTROL_SX,
+  };
+
+  if (filterType === 'enum' || filterType === 'boolean') {
+    const options =
+      filterType === 'boolean'
+        ? [
+            { value: 'true', label: 'Yes' },
+            { value: 'false', label: 'No' },
+          ]
+        : (column.enumValues ?? []);
+    return (
+      <TextField
+        select
+        size="small"
+        label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        sx={sx}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    );
+  }
+
+  return (
+    <TextField
+      size="small"
+      label={label}
+      type={filterType === 'number' ? 'number' : filterType === 'date' ? 'date' : 'text'}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      // A native date input renders its own placeholder text, which overlaps a
+      // floating label unless the label is pinned shrunk.
+      slotProps={filterType === 'date' ? { inputLabel: { shrink: true } } : undefined}
+      sx={sx}
+    />
+  );
+}

--- a/apps/web/src/components/datatable/filter/QuickSearchField.tsx
+++ b/apps/web/src/components/datatable/filter/QuickSearchField.tsx
@@ -1,0 +1,136 @@
+/**
+ * DataTable — global quick search.
+ *
+ * ## The debounce is on the EMISSION, not the input
+ *
+ * This is the whole point of the component. A naive debounce holds the input's
+ * `value` back too, so the caret lags a keystroke or two behind the typist on a
+ * slow phone; MemoriaHub's own search surfaces have shipped that bug before.
+ * Here the `<input>` is driven by local state and repaints on every keystroke,
+ * while `onChange` — the thing that costs an HTTP round trip — fires once the
+ * user has paused.
+ *
+ * A page can therefore refetch straight from `onChange` with no debounce of its
+ * own, which is the contract the props document.
+ *
+ * ## Staying controlled without fighting the parent
+ *
+ * `value` is still the source of truth. `emittedRef` remembers the last term
+ * this component put on the wire, so a change arriving from OUTSIDE (a URL
+ * restore, a "clear all filters" button, a back-navigation) is distinguishable
+ * from the echo of our own emission and re-seeds the input; our own echo is
+ * ignored and never clobbers in-flight typing.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { IconButton, InputAdornment, TextField } from '@mui/material';
+import { Search as SearchIcon, Close as CloseIcon } from '@mui/icons-material';
+import type { DataTableColumn, DataTableQuickSearchConfig } from '../types';
+import { searchableColumns } from './operators';
+
+/** Long enough to swallow a burst of typing, short enough to feel immediate. */
+export const DEFAULT_QUICK_SEARCH_DEBOUNCE_MS = 300;
+
+export interface QuickSearchFieldProps<Row> {
+  config: DataTableQuickSearchConfig;
+  columns: DataTableColumn<Row>[];
+  /** Fill the available width — the phone sheet and the tablet bar both do. */
+  fullWidth?: boolean;
+}
+
+/** "Search type, status or last error" — names what the term actually covers. */
+function defaultPlaceholder<Row>(columns: DataTableColumn<Row>[]): string {
+  const labels = searchableColumns(columns).map((column) => column.label);
+  if (labels.length === 0) return 'Search';
+  if (labels.length === 1) return `Search ${labels[0]}`;
+  const last = labels[labels.length - 1];
+  return `Search ${labels.slice(0, -1).join(', ')} or ${last}`;
+}
+
+export function QuickSearchField<Row>({
+  config,
+  columns,
+  fullWidth = false,
+}: QuickSearchFieldProps<Row>) {
+  const {
+    value,
+    onChange,
+    placeholder,
+    debounceMs = DEFAULT_QUICK_SEARCH_DEBOUNCE_MS,
+    ariaLabel = 'Search',
+  } = config;
+
+  const [draft, setDraft] = useState(value);
+  const emittedRef = useRef(value);
+
+  // `onChange` is very often an inline arrow from the calling page, so its
+  // identity changes every render. Reading it through a ref keeps it out of the
+  // timer effect's deps — otherwise a parent re-render would restart the
+  // debounce window and, under a busy parent, the term would never be emitted.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // An externally-driven change (URL restore, programmatic clear) re-seeds the
+  // input. The echo of our own emission does not.
+  useEffect(() => {
+    if (value === emittedRef.current) return;
+    emittedRef.current = value;
+    setDraft(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (draft === emittedRef.current) return;
+    const timer = setTimeout(() => {
+      emittedRef.current = draft;
+      onChangeRef.current(draft);
+    }, debounceMs);
+    return () => clearTimeout(timer);
+  }, [draft, debounceMs]);
+
+  const clear = () => {
+    setDraft('');
+    // Clearing is an explicit, single gesture — there is nothing to debounce
+    // and waiting 300ms to un-filter a table reads as a broken button.
+    emittedRef.current = '';
+    onChangeRef.current('');
+  };
+
+  return (
+    <TextField
+      size="small"
+      type="search"
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      placeholder={placeholder ?? defaultPlaceholder(columns)}
+      fullWidth={fullWidth}
+      data-testid="datatable-quick-search"
+      slotProps={{
+        htmlInput: { 'aria-label': ariaLabel },
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" />
+            </InputAdornment>
+          ),
+          endAdornment: draft ? (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                aria-label="Clear search"
+                onClick={clear}
+                sx={{ minWidth: 44, minHeight: 44 }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
+        },
+      }}
+      sx={{
+        minWidth: fullWidth ? 0 : 220,
+        // WCAG 2.5.8: the field itself is a touch target.
+        '& .MuiInputBase-root': { minHeight: 44 },
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/datatable/filter/filterModel.ts
+++ b/apps/web/src/components/datatable/filter/filterModel.ts
@@ -1,0 +1,167 @@
+/**
+ * DataTable — normalized filter model helpers.
+ *
+ * Pure functions over `DataTableFilterModel`. No React, no MUI: the model is
+ * data a page owns, and everything that reads or writes it — the panel, the
+ * chips, the URL helper, and a calling page mapping filters onto query params —
+ * shares these primitives so "what counts as a complete filter" has exactly one
+ * definition.
+ */
+
+import type {
+  DataTableColumn,
+  DataTableFilter,
+  DataTableFilterModel,
+  DataTableFilterValue,
+} from '../types';
+import {
+  defaultOperatorForColumn,
+  filterTypeOf,
+  operatorArity,
+  operatorLabel,
+} from './operators';
+
+/** Find the column a filter targets, if the table still declares it. */
+export function columnForFilter<Row>(
+  columns: DataTableColumn<Row>[],
+  filter: DataTableFilter,
+): DataTableColumn<Row> | undefined {
+  return columns.find((column) => column.id === filter.columnId);
+}
+
+/**
+ * The blank operand for a fresh filter: `null` for a 0-arity operator, an empty
+ * pair for `between`, an empty set for `isAnyOf`, `''` otherwise.
+ *
+ * `between` starts as `['', '']` rather than `null` so the two inputs stay
+ * controlled from the first render (a React input that switches from
+ * uncontrolled to controlled warns, and worse, drops the first keystroke).
+ */
+export function blankValueFor(arity: ReturnType<typeof operatorArity>): DataTableFilterValue {
+  if (arity === 0) return null;
+  if (arity === 2) return ['', ''];
+  if (arity === 'many') return [];
+  return '';
+}
+
+/** A fresh, not-yet-complete filter targeting `column`. */
+export function draftFilterFor<Row>(column: DataTableColumn<Row>): DataTableFilter {
+  const operator = defaultOperatorForColumn(column);
+  const filterType = filterTypeOf(column);
+  const arity = operatorArity(operator);
+  // A boolean filter has exactly two meaningful operands and no "empty" state
+  // worth making the user pick, so it opens on `true`.
+  const value =
+    filterType === 'boolean' && arity === 1 ? true : blankValueFor(arity);
+  return { columnId: column.id, operator, value };
+}
+
+/**
+ * Whether a filter carries enough information to be sent to the server.
+ *
+ * The panel keeps an incomplete filter as a LOCAL draft and never emits it —
+ * emitting `{ columnId: 'status', operator: 'is', value: '' }` would make the
+ * page refetch with a meaningless param on the first click of "Add filter".
+ */
+export function isFilterComplete(filter: DataTableFilter): boolean {
+  const arity = operatorArity(filter.operator);
+  if (arity === 0) return true;
+  if (arity === 2) {
+    return (
+      Array.isArray(filter.value) &&
+      filter.value.length === 2 &&
+      filter.value.every((entry) => entry !== '' && entry !== null && entry !== undefined)
+    );
+  }
+  if (arity === 'many') return Array.isArray(filter.value) && filter.value.length > 0;
+  if (typeof filter.value === 'boolean') return true;
+  if (typeof filter.value === 'number') return Number.isFinite(filter.value);
+  return typeof filter.value === 'string' && filter.value.trim() !== '';
+}
+
+/** Structural identity, used to key React lists and to reject exact duplicates. */
+export function filterKey(filter: DataTableFilter): string {
+  return `${filter.columnId}|${filter.operator}|${JSON.stringify(filter.value ?? null)}`;
+}
+
+export function sameFilter(a: DataTableFilter, b: DataTableFilter): boolean {
+  return filterKey(a) === filterKey(b);
+}
+
+/** Whether `model` already contains an identical filter. */
+export function containsFilter(model: DataTableFilterModel, filter: DataTableFilter): boolean {
+  return model.some((entry) => sameFilter(entry, filter));
+}
+
+/** Human-readable operand, used in chip labels. */
+export function describeFilterValue<Row>(
+  filter: DataTableFilter,
+  column: DataTableColumn<Row> | undefined,
+): string {
+  const arity = operatorArity(filter.operator);
+  if (arity === 0) return '';
+
+  const labelOf = (raw: string | number | boolean): string => {
+    if (typeof raw === 'boolean') return raw ? 'Yes' : 'No';
+    if (column?.enumValues) {
+      const match = column.enumValues.find((option) => option.value === String(raw));
+      if (match) return match.label;
+    }
+    return String(raw);
+  };
+
+  if (arity === 2 && Array.isArray(filter.value)) {
+    return `${labelOf(filter.value[0])} and ${labelOf(filter.value[1])}`;
+  }
+  if (Array.isArray(filter.value)) return filter.value.map(labelOf).join(', ');
+  if (filter.value === null) return '';
+  return labelOf(filter.value);
+}
+
+/**
+ * The chip label: `"Status is Failed"`.
+ *
+ * Falls back to the raw `columnId` when the table no longer declares that
+ * column — a filter restored from a URL after a column was renamed should read
+ * as something removable, not crash the chip strip.
+ */
+export function filterChipLabel<Row>(
+  filter: DataTableFilter,
+  columns: DataTableColumn<Row>[],
+): string {
+  const column = columnForFilter(columns, filter);
+  const label = column?.label ?? filter.columnId;
+  const operator = operatorLabel(
+    filter.operator,
+    column ? filterTypeOf(column) : undefined,
+  );
+  const value = describeFilterValue(filter, column);
+  return value ? `${label} ${operator} ${value}` : `${label} ${operator}`;
+}
+
+// ---------------------------------------------------------------------------
+// Model transitions — every one returns a NEW array
+// ---------------------------------------------------------------------------
+
+export function addFilter(
+  model: DataTableFilterModel,
+  filter: DataTableFilter,
+): DataTableFilterModel {
+  if (containsFilter(model, filter)) return model;
+  return [...model, filter];
+}
+
+export function removeFilterAt(
+  model: DataTableFilterModel,
+  index: number,
+): DataTableFilterModel {
+  return model.filter((_, position) => position !== index);
+}
+
+export function replaceFilterAt(
+  model: DataTableFilterModel,
+  index: number,
+  filter: DataTableFilter,
+): DataTableFilterModel {
+  return model.map((entry, position) => (position === index ? filter : entry));
+}

--- a/apps/web/src/components/datatable/filter/filterUrl.ts
+++ b/apps/web/src/components/datatable/filter/filterUrl.ts
@@ -1,0 +1,208 @@
+/**
+ * DataTable — URL serialization for the filter model and quick search.
+ *
+ * Offered as a HELPER, never wired in automatically. A page that already owns a
+ * `useSearchParams` (JobsPage, the shares admin page) opts in with two calls;
+ * a page that doesn't isn't forced to grow a router dependency to render a
+ * table. That is the same posture the rest of the contract takes with
+ * pagination and sort.
+ *
+ * ## Wire format
+ *
+ * One repeated `filter` param per filter:
+ *
+ * ```
+ * ?filter=status:is:failed
+ * &filter=lastError:contains:rate%2520limited
+ * &filter=attempts:between:1,5
+ * &filter=lastError:isEmpty
+ * &q=tagging
+ * ```
+ *
+ * `columnId:operator[:value]`, with each value segment `encodeURIComponent`-ed
+ * so a value containing `:` or `,` survives, and multi-value operands joined
+ * with `,`. The double-encoding you see above (`%2520`) is
+ * `URLSearchParams.toString()` re-encoding our `%20`; it is symmetric, so a
+ * `toString()` → `new URLSearchParams()` round trip is lossless.
+ *
+ * ## Why arity, not a type tag, decides the shape on the way back
+ *
+ * Nothing in the wire format says "this is an array". It doesn't need to: the
+ * operator already determines the operand's shape (`between` → a pair,
+ * `isAnyOf` → a set, everything else → a scalar), so the encoding stays short
+ * and human-editable in an address bar.
+ *
+ * Scalar TYPE is a different question, and the one thing a URL genuinely cannot
+ * carry: `attempts:equals:3` is indistinguishable from a text `'3'`. Pass the
+ * table's `columns` to {@link readDataTableUrlState} and each value is coerced
+ * by its column's `filterType`; omit them and every scalar comes back a string.
+ * Always pass them when you have them.
+ */
+
+import type {
+  DataTableColumn,
+  DataTableFilter,
+  DataTableFilterModel,
+  DataTableFilterValue,
+  FilterOperator,
+} from '../types';
+import { filterTypeOf, operatorArity } from './operators';
+
+/** Repeated param carrying one encoded filter each. */
+export const DATATABLE_FILTER_PARAM = 'filter';
+/** Param carrying the global quick-search term. */
+export const DATATABLE_SEARCH_PARAM = 'q';
+
+export interface DataTableUrlState {
+  filters: DataTableFilterModel;
+  search: string;
+}
+
+export interface DataTableUrlOptions<Row = unknown> {
+  /** Override the repeated filter param name. Default `'filter'`. */
+  filterParam?: string;
+  /** Override the quick-search param name. Default `'q'`. */
+  searchParam?: string;
+  /**
+   * The table's columns. Supplying them lets scalar operands be coerced back to
+   * `number` / `boolean` by each column's `filterType`. Without them every
+   * scalar decodes as a `string`.
+   */
+  columns?: DataTableColumn<Row>[];
+}
+
+// ---------------------------------------------------------------------------
+// One filter <-> one param value
+// ---------------------------------------------------------------------------
+
+function encodeSegment(raw: string | number | boolean): string {
+  return encodeURIComponent(String(raw));
+}
+
+/** Encode a single filter as a `columnId:operator[:value]` param value. */
+export function encodeFilter(filter: DataTableFilter): string {
+  const head = `${encodeSegment(filter.columnId)}:${encodeSegment(filter.operator)}`;
+  const arity = operatorArity(filter.operator);
+  if (arity === 0 || filter.value === null) return head;
+  const body = Array.isArray(filter.value)
+    ? filter.value.map(encodeSegment).join(',')
+    : encodeSegment(filter.value);
+  return `${head}:${body}`;
+}
+
+function coerceScalar(raw: string, filterType: string | undefined): string | number | boolean {
+  if (filterType === 'number') {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : raw;
+  }
+  if (filterType === 'boolean') return raw === 'true';
+  return raw;
+}
+
+/**
+ * Decode one param value. Returns `null` for anything malformed — a hand-edited
+ * or stale URL should drop the offending filter, never throw on render.
+ */
+export function decodeFilter<Row>(
+  encoded: string,
+  columns?: DataTableColumn<Row>[],
+): DataTableFilter | null {
+  // Only the FIRST two colons are delimiters; the value segment may itself be
+  // an encoded string, and splitting greedily would truncate it.
+  const first = encoded.indexOf(':');
+  if (first <= 0) return null;
+  const second = encoded.indexOf(':', first + 1);
+
+  const columnId = safeDecode(encoded.slice(0, first));
+  const operator = safeDecode(
+    second === -1 ? encoded.slice(first + 1) : encoded.slice(first + 1, second),
+  ) as FilterOperator;
+  if (!columnId || !operator) return null;
+
+  const rawValue = second === -1 ? null : encoded.slice(second + 1);
+  const arity = operatorArity(operator);
+  const filterType = columns
+    ? (() => {
+        const column = columns.find((entry) => entry.id === columnId);
+        return column ? filterTypeOf(column) : undefined;
+      })()
+    : undefined;
+
+  let value: DataTableFilterValue;
+  if (arity === 0 || rawValue === null) {
+    value = null;
+  } else if (arity === 2 || arity === 'many') {
+    const parts = rawValue === '' ? [] : rawValue.split(',');
+    value = parts.map((part) => coerceScalar(safeDecode(part), filterType)) as (
+      | string
+      | number
+    )[];
+  } else {
+    value = coerceScalar(safeDecode(rawValue), filterType);
+  }
+
+  return { columnId, operator, value };
+}
+
+function safeDecode(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // A stray `%` in a hand-typed URL throws in decodeURIComponent; the literal
+    // text is a better answer than losing the whole filter.
+    return raw;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Whole-state read / write
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the filter model and quick-search term out of a `URLSearchParams`.
+ * Unknown / malformed filter params are dropped silently.
+ */
+export function readDataTableUrlState<Row>(
+  params: URLSearchParams,
+  options: DataTableUrlOptions<Row> = {},
+): DataTableUrlState {
+  const filterParam = options.filterParam ?? DATATABLE_FILTER_PARAM;
+  const searchParam = options.searchParam ?? DATATABLE_SEARCH_PARAM;
+
+  const filters = params
+    .getAll(filterParam)
+    .map((encoded) => decodeFilter(encoded, options.columns))
+    .filter((filter): filter is DataTableFilter => filter !== null);
+
+  return { filters, search: params.get(searchParam) ?? '' };
+}
+
+/**
+ * Write the filter model and quick-search term into a COPY of `params`, leaving
+ * every unrelated param (page, sort, tab, …) untouched. Returns the copy — the
+ * caller decides whether that becomes a push or a replace.
+ *
+ * An empty model / empty search removes its param entirely rather than leaving
+ * `?filter=&q=` behind, so a cleared table produces a clean URL.
+ */
+export function writeDataTableUrlState<Row>(
+  params: URLSearchParams,
+  state: Partial<DataTableUrlState>,
+  options: DataTableUrlOptions<Row> = {},
+): URLSearchParams {
+  const filterParam = options.filterParam ?? DATATABLE_FILTER_PARAM;
+  const searchParam = options.searchParam ?? DATATABLE_SEARCH_PARAM;
+  const next = new URLSearchParams(params);
+
+  if (state.filters !== undefined) {
+    next.delete(filterParam);
+    for (const filter of state.filters) next.append(filterParam, encodeFilter(filter));
+  }
+
+  if (state.search !== undefined) {
+    if (state.search.trim() === '') next.delete(searchParam);
+    else next.set(searchParam, state.search);
+  }
+
+  return next;
+}

--- a/apps/web/src/components/datatable/filter/operators.ts
+++ b/apps/web/src/components/datatable/filter/operators.ts
@@ -1,0 +1,158 @@
+/**
+ * DataTable — the operator catalog.
+ *
+ * One table maps a column's {@link DataTableFilterType} onto the operators the
+ * filter UI offers for it, and one function decides how many operands each
+ * operator takes. Everything else in `filter/` reads from here, so adding an
+ * operator is a single-file change.
+ *
+ * ## Why a declared type, not an inferred one
+ *
+ * The operator set could have been inferred from the first row's value. It
+ * isn't, because inference is unstable in exactly the cases that matter: an
+ * empty page has nothing to infer from, and a nullable column whose first page
+ * happens to be all nulls would silently offer text operators for a number.
+ * A column declares `filterType` once and the UI is deterministic forever.
+ *
+ * ## Why the defaults are narrow
+ *
+ * The default sets are the ones issue #254 specifies, and they are short on
+ * purpose — six operators on a text column is a menu nobody reads. A column
+ * that genuinely needs more pins them explicitly:
+ * `filterable: ['contains', 'endsWith', 'isNotEmpty']`.
+ */
+
+import type {
+  DataTableColumn,
+  DataTableFilterType,
+  FilterOperator,
+} from '../types';
+
+/** Assumed when a filterable column declares no `filterType`. */
+export const DEFAULT_FILTER_TYPE: DataTableFilterType = 'text';
+
+/**
+ * The default operator set per value type — issue #254's catalog, verbatim.
+ * Order is the order the operator picker lists them in, so the first entry is
+ * also the default operator for a fresh filter on that type.
+ */
+export const OPERATORS_BY_FILTER_TYPE: Record<DataTableFilterType, FilterOperator[]> = {
+  text: ['contains', 'equals', 'startsWith', 'isEmpty'],
+  number: ['equals', 'gt', 'lt', 'between'],
+  date: ['before', 'after', 'between'],
+  enum: ['is', 'isNot', 'isAnyOf'],
+  boolean: ['is'],
+};
+
+/**
+ * Human labels. Number columns override a few so the picker reads `=`, `>`, `<`
+ * rather than "equals / is greater than / is less than", which is how anyone
+ * scanning a numeric filter actually thinks about it.
+ */
+const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  equals: 'equals',
+  contains: 'contains',
+  startsWith: 'starts with',
+  endsWith: 'ends with',
+  gt: 'is greater than',
+  gte: 'is at least',
+  lt: 'is less than',
+  lte: 'is at most',
+  between: 'is between',
+  before: 'is before',
+  after: 'is after',
+  is: 'is',
+  isNot: 'is not',
+  isAnyOf: 'is any of',
+  in: 'is any of',
+  isEmpty: 'is empty',
+  isNotEmpty: 'is not empty',
+};
+
+const NUMBER_OPERATOR_LABELS: Partial<Record<FilterOperator, string>> = {
+  equals: '=',
+  gt: '>',
+  lt: '<',
+  gte: '≥',
+  lte: '≤',
+};
+
+/** Display label for an operator, in the context of a value type. */
+export function operatorLabel(
+  operator: FilterOperator,
+  filterType: DataTableFilterType = DEFAULT_FILTER_TYPE,
+): string {
+  if (filterType === 'number') {
+    return NUMBER_OPERATOR_LABELS[operator] ?? OPERATOR_LABELS[operator];
+  }
+  return OPERATOR_LABELS[operator];
+}
+
+/**
+ * How many operands an operator takes.
+ *
+ *  - `0`      — `isEmpty` / `isNotEmpty`: the operator IS the whole predicate.
+ *  - `1`      — one value.
+ *  - `2`      — `between`: a `[from, to]` tuple.
+ *  - `'many'` — `isAnyOf` / `in`: a set.
+ */
+export type OperatorArity = 0 | 1 | 2 | 'many';
+
+export function operatorArity(operator: FilterOperator): OperatorArity {
+  if (operator === 'isEmpty' || operator === 'isNotEmpty') return 0;
+  if (operator === 'between') return 2;
+  if (operator === 'isAnyOf' || operator === 'in') return 'many';
+  return 1;
+}
+
+/** The value type a column filters as. */
+export function filterTypeOf<Row>(column: DataTableColumn<Row>): DataTableFilterType {
+  return column.filterType ?? DEFAULT_FILTER_TYPE;
+}
+
+/**
+ * Whether a column offers filtering at all.
+ *
+ * An `enum` column with no `enumValues` is treated as NOT filterable: the
+ * operand picker would have nothing to list, and an operator you cannot supply a
+ * value for is exactly the "looks live, does nothing" affordance the contract
+ * refuses elsewhere (see `sortable`'s opt-in rationale).
+ */
+export function isFilterableColumn<Row>(column: DataTableColumn<Row>): boolean {
+  const declared =
+    column.filterable === true ||
+    (Array.isArray(column.filterable) && column.filterable.length > 0);
+  if (!declared) return false;
+  if (filterTypeOf(column) === 'enum') return (column.enumValues?.length ?? 0) > 0;
+  return true;
+}
+
+/** Every filterable column, in declaration order. */
+export function filterableColumns<Row>(
+  columns: DataTableColumn<Row>[],
+): DataTableColumn<Row>[] {
+  return columns.filter(isFilterableColumn);
+}
+
+/**
+ * The operators offered for a column: the explicit array when one is declared,
+ * otherwise the default set for its value type.
+ */
+export function operatorsForColumn<Row>(column: DataTableColumn<Row>): FilterOperator[] {
+  if (Array.isArray(column.filterable) && column.filterable.length > 0) {
+    return column.filterable;
+  }
+  return OPERATORS_BY_FILTER_TYPE[filterTypeOf(column)];
+}
+
+/** The operator a fresh filter on this column starts with. */
+export function defaultOperatorForColumn<Row>(column: DataTableColumn<Row>): FilterOperator {
+  return operatorsForColumn(column)[0];
+}
+
+/** Every column marked `searchable`, in declaration order. */
+export function searchableColumns<Row>(
+  columns: DataTableColumn<Row>[],
+): DataTableColumn<Row>[] {
+  return columns.filter((column) => column.searchable === true);
+}

--- a/apps/web/src/components/datatable/index.ts
+++ b/apps/web/src/components/datatable/index.ts
@@ -51,6 +51,52 @@ export { CardField, ExpandableValue, columnContent, columnText } from './mobile/
 export { CompactPagination } from './mobile/CompactPagination';
 export { CardSortControl } from './mobile/CardSortControl';
 
+// --- Filtering + quick search (#254) ----------------------------------------
+export { DataTableFilterBar, FILTER_COUNT_CLASS } from './filter/DataTableFilterBar';
+export type { DataTableFilterBarProps } from './filter/DataTableFilterBar';
+export { FilterEditor } from './filter/FilterEditor';
+export type { FilterEditorProps } from './filter/FilterEditor';
+export { FilterChips } from './filter/FilterChips';
+export type { FilterChipsProps } from './filter/FilterChips';
+export { QuickSearchField, DEFAULT_QUICK_SEARCH_DEBOUNCE_MS } from './filter/QuickSearchField';
+export type { QuickSearchFieldProps } from './filter/QuickSearchField';
+export {
+  OPERATORS_BY_FILTER_TYPE,
+  DEFAULT_FILTER_TYPE,
+  operatorLabel,
+  operatorArity,
+  operatorsForColumn,
+  defaultOperatorForColumn,
+  filterTypeOf,
+  isFilterableColumn,
+  filterableColumns,
+  searchableColumns,
+} from './filter/operators';
+export type { OperatorArity } from './filter/operators';
+export {
+  addFilter,
+  removeFilterAt,
+  replaceFilterAt,
+  containsFilter,
+  sameFilter,
+  filterKey,
+  filterChipLabel,
+  describeFilterValue,
+  isFilterComplete,
+  draftFilterFor,
+  blankValueFor,
+  columnForFilter,
+} from './filter/filterModel';
+export {
+  readDataTableUrlState,
+  writeDataTableUrlState,
+  encodeFilter,
+  decodeFilter,
+  DATATABLE_FILTER_PARAM,
+  DATATABLE_SEARCH_PARAM,
+} from './filter/filterUrl';
+export type { DataTableUrlState, DataTableUrlOptions } from './filter/filterUrl';
+
 // --- Shared ------------------------------------------------------------------
 export { useRowActionConfirm, confirmCopy } from './shared/rowActionConfirm';
 
@@ -72,4 +118,10 @@ export type {
   DataTableLayout,
   DataTableRendererKind,
   FilterOperator,
+  DataTableFilterType,
+  DataTableEnumValue,
+  DataTableFilter,
+  DataTableFilterModel,
+  DataTableFilterValue,
+  DataTableQuickSearchConfig,
 } from './types';

--- a/apps/web/src/components/datatable/types.ts
+++ b/apps/web/src/components/datatable/types.ts
@@ -20,24 +20,55 @@ import type { ReactNode } from 'react';
 /**
  * Comparison operators a filterable column can advertise.
  *
- * Defined here (rather than in the filtering issue, #254) so column authors can
- * declare `filterable: ['equals', 'contains']` today and have it become live
- * the moment the filter UI ships. Nothing in #252 reads these values.
+ * ONE union covering every value type. Which subset a given column offers is
+ * decided by its {@link DataTableFilterType} (see `filter/operators.ts`), or
+ * pinned explicitly by declaring `filterable: ['equals', 'contains']`.
+ *
+ * The `endsWith` / `gte` / `lte` / `in` / `isNotEmpty` members are not in any
+ * type's DEFAULT set but remain part of the union: a column may pin them, and
+ * they were published by #252 before this issue narrowed the defaults.
  */
 export type FilterOperator =
+  // text
   | 'equals'
   | 'contains'
   | 'startsWith'
   | 'endsWith'
+  // number
   | 'gt'
   | 'gte'
   | 'lt'
   | 'lte'
+  | 'between'
+  // date
   | 'before'
   | 'after'
+  // enum / boolean
+  | 'is'
+  | 'isNot'
+  | 'isAnyOf'
   | 'in'
+  // emptiness (any type)
   | 'isEmpty'
   | 'isNotEmpty';
+
+/**
+ * The kind of value behind a column, which decides BOTH the operator set the
+ * filter UI offers and the input control it draws for the operand.
+ *
+ * Deliberately a declared field rather than something inferred from the first
+ * row: inference would flip a column's operator set when a page happens to be
+ * empty, or when a nullable column's first page is all nulls.
+ *
+ * Default `'text'`.
+ */
+export type DataTableFilterType = 'text' | 'number' | 'date' | 'enum' | 'boolean';
+
+/** One selectable option for an `enum` filter column. */
+export interface DataTableEnumValue {
+  value: string;
+  label: string;
+}
 
 /**
  * The pivot that drives BOTH renderers from one declaration.
@@ -105,10 +136,40 @@ export interface DataTableColumn<Row> {
   sortable?: boolean;
 
   /**
-   * Reserved for #254 (filtering). `true` enables the default operator set for
-   * the column's inferred type; an explicit array narrows it.
+   * Whether the column can be filtered. Default `false`.
+   *
+   * `true` enables the default operator set for the column's
+   * {@link DataTableFilterType}; an explicit array pins exactly which operators
+   * are offered, in the order given.
+   *
+   * Like sorting, filtering is ALWAYS server-side: the table emits a normalized
+   * filter model and NEVER filters `rows` itself. The owning page maps that
+   * model onto its endpoint's query params and refetches.
    */
   filterable?: boolean | FilterOperator[];
+
+  /**
+   * The value type behind this column, for filtering purposes. Decides which
+   * operators are offered and which input control collects the operand.
+   * Default `'text'`. Ignored unless `filterable` is set.
+   */
+  filterType?: DataTableFilterType;
+
+  /**
+   * Options for a `filterType: 'enum'` column. Required for enum filtering —
+   * an enum column with no `enumValues` has nothing to pick from and is treated
+   * as un-filterable by the filter UI.
+   */
+  enumValues?: DataTableEnumValue[];
+
+  /**
+   * Whether this column participates in the global quick search.
+   *
+   * Purely declarative: the search term is a single free-text value sent to the
+   * server, so this field documents (and lets the UI describe) which columns the
+   * endpoint's free-text param actually covers. The table does not search rows.
+   */
+  searchable?: boolean;
 
   /** Reserved for #256 (export). Default `true` when a `value` extractor exists. */
   exportable?: boolean;
@@ -204,6 +265,63 @@ export interface DataTableSortConfig {
 }
 
 /**
+ * The operand of a filter.
+ *
+ * Deliberately a small, JSON-and-URL-serializable set:
+ *   - `string` / `number` / `boolean` — a single operand (most operators).
+ *   - `(string | number)[]` — a two-element `[from, to]` tuple for `between`,
+ *     or the candidate set for `isAnyOf` / `in`.
+ *   - `null` — no operand at all (`isEmpty` / `isNotEmpty`), or "not filled in
+ *     yet" for a draft the user is still composing.
+ *
+ * Dates are carried as `YYYY-MM-DD` strings rather than `Date` objects, so a
+ * filter model survives `JSON.stringify`, a URL round-trip, and a page reload
+ * without a revive step.
+ */
+export type DataTableFilterValue = string | number | boolean | (string | number)[] | null;
+
+/**
+ * One entry in the normalized filter model.
+ *
+ * `columnId` is a column `id` — the same identifier used as the sort field and
+ * the DataGrid `field` — so a page maps it onto its endpoint's query param with
+ * a lookup table it writes once.
+ */
+export interface DataTableFilter {
+  columnId: string;
+  operator: FilterOperator;
+  value: DataTableFilterValue;
+}
+
+/**
+ * The complete, normalized filter model: an ordered list of filters, AND-ed
+ * together by convention. The table treats this as opaque controlled state and
+ * hands it straight back out on every change; interpreting it is the page's job.
+ */
+export type DataTableFilterModel = DataTableFilter[];
+
+/**
+ * Controlled global quick search.
+ *
+ * The DEBOUNCE APPLIES TO THE EMISSION, NOT THE INPUT: the box updates on every
+ * keystroke (so typing never feels laggy) while `onChange` fires once the user
+ * has paused for `debounceMs`. A page can therefore refetch directly from
+ * `onChange` without its own debounce.
+ */
+export interface DataTableQuickSearchConfig {
+  /** The committed search term. */
+  value: string;
+  /** Called with the new term after the debounce window elapses. */
+  onChange: (next: string) => void;
+  /** Input placeholder. Defaults to a term naming the `searchable` columns. */
+  placeholder?: string;
+  /** Debounce window in ms. Default {@link DEFAULT_QUICK_SEARCH_DEBOUNCE_MS} (300). */
+  debounceMs?: number;
+  /** Accessible name for the field. Default `'Search'`. */
+  ariaLabel?: string;
+}
+
+/**
  * Controlled selection.
  *
  * The value is a `Set<string>` of row ids. Selection is page-scoped: because
@@ -260,6 +378,21 @@ export interface DataTableProps<Row> {
   sort?: DataTableSortConfig;
   selection?: DataTableSelectionConfig;
 
+  /**
+   * The active filter model — controlled, exactly like `pagination` and `sort`.
+   *
+   * Supplying `filters` + `onFiltersChange` turns the filter surface on for
+   * every layout (a row on desktop, a collapsible panel on tablet, a full-screen
+   * sheet on a phone). The table NEVER filters `rows`: it emits a new model and
+   * the page refetches.
+   */
+  filters?: DataTableFilterModel;
+  /** Emits the whole next model on every add / edit / remove / clear. */
+  onFiltersChange?: (next: DataTableFilterModel) => void;
+
+  /** Controlled, debounced global quick search. Omit to hide the search box. */
+  quickSearch?: DataTableQuickSearchConfig;
+
   rowActions?: DataTableRowAction<Row>[];
   bulkActions?: DataTableBulkAction[];
 
@@ -300,9 +433,21 @@ export interface DataTableProps<Row> {
 
 /**
  * Props handed to a concrete renderer. {@link DataTableProps} minus the layout
- * switch itself — every renderer consumes the same contract.
+ * switch itself and minus the filter surface — every renderer consumes the same
+ * contract.
+ *
+ * Filtering is deliberately NOT a renderer concern. The filter bar is drawn
+ * once by `DataTable`, above whichever renderer is active, because it is the
+ * one control whose shape is decided by the layout rather than by the row
+ * presentation — and because a renderer that owned filter state would lose it
+ * on every layout switch (§7.4).
  */
 export type DataTableRendererProps<Row> = Omit<
   DataTableProps<Row>,
-  'renderer' | 'mobileBreakpoint' | 'tabletBreakpoint'
+  | 'renderer'
+  | 'mobileBreakpoint'
+  | 'tabletBreakpoint'
+  | 'filters'
+  | 'onFiltersChange'
+  | 'quickSearch'
 >;

--- a/docs/specs/datatable.md
+++ b/docs/specs/datatable.md
@@ -1,6 +1,7 @@
 # DataTable — Shared Column Contract & Renderers
 
-**Status:** foundation shipped (issue #252); mobile + tablet layouts shipped (issue #253) — both of epic #238
+**Status:** foundation shipped (issue #252); mobile + tablet layouts shipped
+(issue #253); filtering + quick search shipped (issue #254) — all of epic #238
 **Location:** `apps/web/src/components/datatable/`
 **Spec owner:** frontend
 
@@ -28,19 +29,19 @@ The contract lives in `types.ts` and is intentionally free of any DataGrid type.
 
 ### Scope of this document
 
-This spec documents the contract as of #253. Fields that exist in the contract
+This spec documents the contract as of #254. Fields that exist in the contract
 but are **not yet consumed** are marked *reserved* and name the issue that will
 consume them, so column authors can declare them today without churn later:
 
 | Field / concept              | Consumed by                            |
 | ---------------------------- | -------------------------------------- |
-| `filterable`                 | #254 — server-backed filter UI         |
 | `hideable`                   | #255 — column visibility / saved views |
 | `exportable`                 | #256 — CSV/export + virtualization     |
 
-Everything else on this page is live behaviour today. `priority` is now fully
+Everything else on this page is live behaviour today. `priority` is fully
 consumed: it drives column visibility on the grid *and* the card's
-headline/body/detail split (§3).
+headline/body/detail split (§3). `filterable` is now live too, together with
+its three companions `filterType`, `enumValues` and `searchable` (§10).
 
 ---
 
@@ -53,6 +54,14 @@ apps/web/src/components/datatable/
   DataTable.tsx                   # layout-switch shell + shared wrapper
   useContainerLayout.ts           # ResizeObserver width -> layout resolution
   BulkActionBar.tsx               # selection toolbar (shared by all layouts)
+  filter/
+    DataTableFilterBar.tsx        # the filter surface — one shape per layout
+    FilterEditor.tsx              # column -> operator -> value form
+    FilterChips.tsx               # active filters, removable (wrap / strip)
+    QuickSearchField.tsx          # debounced global search box
+    operators.ts                  # the operator catalog (pure)
+    filterModel.ts                # normalized-model helpers (pure)
+    filterUrl.ts                  # <-> URLSearchParams helper (pure, opt-in)
   shared/
     rowActionConfirm.tsx          # one confirm dialog, shared by both renderers
   desktop/
@@ -69,6 +78,7 @@ apps/web/src/components/datatable/
     CompactPagination.tsx         # prev / range / next
   __tests__/DataTable.test.tsx            # #252 foundation
   __tests__/ResponsiveDataTable.test.tsx  # #253 layouts
+  __tests__/DataTableFilters.test.tsx     # #254 filtering + quick search
 ```
 
 Consumers import from `components/datatable` only. `desktop/`, `mobile/` and
@@ -125,6 +135,9 @@ interface DataTableColumn<Row> {
   priority: 'primary' | 'secondary' | 'detail';
   sortable?: boolean;
   filterable?: boolean | FilterOperator[];
+  filterType?: 'text' | 'number' | 'date' | 'enum' | 'boolean';
+  enumValues?: { value: string; label: string }[];
+  searchable?: boolean;
   exportable?: boolean;
   hideable?: boolean;
   truncate?: boolean;
@@ -183,24 +196,67 @@ without the owning page handling `sort.onSortChange` produces a control that
 looks live and does nothing. Opt in explicitly, and only for fields the API can
 actually order by.
 
-### `filterable` — *reserved (#254)*
+### `filterable` — **defaults to `false`**
 
-`true` enables the default operator set for the column's inferred type; an
-array narrows it:
+Opt-in, for the same reason `sortable` is: filtering is always server-side, so a
+filter control the owning page doesn't handle is an affordance that looks live
+and does nothing.
+
+`true` enables the default operator set for the column's `filterType`; an
+explicit array pins exactly which operators are offered, **in the order given**
+(the first is the default operator for a fresh filter on that column):
 
 ```ts
-type FilterOperator =
-  | 'equals' | 'contains' | 'startsWith' | 'endsWith'
-  | 'gt' | 'gte' | 'lt' | 'lte'
-  | 'before' | 'after'
-  | 'in' | 'isEmpty' | 'isNotEmpty';
+filterable: true                                    // the type's default set
+filterable: ['contains', 'isEmpty', 'isNotEmpty']   // pinned, in this order
 ```
 
-Note that DataGrid's *own* client-side filtering is hard-disabled by the adapter
-(`filterable: false` on every `GridColDef`, plus `disableColumnFilter` on the
-grid). Client-side filtering would only ever filter the current server page,
-which is worse than no filtering at all. #254 builds a server-backed filter UI
-against these declarations.
+Full operator list and per-type defaults: §10.2.
+
+Note that DataGrid's *own* client-side filtering stays hard-disabled by the
+adapter (`filterable: false` on every `GridColDef`, plus `disableColumnFilter`
+on the grid). Client-side filtering would only ever filter the current server
+page, which is worse than no filtering at all — see §10.1.
+
+### `filterType` / `enumValues`
+
+`filterType` declares the kind of value behind the column, which decides both
+the operator set offered (§10.2) and the input control drawn for the operand
+(§10.3). Default `'text'`. Ignored unless `filterable` is set.
+
+It is **declared, never inferred from the rows.** Inference is unstable in
+exactly the cases that matter: an empty page has nothing to infer from, and a
+nullable column whose first page happens to be all nulls would silently offer
+text operators for a number.
+
+`enumValues` supplies the options for a `filterType: 'enum'` column, as
+`{ value, label }` pairs — `value` is what goes into the filter model and the
+URL, `label` is what the picker and the chip show. An enum column **with no
+`enumValues` is treated as not filterable**: an operator you cannot supply a
+value for is the same dead affordance `sortable` refuses.
+
+```ts
+{
+  id: 'status',
+  label: 'Status',
+  priority: 'primary',
+  value: (job) => job.status,
+  filterable: true,
+  filterType: 'enum',
+  enumValues: [
+    { value: 'pending',   label: 'Pending' },
+    { value: 'failed',    label: 'Failed' },
+  ],
+}
+```
+
+### `searchable`
+
+Marks the column as covered by the global quick search (§10.4). Purely
+declarative: the search term is a single free-text value sent to the server, so
+this field documents *which* columns the endpoint's free-text param actually
+searches, and is what the default placeholder is built from
+(`"Search Type, Status or Last error"`). The table never searches rows.
 
 ### `exportable` — *reserved (#256)*
 
@@ -247,6 +303,10 @@ interface DataTableProps<Row> {
   pagination?: DataTablePaginationConfig;
   sort?: DataTableSortConfig;
   selection?: DataTableSelectionConfig;
+
+  filters?: DataTableFilterModel;
+  onFiltersChange?: (next: DataTableFilterModel) => void;
+  quickSearch?: DataTableQuickSearchConfig;
 
   rowActions?: DataTableRowAction<Row>[];
   bulkActions?: DataTableBulkAction[];
@@ -351,7 +411,20 @@ else onSelectionChange(new Set(rowIds.filter((id) => !model.ids.has(id))));
 
 Clearing the selection (`selectedIds.size === 0`) hides the bulk bar.
 
-### 5.4 Row actions
+### 5.4 Filters and quick search
+
+```ts
+filters?: DataTableFilterModel;                        // controlled
+onFiltersChange?: (next: DataTableFilterModel) => void;
+quickSearch?: DataTableQuickSearchConfig;
+```
+
+Both are controlled exactly like pagination and sort, and both are **server-side
+only** — the table never filters or searches `rows`. Supplying `filters` +
+`onFiltersChange` turns the filter surface on for every layout; supplying
+`quickSearch` adds the debounced search box. Full contract in §10.
+
+### 5.5 Row actions
 
 ```ts
 interface DataTableRowAction<Row> {
@@ -390,7 +463,7 @@ confirm: {
 There is exactly **one** dialog per table (owned by the renderer), not one per
 row — the cell hands the action descriptor back up rather than executing it.
 
-### 5.5 Bulk actions
+### 5.6 Bulk actions
 
 ```ts
 interface DataTableBulkAction {
@@ -495,11 +568,15 @@ unusually wide:
 
 ### 7.4 State lives above the renderers
 
-Selection, pagination, sort (and, from #254, filters) are **controlled props
-owned by the calling page**. No renderer stores any of them. Rotating a device,
-dragging a drawer wider, or resizing a window therefore swaps the layout without
-losing a single selected id, the current page, or the active sort — the switch
-is a pure presentation change.
+Selection, pagination, sort, filters and the quick-search term are all
+**controlled props owned by the calling page**. No renderer stores any of them.
+Rotating a device, dragging a drawer wider, or resizing a window therefore swaps
+the layout without losing a single selected id, the current page, the active
+sort, or an applied filter — the switch is a pure presentation change.
+
+The filter surface is drawn by `DataTable` rather than by a renderer for exactly
+this reason: it changes *shape* per layout (§10.3), and a renderer owning the
+panel's open state would throw it away on every resize.
 
 The only state a renderer owns is which rows/cards are currently expanded, which
 is meaningless in the layout being switched to and is deliberately not carried
@@ -648,7 +725,233 @@ density contract, unchanged from #252.
 
 ---
 
-## 10. Worked example
+## 10. Filtering and quick search
+
+Two related surfaces, both **controlled by the calling page** and both
+**server-side**: per-column filtering (an operator + an operand per column) and
+a single global quick-search box.
+
+### 10.1 Why server-side is not a choice
+
+Every target table in this app is server-paginated. A client-side filter can
+only ever see the page it has been handed, so filtering 25 loaded rows out of
+137 matching rows out of 40 000 total produces an answer that is confidently,
+silently wrong — worse than no filter at all, because the user believes it.
+
+Three consequences follow, and they are the shape of the whole feature:
+
+- **The table never touches `rows`.** It emits a new filter model and the page
+  refetches. There is a test asserting exactly this — a table handed filters
+  that match nothing still draws every row it was given.
+- **DataGrid's own filter UI is not used.** `GridFilterPanel` drives the grid's
+  client-side filter model, which is the thing we just ruled out; multi-column
+  filtering in it is a MUI X **Pro** feature besides. The adapter keeps
+  `filterable: false` on every `GridColDef` plus `disableColumnFilter` on the
+  grid, and the filter surface here is ours (`filter/`).
+- **The model is normalized and endpoint-agnostic.** The component knows nothing
+  about `?status=failed` vs `?state[]=failed`; it emits `columnId` /`operator` /
+  `value` and the page maps that onto its own params.
+
+### 10.2 The normalized filter model
+
+```ts
+type DataTableFilterValue =
+  | string | number | boolean       // one operand
+  | (string | number)[]             // [from, to] for `between`; a set for `isAnyOf`
+  | null;                           // no operand (`isEmpty`), or "not filled in yet"
+
+interface DataTableFilter {
+  columnId: string;                 // a column `id`
+  operator: FilterOperator;
+  value: DataTableFilterValue;
+}
+
+type DataTableFilterModel = DataTableFilter[];   // AND-ed, by convention
+```
+
+Wired up exactly like pagination and sort:
+
+```tsx
+const [filters, setFilters] = useState<DataTableFilterModel>([]);
+
+<DataTable filters={filters} onFiltersChange={setFilters} … />
+```
+
+`onFiltersChange` receives the **whole next model** on every add / edit / remove
+/ clear — never a delta.
+
+Dates travel as `YYYY-MM-DD` strings rather than `Date` objects, so a model
+survives `JSON.stringify`, a URL round trip, and a page reload with no revive
+step.
+
+#### Operator sets, by `filterType`
+
+| `filterType` | Operators offered (in order)          |
+| ------------ | ------------------------------------- |
+| `text`       | `contains`, `equals`, `startsWith`, `isEmpty` |
+| `number`     | `equals` (`=`), `gt` (`>`), `lt` (`<`), `between` |
+| `date`       | `before`, `after`, `between`          |
+| `enum`       | `is`, `isNot`, `isAnyOf`              |
+| `boolean`    | `is`                                  |
+
+`FilterOperator` is one exported union covering all of them, plus `endsWith`,
+`gte`, `lte`, `in` and `isNotEmpty` — not in any default set, but available to a
+column that pins operators explicitly (and published by #252 before the defaults
+were narrowed).
+
+Operator **labels are type-aware**: a number column reads `=` / `>` / `<`, every
+other type reads them in words (`equals`, `is greater than`). `operatorLabel(op,
+filterType)` is the single source of that.
+
+Operator **arity** drives the operand control and the completeness check:
+
+| Arity   | Operators              | Operand           |
+| ------- | ---------------------- | ----------------- |
+| `0`     | `isEmpty`, `isNotEmpty`| none              |
+| `1`     | everything else        | one value         |
+| `2`     | `between`              | `[from, to]`      |
+| `'many'`| `isAnyOf`, `in`        | a non-empty array |
+
+#### Only complete filters are ever emitted
+
+The editor owns the half-built filter (a column picked, no value typed) as
+**local draft state** and emits nothing until `isFilterComplete()` holds. Were
+the draft emitted, the very first click of "Add filter" would refetch with a
+meaningless param and every keystroke after it would refetch again. The emitted
+model — and therefore the chip strip and the URL — always describes a query that
+has actually been applied.
+
+Note that `false` and `0` are complete operands. The check is arity- and
+type-aware, not a truthiness test.
+
+### 10.3 The filter surface, per layout
+
+Drawn by `DataTable` itself, above whichever renderer is active — not by a
+renderer. Filtering is the one control whose *shape* is decided by the layout
+rather than by how rows are presented, and a renderer owning the panel's open
+state would discard it on every resize (§7.4).
+
+| Layout    | Surface                                                            |
+| --------- | ------------------------------------------------------------------ |
+| `desktop` | An always-visible filter **row** above the grid: search box, then column → operator → value → **Add**. Active filters wrap below as removable chips. |
+| `tablet`  | The same row, collapsed behind a **"Filters" button with an active-count badge**. Chips still show below, unconditionally. |
+| `mobile`  | A **full-screen sheet** (MUI `Dialog fullScreen`) holding the stacked form and the active filters. Chips in the bar become a **horizontally scrollable strip**. |
+
+The bar reports its resolved shape as `data-filter-surface` on
+`[data-testid="datatable-filter-bar"]`, mirroring `data-layout` on the wrapper.
+
+Three deliberate decisions:
+
+- **The phone gets a sheet, not a squeezed inline row.** A three-control form at
+  360px is either unusable or pushes the page sideways — the same failure the
+  card list exists to remove. A sheet gets the full screen, a stacked form, and
+  a real focus trap. MUI's `Dialog` supplies the trap, the Escape handling and
+  the `aria-modal` semantics; hand-rolling a "sheet" is how those get dropped.
+- **The phone chip strip is the one correct horizontal scroller.** §6 forbids the
+  *document* scrolling sideways because a table overflowed. This is the opposite:
+  an explicit, discoverable control that owns its own overflow (`overflow-x:
+  auto`, `flex-wrap: nowrap`, `max-width: 100%`) instead of wrapping four chips
+  onto four lines above a card list.
+- **The count is spoken, not just painted.** The badge bubble is invisible to a
+  screen reader, so the button's accessible name is `"Filters (2 active)"` —
+  which still contains the visible word "Filters" (WCAG 2.5.3, Label in Name).
+
+Chips are labelled from **labels, not ids or raw values**: `"Status is Failed"`,
+not `"status is failed"`. A filter whose column the table no longer declares
+(restored from a stale URL after a rename) still renders as a removable chip
+using the raw `columnId` rather than crashing the strip.
+
+Every control in the bar — search box, selects, Add, chips, the Filters button,
+the sheet's close button — is ≥44px and none is hover-revealed (§8.5).
+
+### 10.4 Quick search — the debounce is on the *emission*
+
+```ts
+interface DataTableQuickSearchConfig {
+  value: string;
+  onChange: (next: string) => void;   // fires ONCE, after the pause
+  placeholder?: string;               // default: names the `searchable` columns
+  debounceMs?: number;                // default 300
+  ariaLabel?: string;                 // default 'Search'
+}
+```
+
+The `<input>` is driven by local state and repaints on **every keystroke**;
+`onChange` — the thing that costs an HTTP round trip — fires once the user pauses
+for `debounceMs`. Debouncing the input's *value* instead is the classic version
+of this bug: the caret lags a keystroke or two behind the typist on a slow phone.
+
+A page can therefore refetch straight from `onChange` with no debounce of its own.
+
+Two details that make it survive contact with a real page:
+
+- **`onChange` is read through a ref**, so a parent re-rendering with a fresh
+  inline arrow does not restart the debounce window. Without that, a busy parent
+  can starve the emission indefinitely.
+- **An externally-driven `value` change re-seeds the input; our own echo does
+  not.** A URL restore or a programmatic clear updates the box; the value coming
+  back from the page after our own emission is ignored, so it cannot clobber
+  typing already in flight.
+
+Clearing via the ✕ button emits **immediately** — an explicit single gesture has
+nothing to debounce, and waiting 300ms to un-filter a table reads as a broken
+button.
+
+`searchable: true` on a column is what the default placeholder is built from
+(`"Search Type, Status or Last error"`). The term itself is a single free-text
+value; which columns the server actually searches is the server's business.
+
+### 10.5 URL addressability
+
+An **opt-in helper**, never wired in automatically — a page that doesn't already
+own a `useSearchParams` shouldn't grow a router dependency to render a table.
+Same posture the contract takes with pagination and sort.
+
+```ts
+import {
+  readDataTableUrlState,
+  writeDataTableUrlState,
+} from '../../components/datatable';
+
+const [searchParams, setSearchParams] = useSearchParams();
+
+// Restore. Pass `columns` so scalars are coerced by each column's filterType.
+const { filters, search } = readDataTableUrlState(searchParams, { columns });
+
+// Persist. Returns a COPY; unrelated params (page, tab, …) are untouched.
+const onFiltersChange = (next: DataTableFilterModel) =>
+  setSearchParams(writeDataTableUrlState(searchParams, { filters: next }), {
+    replace: true,
+  });
+```
+
+Wire format — one repeated `filter` param, plus `q` for the search term:
+
+```
+?filter=status:is:failed
+&filter=attempts:between:1,5
+&filter=lastError:isEmpty
+&q=tagging
+```
+
+`columnId:operator[:value]`, each segment `encodeURIComponent`-ed so a value
+containing `:` or `,` survives, multi-value operands joined with `,`. The
+double-encoding a `toString()` produces (`%2520`) is symmetric, so a
+`toString()` → `new URLSearchParams()` round trip is lossless.
+
+Nothing in the format says "this is an array" — it doesn't need to, because the
+operator already determines the operand's shape. Scalar **type** is the one thing
+a URL genuinely cannot carry: `attempts:equals:3` is indistinguishable from a
+text `'3'`. Pass `columns` and each value is coerced by its column's
+`filterType`; omit them and every scalar comes back a `string`. Always pass them.
+
+An empty model or empty search **removes** its param rather than leaving
+`?filter=&q=` behind. A malformed param is dropped silently — a hand-edited URL
+should lose one filter, not throw during render.
+
+---
+
+## 11. Worked example
 
 A jobs table with all four states, server pagination and sorting, selection with
 a bulk retry, and per-row actions including a confirming destructive one:
@@ -657,7 +960,11 @@ a bulk retry, and per-row actions including a confirming destructive one:
 import { useState, useMemo } from 'react';
 import { Chip, Box } from '@mui/material';
 import { Replay as RetryIcon, Delete as DeleteIcon } from '@mui/icons-material';
-import { DataTable, type DataTableColumn } from '../../components/datatable';
+import {
+  DataTable,
+  type DataTableColumn,
+  type DataTableFilterModel,
+} from '../../components/datatable';
 
 export function JobsTable() {
   const [page, setPage] = useState(0);
@@ -667,13 +974,19 @@ export function JobsTable() {
     direction: 'desc',
   });
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [filters, setFilters] = useState<DataTableFilterModel>([]);
+  const [search, setSearch] = useState('');
 
   // page + 1: the API is one-based, the table is zero-based.
+  // `filters` is the normalized model; `toJobQuery` is this page's own mapping
+  // onto the endpoint's params (§10.1) — the table knows nothing about it.
   const { jobs, total, isLoading, error, retryJob, retryMany, deleteJob } = useJobs({
     page: page + 1,
     pageSize,
     sortBy: sort?.field,
     sortOrder: sort?.direction,
+    q: search,                       // already debounced by the table
+    ...toJobQuery(filters),
   });
 
   const columns = useMemo<DataTableColumn<EnrichmentJobDto>[]>(
@@ -684,6 +997,8 @@ export function JobsTable() {
         priority: 'primary',
         sortable: true,
         value: (job) => job.type,
+        filterable: true,        // filterType defaults to 'text'
+        searchable: true,        // covered by the quick-search term
         minWidth: 180,
       },
       {
@@ -693,6 +1008,14 @@ export function JobsTable() {
         sortable: true,
         value: (job) => job.status,                       // scalar for sort/export
         render: (job) => <Chip size="small" label={job.status} />, // what the user sees
+        filterable: true,
+        filterType: 'enum',
+        enumValues: [
+          { value: 'pending', label: 'Pending' },
+          { value: 'running', label: 'Running' },
+          { value: 'succeeded', label: 'Succeeded' },
+          { value: 'failed', label: 'Failed' },
+        ],
         width: 130,
         align: 'center',
       },
@@ -703,6 +1026,8 @@ export function JobsTable() {
         align: 'right',
         sortable: true,
         value: (job) => job.attempts,
+        filterable: true,
+        filterType: 'number',    // offers  =  >  <  is between
         width: 100,
       },
       {
@@ -712,6 +1037,8 @@ export function JobsTable() {
         sortable: true,
         value: (job) => job.createdAt,
         render: (job) => new Date(job.createdAt).toLocaleString(),
+        filterable: true,
+        filterType: 'date',      // offers  is before / is after / is between
         minWidth: 190,
       },
       {
@@ -720,7 +1047,8 @@ export function JobsTable() {
         priority: 'detail',      // folds away on a narrow desktop / into the card's expander
         truncate: true,          // one line + tooltip instead of a five-line row
         value: (job) => job.lastError,
-        filterable: ['contains', 'isEmpty', 'isNotEmpty'],  // reserved for #254
+        filterable: ['contains', 'isEmpty', 'isNotEmpty'],  // pinned, in this order
+        searchable: true,
         flex: 2,
       },
       {
@@ -755,6 +1083,12 @@ export function JobsTable() {
       }}
       sort={{ sort, onSortChange: setSort }}
       selection={{ selectedIds, onSelectionChange: setSelectedIds }}
+      filters={filters}
+      onFiltersChange={(next) => {
+        setFilters(next);
+        setPage(0);              // a new filter invalidates the current offset
+      }}
+      quickSearch={{ value: search, onChange: setSearch }}
       bulkActions={[
         {
           id: 'retry',
@@ -791,7 +1125,7 @@ export function JobsTable() {
 
 ---
 
-## 11. Testing notes
+## 12. Testing notes
 
 `apps/web/src/components/datatable/__tests__/DataTable.test.tsx` covers the
 rendered shell, the four states, pagination/sort/selection round-trips, row and
@@ -812,7 +1146,7 @@ Containment is asserted through computed styles (`overflow-x`, `max-width`,
 800px stub container puts it in the **tablet** layout. It passes unchanged,
 which is the point: tablet is a drop-in variant of the same grid.)*
 
-### 11.1 Testing the responsive layouts
+### 12.1 Testing the responsive layouts
 
 `__tests__/ResponsiveDataTable.test.tsx` covers #253 and needs two things the
 #252 recipe does not:
@@ -833,9 +1167,37 @@ it sweeps every painted control (`button`, `[role="button"]`, `.MuiCheckbox-root
 `pointer-events` is not `none`. Bare `<input>` and MUI X's own hover-revealed
 column-header chrome are excluded, for the reasons given in §8.5.
 
+### 12.2 Testing filtering and quick search
+
+`__tests__/DataTableFilters.test.tsx` covers #254, reusing the #253 stub recipe
+(container-driven width, `matchMedia` pinned to 1440px). Four things in it are
+worth copying rather than reinventing:
+
+1. **The operator catalog is tested twice** — once as a pure function
+   (`operatorsForColumn` per `filterType`) and once through the UI (open the
+   Operator select, read the option names). The pure test pins the contract; the
+   UI test proves it is actually wired to the control a user touches.
+2. **The debounce is driven with fake timers and `fireEvent.change`.** Three
+   changes, then `advanceTimersByTime(299)` → still nothing emitted, then one
+   more millisecond → exactly one emission carrying the *final* term. That
+   asserts both halves of the contract: the input keeps up, the emission does
+   not fire per keystroke.
+3. **A negative test for local filtering.** Every positive assertion about
+   emitting a model would still pass if the component secretly filtered `rows`,
+   so one test hands the table filters matching nothing and asserts all three
+   rows still render (§10.1).
+4. **The #243 guard is re-run against the filter surface** in all three layouts,
+   including inside the opened phone sheet — which lives in a portal, so the
+   sweep roots at the dialog rather than at `[data-testid="datatable"]`.
+
+MUI selects are driven through `getByRole('combobox', { name })` +
+`getByRole('option', { name })`; the phone sheet through
+`getByRole('dialog')`, whose focus trap is asserted by checking that
+`document.activeElement` is inside it.
+
 ---
 
-## 12. Migration path
+## 13. Migration path
 
 The foundation is additive — no existing table changed in #252. Tables migrate
 one at a time, roughly in ascending order of weirdness:
@@ -847,5 +1209,8 @@ one at a time, roughly in ascending order of weirdness:
 
 Each migration should delete the hand-rolled `Table`/`TablePagination`/`Menu`
 block wholesale rather than wrapping it, and should declare `value` on every
-column that has a scalar so the table is ready for #254/#256 without a second
-pass.
+column that has a scalar so the table is ready for filtering (§10) and #256
+without a second pass, and should declare `filterable` / `filterType` /
+`searchable` for the fields its endpoint can actually filter and search on —
+replacing that page's bespoke filter controls (JobsPage's Status/Type/Processed
+selects, Public Sharing's status tabs) as part of the same migration.


### PR DESCRIPTION
## Summary

Filtering is currently hand-rolled per page, and those bespoke filter rows are themselves part of the mobile defect — the Job Queue's fixed-width Status / Type / Processed selects overflow off the right edge on a phone. This builds filtering into the shared component, serving all three layouts, and leaves no page touched (the bespoke filters are replaced during their own migration issues, #258/#259).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Relates to #238
Fixes #254

## Changes Made

**Server-side by default.** Every target table is server-paginated, so the component emits a normalized filter model and **never filters rows itself** — filtering only the loaded page would report a result set that is simply wrong. Pages map the model to their endpoint's params, controlled the same way pagination and sort already are.

```ts
interface DataTableFilter { columnId: string; operator: FilterOperator; value: DataTableFilterValue }
type DataTableFilterModel = DataTableFilter[];

// DataTableProps additions
filters?: DataTableFilterModel;
onFiltersChange?: (next: DataTableFilterModel) => void;
quickSearch?: { value; onChange; placeholder?; debounceMs?; ariaLabel? };

// DataTableColumn additions
filterable?: boolean | FilterOperator[];
filterType?: 'text' | 'number' | 'date' | 'enum' | 'boolean';
enumValues?: { value: string; label: string }[];
searchable?: boolean;
```

**Operators by value type** — text (`contains` / `equals` / `startsWith` / `isEmpty`), number (`equals` / `gt` / `lt` / `between`), date (`before` / `after` / `between`), enum (`is` / `isNot` / `isAnyOf`), boolean (`is`). `FilterOperator` stayed a single union; `between` / `is` / `isNot` / `isAnyOf` were added and the operators #252 published but never defaulted (`endsWith`, `gte`, `lte`, `in`, `isNotEmpty`) remain pinnable per column.

**Per-layout surfaces**, driven by the container-driven switch from #253:
- **Desktop** — expanded filter panel above the grid, active filters as removable chips.
- **Tablet** — the same panel collapsed behind a "Filters" button with an active-count badge.
- **Phone** — a full-screen sheet, never a cramped inline row, with active filters as a horizontally scrollable chip strip. That is the one place a horizontal scroller is the right answer: an explicit, discoverable control rather than accidental table overflow.

**Quick search** debounces the *emission*, not the input value, so the box stays responsive.

**URL addressability** — `readDataTableUrlState` / `writeDataTableUrlState` round-trip the model through `URLSearchParams` (`?filter=status:is:failed&filter=attempts:between:1,5&q=…`), opt-in so pages already using `useSearchParams` can make a filtered view shareable without URL state being forced into the component.

### Decisions worth a reviewer's attention

- **`filterType` / `enumValues` are declared, not inferred.** Inference breaks on an empty page or an all-null first page. An enum column without `enumValues` is treated as un-filterable rather than offering an operator with no operand.
- **Incomplete drafts are never emitted.** The editor holds a half-built filter locally until it is complete; otherwise the first "Add filter" click would refetch with a meaningless param. `false` and `0` count as complete operands.
- **Chips are display + remove only**, not click-to-edit — editing is remove and re-add. Exact duplicates are a no-op.
- **`filterUrl` cannot recover scalar types without `columns`** (`attempts:equals:3` vs. the text `'3'`), so `columns` is threaded through the helper's options. Documented and tested.
- **Adding a filter does not reset pagination** — the component cannot know the page's fetch shape. The worked example in the spec shows `setPage(0)` in the page's handler.
- **Filter props are omitted from `DataTableRendererProps`** — the bar is drawn by `DataTable` itself, so its open/draft state survives a resize.
- `GridFilterPanel` is deliberately unused. MUI X **Pro** is required for multi-column filtering in DataGrid's own filter UI, and DataGrid's filter is client-side regardless, so the filter surface is ours.

## Testing

- [x] Unit tests pass (`npm test`) — **136 passed** in the datatable suite (79 pre-existing unmodified, 57 new)
- [x] Type checks pass (`npm run typecheck`) — zero errors
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

New tests cover the operator set offered per value type, the quick-search debounce emitting once rather than per keystroke, filter-state round-tripping with no local row filtering, chip removal, the phone sheet opening/closing with focus trapping, the tablet active-count badge, and the URL helper round-trip.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Next: #255 (column visibility, density, and per-user persisted views), which is the last dependency before the Job Queue pilot in #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE)_