### PR TITLE
feat(web): DataTable row virtualization and CSV export

### DIFF
--- a/apps/web/src/components/datatable/DataTable.tsx
+++ b/apps/web/src/components/datatable/DataTable.tsx
@@ -41,6 +41,11 @@
  * once, from the layout baseline and the user's stored choice together, so the
  * two renderers can never disagree about which columns exist.
  *
+ * `DataTableExportControl` (CSV export, #256) rides in that bar's trailing slot
+ * on the same logic: one code path serves every renderer, so a phone and a
+ * desktop download byte-identical files, and the control's SHAPE (a button, or
+ * an overflow menu at 360px) is the only thing the layout decides.
+ *
  * ## Layout persistence
  *
  * Supplying `tableId` stores the resolved layout under
@@ -63,6 +68,7 @@ import { DesktopGridRenderer } from './desktop/DesktopGridRenderer';
 import { CardListRenderer } from './mobile/CardListRenderer';
 import { DataTableFilterBar } from './filter/DataTableFilterBar';
 import { DataTableViewBar } from './layout/DataTableViewBar';
+import { DataTableExportControl } from './export/DataTableExportControl';
 import { useDataTableLayoutPrefs } from './layout/useDataTableLayoutPrefs';
 import { useDataTableLayout, useViewportLayout } from './useContainerLayout';
 
@@ -104,6 +110,8 @@ export function DataTable<Row>(props: DataTableProps<Row>) {
     onFiltersChange,
     quickSearch,
     tableId,
+    csvExport,
+    disableExport = false,
     density: densityProp,
     'data-testid': testId,
     ...rendererProps
@@ -149,6 +157,22 @@ export function DataTable<Row>(props: DataTableProps<Row>) {
         onToggleColumn={prefs.toggleColumn}
         onDensityChange={prefs.setDensity}
         onReset={prefs.reset}
+        trailing={
+          disableExport ? undefined : (
+            <DataTableExportControl
+              layout={layout}
+              columns={props.columns}
+              rows={props.rows}
+              // The USER's choice, not the layout's fold: a `detail` column the
+              // tablet tucks into its row expander is still on screen, so a CSV
+              // must not change shape because the window got narrower.
+              visibleColumnIds={prefs.userVisibleColumnIds}
+              config={csvExport}
+              filenameBase={csvExport?.filename ?? tableId ?? props.ariaLabel}
+              total={props.pagination?.total}
+            />
+          )
+        }
       />
 
       <DataTableFilterBar

--- a/apps/web/src/components/datatable/__tests__/DataTableExport.test.tsx
+++ b/apps/web/src/components/datatable/__tests__/DataTableExport.test.tsx
@@ -1,0 +1,1128 @@
+/**
+ * Component tests — DataTable CSV export and row virtualization
+ * (issue #256, epic #238).
+ *
+ * Six things this suite exists to pin down, in the order they can bite:
+ *
+ *  1. **A CSV is a file another program opens.** Commas, quotes and newlines
+ *     have to survive a round trip, and the four formula-injection prefixes
+ *     (`=`, `+`, `-`, `@`) have to be neutralized — a cell reading
+ *     `=cmd|'/c calc'!A1` is code the moment Excel opens the file. The UTF-8
+ *     BOM is asserted on the downloaded bytes, not on a helper's return value.
+ *  2. **Export writes the `value` scalar, never the rendered node.** A column
+ *     whose cell is a `<Chip>` exports what is behind the chip.
+ *  3. **Export writes what is on screen.** The user's column visibility (#255)
+ *     and `exportable: false` both bound the file; the active filters bound it
+ *     by bounding `rows`, because the table never filters rows itself (§10.1).
+ *  4. **The all-rows export is the PAGE's query, replayed.** It never invents a
+ *     request, is bounded at 10 000 rows, and is cancellable.
+ *  5. **Selection stays row-set-derived, not DOM-derived.** That is what makes
+ *     select-all correct once the grid virtualizes and only some rows exist in
+ *     the DOM.
+ *  6. **The card list skips off-screen rendering without guessing heights.**
+ *     The placeholder is measured, the measured card is excluded, and an
+ *     expanding card opts out (issue #237's failure mode).
+ *
+ * ## Test doubles
+ *
+ * Layout stubs are the #253 recipe (container-driven width, `matchMedia` pinned
+ * to a 1440px viewport). The download path is stubbed at `URL.createObjectURL`
+ * plus `HTMLAnchorElement.click`, so the assertions run against the real Blob
+ * the component built rather than against an injected seam.
+ *
+ * jsdom performs no layout, and MUI X switches virtualization off outright when
+ * `platform.env.jsdom` is true — so the grid tests assert the *decision*
+ * (`data-virtualized`, the viewport height) and assert that selection cannot
+ * depend on which rows happen to be mounted.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { Chip } from '@mui/material';
+import { render } from '../../../__tests__/utils/test-utils';
+import { DataTable } from '../DataTable';
+import type { DataTableColumn, DataTableFilterModel } from '../types';
+import {
+  CSV_BOM,
+  escapeCsvField,
+  isFormulaText,
+  neutralizeFormula,
+  toCsv,
+  toCsvFile,
+  toCsvRow,
+} from '../export/csv';
+import {
+  DATA_TABLE_EXPORT_MAX_ROWS,
+  ExportCancelledError,
+  buildCsvForRows,
+  buildExportMatrix,
+  collectAllRows,
+  exportColumns,
+  exportFilename,
+  isExportableColumn,
+  slugifyExportName,
+} from '../export/exportModel';
+import {
+  GRID_VIRTUALIZATION_ROW_THRESHOLD,
+  planGridVirtualization,
+  virtualizedViewportHeight,
+} from '../virtualization/gridVirtualization';
+import {
+  CARD_VIRTUALIZATION_MIN_ROWS,
+  containIntrinsicSize,
+  shouldVirtualizeCards,
+} from '../virtualization/cardVirtualization';
+
+// ---------------------------------------------------------------------------
+// Layout stubs (the #253 recipe)
+// ---------------------------------------------------------------------------
+
+const VIEWPORT_WIDTH = 1440;
+const VIEWPORT_HEIGHT = 900;
+const CARD_HEIGHT = 220;
+
+let containerWidth = 1400;
+
+interface FakeObserver {
+  targets: Set<Element>;
+  fire: () => void;
+}
+
+const observers = new Set<FakeObserver>();
+
+function installLayoutStubs() {
+  for (const prop of ['clientWidth', 'offsetWidth', 'scrollWidth'] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => containerWidth,
+    });
+  }
+  for (const prop of ['clientHeight', 'offsetHeight', 'scrollHeight'] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => VIEWPORT_HEIGHT,
+    });
+  }
+
+  HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect(
+    this: HTMLElement,
+  ) {
+    // A card reports a card-sized height so the measured placeholder is a real
+    // measurement rather than the viewport.
+    const isCard = this.getAttribute?.('data-testid') === 'datatable-card';
+    const height = isCard ? CARD_HEIGHT : VIEWPORT_HEIGHT;
+    return {
+      width: containerWidth,
+      height,
+      top: 0,
+      left: 0,
+      right: containerWidth,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+
+  class ControllableResizeObserver {
+    private readonly entry: FakeObserver;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.entry = {
+        targets: new Set<Element>(),
+        fire: () => {
+          const entries = Array.from(this.entry.targets, (target) => ({
+            target,
+            contentRect: {
+              width: containerWidth,
+              // A card measures a card, not the viewport — otherwise the
+              // "measured placeholder" assertion would be measuring the stub.
+              height:
+                target.getAttribute('data-testid') === 'datatable-card'
+                  ? CARD_HEIGHT
+                  : VIEWPORT_HEIGHT,
+            },
+          })) as unknown as ResizeObserverEntry[];
+          if (entries.length > 0) callback(entries, this as unknown as ResizeObserver);
+        },
+      };
+      observers.add(this.entry);
+    }
+
+    observe(target: Element) {
+      this.entry.targets.add(target);
+      this.entry.fire();
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target);
+    }
+    disconnect() {
+      this.entry.targets.clear();
+      observers.delete(this.entry);
+    }
+  }
+
+  global.ResizeObserver = ControllableResizeObserver as unknown as typeof ResizeObserver;
+
+  window.matchMedia = vi.fn().mockImplementation((query: string) => {
+    const max = /max-width:\s*([\d.]+)px/.exec(query);
+    const min = /min-width:\s*([\d.]+)px/.exec(query);
+    let matches = true;
+    if (max) matches = matches && VIEWPORT_WIDTH <= Number.parseFloat(max[1]);
+    if (min) matches = matches && VIEWPORT_WIDTH >= Number.parseFloat(min[1]);
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  }) as unknown as typeof window.matchMedia;
+}
+
+beforeAll(() => {
+  installLayoutStubs();
+});
+
+// ---------------------------------------------------------------------------
+// Download double
+// ---------------------------------------------------------------------------
+
+interface CapturedDownload {
+  blob: Blob;
+  filename: string;
+}
+
+let captured: CapturedDownload[] = [];
+let pendingBlobs: Blob[] = [];
+let originalCreate: unknown;
+let originalRevoke: unknown;
+
+function installDownloadStubs() {
+  captured = [];
+  pendingBlobs = [];
+  const urlObject = URL as unknown as Record<string, unknown>;
+  originalCreate = urlObject.createObjectURL;
+  originalRevoke = urlObject.revokeObjectURL;
+
+  urlObject.createObjectURL = vi.fn((blob: Blob) => {
+    pendingBlobs.push(blob);
+    return `blob:datatable-export-${pendingBlobs.length}`;
+  });
+  urlObject.revokeObjectURL = vi.fn();
+
+  // jsdom would otherwise log "Not implemented: navigation" for the anchor.
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function click(
+    this: HTMLAnchorElement,
+  ) {
+    const blob = pendingBlobs[pendingBlobs.length - 1];
+    captured.push({ blob, filename: this.download });
+  });
+}
+
+function restoreDownloadStubs() {
+  const urlObject = URL as unknown as Record<string, unknown>;
+  urlObject.createObjectURL = originalCreate;
+  urlObject.revokeObjectURL = originalRevoke;
+}
+
+/** The text of the most recent download. */
+async function lastDownloadedCsv(): Promise<string> {
+  expect(captured.length).toBeGreaterThan(0);
+  return captured[captured.length - 1].blob.text();
+}
+
+/** The most recent download's rows, BOM stripped, CRLF split. */
+async function lastDownloadedRows(): Promise<string[]> {
+  const text = await lastDownloadedCsv();
+  return text.replace(CSV_BOM, '').split('\r\n').filter(Boolean);
+}
+
+beforeEach(() => {
+  containerWidth = 1400;
+  installDownloadStubs();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  restoreDownloadStubs();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+interface Job {
+  id: string;
+  type: string;
+  status: 'pending' | 'failed';
+  attempts: number;
+  lastError: string | null;
+  token: string;
+}
+
+const JOBS: Job[] = [
+  {
+    id: 'job-1',
+    type: 'face_detection',
+    status: 'pending',
+    attempts: 1,
+    lastError: null,
+    token: 'shr_secret_1',
+  },
+  {
+    id: 'job-2',
+    type: 'auto_tagging',
+    status: 'failed',
+    attempts: 3,
+    lastError: 'rate limited, "429"',
+    token: 'shr_secret_2',
+  },
+];
+
+const COLUMNS: DataTableColumn<Job>[] = [
+  { id: 'type', label: 'Type', priority: 'primary', sortable: true, value: (r) => r.type },
+  {
+    id: 'status',
+    label: 'Status',
+    priority: 'primary',
+    // The whole point of `render` vs `value`: the cell is a chip, the CSV is a
+    // word.
+    value: (r) => r.status,
+    render: (r) => <Chip size="small" label={r.status.toUpperCase()} />,
+  },
+  {
+    id: 'attempts',
+    label: 'Attempts',
+    priority: 'secondary',
+    sortable: true,
+    value: (r) => r.attempts,
+  },
+  { id: 'lastError', label: 'Last error', priority: 'detail', value: (r) => r.lastError },
+  // Never exportable: this is what #259/#260 will set on share tokens and PAT
+  // material.
+  {
+    id: 'token',
+    label: 'Token',
+    priority: 'detail',
+    value: (r) => r.token,
+    exportable: false,
+  },
+];
+
+const rowId = (job: Job) => job.id;
+
+type TableProps = React.ComponentProps<typeof DataTable<Job>>;
+
+function renderAtWidth(width: number, overrides: Partial<TableProps> = {}) {
+  containerWidth = width;
+  return render(
+    <DataTable<Job>
+      columns={COLUMNS}
+      rows={JOBS}
+      rowId={rowId}
+      ariaLabel="Enrichment jobs"
+      {...overrides}
+    />,
+  );
+}
+
+/** A page of N synthetic jobs, for the virtualization thresholds. */
+function manyJobs(count: number): Job[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `job-${index + 1}`,
+    type: `type_${index + 1}`,
+    status: index % 2 === 0 ? ('pending' as const) : ('failed' as const),
+    attempts: index,
+    lastError: null,
+    token: `shr_${index}`,
+  }));
+}
+
+// ===========================================================================
+// 1. CSV serialization — the pure rules
+// ===========================================================================
+
+describe('CSV serialization — escaping', () => {
+  it('leaves a plain field untouched', () => {
+    expect(escapeCsvField('face_detection')).toBe('face_detection');
+    expect(escapeCsvField(42)).toBe('42');
+  });
+
+  it('writes null and undefined as an EMPTY field, not an em dash', () => {
+    expect(escapeCsvField(null)).toBe('');
+    expect(escapeCsvField(undefined)).toBe('');
+  });
+
+  it('quotes a field containing a comma', () => {
+    expect(escapeCsvField('San José, Costa Rica')).toBe('"San José, Costa Rica"');
+  });
+
+  it('quotes a field containing a double quote, and doubles the quote', () => {
+    expect(escapeCsvField('rate limited, "429"')).toBe('"rate limited, ""429"""');
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it('quotes a field containing a newline or a carriage return', () => {
+    expect(escapeCsvField('line one\nline two')).toBe('"line one\nline two"');
+    expect(escapeCsvField('line one\r\nline two')).toBe('"line one\r\nline two"');
+  });
+
+  it('quotes leading/trailing whitespace so a parser cannot trim it away', () => {
+    expect(escapeCsvField('  padded  ')).toBe('"  padded  "');
+  });
+});
+
+describe('CSV serialization — formula injection', () => {
+  // The four prefixes named in the issue, plus the two whitespace prefixes some
+  // spreadsheets strip before deciding whether a cell is a formula.
+  it.each([
+    ['=', '=cmd|\'/c calc\'!A1'],
+    ['+', '+1+1'],
+    ['-', '-2+3+cmd|calc'],
+    ['@', '@SUM(A1:A9)'],
+    ['tab', '\t=1+1'],
+    ['CR', '\r=1+1'],
+  ])('neutralizes a %s-prefixed field', (_name, payload) => {
+    expect(isFormulaText(payload)).toBe(true);
+    expect(neutralizeFormula(payload)).toBe(`'${payload}`);
+    expect(escapeCsvField(payload).replace(/^"|"$/g, '')).toMatch(/^'/);
+  });
+
+  it('escapes AND quotes a formula that also contains a comma', () => {
+    expect(escapeCsvField('=SUM(1,2)')).toBe('"\'=SUM(1,2)"');
+  });
+
+  it('does NOT neutralize a negative number, in either representation', () => {
+    // A `-` prefix is only dangerous when the cell is not a number. Prefixing
+    // `-5` would corrupt every numeric column that can go negative.
+    expect(escapeCsvField(-5)).toBe('-5');
+    expect(escapeCsvField('-5')).toBe('-5');
+    expect(escapeCsvField('+1.5e3')).toBe('+1.5e3');
+    expect(isFormulaText('-5')).toBe(false);
+  });
+
+  it('still neutralizes a formula that merely starts like a number', () => {
+    expect(isFormulaText('-1+cmd|calc')).toBe(true);
+    expect(neutralizeFormula('-1+cmd|calc')).toBe("'-1+cmd|calc");
+  });
+
+  it('treats an empty string as harmless', () => {
+    expect(isFormulaText('')).toBe(false);
+    expect(escapeCsvField('')).toBe('');
+  });
+});
+
+describe('CSV serialization — documents', () => {
+  it('joins fields with commas and records with CRLF, ending with a terminator', () => {
+    expect(toCsvRow(['a', 'b', 1])).toBe('a,b,1');
+    expect(toCsv(['A', 'B'], [['1', '2']])).toBe('A,B\r\n1,2\r\n');
+  });
+
+  it('prefixes the FILE (not a field) with the UTF-8 BOM', () => {
+    const file = toCsvFile(['Type'], [['José']]);
+    expect(file.startsWith(CSV_BOM)).toBe(true);
+    expect(file.charCodeAt(0)).toBe(0xfeff);
+    // The BOM is a file concern only — the row serializer stays composable.
+    expect(toCsv(['Type'], [['José']]).startsWith(CSV_BOM)).toBe(false);
+  });
+
+  it('round-trips a header-only export', () => {
+    expect(toCsv(['A', 'B'], [])).toBe('A,B\r\n');
+  });
+});
+
+// ===========================================================================
+// 2. Export model — columns, matrix, filename
+// ===========================================================================
+
+describe('export model — column selection', () => {
+  it('defaults every column to exportable', () => {
+    expect(isExportableColumn(COLUMNS[0])).toBe(true);
+    expect(isExportableColumn(COLUMNS.find((c) => c.id === 'token')!)).toBe(false);
+  });
+
+  it('drops `exportable: false` columns', () => {
+    expect(exportColumns(COLUMNS).map((c) => c.id)).toEqual([
+      'type',
+      'status',
+      'attempts',
+      'lastError',
+    ]);
+  });
+
+  it('drops columns the user has hidden, and keeps declaration order', () => {
+    const visible = new Set(['lastError', 'type', 'token']);
+    expect(exportColumns(COLUMNS, visible).map((c) => c.id)).toEqual(['type', 'lastError']);
+  });
+
+  it('treats an omitted visibility set as "nothing is hidden"', () => {
+    expect(exportColumns(COLUMNS, undefined)).toHaveLength(4);
+  });
+});
+
+describe('export model — matrix', () => {
+  it('uses the `value` scalar, never the rendered node', () => {
+    const { header, body } = buildExportMatrix(exportColumns(COLUMNS), JOBS);
+    expect(header).toEqual(['Type', 'Status', 'Attempts', 'Last error']);
+    // The cell renders <Chip label="PENDING" />; the CSV carries `pending`.
+    expect(body[0]).toEqual(['face_detection', 'pending', 1, null]);
+    expect(body[1]).toEqual(['auto_tagging', 'failed', 3, 'rate limited, "429"']);
+  });
+
+  it('builds a complete file, BOM and quoting included', () => {
+    const csv = buildCsvForRows(COLUMNS, JOBS);
+    const rows = csv.replace(CSV_BOM, '').split('\r\n');
+    expect(csv.startsWith(CSV_BOM)).toBe(true);
+    expect(rows[0]).toBe('Type,Status,Attempts,Last error');
+    expect(rows[1]).toBe('face_detection,pending,1,');
+    expect(rows[2]).toBe('auto_tagging,failed,3,"rate limited, ""429"""');
+    expect(csv).not.toContain('shr_secret');
+  });
+});
+
+describe('export model — filename', () => {
+  it('slugifies a table name and falls back to `export`', () => {
+    expect(slugifyExportName('Enrichment jobs')).toBe('enrichment-jobs');
+    expect(slugifyExportName('  ')).toBe('export');
+    expect(slugifyExportName(undefined)).toBe('export');
+  });
+
+  it('dates the file so two snapshots never collide', () => {
+    expect(exportFilename('jobs', new Date('2026-08-05T10:00:00Z'))).toBe('jobs-2026-08-05.csv');
+  });
+});
+
+// ===========================================================================
+// 3. collectAllRows — the bounded, cancellable walk
+// ===========================================================================
+
+describe('collectAllRows', () => {
+  it('walks zero-based pages until a short page ends the set', async () => {
+    const seen: number[] = [];
+    const fetchPage = vi.fn(async ({ page, pageSize }: { page: number; pageSize: number }) => {
+      seen.push(page);
+      return page < 2 ? manyJobs(pageSize) : manyJobs(3);
+    });
+
+    const { rows, capped } = await collectAllRows<Job>({ fetchPage, pageSize: 10 });
+
+    expect(seen).toEqual([0, 1, 2]);
+    expect(rows).toHaveLength(23);
+    expect(capped).toBe(false);
+  });
+
+  it('stops at an empty page', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) =>
+      page === 0 ? manyJobs(10) : [],
+    );
+    const { rows } = await collectAllRows<Job>({ fetchPage, pageSize: 10 });
+    expect(rows).toHaveLength(10);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps the walk at maxRows and reports it', async () => {
+    const fetchPage = vi.fn(async ({ pageSize }: { pageSize: number }) => manyJobs(pageSize));
+    const { rows, capped } = await collectAllRows<Job>({
+      fetchPage,
+      pageSize: 10,
+      maxRows: 25,
+    });
+    expect(rows).toHaveLength(25);
+    expect(capped).toBe(true);
+  });
+
+  it('defaults the ceiling to 10 000 rows', () => {
+    expect(DATA_TABLE_EXPORT_MAX_ROWS).toBe(10_000);
+  });
+
+  it('reports progress as the running total', async () => {
+    const onProgress = vi.fn();
+    const fetchPage = vi.fn(async ({ page, pageSize }: { page: number; pageSize: number }) =>
+      page === 0 ? manyJobs(pageSize) : manyJobs(2),
+    );
+    await collectAllRows<Job>({ fetchPage, pageSize: 5, onProgress });
+    expect(onProgress.mock.calls.map((call) => call[0])).toEqual([5, 7]);
+  });
+
+  it('throws ExportCancelledError once the signal aborts', async () => {
+    const controller = new AbortController();
+    const fetchPage = vi.fn(async ({ pageSize }: { pageSize: number }) => {
+      controller.abort();
+      return manyJobs(pageSize);
+    });
+
+    await expect(
+      collectAllRows<Job>({ fetchPage, pageSize: 5, signal: controller.signal }),
+    ).rejects.toBeInstanceOf(ExportCancelledError);
+  });
+});
+
+// ===========================================================================
+// 4. The export control — one control, three layouts
+// ===========================================================================
+
+describe('DataTable — the export control', () => {
+  it('offers a labelled Export button on desktop', () => {
+    renderAtWidth(1400);
+    const button = screen.getByTestId('datatable-export-button');
+    expect(button).toHaveAccessibleName('Export CSV');
+    // The visible word is inside the accessible name (WCAG 2.5.3).
+    expect(button).toHaveTextContent('Export');
+  });
+
+  it('offers the same button on a tablet', () => {
+    renderAtWidth(800);
+    expect(screen.getByTestId('datatable-export-button')).toBeInTheDocument();
+  });
+
+  it('collapses into an overflow menu on a phone', () => {
+    renderAtWidth(400);
+    expect(screen.queryByTestId('datatable-export-button')).not.toBeInTheDocument();
+
+    const overflow = screen.getByTestId('datatable-overflow-button');
+    expect(overflow).toHaveAccessibleName('Table actions');
+
+    fireEvent.click(overflow);
+    expect(screen.getByTestId('datatable-export-current-page')).toBeInTheDocument();
+  });
+
+  it('is removed entirely by disableExport', () => {
+    renderAtWidth(1400, { disableExport: true });
+    expect(screen.queryByTestId('datatable-export-button')).not.toBeInTheDocument();
+    // …and the rest of the view bar is untouched.
+    expect(screen.getByTestId('datatable-columns-button')).toBeInTheDocument();
+  });
+
+  it('is removed on a phone too', () => {
+    renderAtWidth(400, { disableExport: true });
+    expect(screen.queryByTestId('datatable-overflow-button')).not.toBeInTheDocument();
+    expect(screen.getByTestId('datatable-view-button')).toBeInTheDocument();
+  });
+
+  it('disables itself when there is nothing to export', () => {
+    renderAtWidth(1400, { rows: [] });
+    expect(screen.getByTestId('datatable-export-button')).toBeDisabled();
+  });
+
+  it('exports without a menu when no all-rows callback is supplied', () => {
+    renderAtWidth(1400);
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    // One click, one file — a one-item menu would be a click nobody needs.
+    expect(captured).toHaveLength(1);
+    expect(screen.queryByTestId('datatable-export-menu')).not.toBeInTheDocument();
+  });
+});
+
+// ===========================================================================
+// 5. Current-page export — what actually lands in the file
+// ===========================================================================
+
+describe('DataTable — current-page export', () => {
+  it('downloads a dated .csv of the loaded rows, BOM first', async () => {
+    renderAtWidth(1400, { tableId: 'jobs' });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+
+    // `Blob.text()` decodes UTF-8, and a UTF-8 decode STRIPS a leading BOM —
+    // so the only honest place to assert it is the bytes themselves.
+    const bytes = new Uint8Array(await captured[0].blob.arrayBuffer());
+    expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+    expect(captured[0].blob.type).toBe('text/csv;charset=utf-8;');
+    expect(captured[0].filename).toMatch(/^jobs-\d{4}-\d{2}-\d{2}\.csv$/);
+
+    const rows = await lastDownloadedRows();
+    expect(rows[0]).toBe('Type,Status,Attempts,Last error');
+    expect(rows).toHaveLength(3);
+  });
+
+  it('exports the scalar behind a rendered chip, never the node', async () => {
+    renderAtWidth(1400);
+    // The cell really is a chip on screen…
+    expect(screen.getAllByText('PENDING').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    const rows = await lastDownloadedRows();
+
+    // …and the file really does carry the scalar.
+    expect(rows[1]).toContain('pending');
+    expect(rows[1]).not.toContain('PENDING');
+    expect(rows.join('\n')).not.toContain('[object Object]');
+  });
+
+  it('never writes an `exportable: false` column', async () => {
+    renderAtWidth(1400);
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    const text = await lastDownloadedCsv();
+
+    expect(text).not.toContain('Token');
+    expect(text).not.toContain('shr_secret_1');
+  });
+
+  it('respects the user’s column visibility choice', async () => {
+    renderAtWidth(1400);
+
+    fireEvent.click(screen.getByTestId('datatable-columns-button'));
+    fireEvent.click(screen.getByTestId('datatable-column-toggle-attempts'));
+    // The menu is modal; close it before touching the bar underneath.
+    fireEvent.keyDown(screen.getByTestId('datatable-columns-menu'), { key: 'Escape' });
+
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    const rows = await lastDownloadedRows();
+
+    expect(rows[0]).toBe('Type,Status,Last error');
+    expect(rows[1]).not.toMatch(/(^|,)1(,|$)/);
+  });
+
+  it('exports the rows the server returned for the ACTIVE filters', async () => {
+    // The table never filters `rows` (§10.1), so "respects the filters" means
+    // exactly this: the file is the filtered page the page handed us, and
+    // nothing else.
+    const filters: DataTableFilterModel = [
+      { columnId: 'status', operator: 'is', value: 'failed' },
+    ];
+    const filtered = JOBS.filter((job) => job.status === 'failed');
+
+    renderAtWidth(1400, { rows: filtered, filters, onFiltersChange: vi.fn() });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+
+    const rows = await lastDownloadedRows();
+    expect(rows).toHaveLength(2); // header + the one matching row
+    expect(rows[1]).toContain('auto_tagging');
+    expect(rows.join('\n')).not.toContain('face_detection');
+  });
+
+  it('exports the same file from the phone overflow menu', async () => {
+    renderAtWidth(400);
+    fireEvent.click(screen.getByTestId('datatable-overflow-button'));
+    fireEvent.click(screen.getByTestId('datatable-export-current-page'));
+
+    const rows = await lastDownloadedRows();
+    expect(rows[0]).toBe('Type,Status,Attempts,Last error');
+    expect(rows).toHaveLength(3);
+  });
+
+  it('names the file from an explicit csvExport.filename', async () => {
+    renderAtWidth(1400, { csvExport: { filename: 'Admin Shares' } });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    expect(captured[0].filename).toMatch(/^admin-shares-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+});
+
+// ===========================================================================
+// 6. All-rows export — the page's own query, replayed
+// ===========================================================================
+
+describe('DataTable — all matching rows export', () => {
+  it('offers the option only when a fetch callback is supplied', () => {
+    renderAtWidth(1400);
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    expect(screen.queryByTestId('datatable-export-all-rows')).not.toBeInTheDocument();
+  });
+
+  it('replays the page’s callback page by page and exports everything', async () => {
+    const fetchAllRows = vi.fn(async ({ page, pageSize }: { page: number; pageSize: number }) =>
+      page === 0 ? manyJobs(pageSize) : manyJobs(4),
+    );
+
+    renderAtWidth(1400, { csvExport: { fetchAllRows, fetchPageSize: 10 } });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    fireEvent.click(screen.getByTestId('datatable-export-all-rows'));
+
+    await waitFor(() => expect(captured).toHaveLength(1));
+
+    expect(fetchAllRows.mock.calls.map((call) => call[0].page)).toEqual([0, 1]);
+    const rows = await lastDownloadedRows();
+    expect(rows).toHaveLength(15); // header + 14 rows
+  });
+
+  it('stops at the row ceiling and says so instead of silently truncating', async () => {
+    const fetchAllRows = vi.fn(async ({ pageSize }: { pageSize: number }) => manyJobs(pageSize));
+
+    renderAtWidth(1400, {
+      csvExport: { fetchAllRows, fetchPageSize: 10, maxRows: 25 },
+    });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    fireEvent.click(screen.getByTestId('datatable-export-all-rows'));
+
+    await waitFor(() => expect(captured).toHaveLength(1));
+    const rows = await lastDownloadedRows();
+    expect(rows).toHaveLength(26);
+
+    const notice = await screen.findByTestId('datatable-export-capped');
+    expect(notice).toHaveTextContent(/25-row limit/);
+  });
+
+  it('surfaces a failed fetch instead of downloading a partial file', async () => {
+    const fetchAllRows = vi.fn(async () => {
+      throw new Error('502 Bad Gateway');
+    });
+
+    renderAtWidth(1400, { csvExport: { fetchAllRows } });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    fireEvent.click(screen.getByTestId('datatable-export-all-rows'));
+
+    const error = await screen.findByTestId('datatable-export-error');
+    expect(error).toHaveTextContent('502 Bad Gateway');
+    expect(captured).toHaveLength(0);
+  });
+
+  it('shows progress and can be cancelled mid-walk', async () => {
+    let release: (() => void) | null = null;
+    const fetchAllRows = vi.fn(async ({ page, pageSize }: { page: number; pageSize: number }) => {
+      if (page === 0) return manyJobs(pageSize);
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return manyJobs(pageSize);
+    });
+
+    renderAtWidth(1400, {
+      csvExport: { fetchAllRows, fetchPageSize: 10 },
+      pagination: { page: 0, pageSize: 25, total: 400, onPaginationChange: vi.fn() },
+    });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    fireEvent.click(screen.getByTestId('datatable-export-all-rows'));
+
+    const dialog = await screen.findByTestId('datatable-export-progress');
+    await waitFor(() =>
+      expect(screen.getByTestId('datatable-export-progress-text')).toHaveTextContent('10 rows'),
+    );
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await act(async () => {
+      release?.();
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('datatable-export-progress')).not.toBeInTheDocument(),
+    );
+    // A cancelled export produces no file.
+    expect(captured).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// 7. Grid virtualization
+// ===========================================================================
+
+describe('grid virtualization — the plan (pure)', () => {
+  it('keeps auto-height for an ordinary page', () => {
+    expect(planGridVirtualization({ rowCount: 25, density: 'standard' })).toEqual({
+      virtualized: false,
+      autoHeight: true,
+      height: undefined,
+    });
+  });
+
+  it('trades auto-height for a bounded viewport past the threshold', () => {
+    const plan = planGridVirtualization({
+      rowCount: GRID_VIRTUALIZATION_ROW_THRESHOLD + 1,
+      density: 'standard',
+    });
+    expect(plan.virtualized).toBe(true);
+    // autoHeight is what MUI X checks: `enabledForRows: … && !autoHeight`.
+    expect(plan.autoHeight).toBe(false);
+    expect(plan.height).toBe(virtualizedViewportHeight('standard', 51));
+  });
+
+  it('does not fire exactly AT the threshold', () => {
+    expect(
+      planGridVirtualization({
+        rowCount: GRID_VIRTUALIZATION_ROW_THRESHOLD,
+        density: 'standard',
+      }).virtualized,
+    ).toBe(false);
+  });
+
+  it('honours an explicit height at any row count', () => {
+    expect(planGridVirtualization({ rowCount: 3, height: 400, density: 'standard' })).toEqual({
+      virtualized: true,
+      autoHeight: false,
+      height: 400,
+    });
+  });
+
+  it('scales the viewport with density', () => {
+    expect(virtualizedViewportHeight('compact', 100)).toBeLessThan(
+      virtualizedViewportHeight('comfortable', 100),
+    );
+    // Never taller than the rows it has.
+    expect(virtualizedViewportHeight('standard', 2)).toBeLessThan(
+      virtualizedViewportHeight('standard', 12),
+    );
+  });
+});
+
+describe('DataTable — grid virtualization, rendered', () => {
+  const bigPage = manyJobs(60);
+
+  it('does not virtualize an ordinary page', () => {
+    renderAtWidth(1400, {
+      pagination: { page: 0, pageSize: 25, total: 2, onPaginationChange: vi.fn() },
+    });
+    const scroller = screen.getByTestId('datatable-scroll-container');
+    expect(scroller).toHaveAttribute('data-virtualized', 'false');
+    // Auto-height: the table grows with its rows and the PAGE scrolls (§5).
+    expect(getComputedStyle(scroller).height).not.toMatch(/px$/);
+  });
+
+  it('virtualizes a large page and bounds the viewport', () => {
+    renderAtWidth(1400, {
+      rows: bigPage,
+      pagination: { page: 0, pageSize: 100, total: 600, onPaginationChange: vi.fn() },
+    });
+    const scroller = screen.getByTestId('datatable-scroll-container');
+    expect(scroller).toHaveAttribute('data-virtualized', 'true');
+    expect(getComputedStyle(scroller).height).toBe(
+      `${virtualizedViewportHeight('standard', 60)}px`,
+    );
+  });
+
+  it('keeps select-all correct with virtualization enabled', () => {
+    const onSelectionChange = vi.fn();
+    renderAtWidth(1400, {
+      rows: bigPage,
+      pagination: { page: 0, pageSize: 100, total: 600, onPaginationChange: vi.fn() },
+      selection: { selectedIds: new Set<string>(), onSelectionChange },
+    });
+
+    expect(screen.getByTestId('datatable-scroll-container')).toHaveAttribute(
+      'data-virtualized',
+      'true',
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all rows/i }));
+
+    const emitted = onSelectionChange.mock.calls[0][0] as Set<string>;
+    // Selection is materialised from the ROW SET, not from the mounted DOM —
+    // which is exactly why windowing cannot break it.
+    expect(emitted.size).toBe(60);
+    expect(emitted.has('job-1')).toBe(true);
+    expect(emitted.has('job-60')).toBe(true);
+  });
+
+  it('keeps synthetic tablet detail rows unselectable while virtualized', () => {
+    const onSelectionChange = vi.fn();
+    renderAtWidth(800, {
+      rows: bigPage,
+      pagination: { page: 0, pageSize: 100, total: 600, onPaginationChange: vi.fn() },
+      selection: { selectedIds: new Set<string>(), onSelectionChange },
+    });
+
+    // Expand a row: a synthetic detail row joins `rows`, so the count the
+    // virtualization plan sees includes it.
+    fireEvent.click(screen.getAllByTestId('datatable-row-expander')[0]);
+    expect(screen.getByTestId('datatable-scroll-container')).toHaveAttribute(
+      'data-virtualized',
+      'true',
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all rows/i }));
+    const emitted = onSelectionChange.mock.calls[0][0] as Set<string>;
+    expect(emitted.size).toBe(60);
+    expect(Array.from(emitted).some((id) => id.startsWith('__datatable_detail__'))).toBe(false);
+  });
+
+  it('still exports every loaded row when the grid is virtualized', async () => {
+    renderAtWidth(1400, {
+      rows: bigPage,
+      pagination: { page: 0, pageSize: 100, total: 600, onPaginationChange: vi.fn() },
+    });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+
+    const rows = await lastDownloadedRows();
+    // The export reads the row array, not the mounted rows.
+    expect(rows).toHaveLength(61);
+  });
+});
+
+// ===========================================================================
+// 8. Card list — render skipping (NOT a virtualizer)
+// ===========================================================================
+
+describe('card render-skipping helpers (pure)', () => {
+  it('kicks in only for a list long enough to be worth it', () => {
+    expect(shouldVirtualizeCards(CARD_VIRTUALIZATION_MIN_ROWS - 1)).toBe(false);
+    expect(shouldVirtualizeCards(CARD_VIRTUALIZATION_MIN_ROWS)).toBe(true);
+  });
+
+  it('emits `auto <length>` so the browser prefers its own remembered size', () => {
+    expect(containIntrinsicSize(220)).toBe('auto 220px');
+    // A missing measurement falls back rather than emitting `auto 0px`.
+    expect(containIntrinsicSize(null)).toMatch(/^auto \d+px$/);
+    expect(containIntrinsicSize(0)).toBe('auto 1px');
+  });
+});
+
+describe('DataTable — card list render skipping, rendered', () => {
+  it('leaves a short list alone', () => {
+    renderAtWidth(400, { rows: manyJobs(5) });
+    for (const card of screen.getAllByTestId('datatable-card')) {
+      expect(card).toHaveAttribute('data-skip-offscreen', 'false');
+    }
+  });
+
+  it('skips off-screen cards past the threshold, except the measured one', () => {
+    renderAtWidth(400, { rows: manyJobs(25) });
+    const cards = screen.getAllByTestId('datatable-card');
+
+    expect(cards[0]).toHaveAttribute('data-skip-offscreen', 'false');
+    expect(cards[1]).toHaveAttribute('data-skip-offscreen', 'true');
+    expect(cards[cards.length - 1]).toHaveAttribute('data-skip-offscreen', 'true');
+  });
+
+  it('uses a MEASURED placeholder height, not a computed guess', async () => {
+    renderAtWidth(400, { rows: manyJobs(25) });
+    await waitFor(() => {
+      const card = screen.getAllByTestId('datatable-card')[1];
+      // CARD_HEIGHT is what a real card in this list measures.
+      expect(card).toHaveAttribute('data-intrinsic-height', `auto ${CARD_HEIGHT}px`);
+    });
+  });
+
+  it('stops skipping a card while its detail region is open', () => {
+    renderAtWidth(400, { rows: manyJobs(25) });
+    const toggles = screen.getAllByTestId('datatable-card-detail-toggle');
+
+    expect(screen.getAllByTestId('datatable-card')[1]).toHaveAttribute(
+      'data-skip-offscreen',
+      'true',
+    );
+    fireEvent.click(toggles[1]);
+    // A card whose height is changing under the user's finger stays rendered —
+    // this is the issue #237 failure mode, avoided rather than estimated.
+    expect(screen.getAllByTestId('datatable-card')[1]).toHaveAttribute(
+      'data-skip-offscreen',
+      'false',
+    );
+  });
+
+  it('marks images produced by a column render as lazy', async () => {
+    const withThumb: DataTableColumn<Job>[] = [
+      ...COLUMNS,
+      {
+        id: 'thumb',
+        label: 'Preview',
+        priority: 'secondary',
+        value: (r) => r.id,
+        render: (r) => <img src={`/thumb/${r.id}.jpg`} alt={`Preview of ${r.type}`} />,
+      },
+    ];
+
+    renderAtWidth(400, { rows: manyJobs(25), columns: withThumb });
+
+    await waitFor(() => {
+      const images = document.querySelectorAll('img[src^="/thumb/"]');
+      expect(images.length).toBeGreaterThan(0);
+      for (const image of Array.from(images)) {
+        expect(image.getAttribute('loading')).toBe('lazy');
+        expect(image.getAttribute('decoding')).toBe('async');
+      }
+    });
+  });
+
+  it('never overrides an explicit loading attribute', async () => {
+    const eager: DataTableColumn<Job>[] = [
+      ...COLUMNS,
+      {
+        id: 'thumb',
+        label: 'Preview',
+        priority: 'secondary',
+        value: (r) => r.id,
+        render: (r) => <img src={`/hero/${r.id}.jpg`} alt="Hero" loading="eager" />,
+      },
+    ];
+
+    renderAtWidth(400, { rows: manyJobs(25), columns: eager });
+    await waitFor(() =>
+      expect(document.querySelector('img[src^="/hero/"]')?.getAttribute('loading')).toBe('eager'),
+    );
+  });
+});
+
+// ===========================================================================
+// 9. Touch-target rule / issue #243 regression guard, extended to export
+// ===========================================================================
+
+// `[role="menuitem"]` is this suite's addition to the #253/#255 sweep: the
+// export menu's controls are menu items, not buttons or checkboxes.
+const VISIBLE_CONTROL_SELECTOR =
+  'button, [role="button"], [role="menuitem"], .MuiCheckbox-root, a[href]';
+const THIRD_PARTY_CHROME = '.MuiDataGrid-columnHeaders, .MuiDataGrid-columnHeader';
+
+function describeControl(control: HTMLElement) {
+  const label = control.getAttribute('aria-label') ?? control.textContent?.slice(0, 24) ?? '';
+  return `${control.tagName.toLowerCase()}[${label}]`;
+}
+
+function assertNoInvisibleHitTargets(root: HTMLElement) {
+  const controls = Array.from(
+    root.querySelectorAll<HTMLElement>(VISIBLE_CONTROL_SELECTOR),
+  ).filter((control) => !control.closest(THIRD_PARTY_CHROME));
+  expect(controls.length).toBeGreaterThan(0);
+
+  const offenders = controls
+    .filter((control) => {
+      const style = getComputedStyle(control);
+      return style.opacity === '0' && style.pointerEvents !== 'none';
+    })
+    .map(describeControl);
+
+  expect(offenders).toEqual([]);
+}
+
+describe('DataTable — export controls obey the touch rules (issue #243 guard)', () => {
+  it('holds for the desktop export button and its menu', () => {
+    renderAtWidth(1400, { csvExport: { fetchAllRows: vi.fn(async () => []) } });
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable-export-menu'));
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable-view-bar'));
+  });
+
+  it('holds for the phone overflow menu', () => {
+    renderAtWidth(400);
+    fireEvent.click(screen.getByTestId('datatable-overflow-button'));
+    assertNoInvisibleHitTargets(screen.getByTestId('datatable-export-menu'));
+  });
+
+  it('gives the export control a >=44px touch target in every layout', () => {
+    renderAtWidth(1400, { csvExport: { fetchAllRows: vi.fn(async () => []) } });
+    expect(
+      Number.parseFloat(
+        getComputedStyle(screen.getByTestId('datatable-export-button')).minHeight || '0',
+      ),
+    ).toBeGreaterThanOrEqual(44);
+
+    fireEvent.click(screen.getByTestId('datatable-export-button'));
+    for (const item of [
+      screen.getByTestId('datatable-export-current-page'),
+      screen.getByTestId('datatable-export-all-rows'),
+    ]) {
+      expect(Number.parseFloat(getComputedStyle(item).minHeight || '0')).toBeGreaterThanOrEqual(
+        44,
+      );
+    }
+  });
+
+  it('gives the phone overflow button a >=44px touch target', () => {
+    renderAtWidth(400);
+    const button = screen.getByTestId('datatable-overflow-button');
+    expect(Number.parseFloat(getComputedStyle(button).minHeight || '0')).toBeGreaterThanOrEqual(
+      44,
+    );
+  });
+
+  it('keeps the view bar inside horizontal containment with export present', () => {
+    renderAtWidth(360);
+    const bar = screen.getByTestId('datatable-view-bar');
+    expect(getComputedStyle(bar).maxWidth).toBe('100%');
+    expect(getComputedStyle(bar).minWidth).toBe('0px');
+    expect(getComputedStyle(bar).flexWrap).toBe('wrap');
+    expect(document.body.style.width).toBe('');
+  });
+});

--- a/apps/web/src/components/datatable/desktop/DesktopGridRenderer.tsx
+++ b/apps/web/src/components/datatable/desktop/DesktopGridRenderer.tsx
@@ -19,6 +19,14 @@
  * When `variant` is omitted the renderer falls back to its historical
  * viewport-based behaviour, so using it directly (outside `DataTable`) still
  * works.
+ *
+ * ## Row virtualization (#256)
+ *
+ * DataGrid virtualizes rows for free — but not while `autoHeight` is on, which
+ * is this table's default sizing. `virtualization/gridVirtualization.ts` decides
+ * per render whether to trade auto-height for a bounded viewport (past a
+ * loaded-row threshold, or whenever the caller passed an explicit `height`), and
+ * the decision is published as `data-virtualized` on the scroll container.
  */
 
 import { useCallback, useMemo, useState } from 'react';
@@ -43,6 +51,7 @@ import { DataTableEmptyOverlay, DataTableLoadingOverlay } from './cells';
 import { RowActionsCell } from './RowActionsCell';
 import { BulkActionBar } from '../BulkActionBar';
 import { useRowActionConfirm } from '../shared/rowActionConfirm';
+import { planGridVirtualization } from '../virtualization/gridVirtualization';
 import {
   DETAIL_ROW_CLASS,
   DETAIL_ROW_SOURCE,
@@ -346,6 +355,19 @@ export function DesktopGridRenderer<Row>({
 
   const selectedIdList = useMemo(() => Array.from(selectedIds), [selectedIds]);
 
+  // --- Row virtualization ---------------------------------------------------
+
+  // MUI X disables row virtualization whenever `autoHeight` is on
+  // (`enabledForRows: !disableVirtualization && !autoHeight && HAS_LAYOUT`), and
+  // auto-height is this table's documented default. So past a threshold the grid
+  // takes a bounded viewport instead — the only condition under which the
+  // built-in virtualizer can actually run. `disableVirtualization` is left at
+  // its default (false) throughout; see `virtualization/gridVirtualization.ts`.
+  const virtualization = useMemo(
+    () => planGridVirtualization({ rowCount: gridRows.length, height, density }),
+    [gridRows.length, height, density],
+  );
+
   // --- Overlays -------------------------------------------------------------
 
   const slots = useMemo(
@@ -376,12 +398,16 @@ export function DesktopGridRenderer<Row>({
       */}
       <Box
         data-testid="datatable-scroll-container"
+        // Whether the grid's own row virtualization is live for this render.
+        // jsdom never lays out, so MUI X keeps it off in tests regardless —
+        // this attribute is how the DECISION stays assertable.
+        data-virtualized={virtualization.virtualized ? 'true' : 'false'}
         sx={{
           width: '100%',
           maxWidth: '100%',
           minWidth: 0,
           overflowX: 'auto',
-          ...(height != null ? { height } : {}),
+          ...(virtualization.height != null ? { height: virtualization.height } : {}),
         }}
       >
         <DataGrid
@@ -391,7 +417,7 @@ export function DesktopGridRenderer<Row>({
           loading={loading}
           density={density}
           aria-label={ariaLabel}
-          autoHeight={height == null}
+          autoHeight={virtualization.autoHeight}
           columnVisibilityModel={columnVisibilityModel}
           disableColumnFilter
           disableColumnMenu

--- a/apps/web/src/components/datatable/export/DataTableExportControl.tsx
+++ b/apps/web/src/components/datatable/export/DataTableExportControl.tsx
@@ -1,0 +1,319 @@
+/**
+ * DataTable — the CSV export control (issue #256, epic #238).
+ *
+ * Lives in the view bar next to the column picker and the density toggle, for
+ * the same reason those do (§7.4): its SHAPE is decided by the layout, not by
+ * how rows are presented.
+ *
+ * | layout    | surface                                                        |
+ * | --------- | -------------------------------------------------------------- |
+ * | `desktop` | an "Export" button — a menu when an all-rows fetch is supplied  |
+ * | `tablet`  | identical                                                       |
+ * | `mobile`  | a `MoreVert` **overflow menu** ("Table actions")                |
+ *
+ * The phone gets an overflow menu rather than a third button because the view
+ * bar there already holds "View" and the filter surface's "Filters"; a fourth
+ * labelled control at 360px is what pushes a row into a horizontal scroller.
+ *
+ * ## Two scopes, one of them optional
+ *
+ * - **Current page** — always available. Serializes the rows the table was
+ *   handed, which are already filtered/sorted/paginated by the server.
+ * - **All matching rows** — only when the page supplies `fetchAllRows`. The
+ *   component cannot know the endpoint, so it replays the page's OWN callback
+ *   with the page's OWN active filters, bounded at
+ *   {@link DATA_TABLE_EXPORT_MAX_ROWS} and cancellable.
+ *
+ * Neither scope ever re-queries with elevated access: the second one is the
+ * first one's fetch, run more times.
+ *
+ * Touch rules (§8.5) apply as everywhere else: ≥44px, nothing hover-revealed,
+ * and the menu/dialog are mounted only while open.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  LinearProgress,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from '@mui/material';
+import {
+  Download as DownloadIcon,
+  MoreVert as MoreVertIcon,
+  TableRows as TableRowsIcon,
+  Storage as StorageIcon,
+} from '@mui/icons-material';
+import type { DataTableColumn, DataTableExportConfig, DataTableLayout } from '../types';
+import {
+  DATA_TABLE_EXPORT_MAX_ROWS,
+  ExportCancelledError,
+  buildCsvForRows,
+  collectAllRows,
+  downloadCsv,
+  exportFilename,
+} from './exportModel';
+
+/** Every control here clears the 44px touch floor. */
+const TOUCH_TARGET = { minWidth: 44, minHeight: 44 } as const;
+
+type ExportPhase = 'running' | 'done' | 'error' | 'cancelled';
+
+interface ExportProgress {
+  phase: ExportPhase;
+  fetched: number;
+  capped: boolean;
+  error?: string;
+}
+
+export interface DataTableExportControlProps<Row> {
+  layout: DataTableLayout;
+  columns: DataTableColumn<Row>[];
+  /** The currently loaded page of rows. */
+  rows: Row[];
+  /** The user's resolved column visibility (#255), layout-independent. */
+  visibleColumnIds?: ReadonlySet<string>;
+  config?: DataTableExportConfig<Row>;
+  /** Seed for the download filename — the page's `tableId` or `ariaLabel`. */
+  filenameBase?: string;
+  /** Total matching rows, when the page knows it. Drives the progress bar. */
+  total?: number;
+}
+
+export function DataTableExportControl<Row>({
+  layout,
+  columns,
+  rows,
+  visibleColumnIds,
+  config,
+  filenameBase,
+  total,
+}: DataTableExportControlProps<Row>) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [progress, setProgress] = useState<ExportProgress | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchAllRows = config?.fetchAllRows;
+  const maxRows = config?.maxRows ?? DATA_TABLE_EXPORT_MAX_ROWS;
+  const fetchPageSize = config?.fetchPageSize;
+  const nameSeed = config?.filename ?? filenameBase;
+  const filename = useCallback(() => exportFilename(nameSeed), [nameSeed]);
+
+  const nothingToExport = rows.length === 0 && !fetchAllRows;
+  const closeMenu = () => setAnchorEl(null);
+
+  const exportCurrentPage = useCallback(() => {
+    closeMenu();
+    downloadCsv(buildCsvForRows(columns, rows, visibleColumnIds), filename());
+  }, [columns, rows, visibleColumnIds, filename]);
+
+  const exportAllRows = useCallback(async () => {
+    closeMenu();
+    if (!fetchAllRows) return;
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setProgress({ phase: 'running', fetched: 0, capped: false });
+
+    try {
+      const { rows: all, capped } = await collectAllRows<Row>({
+        fetchPage: fetchAllRows,
+        pageSize: fetchPageSize,
+        maxRows,
+        signal: controller.signal,
+        onProgress: (fetched) =>
+          setProgress((current) =>
+            current?.phase === 'running' ? { ...current, fetched } : current,
+          ),
+      });
+
+      downloadCsv(buildCsvForRows(columns, all, visibleColumnIds), filename());
+
+      // A clean, complete export needs no acknowledgement — the file is the
+      // feedback. A capped one does: the user must know the CSV is a prefix.
+      if (capped) setProgress({ phase: 'done', fetched: all.length, capped: true });
+      else setProgress(null);
+    } catch (error) {
+      if (error instanceof ExportCancelledError || controller.signal.aborted) {
+        setProgress(null);
+        return;
+      }
+      setProgress({
+        phase: 'error',
+        fetched: 0,
+        capped: false,
+        error: error instanceof Error ? error.message : 'Export failed',
+      });
+    } finally {
+      abortRef.current = null;
+    }
+  }, [fetchAllRows, columns, visibleColumnIds, maxRows, fetchPageSize, filename]);
+
+  const cancelExport = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setProgress(null);
+  };
+
+  // With no all-rows callback there is exactly one thing to do, so the desktop
+  // button does it directly — a one-item menu is a click nobody needs.
+  const directExport = !fetchAllRows && layout !== 'mobile';
+
+  const trigger =
+    layout === 'mobile' ? (
+      <Tooltip title="Table actions">
+        <span>
+          <IconButton
+            size="small"
+            onClick={(event) => setAnchorEl(event.currentTarget)}
+            aria-haspopup="menu"
+            aria-expanded={Boolean(anchorEl)}
+            aria-label="Table actions"
+            data-testid="datatable-overflow-button"
+            disabled={nothingToExport}
+            sx={TOUCH_TARGET}
+          >
+            <MoreVertIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+    ) : (
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<DownloadIcon />}
+        onClick={(event) => (directExport ? exportCurrentPage() : setAnchorEl(event.currentTarget))}
+        {...(directExport
+          ? {}
+          : { 'aria-haspopup': 'menu' as const, 'aria-expanded': Boolean(anchorEl) })}
+        aria-label="Export CSV"
+        data-testid="datatable-export-button"
+        disabled={nothingToExport}
+        sx={{ minHeight: 44, flex: '0 0 auto' }}
+      >
+        Export
+      </Button>
+    );
+
+  return (
+    <>
+      {trigger}
+
+      {!directExport && (
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={closeMenu}
+          slotProps={{ list: { 'aria-label': 'Export options' } }}
+          data-testid="datatable-export-menu"
+        >
+          <MenuItem
+            onClick={exportCurrentPage}
+            disabled={rows.length === 0}
+            data-testid="datatable-export-current-page"
+            sx={{ minHeight: 44 }}
+          >
+            <ListItemIcon sx={{ minWidth: 36 }}>
+              <TableRowsIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Export current page (CSV)"
+              secondary={`${rows.length} ${rows.length === 1 ? 'row' : 'rows'}`}
+            />
+          </MenuItem>
+
+          {fetchAllRows && (
+            <MenuItem
+              onClick={exportAllRows}
+              data-testid="datatable-export-all-rows"
+              sx={{ minHeight: 44 }}
+            >
+              <ListItemIcon sx={{ minWidth: 36 }}>
+                <StorageIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText
+                primary="Export all matching rows (CSV)"
+                secondary={`up to ${maxRows.toLocaleString()} rows`}
+              />
+            </MenuItem>
+          )}
+        </Menu>
+      )}
+
+      {/* Progress / outcome. Only ever opened by the all-rows path: a
+          current-page export is synchronous and needs no dialog. */}
+      <Dialog
+        open={progress !== null}
+        onClose={progress?.phase === 'running' ? undefined : () => setProgress(null)}
+        aria-labelledby="datatable-export-progress-title"
+        data-testid="datatable-export-progress"
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle id="datatable-export-progress-title">
+          {progress?.phase === 'error' ? 'Export failed' : 'Exporting…'}
+        </DialogTitle>
+        <DialogContent>
+          {progress?.phase === 'running' && (
+            <>
+              <DialogContentText data-testid="datatable-export-progress-text">
+                {progress.fetched.toLocaleString()} rows fetched
+                {total ? ` of ${Math.min(total, maxRows).toLocaleString()}` : ''}…
+              </DialogContentText>
+              <LinearProgress
+                sx={{ mt: 2 }}
+                // Determinate only when the page told us the total; a fake
+                // percentage that jumps backwards is worse than a spinner.
+                {...(total
+                  ? {
+                      variant: 'determinate' as const,
+                      value: Math.min(
+                        100,
+                        Math.round((progress.fetched / Math.max(1, Math.min(total, maxRows))) * 100),
+                      ),
+                    }
+                  : { variant: 'indeterminate' as const })}
+                aria-label="Export progress"
+              />
+            </>
+          )}
+
+          {progress?.phase === 'done' && progress.capped && (
+            <Alert severity="warning" data-testid="datatable-export-capped">
+              This export stopped at the {maxRows.toLocaleString()}-row limit. The file contains the
+              first {progress.fetched.toLocaleString()} matching rows — narrow the filters to export
+              the rest.
+            </Alert>
+          )}
+
+          {progress?.phase === 'error' && (
+            <Alert severity="error" data-testid="datatable-export-error">
+              {progress.error}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          {progress?.phase === 'running' ? (
+            <Button onClick={cancelExport} sx={{ minHeight: 44 }}>
+              Cancel
+            </Button>
+          ) : (
+            <Button onClick={() => setProgress(null)} sx={{ minHeight: 44 }}>
+              Close
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/datatable/export/csv.ts
+++ b/apps/web/src/components/datatable/export/csv.ts
@@ -1,0 +1,134 @@
+/**
+ * DataTable — CSV serialization (issue #256, epic #238).
+ *
+ * The PURE half of export: scalars in, a CSV string out. Nothing here knows
+ * about columns, rows, React or the DOM, which is what makes the escaping rules
+ * testable as arithmetic rather than through a rendered table.
+ *
+ * Three rules, and all three exist because a CSV is not just text — it is a
+ * file another program will open:
+ *
+ *  1. **RFC 4180 quoting.** A field containing a comma, a double quote, a CR or
+ *     an LF is wrapped in double quotes with internal quotes doubled. Rows are
+ *     separated by CRLF, which is what the RFC specifies and what Excel expects.
+ *  2. **Formula-injection neutralization.** A cell whose text starts with `=`,
+ *     `+`, `-`, `@` (or a leading tab / CR, which some spreadsheets strip before
+ *     parsing) is executable the moment the file is opened in Excel, Sheets or
+ *     LibreOffice — `=cmd|'/c calc'!A1` is the classic proof. Those fields get a
+ *     leading apostrophe, the one prefix every major spreadsheet treats as
+ *     "this is literal text". See OWASP "CSV Injection".
+ *  3. **A UTF-8 BOM.** Excel on Windows reads a BOM-less UTF-8 CSV as the local
+ *     ANSI code page, so `José` opens as `JosÃ©`. Three bytes fix it, and every
+ *     other consumer skips them.
+ *
+ * ### Why numbers are exempt from rule 2
+ *
+ * Neutralizing blindly would turn the number `-5` into the text `'-5`, breaking
+ * every numeric column that can go negative — a real regression traded for a
+ * theoretical attack, since `-5` is not a formula. So the prefix is applied only
+ * to text that is not a well-formed number. A genuinely dangerous cell
+ * (`-1+cmd|…`) does not parse as a number and is still neutralized.
+ */
+
+/**
+ * The UTF-8 byte-order mark, as a JS string.
+ *
+ * Prepended to the *file*, never to a field: `toCsv` deliberately returns
+ * BOM-less text so it can be composed, and {@link toCsvFile} is the thing that
+ * gets written to disk.
+ */
+export const CSV_BOM = '\uFEFF';
+
+/** RFC 4180 row separator. Excel is the reason this is CRLF and not `\n`. */
+export const CSV_ROW_SEPARATOR = '\r\n';
+
+/** RFC 4180 field separator. */
+export const CSV_FIELD_SEPARATOR = ',';
+
+/**
+ * The characters that make a leading position dangerous.
+ *
+ * `=`, `+`, `-` and `@` start a formula in Excel / Sheets / LibreOffice. Tab and
+ * CR are here because some spreadsheets strip leading whitespace *before*
+ * deciding whether a cell is a formula, so `\t=1+1` is `=1+1`.
+ */
+export const CSV_FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r'] as const;
+
+/** The prefix that forces a spreadsheet to treat a cell as literal text. */
+export const CSV_FORMULA_ESCAPE = "'";
+
+/** Anything a spreadsheet would read as a number, and therefore never a formula. */
+const NUMERIC_TEXT = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+/** Characters that force a field to be quoted. */
+const MUST_QUOTE = /["\r\n,]/;
+
+/**
+ * Whether a raw string would be interpreted as a formula by a spreadsheet.
+ *
+ * Exported because "is this dangerous" is a question worth asserting directly,
+ * separately from what the escaper then does about it.
+ */
+export function isFormulaText(text: string): boolean {
+  if (text.length === 0) return false;
+  if (!(CSV_FORMULA_PREFIXES as readonly string[]).includes(text[0])) return false;
+  // `-5` / `+1.5e3` are numbers, not formulas. Neutralizing them would corrupt
+  // every numeric column that can go negative.
+  return !NUMERIC_TEXT.test(text);
+}
+
+/** Prefix a formula-shaped field so it opens as literal text. */
+export function neutralizeFormula(text: string): string {
+  return isFormulaText(text) ? `${CSV_FORMULA_ESCAPE}${text}` : text;
+}
+
+/**
+ * One scalar → one fully escaped CSV field.
+ *
+ * `null` / `undefined` become an EMPTY field, not `—`: the em dash is a display
+ * convention for a human reading a table (`formatColumnValue`), and writing it
+ * into a CSV would turn "no value" into the literal three-byte string a
+ * downstream import would then have to know about.
+ *
+ * Numbers are stringified and never neutralized (see the module note).
+ */
+export function escapeCsvField(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '';
+
+  const text = typeof value === 'number' ? String(value) : neutralizeFormula(value);
+
+  // Leading/trailing whitespace is quoted too: it is semantically meaningful and
+  // several parsers trim unquoted fields.
+  const needsQuotes = MUST_QUOTE.test(text) || text !== text.trim();
+  if (!needsQuotes) return text;
+
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+/** One record → one CSV line (no trailing separator). */
+export function toCsvRow(fields: readonly (string | number | null | undefined)[]): string {
+  return fields.map(escapeCsvField).join(CSV_FIELD_SEPARATOR);
+}
+
+/**
+ * A header row plus body rows → CSV text, WITHOUT the BOM.
+ *
+ * A trailing CRLF is emitted after the final record (RFC 4180 permits it and
+ * POSIX tools expect a final line terminator) whenever there is at least one
+ * row of content.
+ */
+export function toCsv(
+  header: readonly string[],
+  body: readonly (readonly (string | number | null | undefined)[])[],
+): string {
+  const lines = [toCsvRow(header), ...body.map((row) => toCsvRow(row))];
+  return `${lines.join(CSV_ROW_SEPARATOR)}${CSV_ROW_SEPARATOR}`;
+}
+
+/** {@link toCsv} plus the UTF-8 BOM — i.e. the exact bytes written to disk. */
+export function toCsvFile(
+  header: readonly string[],
+  body: readonly (readonly (string | number | null | undefined)[])[],
+): string {
+  return `${CSV_BOM}${toCsv(header, body)}`;
+}

--- a/apps/web/src/components/datatable/export/exportModel.ts
+++ b/apps/web/src/components/datatable/export/exportModel.ts
@@ -1,0 +1,271 @@
+/**
+ * DataTable — export model (issue #256, epic #238).
+ *
+ * Turns "this table, as the user is currently looking at it" into a CSV file.
+ * Built entirely against the COLUMN CONTRACT (`types.ts`), never against
+ * DataGrid: `GridToolbarExport` would serialize the grid's own rows, which
+ * exist in one renderer out of two and would silently produce a different file
+ * on a phone. One code path serves all three layouts.
+ *
+ * ## The three rules that make an export trustworthy
+ *
+ * 1. **`value`, never `render`.** A column whose cell is a `<Chip>` exports the
+ *    scalar behind the chip. Serializing a ReactNode is either impossible or
+ *    (worse) accidentally lossy — `[object Object]`, or the chip's label
+ *    without its meaning. This is the whole reason `render` and `value` are two
+ *    fields in the contract (§4).
+ * 2. **Only what is on screen.** The columns are the ones the user currently has
+ *    visible (#255), minus any column declaring `exportable: false`.
+ * 3. **Only what the API already returned.** The export never re-queries with
+ *    elevated access, and never reaches for a field the table was not handed.
+ *    "Current page" serializes the loaded rows; "all matching rows" replays the
+ *    page's OWN fetch callback, so it is subject to exactly the same
+ *    authorization and the same active filters as the table itself.
+ */
+
+import type { DataTableColumn, DataTableExportFetchPage } from '../types';
+import { extractColumnValue } from '../desktop/columnAdapter';
+import { toCsvFile } from './csv';
+
+// ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard ceiling on an "all matching rows" export.
+ *
+ * A bound, not a preference: without one, a single click against a 150 000-item
+ * library issues 1 500 requests and builds a ~100 MB string in a tab that then
+ * dies. 10 000 rows is far past any spreadsheet anyone actually reads and still
+ * finishes in seconds.
+ */
+export const DATA_TABLE_EXPORT_MAX_ROWS = 10_000;
+
+/**
+ * Page size used when replaying the page's fetch callback.
+ *
+ * Deliberately larger than any UI page size (the fetch is headless, so the MIT
+ * DataGrid's 100-row page cap does not apply here) and small enough that the
+ * progress indicator moves and a cancel lands promptly.
+ */
+export const DATA_TABLE_EXPORT_FETCH_PAGE_SIZE = 250;
+
+/** Guard against a callback that keeps returning rows forever. */
+const MAX_FETCH_PAGES = 200;
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a column may appear in an export at all.
+ *
+ * Defaults to `true`: most columns carry a scalar and a table that silently
+ * dropped columns from its CSV would be worse than one that exports an empty
+ * cell. `exportable: false` is the opt-out, and it is what #259/#260 will set on
+ * share tokens and PAT material so a credential can never leave through this
+ * door.
+ */
+export function isExportableColumn<Row>(column: DataTableColumn<Row>): boolean {
+  return column.exportable !== false;
+}
+
+/**
+ * The columns an export writes, in declaration order.
+ *
+ * `visibleColumnIds` is the USER's resolved visibility (#255) — deliberately
+ * layout-independent. A `detail` column folded into the tablet row expander is
+ * still shown to the user, just somewhere else, so the CSV must not change
+ * because the window happens to be 900px wide today and 1400px tomorrow. A
+ * column the user actually unchecked is a different thing, and is excluded.
+ *
+ * Omitting `visibleColumnIds` means "nothing is hidden" — what a caller outside
+ * `DataTable` gets.
+ */
+export function exportColumns<Row>(
+  columns: DataTableColumn<Row>[],
+  visibleColumnIds?: ReadonlySet<string>,
+): DataTableColumn<Row>[] {
+  return columns.filter(
+    (column) =>
+      isExportableColumn(column) && (!visibleColumnIds || visibleColumnIds.has(column.id)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rows → matrix → file
+// ---------------------------------------------------------------------------
+
+/** A header row plus one array of scalars per row, ready for serialization. */
+export interface ExportMatrix {
+  header: string[];
+  body: (string | number | null)[][];
+}
+
+/**
+ * Build the scalar matrix for a set of rows.
+ *
+ * `extractColumnValue` is the same extractor the grid's `valueGetter` and the
+ * card's field text use, so a CSV cell can never disagree with what the table
+ * sorted or displayed for that column.
+ */
+export function buildExportMatrix<Row>(
+  columns: DataTableColumn<Row>[],
+  rows: readonly Row[],
+): ExportMatrix {
+  return {
+    header: columns.map((column) => column.label),
+    body: rows.map((row) => columns.map((column) => extractColumnValue(column, row))),
+  };
+}
+
+/** The complete CSV file text (BOM included) for a set of rows. */
+export function buildCsvForRows<Row>(
+  columns: DataTableColumn<Row>[],
+  rows: readonly Row[],
+  visibleColumnIds?: ReadonlySet<string>,
+): string {
+  const cols = exportColumns(columns, visibleColumnIds);
+  const { header, body } = buildExportMatrix(cols, rows);
+  return toCsvFile(header, body);
+}
+
+// ---------------------------------------------------------------------------
+// Filename
+// ---------------------------------------------------------------------------
+
+/** `Enrichment jobs` → `enrichment-jobs`. Empty input falls back to `export`. */
+export function slugifyExportName(name: string | undefined | null): string {
+  const slug = (name ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return slug.length > 0 ? slug : 'export';
+}
+
+/**
+ * `jobs-2026-08-05.csv`.
+ *
+ * Dated because an export is a snapshot: two files downloaded a week apart must
+ * not collide in a Downloads folder, and `jobs (3).csv` tells nobody anything.
+ */
+export function exportFilename(base: string | undefined | null, now: Date = new Date()): string {
+  const iso = Number.isNaN(now.getTime()) ? '' : `-${now.toISOString().slice(0, 10)}`;
+  return `${slugifyExportName(base)}${iso}.csv`;
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+/**
+ * Hand a CSV string to the browser as a file download.
+ *
+ * A Blob + object URL + synthetic anchor click, which is the only approach that
+ * works without a server round trip and without `data:` URI length limits.
+ * Returns `false` when the environment cannot do it (jsdom without a
+ * `createObjectURL` stub, an ancient browser) rather than throwing — a failed
+ * download must not take a render down with it.
+ */
+export function downloadCsv(content: string, filename: string): boolean {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') return false;
+  if (typeof URL.createObjectURL !== 'function') return false;
+
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.rel = 'noopener';
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    return true;
+  } finally {
+    // Deferred: revoking synchronously can cancel the download in some browsers.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// "All matching rows" — replaying the page's own fetch
+// ---------------------------------------------------------------------------
+
+export interface CollectAllRowsOptions<Row> {
+  /** The page's own fetch callback. The component cannot know the endpoint. */
+  fetchPage: DataTableExportFetchPage<Row>;
+  /** Rows per request. Default {@link DATA_TABLE_EXPORT_FETCH_PAGE_SIZE}. */
+  pageSize?: number;
+  /** Hard ceiling. Default {@link DATA_TABLE_EXPORT_MAX_ROWS}. */
+  maxRows?: number;
+  /** Called after every page with the running total. */
+  onProgress?: (fetched: number) => void;
+  signal?: AbortSignal;
+}
+
+export interface CollectAllRowsResult<Row> {
+  rows: Row[];
+  /** `true` when the ceiling stopped the walk before the server ran out. */
+  capped: boolean;
+}
+
+/** Thrown when an in-flight export is cancelled by the user. */
+export class ExportCancelledError extends Error {
+  constructor() {
+    super('Export cancelled');
+    this.name = 'ExportCancelledError';
+  }
+}
+
+/**
+ * Walk the page's fetch callback until it runs dry or the ceiling is reached.
+ *
+ * Page numbers are ZERO-BASED, matching `DataTablePaginationConfig` — the owning
+ * page already converts at its own fetch boundary, and handing it a second
+ * convention here would guarantee an off-by-one nobody notices until row 251 is
+ * missing.
+ *
+ * Termination is defensive on purpose: a short page, an empty page, the row
+ * ceiling, or {@link MAX_FETCH_PAGES}, whichever comes first. A callback that
+ * ignores `page` and keeps returning the same full page would otherwise loop
+ * until the tab dies.
+ */
+export async function collectAllRows<Row>({
+  fetchPage,
+  pageSize = DATA_TABLE_EXPORT_FETCH_PAGE_SIZE,
+  maxRows = DATA_TABLE_EXPORT_MAX_ROWS,
+  onProgress,
+  signal,
+}: CollectAllRowsOptions<Row>): Promise<CollectAllRowsResult<Row>> {
+  const collected: Row[] = [];
+  let page = 0;
+  let capped = false;
+
+  while (page < MAX_FETCH_PAGES) {
+    if (signal?.aborted) throw new ExportCancelledError();
+
+    const batch = await fetchPage({ page, pageSize, signal });
+    if (signal?.aborted) throw new ExportCancelledError();
+
+    const rows = Array.isArray(batch) ? batch : [];
+    if (rows.length === 0) break;
+
+    for (const row of rows) {
+      if (collected.length >= maxRows) {
+        capped = true;
+        break;
+      }
+      collected.push(row);
+    }
+
+    onProgress?.(collected.length);
+
+    if (capped || rows.length < pageSize) break;
+    page += 1;
+  }
+
+  return { rows: collected, capped };
+}

--- a/apps/web/src/components/datatable/index.ts
+++ b/apps/web/src/components/datatable/index.ts
@@ -135,6 +135,63 @@ export type {
   DecodedVisibility,
 } from './layout/layoutModel';
 
+// --- CSV export (#256) -------------------------------------------------------
+export { DataTableExportControl } from './export/DataTableExportControl';
+export type { DataTableExportControlProps } from './export/DataTableExportControl';
+export {
+  CSV_BOM,
+  CSV_FIELD_SEPARATOR,
+  CSV_FORMULA_ESCAPE,
+  CSV_FORMULA_PREFIXES,
+  CSV_ROW_SEPARATOR,
+  escapeCsvField,
+  isFormulaText,
+  neutralizeFormula,
+  toCsv,
+  toCsvFile,
+  toCsvRow,
+} from './export/csv';
+export {
+  DATA_TABLE_EXPORT_FETCH_PAGE_SIZE,
+  DATA_TABLE_EXPORT_MAX_ROWS,
+  ExportCancelledError,
+  buildCsvForRows,
+  buildExportMatrix,
+  collectAllRows,
+  downloadCsv,
+  exportColumns,
+  exportFilename,
+  isExportableColumn,
+  slugifyExportName,
+} from './export/exportModel';
+export type {
+  CollectAllRowsOptions,
+  CollectAllRowsResult,
+  ExportMatrix,
+} from './export/exportModel';
+
+// --- Virtualization (#256) ---------------------------------------------------
+export {
+  GRID_CHROME_HEIGHT,
+  GRID_ROW_HEIGHT,
+  GRID_VIRTUALIZATION_ROW_THRESHOLD,
+  GRID_VIRTUALIZED_VISIBLE_ROWS,
+  planGridVirtualization,
+  virtualizedViewportHeight,
+} from './virtualization/gridVirtualization';
+export type {
+  GridVirtualizationInput,
+  GridVirtualizationPlan,
+} from './virtualization/gridVirtualization';
+export {
+  CARD_FALLBACK_INTRINSIC_HEIGHT,
+  CARD_VIRTUALIZATION_MIN_ROWS,
+  containIntrinsicSize,
+  shouldVirtualizeCards,
+  useLazyImages,
+  useMeasuredCardHeight,
+} from './virtualization/cardVirtualization';
+
 // --- Shared ------------------------------------------------------------------
 export { useRowActionConfirm, confirmCopy } from './shared/rowActionConfirm';
 
@@ -163,4 +220,6 @@ export type {
   DataTableFilterModel,
   DataTableFilterValue,
   DataTableQuickSearchConfig,
+  DataTableExportConfig,
+  DataTableExportFetchPage,
 } from './types';

--- a/apps/web/src/components/datatable/layout/DataTableViewBar.tsx
+++ b/apps/web/src/components/datatable/layout/DataTableViewBar.tsx
@@ -24,6 +24,7 @@
  */
 
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import {
   AppBar,
   Badge,
@@ -79,6 +80,15 @@ export interface DataTableViewBarProps<Row> {
   onToggleColumn: (columnId: string, visible: boolean) => void;
   onDensityChange: (density: DataTableDensity) => void;
   onReset: () => void;
+  /**
+   * Trailing slot, currently the CSV export control (#256).
+   *
+   * A node rather than a config object: the bar owns *placement* (this is the
+   * table's chrome row, and export belongs beside the column picker), while what
+   * export means — which rows, which columns, which fetch — belongs to
+   * `DataTableExportControl` and is none of this component's business.
+   */
+  trailing?: ReactNode;
 }
 
 export function DataTableViewBar<Row>({
@@ -89,6 +99,7 @@ export function DataTableViewBar<Row>({
   onToggleColumn,
   onDensityChange,
   onReset,
+  trailing,
 }: DataTableViewBarProps<Row>) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -277,6 +288,10 @@ export function DataTableViewBar<Row>({
           </Menu>
         </>
       )}
+
+      {/* Trailing slot: the export control, last in the chrome row on every
+          layout (a phone gets the overflow button next to "View"). */}
+      {trailing}
 
       {/* Phone: a real sheet, mirroring the filter sheet. */}
       {layout === 'mobile' && (

--- a/apps/web/src/components/datatable/mobile/CardListRenderer.tsx
+++ b/apps/web/src/components/datatable/mobile/CardListRenderer.tsx
@@ -32,6 +32,10 @@ import { DataCard } from './DataCard';
 import { CompactPagination } from './CompactPagination';
 import { CardSortControl } from './CardSortControl';
 import { cardDensityMetrics } from '../layout/layoutModel';
+import {
+  shouldVirtualizeCards,
+  useMeasuredCardHeight,
+} from '../virtualization/cardVirtualization';
 
 const EMPTY_SELECTION: ReadonlySet<string> = new Set<string>();
 
@@ -112,6 +116,15 @@ export function CardListRenderer<Row>({
 
   const selectedIdList = useMemo(() => Array.from(selectedIds), [selectedIds]);
 
+  // --- Render skipping (#256) -----------------------------------------------
+
+  // NOT a virtualizer: cards are variable-height and a wrong height estimate
+  // makes scrolling jump (issue #237), which is worse than rendering every card.
+  // Instead the browser is allowed to skip layout/paint for off-screen cards,
+  // with a placeholder height MEASURED from a real card in this very table.
+  const skipOffscreenCards = shouldVirtualizeCards(rows.length);
+  const { measureRef, height: measuredCardHeight } = useMeasuredCardHeight(skipOffscreenCards);
+
   // --- Render ---------------------------------------------------------------
 
   const showEmpty = !loading && rows.length === 0;
@@ -191,6 +204,12 @@ export function CardListRenderer<Row>({
                   rowActions={rowActions}
                   onRunAction={runAction}
                   density={density}
+                  // The first card is the one being measured, so it never skips
+                  // its own layout — and it is on screen by definition, so it
+                  // would gain nothing by doing so.
+                  measureRef={index === 0 ? measureRef : undefined}
+                  skipOffscreen={skipOffscreenCards && index > 0}
+                  intrinsicHeight={measuredCardHeight}
                 />
               );
             })}

--- a/apps/web/src/components/datatable/mobile/DataCard.tsx
+++ b/apps/web/src/components/datatable/mobile/DataCard.tsx
@@ -17,9 +17,15 @@
  * is hidden with `opacity: 0` while staying clickable. There are no
  * hover-revealed affordances on a card at all — a card list is a touch surface
  * first, and an invisible-but-tappable control is the exact bug #243 filed.
+ *
+ * Render skipping (#256): a long list lets the browser skip layout and paint for
+ * off-screen cards (`content-visibility: auto`) against a MEASURED placeholder
+ * height — deliberately not a windowing virtualizer, since a wrong height
+ * estimate makes scrolling jump (issue #237). See
+ * `virtualization/cardVirtualization.ts`.
  */
 
-import { useId, useState } from 'react';
+import { useCallback, useId, useRef, useState } from 'react';
 import {
   Box,
   Card,
@@ -38,6 +44,7 @@ import type { DataTableColumn, DataTableDensity, DataTableRowAction } from '../t
 import { RowActionsCell } from '../desktop/RowActionsCell';
 import { CardField, columnContent, columnText } from './CardField';
 import { cardDensityMetrics } from '../layout/layoutModel';
+import { containIntrinsicSize, useLazyImages } from '../virtualization/cardVirtualization';
 
 export interface DataCardProps<Row> {
   row: Row;
@@ -56,6 +63,20 @@ export interface DataCardProps<Row> {
    * it: 44px is a floor, not a style.
    */
   density?: DataTableDensity;
+  /**
+   * Let the browser skip layout/paint for this card while it is off screen
+   * (`content-visibility: auto`, #256). Never set on the measured card, and
+   * automatically suspended while the card's detail region is open — a card
+   * whose height is changing under the user's finger must stay fully rendered.
+   */
+  skipOffscreen?: boolean;
+  /**
+   * Placeholder height, in px, for a skipped card — MEASURED from a real card
+   * in this list rather than estimated from a column count (issue #237).
+   */
+  intrinsicHeight?: number | null;
+  /** Callback ref used by the card list to measure one representative card. */
+  measureRef?: (node: HTMLElement | null) => void;
 }
 
 export function DataCard<Row>({
@@ -70,10 +91,29 @@ export function DataCard<Row>({
   rowActions,
   onRunAction,
   density,
+  skipOffscreen = false,
+  intrinsicHeight,
+  measureRef,
 }: DataCardProps<Row>) {
   const [expanded, setExpanded] = useState(false);
   const detailRegionId = useId();
   const metrics = cardDensityMetrics(density);
+
+  // One ref, two jobs: annotating whatever a column's `render` produced with
+  // `loading="lazy"`, and (for the one card the list measures) reporting height.
+  const cardRef = useRef<HTMLElement | null>(null);
+  const setCardRef = useCallback(
+    (node: HTMLElement | null) => {
+      cardRef.current = node;
+      measureRef?.(node);
+    },
+    [measureRef],
+  );
+  useLazyImages(cardRef);
+
+  // An expanding card is changing height right now; skipping its layout is how
+  // a scroll position ends up somewhere the user did not put it.
+  const skipping = skipOffscreen && !expanded;
 
   const hasDetail = detailColumns.length > 0;
   const hasActions = Boolean(rowActions && rowActions.length > 0);
@@ -84,17 +124,29 @@ export function DataCard<Row>({
 
   return (
     <Card
+      ref={setCardRef}
       variant="outlined"
       component="li"
       data-testid="datatable-card"
       data-row-id={id}
       data-density={density ?? 'standard'}
       data-selected={selected ? 'true' : 'false'}
+      // Published as data attributes because jsdom's CSS parser drops
+      // `content-visibility` outright, so a computed-style assertion could not
+      // see it. These are the test hooks for the decision, not the styling.
+      data-skip-offscreen={skipping ? 'true' : 'false'}
+      data-intrinsic-height={skipping ? containIntrinsicSize(intrinsicHeight) : undefined}
       sx={{
         listStyle: 'none',
         minWidth: 0,
         maxWidth: '100%',
         overflow: 'hidden',
+        ...(skipping
+          ? {
+              contentVisibility: 'auto',
+              containIntrinsicSize: containIntrinsicSize(intrinsicHeight),
+            }
+          : {}),
         ...(selected
           ? {
               borderColor: 'primary.main',

--- a/apps/web/src/components/datatable/types.ts
+++ b/apps/web/src/components/datatable/types.ts
@@ -181,7 +181,15 @@ export interface DataTableColumn<Row> {
    */
   searchable?: boolean;
 
-  /** Reserved for #256 (export). Default `true` when a `value` extractor exists. */
+  /**
+   * Whether this column appears in a CSV export (#256). Default `true`.
+   *
+   * Export always writes the `value` scalar, never the rendered node, so a
+   * column with no usable scalar exports empty cells — declare `value`, or set
+   * this to `false`. `false` is also how a column carrying material that must
+   * never leave the app (a share token, personal-access-token material) is kept
+   * out of the file entirely.
+   */
   exportable?: boolean;
 
   /**
@@ -333,6 +341,50 @@ export interface DataTableQuickSearchConfig {
   ariaLabel?: string;
 }
 
+// ---------------------------------------------------------------------------
+// CSV export (#256)
+// ---------------------------------------------------------------------------
+
+/**
+ * The page's own fetch callback, replayed by the "all matching rows" export.
+ *
+ * The table cannot know the endpoint, the auth scheme, or how this page maps a
+ * filter model onto query params — so the WHOLE query is the page's. That is
+ * also the security property: an export can only ever return what this user's
+ * own list request already returns, with the active filters applied.
+ *
+ * `page` is ZERO-BASED, matching {@link DataTablePaginationConfig}. Return fewer
+ * rows than `pageSize` (or an empty array) to signal the end of the result set.
+ */
+export type DataTableExportFetchPage<Row> = (params: {
+  page: number;
+  pageSize: number;
+  signal?: AbortSignal;
+}) => Promise<Row[]>;
+
+/**
+ * Optional export configuration. Export itself needs no configuration: every
+ * table can export its current page out of the box (turn it off entirely with
+ * {@link DataTableProps.disableExport}).
+ */
+export interface DataTableExportConfig<Row> {
+  /**
+   * Filename stem, slugified and dated (`jobs` → `jobs-2026-08-05.csv`).
+   * Defaults to `tableId`, then `ariaLabel`, then `export`.
+   */
+  filename?: string;
+  /**
+   * Supplying this adds an "Export all matching rows" option that re-queries
+   * page by page with the active filters and sort. Omit it and the table offers
+   * current-page export only.
+   */
+  fetchAllRows?: DataTableExportFetchPage<Row>;
+  /** Hard row ceiling for an all-rows export. Default 10 000. */
+  maxRows?: number;
+  /** Rows per request while walking `fetchAllRows`. Default 250. */
+  fetchPageSize?: number;
+}
+
 /**
  * Controlled selection.
  *
@@ -409,6 +461,22 @@ export interface DataTableProps<Row> {
   bulkActions?: DataTableBulkAction[];
 
   /**
+   * CSV export options (#256). Optional: every table can already export its
+   * current page. Supply this to name the file, or to add the "all matching
+   * rows" option by handing the table the page's own fetch callback.
+   */
+  csvExport?: DataTableExportConfig<Row>;
+
+  /**
+   * Removes the export control from every layout.
+   *
+   * For a table that owns a bespoke export/import of its own (the Tags page's
+   * CSV vocabulary round trip, #259) — two export buttons offering different
+   * files is worse than one.
+   */
+  disableExport?: boolean;
+
+  /**
    * Stable identity of THIS table instance, e.g. `'jobs'`, `'admin-shares'`.
    *
    * Supplying it turns on per-user layout persistence: column visibility,
@@ -482,6 +550,11 @@ export type DataTableRendererProps<Row> = Omit<
   | 'onFiltersChange'
   | 'quickSearch'
   | 'tableId'
+  // Export is drawn once by `DataTable`, in the view bar, for the same reason
+  // the filter bar is: its shape is a layout decision, not a row-presentation
+  // one, and one code path must serve every renderer (#256).
+  | 'csvExport'
+  | 'disableExport'
 > & {
   /**
    * The USER's resolved column-visibility choice (#255) — layout-independent,

--- a/apps/web/src/components/datatable/virtualization/cardVirtualization.ts
+++ b/apps/web/src/components/datatable/virtualization/cardVirtualization.ts
@@ -1,0 +1,145 @@
+/**
+ * DataTable — card-list render skipping (issue #256, epic #238).
+ *
+ * ## What this is, and what it deliberately is not
+ *
+ * Cards are variable height: a card's body grows with its `secondary` column
+ * count and its detail region expands in place. A windowing virtualizer needs a
+ * height estimate per item, and a WRONG estimate is not a small inefficiency —
+ * it is a scroll position that jumps under the user's thumb. Issue #237 is that
+ * bug, shipped: a gallery placeholder computed for the wrong column count made
+ * scrolling jump. An incorrect virtualizer is worse than none.
+ *
+ * So this is not a virtualizer. It is the browser's own render-skipping:
+ *
+ * - **`content-visibility: auto`** lets the engine skip layout, paint and style
+ *   for a card that is outside the viewport, and un-skip it when it approaches.
+ *   Unlike `display: none` the subtree stays focusable and find-in-page-able —
+ *   the browser force-renders it when focus or a find lands inside — so
+ *   keyboard navigation and Ctrl-F are unaffected.
+ * - **`contain-intrinsic-size: auto <measured>px`** supplies the placeholder
+ *   height while a card is skipped. The `auto` keyword makes the browser
+ *   remember each card's LAST RENDERED size and prefer it over the estimate, so
+ *   the estimate only ever has to be right for cards that have never been on
+ *   screen — and it is a *measurement* of a real card in this table, not a
+ *   guess derived from a column count.
+ * - **`loading="lazy"` on card images**, applied to whatever a column's `render`
+ *   produced. A card list of thumbnails otherwise fetches every image on the
+ *   page at once.
+ *
+ * ## Why the first card is excluded
+ *
+ * It is the one being measured. A card that may skip its own layout is a card
+ * whose `getBoundingClientRect()` can legitimately report the placeholder size,
+ * which would feed the measurement back into itself. The first card is on screen
+ * by definition, so skipping it would buy nothing anyway.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Rows below which nothing is applied.
+ *
+ * `content-visibility` costs a containment context per card; below ~20 cards
+ * there is nothing to skip and the plain list is both simpler and faster.
+ */
+export const CARD_VIRTUALIZATION_MIN_ROWS = 20;
+
+/**
+ * Placeholder height used until a real card has been measured, in px.
+ *
+ * Only ever visible for the frames between mount and the first measurement, and
+ * only for cards that are already off screen.
+ */
+export const CARD_FALLBACK_INTRINSIC_HEIGHT = 168;
+
+/** Re-measure only past this delta, so a 1px reflow cannot loop the state. */
+const MEASURE_EPSILON_PX = 4;
+
+/** Whether a card list of this size is worth skipping renders for. */
+export function shouldVirtualizeCards(
+  rowCount: number,
+  minRows: number = CARD_VIRTUALIZATION_MIN_ROWS,
+): boolean {
+  return rowCount >= minRows;
+}
+
+/**
+ * The `contain-intrinsic-size` value for a measured card height.
+ *
+ * `auto <length>` rather than a bare length: the browser then remembers each
+ * card's real rendered size and uses the length only for cards it has never
+ * laid out. That is what keeps the scrollbar honest as the user scrolls through
+ * cards of genuinely different heights.
+ */
+export function containIntrinsicSize(height: number | null | undefined): string {
+  const px = Math.max(1, Math.round(height ?? CARD_FALLBACK_INTRINSIC_HEIGHT));
+  return `auto ${px}px`;
+}
+
+/**
+ * Measure one real card and report its height.
+ *
+ * A callback ref plus a `ResizeObserver`, so a card that reflows (a wider
+ * container, a density change, a longer value) updates the placeholder instead
+ * of pinning it to the first paint.
+ */
+export function useMeasuredCardHeight(enabled: boolean): {
+  measureRef: (node: HTMLElement | null) => void;
+  height: number | null;
+} {
+  const [height, setHeight] = useState<number | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const record = useCallback((next: number) => {
+    if (!Number.isFinite(next) || next <= 0) return;
+    setHeight((current) =>
+      current !== null && Math.abs(current - next) < MEASURE_EPSILON_PX ? current : next,
+    );
+  }, []);
+
+  const measureRef = useCallback(
+    (node: HTMLElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (!node || !enabled) return;
+
+      record(node.getBoundingClientRect().height);
+
+      if (typeof ResizeObserver === 'undefined') return;
+      const observer = new ResizeObserver((entries) => {
+        for (const entry of entries) record(entry.contentRect.height);
+      });
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [enabled, record],
+  );
+
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  return { measureRef, height: enabled ? height : null };
+}
+
+/**
+ * Mark every image inside a subtree lazy, unless the author already said
+ * otherwise.
+ *
+ * A column's `render` is used verbatim (§3) and belongs to the calling page, so
+ * the card cannot rewrite it — but it can annotate what that render produced.
+ * An explicit `loading` attribute is never overwritten: a page that deliberately
+ * wrote `loading="eager"` on an above-the-fold thumbnail keeps it.
+ */
+export function useLazyImages(
+  ref: { current: HTMLElement | null },
+  enabled: boolean = true,
+): void {
+  useEffect(() => {
+    const root = ref.current;
+    if (!enabled || !root) return;
+    for (const image of Array.from(root.querySelectorAll('img'))) {
+      if (!image.hasAttribute('loading')) image.setAttribute('loading', 'lazy');
+      if (!image.hasAttribute('decoding')) image.setAttribute('decoding', 'async');
+    }
+  });
+}

--- a/apps/web/src/components/datatable/virtualization/gridVirtualization.ts
+++ b/apps/web/src/components/datatable/virtualization/gridVirtualization.ts
@@ -1,0 +1,121 @@
+/**
+ * DataTable — grid row virtualization (issue #256, epic #238).
+ *
+ * MUI X's DataGrid virtualizes rows out of the box, but with ONE precondition
+ * that is easy to miss and that this table tripped over from #252 onward:
+ *
+ * ```js
+ * // @mui/x-data-grid/hooks/features/virtualization/useGridVirtualization.js
+ * enabledForRows: !disableVirtualization && !autoHeight && HAS_LAYOUT
+ * ```
+ *
+ * `autoHeight` **disables row virtualization**, and `autoHeight` is exactly what
+ * this renderer uses whenever the caller omits `height` (the documented default,
+ * §5: the table grows with its rows and the PAGE scrolls). So the default table
+ * was rendering every loaded row, virtualizer or not.
+ *
+ * The fix is not "always take a fixed height" — auto-height is the right
+ * behaviour for a 10- or 25-row page and turning every table into an internally
+ * scrolling box would be a worse regression than the one being fixed. It is a
+ * threshold: past {@link GRID_VIRTUALIZATION_ROW_THRESHOLD} loaded rows the grid
+ * takes a bounded viewport, which is precisely the condition under which
+ * virtualization pays for itself.
+ *
+ * ## Scale, honestly stated
+ *
+ * Every target table is server-paginated, and the MIT DataGrid throws above a
+ * 100-row page, so the realistic worst case is 100 rows plus a few synthetic
+ * tablet detail rows (§9.1). This is **robustness for large page sizes**, not
+ * the performance strategy — the performance strategy is server-side
+ * pagination, and it already shipped in #252.
+ *
+ * Nothing here needs a custom virtualizer. `disableVirtualization` is left at
+ * its default (`false`) and the grid's own row/column windowing does the work;
+ * this module only decides whether the grid is *allowed* to use it.
+ *
+ * (In jsdom `HAS_LAYOUT` is false, so virtualization is off in tests no matter
+ * what — which is why the tests assert the *plan* and assert that selection is
+ * row-set-derived rather than DOM-derived.)
+ */
+
+import type { DataTableDensity } from '../types';
+
+/**
+ * Loaded-row count above which the grid swaps auto-height for a bounded,
+ * virtualizing viewport.
+ *
+ * 50 sits between the two page sizes that matter: the default 25-row page keeps
+ * growing naturally, a 100-row page virtualizes.
+ */
+export const GRID_VIRTUALIZATION_ROW_THRESHOLD = 50;
+
+/** Rows visible at once in a virtualized viewport, before scrolling. */
+export const GRID_VIRTUALIZED_VISIBLE_ROWS = 12;
+
+/** MUI X row heights per density preset, in px. */
+export const GRID_ROW_HEIGHT: Record<DataTableDensity, number> = {
+  compact: 36,
+  standard: 52,
+  comfortable: 67,
+};
+
+/** Column header (56px) + footer (53px) — the chrome a viewport must also fit. */
+export const GRID_CHROME_HEIGHT = 109;
+
+/** The height a virtualized viewport takes when the caller supplied none. */
+export function virtualizedViewportHeight(
+  density: DataTableDensity,
+  rowCount: number,
+  visibleRows: number = GRID_VIRTUALIZED_VISIBLE_ROWS,
+): number {
+  const rowHeight = GRID_ROW_HEIGHT[density] ?? GRID_ROW_HEIGHT.standard;
+  return Math.min(rowCount, visibleRows) * rowHeight + GRID_CHROME_HEIGHT;
+}
+
+export interface GridVirtualizationPlan {
+  /** Whether DataGrid's row virtualization is enabled for this render. */
+  virtualized: boolean;
+  /** What to pass as the grid's `autoHeight`. */
+  autoHeight: boolean;
+  /** Height for the scroll container, or `undefined` for auto-height. */
+  height: number | string | undefined;
+}
+
+export interface GridVirtualizationInput {
+  /** Rows handed to the grid, INCLUDING any synthetic tablet detail rows. */
+  rowCount: number;
+  /** The caller's explicit `height` prop, if any. */
+  height?: number | string;
+  density: DataTableDensity;
+  /** Override for tests / unusual hosts. */
+  threshold?: number;
+}
+
+/**
+ * Decide how this render sizes itself, and therefore whether rows virtualize.
+ *
+ * Three cases:
+ *
+ * 1. **An explicit `height`** — the caller already asked for an internally
+ *    scrolling body, so virtualization is on and nothing is overridden.
+ * 2. **More loaded rows than the threshold** — auto-height is dropped in favour
+ *    of a computed viewport so the grid may virtualize.
+ * 3. **Anything else** — auto-height, unchanged from #252. The table grows with
+ *    its rows and the page scrolls.
+ */
+export function planGridVirtualization({
+  rowCount,
+  height,
+  density,
+  threshold = GRID_VIRTUALIZATION_ROW_THRESHOLD,
+}: GridVirtualizationInput): GridVirtualizationPlan {
+  if (height != null) return { virtualized: true, autoHeight: false, height };
+  if (rowCount > threshold) {
+    return {
+      virtualized: true,
+      autoHeight: false,
+      height: virtualizedViewportHeight(density, rowCount),
+    };
+  }
+  return { virtualized: false, autoHeight: true, height: undefined };
+}

--- a/docs/specs/datatable.md
+++ b/docs/specs/datatable.md
@@ -2,8 +2,8 @@
 
 **Status:** foundation shipped (issue #252); mobile + tablet layouts shipped
 (issue #253); filtering + quick search shipped (issue #254); column visibility,
-density and per-user layout persistence shipped (issue #255, §14–§15) — all of
-epic #238
+density and per-user layout persistence shipped (issue #255, §14–§15); row
+virtualization + CSV export shipped (issue #256, §16) — all of epic #238
 **Location:** `apps/web/src/components/datatable/`,
 `apps/api/src/common/schemas/settings.schema.ts` (persistence schema)
 **Spec owner:** frontend
@@ -32,23 +32,20 @@ The contract lives in `types.ts` and is intentionally free of any DataGrid type.
 
 ### Scope of this document
 
-This spec documents the contract as of #254. Fields that exist in the contract
-but are **not yet consumed** are marked *reserved* and name the issue that will
-consume them, so column authors can declare them today without churn later:
-
-| Field / concept              | Consumed by                            |
-| ---------------------------- | -------------------------------------- |
-| `exportable`                 | #256 — CSV/export + virtualization     |
+This spec documents the contract as of #256. **Every field in the contract is
+now live** — nothing is reserved any more.
 
 §14 documents the storage contract for #255 (what the API accepts and how it
 merges); §15 documents the client half (the `tableId` prop, the picker and
-density surfaces, the resolution rules, and the write discipline).
+density surfaces, the resolution rules, and the write discipline); §16 documents
+virtualization and CSV export (#256), including what was deliberately *not*
+built.
 
-Everything else on this page is live behaviour today. `priority` is fully
-consumed: it drives column visibility on the grid *and* the card's
-headline/body/detail split (§3). `filterable` is now live too, together with
-its three companions `filterType`, `enumValues` and `searchable` (§10), and
-`hideable` is now consumed by the column picker (§15.2).
+`priority` drives column visibility on the grid *and* the card's
+headline/body/detail split (§3). `filterable` is live together with its three
+companions `filterType`, `enumValues` and `searchable` (§10), `hideable` is
+consumed by the column picker (§15.2), and `exportable` is consumed by the CSV
+writer (§16.4).
 
 ---
 
@@ -72,7 +69,14 @@ apps/web/src/components/datatable/
   layout/
     layoutModel.ts                # stored shape, encoding, resolution (pure)
     useDataTableLayoutPrefs.ts    # load / debounced fire-and-forget write
-    DataTableViewBar.tsx          # column picker + density — one shape per layout
+    DataTableViewBar.tsx          # column picker + density (+ export slot)
+  export/
+    csv.ts                        # escaping, formula neutralization, BOM (pure)
+    exportModel.ts                # columns -> matrix -> file; the all-rows walk
+    DataTableExportControl.tsx    # the control — one shape per layout
+  virtualization/
+    gridVirtualization.ts         # autoHeight-vs-viewport decision (pure)
+    cardVirtualization.ts         # content-visibility + measured placeholders
   shared/
     rowActionConfirm.tsx          # one confirm dialog, shared by both renderers
   desktop/
@@ -91,6 +95,7 @@ apps/web/src/components/datatable/
   __tests__/ResponsiveDataTable.test.tsx  # #253 layouts
   __tests__/DataTableFilters.test.tsx     # #254 filtering + quick search
   __tests__/DataTableLayoutPrefs.test.tsx # #255 visibility / density / persistence
+  __tests__/DataTableExport.test.tsx      # #256 CSV export + virtualization
 ```
 
 Consumers import from `components/datatable` only. `desktop/`, `mobile/`,
@@ -270,10 +275,13 @@ this field documents *which* columns the endpoint's free-text param actually
 searches, and is what the default placeholder is built from
 (`"Search Type, Status or Last error"`). The table never searches rows.
 
-### `exportable` — *reserved (#256)*
+### `exportable`
 
-Defaults to `true` for any column with a usable scalar. Set `false` to keep a
-column out of CSV/export (e.g. a pure-affordance column).
+Default `true`. `false` keeps the column out of every CSV export — a
+pure-affordance column, or one carrying material that must never leave the app
+(a share token, PAT material). Export always writes the `value` scalar, never
+the rendered node, so a `render`-only column exports empty cells. Full contract:
+§16.4.
 
 ### `hideable`
 
@@ -323,6 +331,9 @@ interface DataTableProps<Row> {
   rowActions?: DataTableRowAction<Row>[];
   bulkActions?: DataTableBulkAction[];
 
+  csvExport?: DataTableExportConfig<Row>;  // filename / all-rows fetch (§16)
+  disableExport?: boolean;                 // removes the export control (§16.4)
+
   tableId?: string;            // turns on per-user layout persistence (§15)
   density?: DataTableDensity;  // 'compact' | 'standard' | 'comfortable'
   ariaLabel?: string;
@@ -343,6 +354,8 @@ interface DataTableProps<Row> {
 | `loading`    | Shows the loading overlay. Rows already present stay visible underneath, so a refetch doesn't blank the table. |
 | `error`      | Rendered as an `Alert severity="error"` **above** the table; the table still renders beneath it, so a stale page remains readable while the error is shown. |
 | `emptyState` | Any node; rendered by the no-rows overlay. Defaults to a plain "No results". |
+| `csvExport`  | Optional. Every table exports its current page without configuration; this names the file and/or adds the "all matching rows" option by handing the table the page's own fetch callback (§16.5). |
+| `disableExport` | Removes the export control from every layout. For a table that owns a bespoke export of its own — the Tags page's CSV vocabulary round trip (#259). |
 | `tableId`    | Stable id of this table instance. Supplying it persists the layout per user (§15); omitting it keeps every control working but session-scoped. |
 | `density`    | The page's **default** row-density preset, not a lock — a user's own choice overrides it. Maps onto DataGrid row density in the grid and onto card padding in the card list (§15.4). |
 | `ariaLabel`  | Accessible name of the grid. Strongly recommended — a table with no name is an unnavigable blob to a screen reader. |
@@ -1622,3 +1635,269 @@ multi-view model, no "save this view as…", and no sharing of a layout between
 users — a table stores exactly one layout per user, and "Reset to defaults" is
 the only other state it can be in. Adding named views later would be a new
 namespace beside `dataTables`, not a reinterpretation of it.
+
+---
+
+## 16. Row virtualization and CSV export (#256)
+
+Two features that share one property: both are about a table that has *more*
+than fits — more rows than a frame can paint, or more rows than a screen can be
+read from.
+
+### 16.1 The honest framing
+
+Every target table in this app is **server-paginated**, and the MIT DataGrid
+throws above a 100-row page (`pageSize` cannot exceed 100). So the realistic
+worst case a renderer ever holds is ~100 rows plus a handful of synthetic tablet
+detail rows (§9.1).
+
+Virtualization here is therefore **robustness for large page sizes, not the
+performance strategy.** The performance strategy is server-side pagination and
+it shipped in #252. This section says what is on per renderer, and — as
+importantly — what was deliberately not built.
+
+### 16.2 Desktop / tablet: DataGrid's own virtualizer, actually turned on
+
+MUI X virtualizes rows out of the box. It also silently stops doing so under one
+condition:
+
+```js
+// @mui/x-data-grid/hooks/features/virtualization/useGridVirtualization.js
+enabledForRows: !disableVirtualization && !autoHeight && HAS_LAYOUT
+```
+
+`autoHeight` **disables row virtualization** — and `autoHeight` is exactly what
+this renderer uses whenever the caller omits `height`, which is the documented
+default (§5: the table grows with its rows and the *page* scrolls). From #252
+until this issue, the default table therefore rendered every loaded row with the
+virtualizer inert.
+
+The fix is a threshold rather than a blanket "always take a fixed height", since
+auto-height is the right behaviour for a 10- or 25-row page and turning every
+table into an internally scrolling box would be a worse regression than the one
+being fixed. `virtualization/gridVirtualization.ts` decides per render:
+
+| Condition                          | `autoHeight` | Height                         | Virtualized |
+| ---------------------------------- | ------------ | ------------------------------ | ----------- |
+| explicit `height` prop             | `false`      | the caller's                   | yes         |
+| `rows.length > 50`                 | `false`      | computed viewport (12 rows)    | yes         |
+| anything else                      | `true`       | none — grows with its rows     | no          |
+
+The computed viewport is `min(rowCount, 12) × rowHeight(density) + 109px` of
+header/footer chrome, so a virtualized table is bounded but still shows a
+screenful. `disableVirtualization` is never passed (it stays `false`); this
+module only decides whether the grid is *allowed* to use what it already has.
+The decision is published as `data-virtualized` on
+`[data-testid="datatable-scroll-container"]`.
+
+Three things that had to keep working, and do:
+
+- **Server pagination.** `paginationMode="server"` still means the grid never
+  slices `rows`; virtualization changes which rows are *painted*, never which
+  rows exist.
+- **Synthetic detail rows (§9.1).** They are ordinary rows with a computed
+  height, so windowing treats them like any other; `isRowSelectable` still
+  rejects them, and a select-all over a virtualized tablet grid still yields
+  only real ids.
+- **Select-all.** It never reads the DOM. The renderer materialises MUI X's
+  *exclude* model against `rowIds` derived from the `rows` prop (§5.3), which is
+  precisely why windowing cannot corrupt it. There is a test asserting a 60-row
+  page selects 60 ids while `data-virtualized` is `true`.
+
+### 16.3 Mobile: render skipping, and NOT a virtualizer
+
+Cards are variable height — the body grows with the `secondary` column count and
+the detail region expands in place. A windowing virtualizer needs a height
+estimate per item, and a **wrong** estimate is not a small inefficiency; it is a
+scroll position that jumps under the user's thumb. Issue #237 is that bug,
+shipped: a gallery placeholder computed for the wrong column count made
+scrolling jump. An incorrect virtualizer is worse than none.
+
+So the card list does not virtualize. It uses the browser's own render
+skipping, which needs no correct estimate to be correct:
+
+- **`content-visibility: auto`** on each card past the 20-row mark lets the
+  engine skip style, layout and paint for off-screen cards. Unlike
+  `display: none`, the subtree stays focusable and find-in-page-able — the
+  browser force-renders it when focus or Ctrl-F lands inside — so keyboard
+  navigation is unaffected.
+- **`contain-intrinsic-size: auto <measured>px`** supplies the placeholder while
+  a card is skipped. Two deliberate details: the `auto` keyword makes the browser
+  prefer each card's own *last rendered* size, so the number only has to be right
+  for cards never yet seen; and the number is **measured from a real card in this
+  very list** (a callback ref plus a `ResizeObserver`), never computed from a
+  column count — which is the exact thing #237 got wrong.
+- **`loading="lazy"` / `decoding="async"`** are applied to `<img>` elements a
+  column's `render` produced. A column's render is used verbatim (§3) and belongs
+  to the calling page, so the card annotates rather than rewrites it, and an
+  explicit `loading` the page already wrote is never overridden.
+
+Two cards deliberately opt out: the **first** card (it is the one being measured,
+and it is on screen anyway) and any card whose **detail region is open** (a card
+whose height is changing under the user's finger must stay fully rendered).
+
+**Explicitly not built:** a true dynamic-height card virtualizer. It remains
+available as a follow-up if a card list ever holds thousands of rows — which,
+given server-side pagination, it currently cannot.
+
+### 16.4 CSV export — scope and contract
+
+**Ships here: "current page".** The rows the table is holding, with the columns
+the user currently has visible, respecting `exportable`, written from each
+column's `value` accessor. Available in **all three layouts**, and implemented
+against the column contract — *not* DataGrid's `GridToolbarExport`, which
+serializes the grid's own rows and therefore exists in one renderer out of two.
+One code path, one file, whatever width the window happens to be.
+
+Three rules decide what lands in the file:
+
+1. **`value`, never `render`.** A column whose cell is a `<Chip label="FAILED">`
+   exports `failed`. Serializing a `ReactNode` is either impossible or, worse,
+   accidentally lossy. This is what `render` and `value` being two fields (§4) is
+   *for*.
+2. **Only what is on screen.** The column set is the user's resolved visibility
+   (#255) minus `exportable: false`. Note this is the **user's** choice, which is
+   layout-independent — deliberately *not* the tablet's `detail` fold. A column
+   tucked into the row expander is still shown to the user, just elsewhere, and a
+   CSV that changed shape because the window is 900px wide today would be a
+   surprise, not a feature.
+3. **Only what the API already returned.** See §16.6.
+
+"Active filters" need no machinery: the table never filters `rows` (§10.1), so
+the loaded page already *is* the filtered result and exporting it is exporting
+the filtered set. The all-rows path (§16.5) inherits the same property by
+replaying the page's own query.
+
+`disableExport` removes the control from every layout. It exists for a table
+that already owns a bespoke export — the Tags page keeps its own CSV vocabulary
+import/export (#259), and two export buttons producing different files is worse
+than one.
+
+#### The surface, per layout
+
+| Layout    | Surface                                                              |
+| --------- | -------------------------------------------------------------------- |
+| `desktop` | An **"Export" button** in the view bar. One click, one file, when no all-rows callback is supplied — a one-item menu is a click nobody needs. |
+| `tablet`  | Identical.                                                            |
+| `mobile`  | A `MoreVert` **overflow menu** ("Table actions") beside "View". A fourth labelled control at 360px is what pushes the chrome row into a horizontal scroller. |
+
+It lives in `DataTableViewBar`'s trailing slot for the same reason the picker and
+the filter bar live there (§7.4): its *shape* is a layout decision, not a
+row-presentation one. Touch rules (§8.5) hold — ≥44px everywhere, nothing
+hover-revealed, and the menu and progress dialog are mounted only while open.
+
+#### Escaping rules
+
+`export/csv.ts`, pure and unit-tested:
+
+| Input                       | Output                    | Why |
+| --------------------------- | ------------------------- | --- |
+| `San José, Costa Rica`      | `"San José, Costa Rica"`  | RFC 4180 quoting |
+| `say "hi"`                  | `"say ""hi"""`            | internal quotes doubled |
+| `line one\nline two`        | `"line one\nline two"`    | embedded newline / CR |
+| `  padded  `                | `"  padded  "`            | several parsers trim unquoted fields |
+| `null` / `undefined`        | *(empty)*                 | never `—`; that em dash is a *display* convention (`formatColumnValue`) |
+| `=cmd\|'/c calc'!A1`        | `'=cmd\|'/c calc'!A1`     | formula injection |
+| `+1+1`, `-2+3+cmd`, `@SUM(…)` | `'…`                    | the other three prefixes |
+| `\t=1+1`, `\r=1+1`          | `'…`                      | some spreadsheets strip leading whitespace *before* deciding |
+| `-5` (number **or** string) | `-5`                      | see below |
+
+Records are joined with **CRLF** and the file is prefixed with a **UTF-8 BOM**
+(`U+FEFF`, `EF BB BF`) — without it, Excel on Windows reads UTF-8 as the local ANSI code
+page and `José` opens as `JosÃ©`. The BOM is a property of the *file*
+(`toCsvFile`), not of a field, so `toCsv` stays composable.
+
+**Why numbers are exempt from neutralization.** Prefixing blindly turns `-5`
+into the text `'-5` and breaks every numeric column that can go negative — a
+real regression traded for a non-attack, since `-5` is not a formula. The
+apostrophe is applied only to text that is not a well-formed number, so
+`-1+cmd|calc` is still neutralized while `-5` and `+1.5e3` are not.
+
+*(A test-harness note worth keeping: `Blob.text()` decodes UTF-8, and a UTF-8
+decode **strips** a leading BOM. The BOM has to be asserted on the bytes
+(`arrayBuffer()`), never on the decoded string.)*
+
+Files are named `<slug>-<YYYY-MM-DD>.csv` from `csvExport.filename`, else
+`tableId`, else `ariaLabel`, else `export`. An export is a snapshot; two of them
+a week apart must not collide in a Downloads folder.
+
+### 16.5 "All matching rows" — the page's query, replayed
+
+Shipped, as the issue's stretch goal, and **opt-in**: it appears only when the
+page hands the table a fetch callback, because the component cannot know the
+endpoint, the auth scheme, or how this page maps a filter model onto params.
+
+```tsx
+<DataTable
+  {...props}
+  csvExport={{
+    filename: 'jobs',
+    // page is ZERO-BASED, matching DataTablePaginationConfig.
+    fetchAllRows: ({ page, pageSize, signal }) =>
+      fetchJobs({ page: page + 1, pageSize, signal, ...toJobQuery(filters), q: search }),
+  }}
+/>
+```
+
+The walk is deliberately dull: request page 0, 1, 2… and stop at the first short
+or empty page. Termination is defensive on three axes — a short page, the row
+ceiling, and a 200-request hard stop — because a callback that ignores `page`
+and keeps returning a full page would otherwise loop until the tab dies.
+
+- **Bounded at 10 000 rows** (`csvExport.maxRows`). Not a preference: without it
+  one click against a 150 000-item library issues 1 500 requests and builds a
+  ~100 MB string. Hitting the ceiling is *reported* — a warning alert naming the
+  limit — rather than silently truncating, because a CSV that is quietly a prefix
+  is a wrong answer the user believes.
+- **250 rows per request** by default (`csvExport.fetchPageSize`). The fetch is
+  headless, so the DataGrid's 100-row page cap does not apply.
+- **A progress dialog with a Cancel**, determinate when `pagination.total` is
+  known and indeterminate when it is not — a fake percentage that jumps backwards
+  is worse than a spinner. Cancel aborts via `AbortSignal` and produces **no**
+  file; a clean, complete export shows no dialog at the end, because the file
+  is the feedback.
+- **A failed page produces no file at all**, with the error surfaced in the
+  dialog. Half an export that looks like a whole one is the worst outcome
+  available here.
+
+### 16.6 Security
+
+**Export never re-queries with elevated access.** It can only ever serialize what
+the API has already returned to this authenticated user:
+
+- current-page export reads the `rows` prop — data already on screen;
+- all-rows export replays the **page's own** callback, so it goes through the
+  same endpoint, the same token, the same RBAC checks and the same active filters
+  as the table itself. It is the first one's request, run more times.
+
+There is no privileged export path, no server-side "export everything" endpoint,
+and no field the table can reach that the list response did not contain.
+Sensitive columns are excluded declaratively with `exportable: false`; the
+migration issues (#259, #260) will set it on share tokens and PAT material. A
+column author who forgets it exports what the API already sent to the browser —
+which is why the flag is a *narrowing* control rather than the only barrier.
+
+### 16.7 Tests
+
+`__tests__/DataTableExport.test.tsx` (75 cases), on the #253 stub recipe
+(container-driven width, `matchMedia` pinned to 1440px). Four things worth
+copying rather than reinventing:
+
+1. **The download is stubbed at the browser boundary**, not behind an injected
+   seam: `URL.createObjectURL` captures the real `Blob` the component built and
+   `HTMLAnchorElement.click` is spied so jsdom does not log a navigation. Every
+   assertion about "what the user got" reads those bytes.
+2. **The escaping rules are tested twice** — as pure functions (each of the four
+   formula prefixes, quotes, commas, newlines, the numeric exemption) and through
+   a rendered table (a chip column exports its scalar; an `exportable: false`
+   column never appears; unchecking a column in the picker changes the header
+   row).
+3. **jsdom disables MUI X virtualization outright** (`HAS_LAYOUT =
+   !platform.env.jsdom`), so the grid tests assert the *decision*
+   (`data-virtualized`, the computed viewport height, the threshold boundary) and
+   assert the property that makes windowing safe: a 60-row page still select-alls
+   to 60 ids, and a virtualized tablet grid with an expanded row still selects no
+   synthetic detail row.
+4. **The #243 guard is re-run** against the export menu and the phone overflow
+   menu, with `[role="menuitem"]` added to the sweep's selector — the export
+   menu's controls are menu items rather than buttons or checkboxes.


### PR DESCRIPTION
## Summary

The two capabilities that round out the component: row virtualization in both renderers, and CSV export built against the column contract. Last of the build issues before the a11y/shared-suite pass (#257) and the Job Queue pilot (#258).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Relates to #238
Fixes #256

## Changes Made

### The load-bearing finding

**`autoHeight` disables DataGrid's row virtualization**, and `autoHeight` is this table's documented default:

```js
// @mui/x-data-grid@9.10.1/hooks/features/virtualization/useGridVirtualization.js
enabledForRows: !disableVirtualization && !autoHeight && HAS_LAYOUT
```

So from #252 until now the virtualizer was inert on every default-sized table. `planGridVirtualization` now trades auto-height for a computed viewport past **50 loaded rows** (or whenever an explicit `height` was passed); at or below 50 the table stays auto-height, unchanged. Published as `data-virtualized` on the scroll container.

Select-all is unaffected by construction — it materialises MUI X's exclude model against `rowIds` from the `rows` prop, never the DOM. There are tests proving a 60-row virtualized page selects all 60 ids, and that a virtualized *tablet* grid with an expanded row still selects zero of #253's synthetic detail rows.

Note the threshold is 50 rather than 100 because MIT DataGrid throws above a 100-row `pageSize`, making ">100 loaded rows" unreachable through pagination. All target tables are server-paginated at modest page sizes, so this is robustness for large `pageSize` values, **not** the performance strategy.

### Mobile virtualization — deliberately not a virtualizer

`content-visibility: auto` + `contain-intrinsic-size` + `loading="lazy"` / `decoding="async"` on card images, per the issue's explicit permission that **"an incorrect virtualizer is worse than none"**. The placeholder height is genuinely **measured** from a real card in the list (callback ref + `ResizeObserver`), not computed — computing it from a column count is exactly the #237 failure mode that made gallery scrolling jump. Two cards opt out of containment: the measured first card, and any card whose detail region is open.

A true dynamic-height card virtualizer remains unbuilt. It is only worth building if a card list ever holds thousands of rows, which server-side pagination currently prevents.

### CSV export

- **Current-page export** in all three layouts, and the **all-rows stretch goal shipped too** — opt-in via a page-supplied `csvExport.fetchAllRows` callback, bounded at 10,000 rows, 250 rows/request, progress dialog (determinate when `pagination.total` is known), `AbortSignal` cancel that produces no file, a warning when the ceiling truncates, and no file at all if a page fails.
- Built **against the column contract**, one code path for both renderers — not `GridToolbarExport`.
- Uses each column's `value` accessor, **never the rendered ReactNode**, so a column whose `render` returns a chip exports the value behind it.
- Respects active filters, the user's column visibility, and `exportable: false`; `disableExport` turns the control off entirely (#259 needs this — the Tags page keeps its own bespoke CSV round-trip and must not show two export buttons).
- **Security:** exports only what the API already returned to this authorized user; never a privileged re-query.

### Escaping

RFC 4180 quoting for commas, quotes and newlines; UTF-8 BOM for Excel; formula-injection neutralization for `=`, `+`, `-`, `@` — plus leading `\t` and `\r`, since some spreadsheets strip leading whitespace before deciding.

### Decisions worth a reviewer's attention

- **Numbers are exempt from formula neutralization.** Blind prefixing turns `-5` into `'-5` and breaks every numeric column that can go negative. The apostrophe is applied only to text that is not a well-formed number, so `-1+cmd|calc` is still neutralized.
- **Export follows the *user's* column visibility, not the tablet layout fold.** A `detail` column tucked into the row expander is still shown to the user, and a CSV that changed shape because the window is 900 px wide would be a surprise. A column the user actually unchecked *is* excluded.
- **The mobile overflow menu is new UI** — the phone view bar previously had only "View".
- **Desktop with no all-rows callback exports on a single click** rather than opening a one-item menu.
- **The #243 guard sweep gained `[role="menuitem"]`** — the export menu's controls are menu items, not buttons or checkboxes, so the existing selector would have found zero controls and passed vacuously.

## Testing

- [x] Unit tests pass (`npm test`) — **251 passed** in the datatable suite (176 pre-existing unmodified, 75 new); full web suite **194 files / 3968 tests passed**
- [x] Type checks pass (`npm run typecheck`) — zero errors
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

Tests cover CSV escaping including all four formula-injection prefixes and the BOM, export respecting filters / visibility / `exportable: false`, export using the `value` accessor rather than the rendered node, `disableExport`, and select-all correctness with virtualization enabled (including the tablet detail-row case).

Two test-harness notes are now in the spec because both will bite the next person: `Blob.text()` decodes UTF-8 and **strips** the BOM, so the BOM must be asserted on `arrayBuffer()` bytes; and MUI X hard-disables virtualization under jsdom (`HAS_LAYOUT = !platform.env.jsdom`), so the grid tests assert the *decision* plus the DOM-independence of selection.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

No page is touched — no table is migrated yet. Next: #257 (accessibility, keyboard navigation, and the shared test suite), which the epic wants landed before the bulk migrations so the suite is catching regressions while they happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE)_