### PR TITLE
feat(web): migrate admin operations tables to the shared DataTable

### DIFF
--- a/apps/web/src/__tests__/pages/BackupPage.test.tsx
+++ b/apps/web/src/__tests__/pages/BackupPage.test.tsx
@@ -1,7 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+/**
+ * BackupPage tests — the run-history table was migrated onto the shared
+ * DataTable in issue #259. Per docs/specs/datatable.md §18.5 this file covers
+ * the page's own column declarations (`./backupTable.tsx`) and its behaviour;
+ * table mechanics belong to `runDataTableConformanceSuite`.
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
 
 // Mock hooks before importing them
 vi.mock('../../hooks/usePermissions', () => ({
@@ -20,6 +32,8 @@ import { usePermissions } from '../../hooks/usePermissions';
 import { useBackup } from '../../hooks/useBackup';
 import { useCircles } from '../../hooks/useCircles';
 import BackupPage from '../../pages/Admin/BackupPage';
+import { BACKUP_RUN_COLUMNS, backupRunStatus } from '../../pages/Admin/backupTable';
+import { api } from '../../services/api';
 
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseBackup = vi.mocked(useBackup);
@@ -65,13 +79,51 @@ function makeCircles(overrides: Partial<ReturnType<typeof useCircles>> = {}): Re
   };
 }
 
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: 'run-1',
+    scope: 'all',
+    copied: 3,
+    skipped: 0,
+    failed: 0,
+    errors: [] as string[],
+    startedAt: new Date('2024-01-15T10:00:00Z').toISOString(),
+    completedAt: new Date('2024-01-15T10:01:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
 describe('BackupPage', () => {
+  beforeAll(() => {
+    // jsdom performs no layout — the shared stub recipe is what makes MUI X
+    // render rows at all (docs/specs/datatable.md §12).
+    installLayoutStubs();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400);
     // Default: admin user
     mockUsePermissions.mockReturnValue(makePermissions(true));
     mockUseBackup.mockReturnValue(makeBackup());
     mockUseCircles.mockReturnValue(makeCircles());
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
+  });
+
+  describe('Column definitions', () => {
+    it('leads the card with Scope then Status (issue #259: status is primary)', () => {
+      const primaries = BACKUP_RUN_COLUMNS.filter((c) => c.priority === 'primary').map((c) => c.id);
+      expect(primaries).toEqual(['scope', 'status']);
+    });
+
+    it('derives a run status the endpoint does not return', () => {
+      expect(backupRunStatus(makeRun() as never)).toBe('Succeeded');
+      expect(backupRunStatus(makeRun({ failed: 2 }) as never)).toBe('Failed');
+      expect(backupRunStatus(makeRun({ completedAt: undefined }) as never)).toBe('Running');
+      // A failure outranks "still running".
+      expect(backupRunStatus(makeRun({ failed: 1, completedAt: undefined }) as never)).toBe('Failed');
+    });
   });
 
   describe('Authorization', () => {
@@ -329,6 +381,50 @@ describe('BackupPage', () => {
         const chips = screen.getAllByText('2');
         expect(chips.length).toBeGreaterThan(0);
       });
+    });
+  });
+
+  describe('Run status column (rendered)', () => {
+    it('shows a Succeeded chip for a clean completed run', async () => {
+      mockUseBackup.mockReturnValue(makeBackup({ runs: [makeRun()] as never }));
+
+      render(<BackupPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const grid = await screen.findByRole('grid', { name: /backup runs/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('Succeeded')).toBeInTheDocument();
+      });
+    });
+
+    it('shows a Failed chip when the run had failures', async () => {
+      mockUseBackup.mockReturnValue(
+        makeBackup({ runs: [makeRun({ runId: 'run-2', failed: 2, completedAt: undefined })] as never }),
+      );
+
+      render(<BackupPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const grid = await screen.findByRole('grid', { name: /backup runs/i });
+      await waitFor(() => {
+        // Both the derived status chip and the Failed column header read
+        // "Failed"; the chip is the one inside a row.
+        const cells = within(grid).getAllByRole('gridcell');
+        expect(cells.some((cell) => cell.textContent === 'Failed')).toBe(true);
+      });
+    });
+  });
+
+  describe('Phone layout (360px)', () => {
+    it('renders cards and contains its own width', async () => {
+      setInitialContainerWidth(360);
+      mockUseBackup.mockReturnValue(makeBackup({ runs: [makeRun()] as never }));
+
+      render(<BackupPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const table = await screen.findByTestId('datatable');
+      expect(table).toHaveAttribute('data-layout', 'mobile');
+      const styles = window.getComputedStyle(table);
+      expect(styles.maxWidth).toBe('100%');
+      expect(styles.minWidth).toBe('0px');
     });
   });
 });

--- a/apps/web/src/__tests__/pages/JobInsightsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/JobInsightsPage.test.tsx
@@ -11,9 +11,14 @@
  *   - "Refresh now" button is present and clickable
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { render, mockAdminUser, mockUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
 
 // ---------------------------------------------------------------------------
 // Module mocks (must be hoisted before component imports)
@@ -56,6 +61,12 @@ import JobInsightsPage from '../../pages/Admin/JobInsightsPage';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useJobInsights } from '../../hooks/useJobInsights';
 import type { JobInsights } from '../../services/jobInsights';
+import {
+  JOB_INSIGHTS_COLUMNS,
+  buildPerTypeRows,
+  formatThroughput,
+} from '../../pages/Admin/jobInsightsTable';
+import { api } from '../../services/api';
 
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseJobInsights = vi.mocked(useJobInsights);
@@ -171,10 +182,56 @@ function makeHookReturn(
 // ---------------------------------------------------------------------------
 
 describe('JobInsightsPage', () => {
+  beforeAll(() => {
+    // jsdom performs no layout — without the shared stub recipe MUI X measures
+    // a 0×0 viewport (docs/specs/datatable.md §12).
+    installLayoutStubs();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400);
     mockUsePermissions.mockReturnValue(makeAdminPermissions());
     mockUseJobInsights.mockReturnValue(makeHookReturn());
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
+  });
+
+  // =========================================================================
+  // Column definitions (issue #259 — the per-type table on the shared DataTable)
+  // =========================================================================
+
+  describe('column definitions', () => {
+    it('leads the card with the type and its backlog', () => {
+      const primaries = JOB_INSIGHTS_COLUMNS.filter((c) => c.priority === 'primary').map(
+        (c) => c.id,
+      );
+      expect(primaries).toEqual(['type', 'queued']);
+    });
+
+    it('joins the four per-type arrays into one row, backlog first', () => {
+      const rows = buildPerTypeRows(
+        [
+          { type: 'auto_tagging', pending: 1, running: 1, succeeded: 0, failed: 0, total: 2 },
+          { type: 'face_detection', pending: 5, running: 2, succeeded: 0, failed: 0, total: 7 },
+        ] as never,
+        [{ type: 'face_detection', samples: 3, avgMs: 10, p50Ms: 9, p95Ms: 20, throughputPerMin: 2 }] as never,
+        [{ type: 'auto_tagging', remaining: 2, avgMs: 5, etcMs: 10 }] as never,
+        [{ type: 'geocode', succeeded: 4, failed: 1, total: 5, avgMs: 3, samples: 4 }] as never,
+      );
+
+      // Ordered by queued desc, then alphabetically; every type present exactly once.
+      expect(rows.map((r) => r.type)).toEqual(['face_detection', 'auto_tagging', 'geocode']);
+      expect(rows[0]).toMatchObject({ queued: 7, avgMs: 10, p95Ms: 20, etcMs: null });
+      expect(rows[1]).toMatchObject({ queued: 2, etcMs: 10, avgMs: null });
+      expect(rows[2]).toMatchObject({ queued: 0, lifetimeTotal: 5 });
+    });
+
+    it('formats throughput the way the old table did', () => {
+      expect(formatThroughput(1.5)).toBe('1.5/min');
+      expect(formatThroughput(0)).toBe('—');
+      expect(formatThroughput(null)).toBe('—');
+    });
   });
 
   // =========================================================================
@@ -484,6 +541,27 @@ describe('JobInsightsPage', () => {
       render(<JobInsightsPage />, { wrapperOptions: { user: mockAdminUser } });
 
       expect(screen.queryByTestId('freshness-pill')).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Phone
+  // =========================================================================
+
+  describe('phone layout (360px)', () => {
+    it('renders the per-type breakdown as cards, folding the detail columns', async () => {
+      setInitialContainerWidth(360);
+
+      render(<JobInsightsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const table = await screen.findByTestId('datatable');
+      expect(table).toHaveAttribute('data-layout', 'mobile');
+      expect(within(table).getByText('face_detection')).toBeInTheDocument();
+      // p95 / Throughput / All-time are `detail` — behind "More details".
+      expect(screen.getByTestId('datatable-card-detail-toggle')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      );
     });
   });
 });

--- a/apps/web/src/__tests__/pages/PublicSharesPage.test.tsx
+++ b/apps/web/src/__tests__/pages/PublicSharesPage.test.tsx
@@ -1,37 +1,34 @@
 /**
- * Tests for apps/web/src/pages/Admin/PublicSharesPage.tsx
+ * Unit tests for PublicSharesPage — post-#259 (the shared-DataTable migration).
  *
- * Covers:
- *  Authorization:
- *   - redirects non-admin users to /
- *   - renders page content for admin users
+ * Scope note, per docs/specs/datatable.md §17.8 / §18.5: TABLE MECHANICS are a
+ * property of the component and are covered end to end by
+ * `runDataTableConformanceSuite` (pagination/sort/selection round-trips, the
+ * negative "never filters rows locally" test, loading/empty/error overlays,
+ * column visibility + density, CSV escaping, the issue #243 invisible-but-
+ * tappable sweep, axe in both renderers and both themes). None of that is
+ * re-tested here.
  *
- *  Table rendering:
- *   - shows shares from listShares({ scope: 'all' })
- *   - renders status chip for each share
- *   - shows "No shares found." when list is empty
- *   - shows "Public Sharing" heading
- *
- *  Single revoke:
- *   - clicking revoke icon opens confirmation dialog
- *   - confirming revoke calls revokeShare(id)
- *
- *  Copy link:
- *   - clicking copy icon calls navigator.clipboard.writeText with the publicUrl
- *
- *  Bulk select + revoke:
- *   - selecting all rows shows bulk action bar
- *   - clicking "Revoke" in bulk bar opens confirmation dialog
- *   - confirming bulk revoke calls bulkShares with correct ids and action
- *
- *  Status filter tabs:
- *   - renders "All", "Active", "Expired", "Revoked" tabs
+ * What IS here is everything this migration could plausibly break:
+ *   - the status TABS ↔ filter-model wiring (issue #259's headline decision),
+ *     including that the status column is absent from the generic filter picker,
+ *   - the public URL column: truncated, never in full, and NOT exportable,
+ *   - every mutation: copy, edit expiration, single revoke, bulk revoke /
+ *     set-expiration / delete,
+ *   - permission gating,
+ *   - the phone layout actually reaching the row actions that used to be off
+ *     screen (the bug the issue was filed for).
  */
 
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
 import type { MediaShare } from '../../types/sharing';
 
 // ---------------------------------------------------------------------------
@@ -49,6 +46,16 @@ vi.mock('../../hooks/useMediaShares', () => ({
 import { usePermissions } from '../../hooks/usePermissions';
 import { useMediaShares } from '../../hooks/useMediaShares';
 import PublicSharesPage from '../../pages/Admin/PublicSharesPage';
+import {
+  buildShareColumns,
+  normalizeShareFilters,
+  statusFromFilters,
+  toShareQuery,
+  truncateShareUrl,
+  withStatusFilter,
+} from '../../pages/Admin/sharesTable';
+import type { DataTableFilterModel } from '../../components/datatable';
+import { api } from '../../services/api';
 
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseMediaShares = vi.mocked(useMediaShares);
@@ -104,6 +111,22 @@ function makeHook(
   };
 }
 
+/** The row-scoped accessible-name suffix: the first `primary` column's value. */
+function rowLabel(id: string) {
+  return id.slice(0, 8);
+}
+
+function renderPage() {
+  return render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+}
+
+async function openRowMenu(user: ReturnType<typeof userEvent.setup>, id: string) {
+  const trigger = await screen.findByRole('button', {
+    name: `Row actions for ${rowLabel(id)}`,
+  });
+  await user.click(trigger);
+}
+
 // ---------------------------------------------------------------------------
 // Clipboard setup — done once at suite level so the same mock object is
 // referenced by both the outer beforeEach (which calls vi.clearAllMocks)
@@ -113,6 +136,9 @@ function makeHook(
 const writeTextMock = vi.fn();
 
 beforeAll(() => {
+  // jsdom performs no layout, so MUI X measures a 0×0 viewport and renders zero
+  // rows without these. Same recipe every DataTable suite uses.
+  installLayoutStubs();
   Object.defineProperty(navigator, 'clipboard', {
     value: { writeText: writeTextMock },
     writable: true,
@@ -127,20 +153,30 @@ beforeAll(() => {
 describe('PublicSharesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400); // desktop layout unless a test says otherwise
 
-    // Default: admin permissions
     mockUsePermissions.mockReturnValue(makePermissions(true));
-
-    // Default: empty share list
     mockUseMediaShares.mockReturnValue(makeHook());
 
-    // Restore clipboard mock after vi.clearAllMocks clears it
+    // Re-installed per test: `userEvent.setup()` swaps in its own
+    // `navigator.clipboard` stub and never restores it, so a suite-level
+    // definition would be gone by the time the copy tests run.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      writable: true,
+      configurable: true,
+    });
     writeTextMock.mockResolvedValue(undefined);
+
+    // The table's layout-persistence hook reads/writes `/user-settings`
+    // (docs/specs/datatable.md §15). Stub the real `api` singleton.
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
   });
 
-  // -------------------------------------------------------------------------
+  // =========================================================================
   // Authorization
-  // -------------------------------------------------------------------------
+  // =========================================================================
 
   describe('Authorization', () => {
     it('redirects non-admin users — page content is not rendered', () => {
@@ -154,85 +190,106 @@ describe('PublicSharesPage', () => {
     });
 
     it('renders page content for admin users', () => {
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      expect(screen.getByText(/public sharing/i)).toBeInTheDocument();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Table rendering
-  // -------------------------------------------------------------------------
-
-  describe('Table rendering', () => {
-    it('shows "Public Sharing" heading', () => {
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByRole('heading', { name: /public sharing/i })).toBeInTheDocument();
     });
+  });
 
-    it('shows "No shares found." when share list is empty', () => {
+  // =========================================================================
+  // Column definitions
+  // =========================================================================
+
+  describe('Column definitions', () => {
+    const columns = buildShareColumns({ onCopy: vi.fn() });
+    const byId = (id: string) => columns.find((column) => column.id === id)!;
+
+    it('marks the public URL column non-exportable — the token is a credential', () => {
+      expect(byId('publicUrl').exportable).toBe(false);
+    });
+
+    it('does not declare the status column as generically filterable (the tabs own it)', () => {
+      expect(byId('status').filterable).toBeUndefined();
+      // …but it still carries the enum labels the tab-produced chip reads from.
+      expect(byId('status').enumValues?.map((option) => option.value)).toEqual([
+        'active',
+        'expired',
+        'revoked',
+      ]);
+    });
+
+    it('declares targetType as filterable — no bespoke control competes for it', () => {
+      expect(byId('targetType').filterable).toEqual(['is']);
+    });
+
+    it('leads with a row-unique primary column so per-row controls are nameable', () => {
+      const firstPrimary = columns.find((column) => column.priority === 'primary')!;
+      expect(firstPrimary.id).toBe('id');
+      expect(firstPrimary.value!(makeShare({ id: 'abcdefgh-1234' }))).toBe('abcdefgh');
+    });
+
+    it('truncates a URL rather than printing it in full', () => {
+      const long = 'https://app.example.com/s/tok-abcdefghijklmnopqrstuvwxyz';
+      const shown = truncateShareUrl(long);
+      expect(shown.length).toBeLessThan(long.length);
+      expect(shown.endsWith('…')).toBe(true);
+      expect(truncateShareUrl('https://a.co/s/x')).toBe('https://a.co/s/x');
+    });
+  });
+
+  // =========================================================================
+  // Table rendering
+  // =========================================================================
+
+  describe('Table rendering', () => {
+    it('shows "No shares found." when the share list is empty', async () => {
       mockUseMediaShares.mockReturnValue(makeHook({ shares: [] }));
 
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      expect(screen.getByText(/no shares found/i)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/no shares found/i)).toBeInTheDocument();
+      });
     });
 
-    it('renders a row for each share in the list', () => {
+    it('renders a row per share with its status chip', async () => {
       mockUseMediaShares.mockReturnValue(
         makeHook({
           shares: [
-            makeShare({ id: 's1' }),
-            makeShare({ id: 's2' }),
-            makeShare({ id: 's3' }),
+            makeShare({ id: 's1-aaaaaaa', status: 'active' }),
+            makeShare({ id: 's2-bbbbbbb', status: 'expired' }),
+            makeShare({ id: 's3-ccccccc', status: 'revoked', targetType: 'album', itemCount: 4 }),
           ],
         }),
       );
 
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Each share row has a checkbox — 3 data rows + 1 header checkbox = 4 checkboxes
-      const checkboxes = screen.getAllByRole('checkbox');
-      // 1 header (select-all) + 3 rows
-      expect(checkboxes.length).toBeGreaterThanOrEqual(3);
+      const grid = await screen.findByRole('grid', { name: /public shares/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('Active')).toBeInTheDocument();
+      });
+      expect(within(grid).getByText('Expired')).toBeInTheDocument();
+      expect(within(grid).getByText('Revoked')).toBeInTheDocument();
+      expect(within(grid).getByText('Album')).toBeInTheDocument();
     });
 
-    it('renders a status chip for each share', () => {
+    it('renders the public URL TRUNCATED, never in full', async () => {
+      const publicUrl = 'https://app.example.com/s/tok-abcdefghijklmnopqrstuvwxyz';
       mockUseMediaShares.mockReturnValue(
-        makeHook({
-          shares: [
-            makeShare({ id: 's1', status: 'active' }),
-            makeShare({ id: 's2', status: 'expired' }),
-            makeShare({ id: 's3', status: 'revoked' }),
-          ],
-        }),
+        makeHook({ shares: [makeShare({ id: 's1-aaaaaaa', publicUrl })] }),
       );
 
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // "Active" appears both in the tab and as a chip — use getAllByText
-      expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText('Expired').length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText('Revoked').length).toBeGreaterThanOrEqual(1);
-
-      // Verify the MUI Chip elements specifically
-      const { container } = render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-      const chips = container.querySelectorAll('.MuiChip-root');
-      expect(chips.length).toBe(3);
+      await waitFor(() => {
+        expect(screen.getByText(truncateShareUrl(publicUrl))).toBeInTheDocument();
+      });
+      expect(screen.queryByText(publicUrl)).not.toBeInTheDocument();
     });
 
-    it('renders the public URL for each share', () => {
-      const share = makeShare({ id: 's1', publicUrl: 'https://app.example.com/s/tok-s1' });
-      mockUseMediaShares.mockReturnValue(makeHook({ shares: [share] }));
-
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      expect(screen.getByText(/tok-s1/)).toBeInTheDocument();
-    });
-
-    it('renders status filter tabs: All, Active, Expired, Revoked', () => {
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+    it('renders the status filter tabs: All, Active, Expired, Revoked', () => {
+      renderPage();
 
       expect(screen.getByRole('tab', { name: /^all$/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /^active$/i })).toBeInTheDocument();
@@ -240,50 +297,175 @@ describe('PublicSharesPage', () => {
       expect(screen.getByRole('tab', { name: /^revoked$/i })).toBeInTheDocument();
     });
 
-    it('shows loading spinner in the table body when isLoading is true and shares list is empty', () => {
-      mockUseMediaShares.mockReturnValue(makeHook({ isLoading: true, shares: [] }));
+    it('surfaces a list error without blanking the rows underneath it', async () => {
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 's1-aaaaaaa' })], error: 'Share load failed' }),
+      );
 
-      const { container } = render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Multiple spinners can appear (table cell + refresh button); at least one must exist
-      const progressbars = screen.getAllByRole('progressbar');
-      expect(progressbars.length).toBeGreaterThanOrEqual(1);
-
-      // The table body contains a cell with a spinner (24px size)
-      const tableSpinner = container.querySelector('tbody .MuiCircularProgress-root');
-      expect(tableSpinner).not.toBeNull();
-    });
-
-    it('renders column headers: Preview, Type, Items, Public URL, Expires, Status, Created', () => {
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      expect(screen.getByText('Preview')).toBeInTheDocument();
-      expect(screen.getByText('Type')).toBeInTheDocument();
-      expect(screen.getByText('Status')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/share load failed/i)).toBeInTheDocument();
+      });
+      expect(screen.getByText('s1-aaaaa'.slice(0, 8))).toBeInTheDocument();
     });
   });
 
-  // -------------------------------------------------------------------------
+  // =========================================================================
+  // Status tabs ⇄ filter model (issue #259's headline decision)
+  // =========================================================================
+
+  describe('Status tabs ⇄ filter model (pure)', () => {
+    it('reads the active tab back out of the model', () => {
+      expect(statusFromFilters([])).toBe('all');
+      expect(
+        statusFromFilters([{ columnId: 'status', operator: 'is', value: 'revoked' }]),
+      ).toBe('revoked');
+      // An unknown status value is not a tab.
+      expect(
+        statusFromFilters([{ columnId: 'status', operator: 'is', value: 'bogus' }]),
+      ).toBe('all');
+    });
+
+    it('writes a tab selection into the model, replacing any previous status', () => {
+      const first = withStatusFilter([], 'active');
+      expect(first).toEqual([{ columnId: 'status', operator: 'is', value: 'active' }]);
+
+      const second = withStatusFilter(first, 'revoked');
+      expect(second).toEqual([{ columnId: 'status', operator: 'is', value: 'revoked' }]);
+    });
+
+    it('"All" REMOVES the status entry — absence is what the endpoint means by all', () => {
+      const model = withStatusFilter([], 'expired');
+      expect(withStatusFilter(model, 'all')).toEqual([]);
+    });
+
+    it('leaves other filters untouched when the tab changes', () => {
+      const model: DataTableFilterModel = [
+        { columnId: 'targetType', operator: 'is', value: 'album' },
+      ];
+      expect(withStatusFilter(model, 'active')).toEqual([
+        { columnId: 'targetType', operator: 'is', value: 'album' },
+        { columnId: 'status', operator: 'is', value: 'active' },
+      ]);
+    });
+
+    it('maps the model onto the endpoint params', () => {
+      expect(toShareQuery([])).toEqual({});
+      expect(toShareQuery([{ columnId: 'status', operator: 'is', value: 'expired' }])).toEqual({
+        status: 'expired',
+      });
+      expect(
+        toShareQuery([
+          { columnId: 'status', operator: 'is', value: 'active' },
+          { columnId: 'targetType', operator: 'is', value: 'album' },
+        ]),
+      ).toEqual({ status: 'active', targetType: 'album' });
+    });
+
+    it('ignores operators and values this endpoint cannot express', () => {
+      expect(
+        toShareQuery([
+          { columnId: 'status', operator: 'isNot', value: 'active' },
+          { columnId: 'status', operator: 'is', value: 'bogus' },
+          { columnId: 'targetType', operator: 'is', value: 'nope' },
+          { columnId: 'expiresAt', operator: 'is', value: 'whenever' },
+        ]),
+      ).toEqual({});
+    });
+
+    it('keeps one filter per column, last one wins', () => {
+      const model: DataTableFilterModel = [
+        { columnId: 'targetType', operator: 'is', value: 'media_item' },
+        { columnId: 'targetType', operator: 'is', value: 'album' },
+      ];
+      expect(normalizeShareFilters(model)).toEqual([
+        { columnId: 'targetType', operator: 'is', value: 'album' },
+      ]);
+      const legal: DataTableFilterModel = [
+        { columnId: 'status', operator: 'is', value: 'active' },
+      ];
+      expect(normalizeShareFilters(legal)).toBe(legal);
+    });
+  });
+
+  describe('Status tabs ⇄ filter model (rendered)', () => {
+    it('selecting a tab sends that status to the API and shows it as a chip', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(screen.getByRole('tab', { name: /^revoked$/i }));
+
+      await waitFor(() => {
+        expect(mockUseMediaShares).toHaveBeenCalledWith(
+          expect.objectContaining({ scope: 'all', status: 'revoked', page: 1 }),
+        );
+      });
+      expect(await screen.findByText('Status is Revoked')).toBeInTheDocument();
+    });
+
+    it('removing the status chip returns the tab to "All" and drops the param', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(screen.getByRole('tab', { name: /^active$/i }));
+      const chip = await screen.findByText('Status is Active');
+
+      const deleteIcon = chip.closest('.MuiChip-root')!.querySelector('.MuiChip-deleteIcon')!;
+      await user.click(deleteIcon);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Status is Active')).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('tab', { name: /^all$/i })).toHaveAttribute('aria-selected', 'true');
+      expect(mockUseMediaShares).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: undefined }),
+      );
+    });
+
+    it('does NOT offer Status in the generic filter picker — the tabs are the only control', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const combo = await screen.findByRole('combobox', { name: 'Column' });
+      await user.click(combo);
+
+      expect(await screen.findByRole('option', { name: 'Type' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Status' })).not.toBeInTheDocument();
+    });
+
+    it('applies a Type filter through the generic filter bar', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(await screen.findByRole('combobox', { name: 'Column' }));
+      await user.click(await screen.findByRole('option', { name: 'Type' }));
+      await user.click(await screen.findByRole('combobox', { name: 'Value' }));
+      await user.click(await screen.findByRole('option', { name: 'Album' }));
+      await user.click(screen.getByTestId('datatable-filter-apply'));
+
+      await waitFor(() => {
+        expect(mockUseMediaShares).toHaveBeenLastCalledWith(
+          expect.objectContaining({ targetType: 'album', page: 1 }),
+        );
+      });
+    });
+  });
+
+  // =========================================================================
   // Copy link
-  // -------------------------------------------------------------------------
+  // =========================================================================
 
   describe('Copy link', () => {
-    // navigator.clipboard is mocked at suite level (see writeTextMock above).
-    // vi.clearAllMocks() in the outer beforeEach clears call counts; the outer
-    // beforeEach also re-applies mockResolvedValue so the mock stays functional.
-
-    it('clicking copy icon calls navigator.clipboard.writeText with the publicUrl', async () => {
-      const share = makeShare({
-        id: 's1',
-        publicUrl: 'https://app.example.com/s/tok-s1',
-      });
+    it('clicking the in-cell copy button writes the FULL url to the clipboard', async () => {
+      const share = makeShare({ id: 's1-aaaaaaa', publicUrl: 'https://app.example.com/s/tok-s1' });
       mockUseMediaShares.mockReturnValue(makeHook({ shares: [share] }));
 
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Use fireEvent instead of userEvent so that user-event's own clipboard
-      // stub does not intercept the navigator.clipboard.writeText call.
-      const copyButton = screen.getByRole('button', { name: /copy link/i });
+      // fireEvent rather than userEvent so user-event's own clipboard stub does
+      // not intercept the navigator.clipboard.writeText call.
+      const copyButton = await screen.findByRole('button', { name: /copy link/i });
       fireEvent.click(copyButton);
 
       await waitFor(() => {
@@ -291,198 +473,266 @@ describe('PublicSharesPage', () => {
       });
     });
 
-    it('clicking copy icon shows a success snackbar', async () => {
-      const share = makeShare({
-        id: 's1',
-        publicUrl: 'https://app.example.com/s/tok-s1',
-      });
-      mockUseMediaShares.mockReturnValue(makeHook({ shares: [share] }));
+    it('shows a success snackbar after copying', async () => {
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 's1-aaaaaaa' })] }),
+      );
 
-      const user = userEvent.setup();
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      const copyButton = screen.getByRole('button', { name: /copy link/i });
-      await user.click(copyButton);
+      fireEvent.click(await screen.findByRole('button', { name: /copy link/i }));
 
       await waitFor(() => {
         expect(screen.getByText(/link copied to clipboard/i)).toBeInTheDocument();
       });
     });
 
-    it('copy icon button is rendered for each share', () => {
-      const shares = [makeShare({ id: 's1' }), makeShare({ id: 's2' })];
-      mockUseMediaShares.mockReturnValue(makeHook({ shares }));
+    it('renders one copy button per share', async () => {
+      mockUseMediaShares.mockReturnValue(
+        makeHook({
+          shares: [makeShare({ id: 's1-aaaaaaa' }), makeShare({ id: 's2-bbbbbbb' })],
+        }),
+      );
 
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      const copyButtons = screen.getAllByRole('button', { name: /copy link/i });
-      expect(copyButtons).toHaveLength(2);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Single revoke
-  // -------------------------------------------------------------------------
-
-  describe('Single revoke', () => {
-    function setupWithShare(id = 'share-1') {
-      const share = makeShare({ id, status: 'active' });
-      const hookResult = makeHook({ shares: [share] });
-      mockUseMediaShares.mockReturnValue(hookResult);
-      return { share, hookResult };
-    }
-
-    it('clicking the revoke icon opens a confirmation dialog', async () => {
-      setupWithShare('s1');
-
-      const user = userEvent.setup();
-      const { container } = render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // The revoke IconButton is wrapped in a <span> (for Tooltip with disabled child support),
-      // so aria-label is on the span, not the button. Query by the Block icon's data-testid.
-      const revokeIcon = container.querySelector('[data-testid="BlockIcon"]');
-      expect(revokeIcon).toBeTruthy();
-      const revokeBtn = revokeIcon!.closest('button') as HTMLButtonElement;
-      expect(revokeBtn).toBeTruthy();
-
-      await user.click(revokeBtn);
+      renderPage();
 
       await waitFor(() => {
-        expect(screen.getByText(/revoke share\?/i)).toBeInTheDocument();
-      });
-    });
-
-    it('confirming revoke calls revokeShare with the share id', async () => {
-      const { hookResult } = setupWithShare('share-abc');
-
-      const user = userEvent.setup();
-      const { container } = render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Find and click the revoke icon button
-      const revokeIcon = container.querySelector('[data-testid="BlockIcon"]');
-      const revokeBtn = revokeIcon!.closest('button') as HTMLButtonElement;
-      await user.click(revokeBtn);
-
-      await waitFor(() => screen.getByText(/revoke share\?/i));
-
-      // The dialog has a Revoke confirm button with text "Revoke"
-      const dialogRevokeBtns = screen.getAllByRole('button', { name: /^revoke$/i });
-      // Pick the last "Revoke" button (the one inside the dialog)
-      await user.click(dialogRevokeBtns[dialogRevokeBtns.length - 1]);
-
-      await waitFor(() => {
-        expect(hookResult.revokeShare).toHaveBeenCalledWith('share-abc');
+        expect(screen.getAllByRole('button', { name: /copy link/i })).toHaveLength(2);
       });
     });
   });
 
-  // -------------------------------------------------------------------------
-  // Bulk select + revoke
-  // -------------------------------------------------------------------------
+  // =========================================================================
+  // Row actions
+  // =========================================================================
 
-  describe('Bulk select and revoke', () => {
+  describe('Row actions', () => {
+    it('revoking confirms first, then calls revokeShare with the share id', async () => {
+      const hook = makeHook({ shares: [makeShare({ id: 'share-abc12345', status: 'active' })] });
+      mockUseMediaShares.mockReturnValue(hook);
+      const user = userEvent.setup();
+
+      renderPage();
+      await openRowMenu(user, 'share-abc12345');
+      await user.click(await screen.findByRole('menuitem', { name: /^revoke$/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(/revoke share\?/i)).toBeInTheDocument();
+      await user.click(within(dialog).getByRole('button', { name: /^revoke$/i }));
+
+      await waitFor(() => {
+        expect(hook.revokeShare).toHaveBeenCalledWith('share-abc12345');
+      });
+    });
+
+    it('cancelling the revoke confirmation calls nothing', async () => {
+      const hook = makeHook({ shares: [makeShare({ id: 'share-abc12345', status: 'active' })] });
+      mockUseMediaShares.mockReturnValue(hook);
+      const user = userEvent.setup();
+
+      renderPage();
+      await openRowMenu(user, 'share-abc12345');
+      await user.click(await screen.findByRole('menuitem', { name: /^revoke$/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
+
+      expect(hook.revokeShare).not.toHaveBeenCalled();
+    });
+
+    it('disables both row actions for an already-revoked share', async () => {
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 'share-dead1234', status: 'revoked' })] }),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+      await openRowMenu(user, 'share-dead1234');
+
+      expect(await screen.findByRole('menuitem', { name: /^revoke$/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+      expect(screen.getByRole('menuitem', { name: /edit expiration/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+
+    it('edits an expiration through the dialog', async () => {
+      const hook = makeHook({ shares: [makeShare({ id: 'share-abc12345' })] });
+      mockUseMediaShares.mockReturnValue(hook);
+      const user = userEvent.setup();
+
+      renderPage();
+      await openRowMenu(user, 'share-abc12345');
+      await user.click(await screen.findByRole('menuitem', { name: /edit expiration/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(/edit expiration/i)).toBeInTheDocument();
+      await user.click(within(dialog).getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(hook.updateShare).toHaveBeenCalledWith('share-abc12345', { expiresAt: null });
+      });
+    });
+  });
+
+  // =========================================================================
+  // Bulk actions
+  // =========================================================================
+
+  describe('Bulk actions', () => {
     function setupWithShares() {
-      const shares = [
-        makeShare({ id: 'bulk-1', status: 'active' }),
-        makeShare({ id: 'bulk-2', status: 'active' }),
-      ];
-      const hookResult = makeHook({ shares });
-      mockUseMediaShares.mockReturnValue(hookResult);
-      return { shares, hookResult };
+      const hook = makeHook({
+        shares: [
+          makeShare({ id: 'bulk-1aaaaaa', status: 'active' }),
+          makeShare({ id: 'bulk-2bbbbbb', status: 'active' }),
+        ],
+      });
+      mockUseMediaShares.mockReturnValue(hook);
+      return hook;
     }
 
-    it('selecting all rows via header checkbox shows bulk action bar', async () => {
+    it('select-all shows the bulk bar with a count', async () => {
       setupWithShares();
-
       const user = userEvent.setup();
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
 
-      const checkboxes = screen.getAllByRole('checkbox');
-      // First checkbox is the select-all header checkbox
-      await user.click(checkboxes[0]);
+      renderPage();
+      await user.click(await screen.findByRole('checkbox', { name: /select all rows/i }));
 
       await waitFor(() => {
-        expect(screen.getByText(/selected/i)).toBeInTheDocument();
+        expect(screen.getByTestId('datatable-bulk-action-bar')).toBeInTheDocument();
       });
+      expect(screen.getByText(/2 of 2 selected/i)).toBeInTheDocument();
     });
 
-    it('bulk "Revoke" opens confirmation dialog mentioning count', async () => {
-      setupWithShares();
-
+    it('bulk revoke confirms with the count, then calls bulkAction', async () => {
+      const hook = setupWithShares();
+      hook.bulkAction = vi.fn().mockResolvedValue({ affected: 2 });
       const user = userEvent.setup();
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
 
-      // Select all
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[0]);
-
-      await waitFor(() => screen.getByText(/selected/i));
-
-      // Click the Revoke button in the bulk action bar (there can be multiple "Revoke" buttons)
-      const revokeButtons = screen.getAllByRole('button', { name: /revoke/i });
-      // The bulk action bar "Revoke" is the one after the per-row ones; pick the one in the bulk bar
-      // Since select-all was clicked, per-row buttons are gone; the first "Revoke" should be the bulk one
-      await user.click(revokeButtons[0]);
+      renderPage();
+      await user.click(await screen.findByRole('checkbox', { name: /select all rows/i }));
+      await user.click(await screen.findByRole('button', { name: /^revoke$/i }));
 
       await waitFor(() => {
-        // Confirmation dialog for bulk (2 shares)
         expect(screen.getByText(/revoke 2 shares\?/i)).toBeInTheDocument();
       });
-    });
-
-    it('confirming bulk revoke calls bulkShares with correct ids and action "revoke"', async () => {
-      const { hookResult } = setupWithShares();
-      hookResult.bulkAction.mockResolvedValue({ affected: 2 });
-
-      const user = userEvent.setup();
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Select all rows
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[0]);
-
-      await waitFor(() => screen.getByText(/selected/i));
-
-      // Click bulk Revoke
-      const revokeButtons = screen.getAllByRole('button', { name: /revoke/i });
-      await user.click(revokeButtons[0]);
-
-      await waitFor(() => screen.getByText(/revoke 2 shares\?/i));
-
-      // Confirm in the dialog
-      const confirmBtns = screen.getAllByRole('button', { name: /^revoke$/i });
-      // The confirm button in the dialog
-      await user.click(confirmBtns[confirmBtns.length - 1]);
+      const dialog = screen.getByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /^revoke$/i }));
 
       await waitFor(() => {
-        expect(hookResult.bulkAction).toHaveBeenCalledWith(
-          expect.objectContaining({
-            ids: expect.arrayContaining(['bulk-1', 'bulk-2']),
-            action: 'revoke',
-          }),
+        expect(hook.bulkAction).toHaveBeenCalledWith({
+          ids: ['bulk-1aaaaaa', 'bulk-2bbbbbb'],
+          action: 'revoke',
+        });
+      });
+    });
+
+    it('bulk set-expiration calls bulkAction with set_expiration', async () => {
+      const hook = setupWithShares();
+      hook.bulkAction = vi.fn().mockResolvedValue({ affected: 2 });
+      const user = userEvent.setup();
+
+      renderPage();
+      await user.click(await screen.findByRole('checkbox', { name: /select all rows/i }));
+      await user.click(await screen.findByRole('button', { name: /set expiration/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /apply/i }));
+
+      await waitFor(() => {
+        expect(hook.bulkAction).toHaveBeenCalledWith(
+          expect.objectContaining({ action: 'set_expiration', expiresAt: null }),
         );
       });
     });
 
-    it('shows count of selected items in the bulk bar', async () => {
-      const shares = [
-        makeShare({ id: 'x1', status: 'active' }),
-        makeShare({ id: 'x2', status: 'active' }),
-        makeShare({ id: 'x3', status: 'active' }),
-      ];
-      mockUseMediaShares.mockReturnValue(makeHook({ shares }));
-
+    it('bulk delete confirms, then calls bulkAction with delete', async () => {
+      const hook = setupWithShares();
+      hook.bulkAction = vi.fn().mockResolvedValue({ affected: 2 });
       const user = userEvent.setup();
-      render(<PublicSharesPage />, { wrapperOptions: { user: mockAdminUser } });
 
-      // Select first two rows individually
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[1]); // row 1
-      await user.click(checkboxes[2]); // row 2
+      renderPage();
+      await user.click(await screen.findByRole('checkbox', { name: /select all rows/i }));
+      await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(/delete 2 shares\?/i)).toBeInTheDocument();
+      await user.click(within(dialog).getByRole('button', { name: /^delete$/i }));
 
       await waitFor(() => {
-        expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+        expect(hook.bulkAction).toHaveBeenCalledWith(
+          expect.objectContaining({ action: 'delete' }),
+        );
       });
+    });
+  });
+
+  // =========================================================================
+  // Phone — the bug this issue was filed for
+  // =========================================================================
+
+  describe('Phone layout (360px)', () => {
+    it('renders cards and still reaches every row action', async () => {
+      setInitialContainerWidth(360);
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 'share-abc12345', status: 'active' })] }),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+
+      const table = await screen.findByTestId('datatable');
+      expect(table).toHaveAttribute('data-layout', 'mobile');
+
+      await openRowMenu(user, 'share-abc12345');
+      expect(await screen.findByRole('menuitem', { name: /^revoke$/i })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /edit expiration/i })).toBeInTheDocument();
+    });
+
+    it('keeps the copy button reachable on a card', async () => {
+      setInitialContainerWidth(360);
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 'share-abc12345' })] }),
+      );
+
+      renderPage();
+
+      expect(await screen.findByRole('button', { name: /copy link/i })).toBeInTheDocument();
+    });
+
+    it('runs the bulk bar identically on a phone', async () => {
+      setInitialContainerWidth(360);
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 'share-abc12345', status: 'active' })] }),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+      await user.click(await screen.findByRole('checkbox', { name: /select all rows/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('datatable-bulk-action-bar')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: /^revoke$/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /set expiration/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+    });
+
+    it('contains its own width — nothing forces the document sideways', async () => {
+      setInitialContainerWidth(360);
+      mockUseMediaShares.mockReturnValue(
+        makeHook({ shares: [makeShare({ id: 'share-abc12345' })] }),
+      );
+
+      renderPage();
+
+      const table = await screen.findByTestId('datatable');
+      const styles = window.getComputedStyle(table);
+      expect(styles.maxWidth).toBe('100%');
+      expect(styles.minWidth).toBe('0px');
     });
   });
 });

--- a/apps/web/src/__tests__/pages/StorageProvidersPage.test.tsx
+++ b/apps/web/src/__tests__/pages/StorageProvidersPage.test.tsx
@@ -1,7 +1,27 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+/**
+ * Unit tests for StorageProvidersPage — post-#259 (the shared-DataTable
+ * migration).
+ *
+ * Two surfaces changed and are covered here:
+ *   - the provider CARDS became a table plus a per-row "Configure…" dialog, so
+ *     every credential mutation (save / remove / test, and the pre-save secret
+ *     guard) is now reached through the row menu;
+ *   - the migration run history became a DataTable with `status` as a `primary`
+ *     column.
+ *
+ * Table MECHANICS are the component's, covered by
+ * `runDataTableConformanceSuite` (docs/specs/datatable.md §18.5) and not
+ * re-tested here.
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared BEFORE the imports they affect
@@ -24,9 +44,15 @@ vi.mock('../../hooks/useStorageMigration', () => ({
 // ---------------------------------------------------------------------------
 
 import StorageProvidersPage from '../../pages/Admin/StorageProvidersPage';
+import {
+  MIGRATION_RUN_COLUMNS,
+  buildStorageProviderColumns,
+  providerState,
+} from '../../pages/Admin/storageProvidersTable';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useStorageProviders } from '../../hooks/useStorageProviders';
 import { useStorageMigration } from '../../hooks/useStorageMigration';
+import { api } from '../../services/api';
 
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseStorageProviders = vi.mocked(useStorageProviders);
@@ -116,14 +142,37 @@ function defaultMigrationMock() {
   };
 }
 
+function renderPage() {
+  return render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+}
+
+/** Open a provider's credential dialog through its row menu. */
+async function openConfigure(user: ReturnType<typeof userEvent.setup>, rowLabel: string) {
+  await user.click(await screen.findByRole('button', { name: `Row actions for ${rowLabel}` }));
+  await user.click(await screen.findByRole('menuitem', { name: /^configure$/i }));
+  return screen.findByRole('dialog');
+}
+
+/** Open a provider's row menu without picking anything. */
+async function openRowMenu(user: ReturnType<typeof userEvent.setup>, rowLabel: string) {
+  await user.click(await screen.findByRole('button', { name: `Row actions for ${rowLabel}` }));
+}
+
 // ---------------------------------------------------------------------------
 
 describe('StorageProvidersPage', () => {
+  beforeAll(() => {
+    installLayoutStubs();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400);
     mockUsePermissions.mockReturnValue(defaultPermissionsMock() as any);
     mockUseStorageProviders.mockReturnValue(defaultStorageProvidersMock() as any);
     mockUseStorageMigration.mockReturnValue(defaultMigrationMock() as any);
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
   });
 
   // -------------------------------------------------------------------------
@@ -134,13 +183,13 @@ describe('StorageProvidersPage', () => {
         isAdmin: false,
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.queryByRole('heading', { name: /storage providers/i })).not.toBeInTheDocument();
     });
 
     it('renders the page heading for admin users', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByRole('heading', { name: /storage providers/i })).toBeInTheDocument();
     });
@@ -155,7 +204,7 @@ describe('StorageProvidersPage', () => {
         settings: null,
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
       expect(screen.queryByRole('heading', { name: /storage providers/i })).not.toBeInTheDocument();
@@ -165,10 +214,9 @@ describe('StorageProvidersPage', () => {
       mockUseStorageProviders.mockReturnValue({
         ...defaultStorageProvidersMock(),
         loading: true,
-        // settings is NOT null — previous load succeeded
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByRole('heading', { name: /storage providers/i })).toBeInTheDocument();
     });
@@ -184,7 +232,7 @@ describe('StorageProvidersPage', () => {
         error: 'Failed to load storage settings',
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       const alert = screen.getByRole('alert');
       expect(alert).toBeInTheDocument();
@@ -193,156 +241,336 @@ describe('StorageProvidersPage', () => {
   });
 
   // -------------------------------------------------------------------------
-  describe('Provider cards', () => {
-    it('renders a card for each provider — AWS S3, Cloudflare R2, Local Disk', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Each provider name appears at least once (in card heading + possibly radio label)
-      expect(screen.getAllByText('AWS S3').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Cloudflare R2').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Local Disk').length).toBeGreaterThan(0);
+  describe('Column definitions', () => {
+    it('leads the provider card with Provider then Status (issue #259)', () => {
+      const primaries = buildStorageProviderColumns('s3')
+        .filter((column) => column.priority === 'primary')
+        .map((column) => column.id);
+      expect(primaries).toEqual(['provider', 'state']);
     });
 
-    it('shows "Active" chip on the currently active provider', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      const activeChips = screen.getAllByText('Active');
-      expect(activeChips.length).toBeGreaterThan(0);
+    it('leads the migration-run card with Route then Status', () => {
+      const primaries = MIGRATION_RUN_COLUMNS.filter(
+        (column) => column.priority === 'primary',
+      ).map((column) => column.id);
+      expect(primaries).toEqual(['route', 'status']);
     });
 
-    it('shows Enabled chip for enabled providers', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      const enabledChips = screen.getAllByText('Enabled');
-      expect(enabledChips.length).toBeGreaterThan(0);
+    it('keeps the masked secret out of a CSV export', () => {
+      const secret = buildStorageProviderColumns('s3').find((column) => column.id === 'last4')!;
+      expect(secret.exportable).toBe(false);
     });
 
-    it('shows Configured chip for configured providers', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      const configuredChips = screen.getAllByText('Configured');
-      expect(configuredChips.length).toBeGreaterThan(0);
-    });
-
-    it('shows masked secret key for configured S3 provider with last4', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // The masked field renders "••••••••wxyz"
-      expect(screen.getByDisplayValue(/••••.*wxyz/)).toBeInTheDocument();
-    });
-
-    it('shows no-credentials alert for the Local Disk provider', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      expect(screen.getByText(/no credentials required/i)).toBeInTheDocument();
-    });
-
-    it('shows Test connection buttons', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
-      expect(testButtons.length).toBeGreaterThan(0);
-    });
-
-    it('shows Save button for credentialed providers', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      const saveButtons = screen.getAllByRole('button', { name: /^save$/i });
-      expect(saveButtons.length).toBeGreaterThan(0);
-    });
-
-    it('shows Remove button for configured credentialed providers', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Both S3 and R2 are configured
-      const removeButtons = screen.getAllByRole('button', { name: /^remove$/i });
-      expect(removeButtons.length).toBeGreaterThan(0);
+    it('derives the four-way provider state', () => {
+      expect(providerState(makeProviderRow() as any, 's3')).toBe('Active');
+      expect(providerState(makeProviderRow({ provider: 'r2' }) as any, 's3')).toBe('Enabled');
+      expect(
+        providerState(makeProviderRow({ provider: 'r2', enabled: false }) as any, 's3'),
+      ).toBe('Disabled');
+      expect(
+        providerState(makeProviderRow({ provider: 'r2', configured: false }) as any, 's3'),
+      ).toBe('Not configured');
     });
   });
 
   // -------------------------------------------------------------------------
-  describe('Test connection per card', () => {
-    it('calls testProvider and shows success indicator on ok:true', async () => {
-      const mockTestProvider = vi.fn().mockResolvedValue({ ok: true, bucket: 'my-bucket' });
+  describe('Provider table', () => {
+    it('renders a row for each provider — AWS S3, Cloudflare R2, Local Disk', async () => {
+      renderPage();
 
-      mockUseStorageProviders.mockReturnValue({
-        ...defaultStorageProvidersMock(),
-        testProvider: mockTestProvider,
-        // Pre-populate the test result so the result indicator renders
-        testResults: { s3: { ok: true, bucket: 'my-bucket' } },
-        testLoading: { s3: false },
-      } as any);
-
-      const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Find the first "Test connection" button (belongs to S3 card)
-      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
-      await user.click(testButtons[0]);
-
+      const grid = await screen.findByRole('grid', { name: /storage providers/i });
       await waitFor(() => {
-        expect(mockTestProvider).toHaveBeenCalled();
+        expect(within(grid).getByText('AWS S3')).toBeInTheDocument();
+      });
+      expect(within(grid).getByText('Cloudflare R2')).toBeInTheDocument();
+      expect(within(grid).getByText('Local Disk')).toBeInTheDocument();
+    });
+
+    it('shows the "Active" status on the currently active provider', async () => {
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /storage providers/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('Active')).toBeInTheDocument();
       });
     });
 
-    it('shows success text when testResult is ok:true', () => {
+    it('shows a Configured chip for configured providers', async () => {
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /storage providers/i });
+      await waitFor(() => {
+        expect(within(grid).getAllByText('Configured').length).toBeGreaterThan(0);
+      });
+    });
+
+    it('shows the masked secret in the table, never the secret itself', async () => {
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /storage providers/i });
+      await waitFor(() => {
+        expect(within(grid).getByText(/••••.*wxyz/)).toBeInTheDocument();
+      });
+    });
+
+    it('renders without crashing when providers and knownProviders are both empty', async () => {
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        settings: { providers: [], knownProviders: [], activeProvider: '' },
+      } as any);
+
+      renderPage();
+
+      expect(screen.getByRole('heading', { name: /storage providers/i })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/no storage providers available/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Configure dialog', () => {
+    it('shows the masked current secret and the credential fields', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const dialog = await openConfigure(user, 'AWS S3');
+
+      expect(within(dialog).getByDisplayValue(/••••.*wxyz/)).toBeInTheDocument();
+      expect(within(dialog).getByLabelText(/access key id/i)).toBeInTheDocument();
+      expect(within(dialog).getByLabelText(/new secret access key/i)).toBeInTheDocument();
+      expect(within(dialog).getByRole('button', { name: /^save$/i })).toBeInTheDocument();
+      expect(within(dialog).getByRole('button', { name: /test connection/i })).toBeInTheDocument();
+    });
+
+    it('shows the no-credentials alert for Local Disk, and no credential fields', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const dialog = await openConfigure(user, 'Local Disk');
+
+      expect(within(dialog).getByText(/no credentials required/i)).toBeInTheDocument();
+      expect(within(dialog).queryByLabelText(/access key id/i)).not.toBeInTheDocument();
+      expect(within(dialog).queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
+    });
+
+    it('saves credentials with the typed values', async () => {
+      const saveCredentials = vi.fn().mockResolvedValue(makeProviderRow());
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        saveCredentials,
+      } as any);
+      const user = userEvent.setup();
+      renderPage();
+
+      const dialog = await openConfigure(user, 'AWS S3');
+      // `fireEvent.change` rather than `user.type`: every keystroke re-renders
+      // the page (and its two DataGrids), which is a needless ~10s in CI.
+      fireEvent.change(within(dialog).getByLabelText(/new secret access key/i), {
+        target: { value: 'brand-new' },
+      });
+      await user.click(within(dialog).getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(saveCredentials).toHaveBeenCalledWith(
+          's3',
+          expect.objectContaining({ secretAccessKey: 'brand-new', bucket: 'my-bucket' }),
+        );
+      });
+    });
+
+    it('shows the helper text explaining a blank secret keeps the stored one', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const dialog = await openConfigure(user, 'AWS S3');
+
+      expect(
+        within(dialog).getByText(/leave blank to use the saved secret when testing or saving/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Test connection', () => {
+    it('calls testProvider from the row menu', async () => {
+      const testProvider = vi.fn().mockResolvedValue({ ok: true, bucket: 'my-bucket' });
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        testProvider,
+      } as any);
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'AWS S3');
+      await user.click(await screen.findByRole('menuitem', { name: /test connection/i }));
+
+      await waitFor(() => {
+        expect(testProvider).toHaveBeenCalledWith('s3', expect.any(Object));
+      });
+    });
+
+    it('shows the ok result inside the dialog', async () => {
       mockUseStorageProviders.mockReturnValue({
         ...defaultStorageProvidersMock(),
         testResults: { s3: { ok: true, bucket: 'my-bucket' } },
-        testLoading: {},
       } as any);
+      const user = userEvent.setup();
+      renderPage();
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      const dialog = await openConfigure(user, 'AWS S3');
 
-      // The page renders "Connected — bucket: my-bucket" for S3
-      expect(screen.getByText(/connected/i)).toBeInTheDocument();
+      expect(within(dialog).getByText(/connected/i)).toBeInTheDocument();
     });
 
-    it('shows error text when testResult is ok:false', () => {
+    it('shows the failure reason inside the dialog', async () => {
       mockUseStorageProviders.mockReturnValue({
         ...defaultStorageProvidersMock(),
         testResults: { s3: { ok: false, error: 'Invalid credentials' } },
-        testLoading: {},
       } as any);
+      const user = userEvent.setup();
+      renderPage();
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      const dialog = await openConfigure(user, 'AWS S3');
 
-      expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument();
+      expect(within(dialog).getByText(/invalid credentials/i)).toBeInTheDocument();
     });
 
-    it('shows a spinner on the test button while loading', () => {
-      mockUseStorageProviders.mockReturnValue({
-        ...defaultStorageProvidersMock(),
-        testResults: {},
-        testLoading: { s3: true },
-      } as any);
-
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // The button's startIcon switches to CircularProgress when testLoading[provider] is true
-      // The button itself becomes disabled; check it is disabled
-      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
-      // The s3 button (first credentialed card) should be disabled while loading
-      expect(testButtons[0]).toBeDisabled();
-    });
-
-    it('shows "Accessible" for Local Disk when test ok:true', () => {
+    it('shows "Accessible" for Local Disk when the test succeeded', async () => {
       mockUseStorageProviders.mockReturnValue({
         ...defaultStorageProvidersMock(),
         testResults: { local: { ok: true } },
-        testLoading: {},
       } as any);
+      const user = userEvent.setup();
+      renderPage();
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      const dialog = await openConfigure(user, 'Local Disk');
 
-      expect(screen.getByText(/accessible/i)).toBeInTheDocument();
+      expect(within(dialog).getByText(/accessible/i)).toBeInTheDocument();
+    });
+
+    it('disables the test control while a test is in flight', async () => {
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        testLoading: { s3: true },
+      } as any);
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'AWS S3');
+
+      expect(await screen.findByRole('menuitem', { name: /test connection/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Test guard: unconfigured provider requiring credentials', () => {
+    function unconfiguredR2Settings() {
+      return {
+        providers: [],
+        knownProviders: [
+          makeProviderRow({
+            provider: 'r2',
+            label: 'Cloudflare R2',
+            configured: false,
+            enabled: false,
+            last4: null,
+            accessKeyId: null,
+            region: null,
+            bucket: null,
+          }),
+        ],
+        activeProvider: 's3',
+      };
+    }
+
+    it('disables the test action and shows the caption while the secret is empty', async () => {
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        settings: unconfiguredR2Settings(),
+      } as any);
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'Cloudflare R2');
+      expect(await screen.findByRole('menuitem', { name: /test connection/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+      await user.keyboard('{Escape}');
+
+      const dialog = await openConfigure(user, 'Cloudflare R2');
+      expect(
+        within(dialog).getByText(/enter the secret access key to test before saving/i),
+      ).toBeInTheDocument();
+      expect(within(dialog).getByRole('button', { name: /test connection/i })).toBeDisabled();
+    });
+
+    it('enables the test button and hides the caption once a secret is typed', async () => {
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        settings: unconfiguredR2Settings(),
+      } as any);
+      const user = userEvent.setup();
+      renderPage();
+
+      const dialog = await openConfigure(user, 'Cloudflare R2');
+      fireEvent.change(within(dialog).getByLabelText(/new secret access key/i), {
+        target: { value: 'my-r2-secret' },
+      });
+
+      await waitFor(() => {
+        expect(within(dialog).getByRole('button', { name: /test connection/i })).not.toBeDisabled();
+      });
+      expect(
+        within(dialog).queryByText(/enter the secret access key to test before saving/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('Remove credentials', () => {
+    it('confirms, then calls removeCredentials', async () => {
+      const removeCredentials = vi.fn().mockResolvedValue(undefined);
+      mockUseStorageProviders.mockReturnValue({
+        ...defaultStorageProvidersMock(),
+        removeCredentials,
+      } as any);
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'Cloudflare R2');
+      await user.click(await screen.findByRole('menuitem', { name: /^remove$/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(/remove credentials\?/i)).toBeInTheDocument();
+      await user.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+
+      await waitFor(() => {
+        expect(removeCredentials).toHaveBeenCalledWith('r2');
+      });
+    });
+
+    it('is disabled for the local provider, which has no credentials to remove', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'Local Disk');
+
+      expect(await screen.findByRole('menuitem', { name: /^remove$/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
   });
 
   // -------------------------------------------------------------------------
   describe('Active provider selector', () => {
     it('renders a radio group with each provider', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       const radios = screen.getAllByRole('radio');
       // 3 providers → 3 radios
@@ -350,11 +578,10 @@ describe('StorageProvidersPage', () => {
     });
 
     it('has the current active provider pre-selected', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       // defaultSettings has activeProvider = 's3'
       const radios = screen.getAllByRole('radio');
-      // The s3 radio corresponds to the first radio (provider order: s3, r2, local)
       expect(radios[0]).toBeChecked();
     });
 
@@ -367,9 +594,8 @@ describe('StorageProvidersPage', () => {
       } as any);
 
       const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Select r2 radio
       const radios = screen.getAllByRole('radio');
       await user.click(radios[1]); // r2 is the second radio
 
@@ -382,9 +608,8 @@ describe('StorageProvidersPage', () => {
     });
 
     it('disables Save Active Provider button when selection matches current active provider', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Active is 's3', first radio is pre-selected → Save button disabled
       const saveActiveBtn = screen.getByRole('button', { name: /save active provider/i });
       expect(saveActiveBtn).toBeDisabled();
     });
@@ -393,16 +618,14 @@ describe('StorageProvidersPage', () => {
   // -------------------------------------------------------------------------
   describe('Migration panel', () => {
     it('renders Source and Target provider selects', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // MUI Select renders the label in a <label> and also in a <span> inside the fieldset —
-      // use getAllByText to tolerate either occurrence.
       expect(screen.getAllByText(/source provider/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/target provider/i).length).toBeGreaterThan(0);
     });
 
     it('Start Migration button is disabled until source and target are different', () => {
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       const startBtn = screen.getByRole('button', { name: /start migration/i });
       expect(startBtn).toBeDisabled();
@@ -410,27 +633,21 @@ describe('StorageProvidersPage', () => {
 
     it('opens confirmation dialog when Start Migration is clicked with valid source and target', async () => {
       const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Open source select and pick 's3'
-      const comboboxes = screen.getAllByRole('combobox');
-      // First combobox = source, second = target
-      await user.click(comboboxes[0]);
-      const s3Option = await screen.findByRole('option', { name: /aws s3/i });
-      await user.click(s3Option);
+      const source = screen.getByRole('combobox', { name: /source provider/i });
+      await user.click(source);
+      await user.click(await screen.findByRole('option', { name: /aws s3/i }));
 
-      // Open target select and pick 'r2'
-      await user.click(comboboxes[1]);
-      const r2Option = await screen.findByRole('option', { name: /cloudflare r2/i });
-      await user.click(r2Option);
+      const target = screen.getByRole('combobox', { name: /target provider/i });
+      await user.click(target);
+      await user.click(await screen.findByRole('option', { name: /cloudflare r2/i }));
 
-      const startBtn = screen.getByRole('button', { name: /start migration/i });
-      await user.click(startBtn);
+      await user.click(screen.getByRole('button', { name: /start migration/i }));
 
       await waitFor(() => {
         expect(screen.getByRole('dialog')).toBeInTheDocument();
       });
-
       expect(screen.getByText(/start migration\?/i)).toBeInTheDocument();
     });
 
@@ -442,23 +659,16 @@ describe('StorageProvidersPage', () => {
       } as any);
 
       const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      // Select source and target
-      const comboboxes = screen.getAllByRole('combobox');
-      await user.click(comboboxes[0]);
-      const s3Option = await screen.findByRole('option', { name: /aws s3/i });
-      await user.click(s3Option);
-
-      await user.click(comboboxes[1]);
-      const r2Option = await screen.findByRole('option', { name: /cloudflare r2/i });
-      await user.click(r2Option);
-
+      await user.click(screen.getByRole('combobox', { name: /source provider/i }));
+      await user.click(await screen.findByRole('option', { name: /aws s3/i }));
+      await user.click(screen.getByRole('combobox', { name: /target provider/i }));
+      await user.click(await screen.findByRole('option', { name: /cloudflare r2/i }));
       await user.click(screen.getByRole('button', { name: /start migration/i }));
 
-      // Confirm in dialog
-      const confirmBtn = await screen.findByRole('button', { name: /^start migration$/i });
-      await user.click(confirmBtn);
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /^start migration$/i }));
 
       await waitFor(() => {
         expect(mockStartMigration).toHaveBeenCalledWith('s3', 'r2');
@@ -473,54 +683,47 @@ describe('StorageProvidersPage', () => {
       } as any);
 
       const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      const comboboxes = screen.getAllByRole('combobox');
-      await user.click(comboboxes[0]);
+      await user.click(screen.getByRole('combobox', { name: /source provider/i }));
       await user.click(await screen.findByRole('option', { name: /aws s3/i }));
-      await user.click(comboboxes[1]);
+      await user.click(screen.getByRole('combobox', { name: /target provider/i }));
       await user.click(await screen.findByRole('option', { name: /cloudflare r2/i }));
       await user.click(screen.getByRole('button', { name: /start migration/i }));
 
-      // Click Cancel in dialog (first button is "Cancel")
-      const dialogCancelBtn = await screen.findByRole('button', { name: /^cancel$/i });
-      await user.click(dialogCancelBtn);
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /^cancel$/i }));
 
       await waitFor(() => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       });
-
       expect(mockStartMigration).not.toHaveBeenCalled();
     });
 
     it('shows migration progress when activeRun is in-flight', () => {
-      const activeRun = {
-        id: 'run-1',
-        sourceProvider: 's3',
-        targetProvider: 'r2',
-        status: 'running',
-        totalCount: 100,
-        migratedCount: 45,
-        failedCount: 0,
-        skippedCount: 0,
-        startedAt: '2024-01-01T00:00:00Z',
-        finishedAt: null,
-        lastError: null,
-      };
-
       mockUseStorageMigration.mockReturnValue({
         ...defaultMigrationMock(),
-        activeRun,
+        activeRun: {
+          id: 'run-1',
+          sourceProvider: 's3',
+          targetProvider: 'r2',
+          status: 'running',
+          totalCount: 100,
+          migratedCount: 45,
+          failedCount: 0,
+          skippedCount: 0,
+          startedAt: '2024-01-01T00:00:00Z',
+          finishedAt: null,
+          lastError: null,
+        },
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByText(/migration in progress/i)).toBeInTheDocument();
-      // Progress counters: "Copied: 45 / 100"
       expect(screen.getByText(/copied:/i)).toBeInTheDocument();
       expect(screen.getByText(/45 \/ 100/)).toBeInTheDocument();
-      // LinearProgress should be rendered
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getAllByRole('progressbar').length).toBeGreaterThan(0);
     });
 
     it('shows Cancel Migration button while migration is running', () => {
@@ -541,7 +744,7 @@ describe('StorageProvidersPage', () => {
         },
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByRole('button', { name: /cancel migration/i })).toBeInTheDocument();
     });
@@ -568,10 +771,9 @@ describe('StorageProvidersPage', () => {
       } as any);
 
       const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
-      const cancelBtn = screen.getByRole('button', { name: /cancel migration/i });
-      await user.click(cancelBtn);
+      await user.click(screen.getByRole('button', { name: /cancel migration/i }));
 
       await waitFor(() => {
         expect(mockCancel).toHaveBeenCalledTimes(1);
@@ -596,12 +798,12 @@ describe('StorageProvidersPage', () => {
         },
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.queryByRole('button', { name: /^start migration$/i })).not.toBeInTheDocument();
     });
 
-    it('shows run history table when there are past runs', () => {
+    it('shows the run history table when there are past runs', async () => {
       mockUseStorageMigration.mockReturnValue({
         ...defaultMigrationMock(),
         runs: [
@@ -621,139 +823,15 @@ describe('StorageProvidersPage', () => {
         ],
       } as any);
 
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
+      renderPage();
 
       expect(screen.getByText(/recent migration runs/i)).toBeInTheDocument();
-      // The table renders the route as a monospace Typography: "Local Disk → AWS S3"
-      // Provider names also appear in card headings/radios, so use getAllByText.
-      expect(screen.getAllByText(/local disk/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/aws s3/i).length).toBeGreaterThan(0);
-      // The route cell has text "Local Disk → AWS S3" — assert the arrow character exists
-      expect(screen.getByText(/local disk.*→.*aws s3/i)).toBeInTheDocument();
-    });
-  });
 
-  // -------------------------------------------------------------------------
-  describe('Test button guard: unconfigured provider requiring credentials', () => {
-    function unconfiguredR2Settings() {
-      return {
-        providers: [],
-        knownProviders: [
-          makeProviderRow({
-            provider: 'r2',
-            label: 'Cloudflare R2',
-            configured: false,
-            enabled: false,
-            last4: null,
-            accessKeyId: null,
-            region: null,
-            bucket: null,
-          }),
-        ],
-        activeProvider: 's3',
-      };
-    }
-
-    it('disables Test button and shows caption when unconfigured requiresCredentials provider has empty secret field', () => {
-      mockUseStorageProviders.mockReturnValue({
-        ...defaultStorageProvidersMock(),
-        settings: unconfiguredR2Settings(),
-      } as any);
-
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // The Test connection button for R2 must be disabled
-      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
-      // Only one provider card (R2)
-      expect(testButtons[0]).toBeDisabled();
-
-      // The instructional caption must be visible
-      expect(
-        screen.getByText(/enter the secret access key to test before saving/i),
-      ).toBeInTheDocument();
-    });
-
-    it('enables Test button and hides caption once the user types a secret', async () => {
-      mockUseStorageProviders.mockReturnValue({
-        ...defaultStorageProvidersMock(),
-        settings: unconfiguredR2Settings(),
-      } as any);
-
-      const user = userEvent.setup();
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Before typing: button is disabled
-      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
-      expect(testButtons[0]).toBeDisabled();
-
-      // Type a secret into the New Secret Access Key field
-      const secretField = screen.getByLabelText(/new secret access key/i);
-      await user.type(secretField, 'my-r2-secret');
-
-      // After typing: button should be enabled
+      const grid = await screen.findByRole('grid', { name: /migration runs/i });
       await waitFor(() => {
-        const buttons = screen.getAllByRole('button', { name: /test connection/i });
-        expect(buttons[0]).not.toBeDisabled();
+        expect(within(grid).getByText(/local disk.*→.*aws s3/i)).toBeInTheDocument();
       });
-
-      // Caption must no longer be shown
-      expect(
-        screen.queryByText(/enter the secret access key to test before saving/i),
-      ).not.toBeInTheDocument();
-    });
-
-    it('shows secret field helper text and keeps Test button enabled for a configured provider with empty secret', () => {
-      // Configured = true means a secret is already saved; empty field means "use saved"
-      mockUseStorageProviders.mockReturnValue({
-        ...defaultStorageProvidersMock(),
-        settings: {
-          providers: [
-            makeProviderRow({
-              provider: 's3',
-              label: 'AWS S3',
-              configured: true,
-              enabled: true,
-              last4: 'wxyz',
-            }),
-          ],
-          knownProviders: [],
-          activeProvider: 's3',
-        },
-      } as any);
-
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      // Helper text for the secret field must be present (explains blank = use saved)
-      expect(
-        screen.getByText(/leave blank to use the saved secret when testing or saving/i),
-      ).toBeInTheDocument();
-
-      // Test button must be enabled (no guard fires for configured provider)
-      const testButtons = screen.getAllByRole('button', { name: /test connection/i });
-      expect(testButtons[0]).not.toBeDisabled();
-
-      // The "enter secret to test" caption must NOT appear (guard only fires when !configured)
-      expect(
-        screen.queryByText(/enter the secret access key to test before saving/i),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  describe('Empty providers state', () => {
-    it('renders without crashing when providers and knownProviders are both empty', () => {
-      mockUseStorageProviders.mockReturnValue({
-        ...defaultStorageProvidersMock(),
-        settings: {
-          providers: [],
-          knownProviders: [],
-          activeProvider: '',
-        },
-      } as any);
-
-      render(<StorageProvidersPage />, { wrapperOptions: { user: mockAdminUser } });
-
-      expect(screen.getByRole('heading', { name: /storage providers/i })).toBeInTheDocument();
+      expect(within(grid).getByText('completed')).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/pages/TagsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/TagsPage.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for TagsPage — post-#259 (the shared-DataTable migration).
+ *
+ * Scope, per docs/specs/datatable.md §18.5: this file covers the page's own
+ * column declarations (`./tagsTable.tsx`) and its mutations — NOT table
+ * mechanics, which `runDataTableConformanceSuite` owns.
+ *
+ * The migration-specific things asserted here:
+ *   - the generic DataTable CSV export is DISABLED while the bespoke
+ *     `id,name` import/export round trip keeps its own two buttons (issue #259);
+ *   - the inline row edit became a rename dialog and the `window.confirm`
+ *     delete became the row action's own confirmation;
+ *   - the enabled switch still lives in the cell (and therefore on the card).
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, mockAdminUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared before the imports they affect
+// ---------------------------------------------------------------------------
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../../services/tagLabels', () => ({
+  listTagLabels: vi.fn(),
+  createTagLabel: vi.fn(),
+  updateTagLabel: vi.fn(),
+  deleteTagLabel: vi.fn(),
+  exportTagLabels: vi.fn(),
+  importTagLabels: vi.fn(),
+}));
+
+import TagsPage from '../../pages/Admin/TagsPage';
+import { buildTagColumns } from '../../pages/Admin/tagsTable';
+import { usePermissions } from '../../hooks/usePermissions';
+import {
+  listTagLabels,
+  createTagLabel,
+  updateTagLabel,
+  deleteTagLabel,
+  exportTagLabels,
+} from '../../services/tagLabels';
+import type { TagLabel } from '../../services/tagLabels';
+import { api } from '../../services/api';
+
+const mockUsePermissions = vi.mocked(usePermissions);
+const mockList = vi.mocked(listTagLabels);
+const mockCreate = vi.mocked(createTagLabel);
+const mockUpdate = vi.mocked(updateTagLabel);
+const mockDelete = vi.mocked(deleteTagLabel);
+const mockExport = vi.mocked(exportTagLabels);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makePermissions(isAdmin: boolean) {
+  return {
+    permissions: new Set<string>(),
+    roles: new Set<string>(isAdmin ? ['admin'] : ['viewer']),
+    hasPermission: vi.fn().mockReturnValue(isAdmin),
+    hasAnyPermission: vi.fn().mockReturnValue(isAdmin),
+    hasAllPermissions: vi.fn().mockReturnValue(isAdmin),
+    hasRole: vi.fn().mockReturnValue(isAdmin),
+    hasAnyRole: vi.fn().mockReturnValue(isAdmin),
+    isAdmin,
+  };
+}
+
+function makeLabel(overrides: Partial<TagLabel> = {}): TagLabel {
+  return {
+    id: 'label-1',
+    name: 'beach',
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(<TagsPage />, { wrapperOptions: { user: mockAdminUser } });
+}
+
+async function openRowMenu(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await user.click(await screen.findByRole('button', { name: `Row actions for ${name}` }));
+}
+
+// ---------------------------------------------------------------------------
+
+describe('TagsPage', () => {
+  beforeAll(() => {
+    installLayoutStubs();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetContainerWidth(1400);
+    mockUsePermissions.mockReturnValue(makePermissions(true));
+    mockList.mockResolvedValue([makeLabel({ id: 'l1', name: 'beach' })]);
+    mockCreate.mockResolvedValue(makeLabel({ id: 'l2', name: 'sunset' }));
+    mockUpdate.mockResolvedValue(makeLabel({ id: 'l1', name: 'seaside' }));
+    mockDelete.mockResolvedValue(undefined as never);
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
+  });
+
+  // =========================================================================
+  // Authorization
+  // =========================================================================
+
+  it('redirects non-admin users — page content not shown', () => {
+    mockUsePermissions.mockReturnValue(makePermissions(false));
+
+    renderPage();
+
+    expect(screen.queryByRole('heading', { name: /^tags$/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the heading for admins', async () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: /^tags$/i })).toBeInTheDocument();
+    await waitFor(() => expect(mockList).toHaveBeenCalled());
+  });
+
+  // =========================================================================
+  // Column definitions
+  // =========================================================================
+
+  describe('Column definitions', () => {
+    const columns = buildTagColumns({ onToggleEnabled: vi.fn() });
+
+    it('leads with the (row-unique) name column', () => {
+      expect(columns[0].id).toBe('name');
+      expect(columns[0].priority).toBe('primary');
+    });
+
+    it('keeps the enabled switch as a rendered cell with a scalar behind it', () => {
+      const enabled = columns.find((column) => column.id === 'enabled')!;
+      expect(enabled.render).toBeTypeOf('function');
+      expect(enabled.value!(makeLabel({ enabled: false }))).toBe('false');
+    });
+  });
+
+  // =========================================================================
+  // Vocabulary table
+  // =========================================================================
+
+  describe('Vocabulary table', () => {
+    it('renders a row per label with its enable switch', async () => {
+      mockList.mockResolvedValue([
+        makeLabel({ id: 'l1', name: 'beach' }),
+        makeLabel({ id: 'l2', name: 'sunset', enabled: false }),
+      ]);
+
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /tag vocabulary/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('beach')).toBeInTheDocument();
+      });
+      expect(within(grid).getByText('sunset')).toBeInTheDocument();
+      expect(screen.getByRole('switch', { name: 'Toggle beach' })).toBeChecked();
+      expect(screen.getByRole('switch', { name: 'Toggle sunset' })).not.toBeChecked();
+    });
+
+    it('shows the empty state when the vocabulary is empty', async () => {
+      mockList.mockResolvedValue([]);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText(/no tag labels defined yet/i)).toBeInTheDocument();
+      });
+    });
+
+    it('toggling the switch calls updateTagLabel with the new flag', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const toggle = await screen.findByRole('switch', { name: 'Toggle beach' });
+      await user.click(toggle);
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith('l1', { enabled: false });
+      });
+    });
+  });
+
+  // =========================================================================
+  // Mutations through the row menu
+  // =========================================================================
+
+  describe('Row actions', () => {
+    it('renames a label through the dialog', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'beach');
+      await user.click(await screen.findByRole('menuitem', { name: /rename/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      const field = within(dialog).getByLabelText(/label name/i);
+      await user.clear(field);
+      await user.type(field, 'seaside');
+      await user.click(within(dialog).getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith('l1', { name: 'seaside' });
+      });
+    });
+
+    it('deletes a label only after confirming', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await openRowMenu(user, 'beach');
+      await user.click(await screen.findByRole('menuitem', { name: /^delete$/i }));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(/delete tag label\?/i)).toBeInTheDocument();
+
+      await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
+      expect(mockDelete).not.toHaveBeenCalled();
+
+      await openRowMenu(user, 'beach');
+      await user.click(await screen.findByRole('menuitem', { name: /^delete$/i }));
+      const confirm = await screen.findByRole('dialog');
+      await user.click(within(confirm).getByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() => {
+        expect(mockDelete).toHaveBeenCalledWith('l1');
+      });
+    });
+  });
+
+  // =========================================================================
+  // The bespoke CSV round trip — and the absence of the generic one
+  // =========================================================================
+
+  describe('CSV import / export', () => {
+    it('keeps its own Export CSV and Import CSV buttons', async () => {
+      renderPage();
+
+      expect(await screen.findByRole('button', { name: /export csv/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /import csv/i })).toBeInTheDocument();
+    });
+
+    it('DISABLES the generic DataTable export so there is only one export button', async () => {
+      renderPage();
+
+      await screen.findByRole('grid', { name: /tag vocabulary/i });
+      // The shared control renders as an "Export" button (desktop) or an
+      // "Export CSV" menu item; neither may exist here.
+      expect(screen.queryByRole('button', { name: /^export$/i })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('datatable-export-control')).not.toBeInTheDocument();
+    });
+
+    it('Export CSV downloads through the bespoke endpoint', async () => {
+      const blob = new Blob(['id,name\n'], { type: 'text/csv' });
+      mockExport.mockResolvedValue(blob);
+      const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+      const revokeObjectURL = vi.fn();
+      Object.defineProperty(global.URL, 'createObjectURL', {
+        value: createObjectURL,
+        writable: true,
+      });
+      Object.defineProperty(global.URL, 'revokeObjectURL', {
+        value: revokeObjectURL,
+        writable: true,
+      });
+
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(await screen.findByRole('button', { name: /export csv/i }));
+
+      await waitFor(() => {
+        expect(mockExport).toHaveBeenCalled();
+      });
+      expect(createObjectURL).toHaveBeenCalledWith(blob);
+    });
+  });
+
+  // =========================================================================
+  // Add form (unchanged by the migration)
+  // =========================================================================
+
+  it('adds a label and appends it to the table', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText(/label name/i), 'sunset');
+    await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({ name: 'sunset' });
+    });
+    await waitFor(() => {
+      expect(screen.getByText('sunset')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Phone
+  // =========================================================================
+
+  it('renders cards on a phone with the rename/delete actions still reachable', async () => {
+    setInitialContainerWidth(360);
+    const user = userEvent.setup();
+    renderPage();
+
+    const table = await screen.findByTestId('datatable');
+    expect(table).toHaveAttribute('data-layout', 'mobile');
+
+    await openRowMenu(user, 'beach');
+    expect(await screen.findByRole('menuitem', { name: /rename/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /^delete$/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/pages/WorkersPage.test.tsx
+++ b/apps/web/src/__tests__/pages/WorkersPage.test.tsx
@@ -1,17 +1,23 @@
 /**
- * Unit tests for WorkersPage — Node credentials section.
+ * Unit tests for WorkersPage — post-#259 (the shared-DataTable migration).
  *
- * Tests: the credentials table renders rows (name, prefix, owner, status);
- * "Never"/"—" placeholders; the create flow calls createCredential and reveals
- * the raw token exactly once (with the MEMORIAHUB_TOKEN warning), clearing it on
- * close; the revoke flow confirms then calls revokeCredential; non-admins are
- * redirected.
+ * Scope note, per docs/specs/datatable.md §18.5: table MECHANICS live in
+ * `runDataTableConformanceSuite`, not here. This file covers the two column
+ * sets this page declares (`./workersTable.tsx`) and its own behaviour: the
+ * fleet table's deregister flow, the credentials table's create/reveal/revoke
+ * flow, permission gating, and the phone layout reaching both destructive
+ * actions that used to sit in an off-screen last column.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be declared BEFORE imports they affect
@@ -34,6 +40,11 @@ vi.mock('../../hooks/useNodeCredentials', () => ({
 // ---------------------------------------------------------------------------
 
 import WorkersPage from '../../pages/Admin/WorkersPage';
+import {
+  buildNodeCredentialColumns,
+  buildWorkerNodeColumns,
+  credentialState,
+} from '../../pages/Admin/workersTable';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useWorkers } from '../../hooks/useWorkers';
 import type { UseWorkersResult } from '../../hooks/useWorkers';
@@ -42,7 +53,9 @@ import type { UseNodeCredentialsResult } from '../../hooks/useNodeCredentials';
 import type {
   AdminNodeCredentialDto,
   CreatedNodeCredentialDto,
+  WorkerNodeDto,
 } from '../../services/workers';
+import { api } from '../../services/api';
 
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseWorkers = vi.mocked(useWorkers);
@@ -74,6 +87,26 @@ function makeWorkersHook(overrides: Partial<UseWorkersResult> = {}): UseWorkersR
     setAutoRefresh: vi.fn(),
     refresh: vi.fn().mockResolvedValue(undefined),
     deleteWorker: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeNode(overrides: Partial<WorkerNodeDto> = {}): WorkerNodeDto {
+  return {
+    id: 'node-uuid-1',
+    name: 'gpu-box-1',
+    hostname: 'gpu1.local',
+    platform: 'linux-x64',
+    cliVersion: '1.4.2',
+    eligibleTypes: ['face_detection', 'auto_tagging'],
+    concurrency: 2,
+    status: 'online',
+    capabilities: null,
+    registeredAt: '2026-07-01T10:00:00Z',
+    lastHeartbeatAt: '2026-07-16T10:00:00Z',
+    createdById: 'user-uuid-1',
+    health: 'healthy',
+    jobCounts: { running: 1, succeeded: 42, failed: 0 },
     ...overrides,
   };
 }
@@ -122,14 +155,27 @@ function makeCreatedCredential(
   };
 }
 
+function renderPage() {
+  return render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+}
+
 // ---------------------------------------------------------------------------
 
-describe('WorkersPage — Node credentials', () => {
+describe('WorkersPage', () => {
+  beforeAll(() => {
+    // jsdom performs no layout; the shared stub recipe is what makes MUI X
+    // render rows at all (docs/specs/datatable.md §12).
+    installLayoutStubs();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400);
     mockUsePermissions.mockReturnValue(makePermissions(true));
     mockUseWorkers.mockReturnValue(makeWorkersHook());
     mockUseNodeCredentials.mockReturnValue(makeCredentialsHook());
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
   });
 
   // =========================================================================
@@ -139,13 +185,13 @@ describe('WorkersPage — Node credentials', () => {
   it('redirects non-admin users — page content not shown', () => {
     mockUsePermissions.mockReturnValue(makePermissions(false));
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     expect(screen.queryByText(/node credentials/i)).not.toBeInTheDocument();
   });
 
   it('renders the Node credentials section heading for admins', async () => {
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /node credentials/i })).toBeInTheDocument();
@@ -153,7 +199,142 @@ describe('WorkersPage — Node credentials', () => {
   });
 
   // =========================================================================
-  // List rendering
+  // Column definitions
+  // =========================================================================
+
+  describe('Column definitions', () => {
+    it('leads the fleet card with Node then Status (issue #259: status is primary)', () => {
+      const primaries = buildWorkerNodeColumns()
+        .filter((column) => column.priority === 'primary')
+        .map((column) => column.id);
+      expect(primaries).toEqual(['name', 'status']);
+    });
+
+    it('leads the credential card with Name then Status', () => {
+      const primaries = buildNodeCredentialColumns()
+        .filter((column) => column.priority === 'primary')
+        .map((column) => column.id);
+      expect(primaries).toEqual(['name', 'state']);
+    });
+
+    it('derives the credential state from revokedAt, then expiresAt', () => {
+      expect(credentialState(makeCredential())).toBe('Active');
+      expect(credentialState(makeCredential({ expiresAt: '2000-01-01T00:00:00Z' }))).toBe(
+        'Expired',
+      );
+      expect(
+        credentialState(
+          makeCredential({ revokedAt: '2026-07-10T00:00:00Z', expiresAt: '2000-01-01T00:00:00Z' }),
+        ),
+      ).toBe('Revoked');
+    });
+  });
+
+  // =========================================================================
+  // Fleet table
+  // =========================================================================
+
+  describe('Worker node fleet', () => {
+    it('renders a row per node with its name, hostname and status', async () => {
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({
+          nodes: [
+            makeNode({ id: 'n1', name: 'gpu-box-1', status: 'online' }),
+            makeNode({ id: 'n2', name: 'vps-2', hostname: 'vps2.local', status: 'offline' }),
+          ],
+        }),
+      );
+
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /worker nodes/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('gpu-box-1')).toBeInTheDocument();
+      });
+      expect(within(grid).getByText('vps2.local')).toBeInTheDocument();
+      expect(within(grid).getByText('online')).toBeInTheDocument();
+      expect(within(grid).getByText('offline')).toBeInTheDocument();
+    });
+
+    it('shows an empty-state message when no nodes are registered', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText(/no worker nodes registered/i)).toBeInTheDocument();
+      });
+    });
+
+    it('surfaces the fleet error without blanking the rows underneath it', async () => {
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({ nodes: [makeNode()], error: 'Fleet load failed' }),
+      );
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText(/fleet load failed/i)).toBeInTheDocument();
+      });
+      expect(screen.getByText('gpu-box-1')).toBeInTheDocument();
+    });
+
+    it('deregisters a node after confirming', async () => {
+      const deleteWorker = vi.fn().mockResolvedValue(undefined);
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({ nodes: [makeNode({ id: 'node-doomed' })], deleteWorker }),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+      await user.click(
+        await screen.findByRole('button', { name: /deregister node for gpu-box-1/i }),
+      );
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(/deregister worker node\?/i)).toBeInTheDocument();
+      await user.click(within(dialog).getByRole('button', { name: /^deregister$/i }));
+
+      await waitFor(() => {
+        expect(deleteWorker).toHaveBeenCalledWith('node-doomed');
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/deregistered/i)).toBeInTheDocument();
+      });
+    });
+
+    it('does not deregister when the confirmation is cancelled', async () => {
+      const deleteWorker = vi.fn().mockResolvedValue(undefined);
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({ nodes: [makeNode({ id: 'node-safe' })], deleteWorker }),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+      await user.click(
+        await screen.findByRole('button', { name: /deregister node for gpu-box-1/i }),
+      );
+
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
+
+      expect(deleteWorker).not.toHaveBeenCalled();
+    });
+
+    it('keeps the auto-refresh toggle and reports it to the hook', async () => {
+      const setAutoRefresh = vi.fn();
+      mockUseWorkers.mockReturnValue(makeWorkersHook({ setAutoRefresh }));
+      const user = userEvent.setup();
+
+      renderPage();
+
+      const toggle = await screen.findByRole('switch', { name: /auto-refresh/i });
+      expect(toggle).toBeChecked();
+      await user.click(toggle);
+      expect(setAutoRefresh).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // =========================================================================
+  // Credentials list rendering
   // =========================================================================
 
   it('renders a row for each credential with name, prefix, owner and status', async () => {
@@ -166,7 +347,7 @@ describe('WorkersPage — Node credentials', () => {
       }),
     );
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('GPU box 1')).toBeInTheDocument();
@@ -190,7 +371,7 @@ describe('WorkersPage — Node credentials', () => {
       }),
     );
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('Never')).toBeInTheDocument();
@@ -201,7 +382,7 @@ describe('WorkersPage — Node credentials', () => {
   it('shows an empty-state message when there are no credentials', async () => {
     mockUseNodeCredentials.mockReturnValue(makeCredentialsHook({ credentials: [] }));
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByText(/no node credentials/i)).toBeInTheDocument();
@@ -213,7 +394,7 @@ describe('WorkersPage — Node credentials', () => {
       makeCredentialsHook({ error: 'Credential load failed' }),
     );
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByText(/credential load failed/i)).toBeInTheDocument();
@@ -230,7 +411,7 @@ describe('WorkersPage — Node credentials', () => {
     mockUseNodeCredentials.mockReturnValue(makeCredentialsHook({ createCredential }));
     const user = userEvent.setup();
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     // Open the create dialog
     const createBtn = await screen.findByRole('button', { name: /create credential/i });
@@ -244,8 +425,6 @@ describe('WorkersPage — Node credentials', () => {
     const submitBtn = await screen.findByRole('button', { name: /^create$/i });
     await user.click(submitBtn);
 
-    // Hook mutation called with expiresAt null (never expires default) — this is
-    // what invalidates/refreshes the list inside the real hook.
     await waitFor(() => {
       expect(createCredential).toHaveBeenCalledWith({ name: 'New worker', expiresAt: null });
     });
@@ -254,8 +433,6 @@ describe('WorkersPage — Node credentials', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('nod_ab12_super_secret_raw_token')).toBeInTheDocument();
     });
-    // Scope MEMORIAHUB_TOKEN to the reveal dialog — it also appears in the
-    // section caption above the table.
     const revealDialog = screen.getByRole('dialog');
     expect(within(revealDialog).getByText(/will not be shown again/i)).toBeInTheDocument();
     expect(within(revealDialog).getByText(/MEMORIAHUB_TOKEN/i)).toBeInTheDocument();
@@ -272,7 +449,7 @@ describe('WorkersPage — Node credentials', () => {
   it('disables the Create submit button until a name is entered', async () => {
     const user = userEvent.setup();
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     const createBtn = await screen.findByRole('button', { name: /create credential/i });
     await user.click(createBtn);
@@ -300,21 +477,16 @@ describe('WorkersPage — Node credentials', () => {
     );
     const user = userEvent.setup();
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
-    // Click the per-row revoke icon button
-    const revokeIcon = await screen.findByRole('button', { name: /revoke credential/i });
+    // Per-row revoke control, now named after its row (§17.6)
+    const revokeIcon = await screen.findByRole('button', { name: /revoke credential for doomed/i });
     await user.click(revokeIcon);
 
-    // Confirm dialog appears
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(screen.getByText(/revoke credential\?/i)).toBeInTheDocument();
-    });
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/revoke credential\?/i)).toBeInTheDocument();
 
-    // Confirm
-    const confirmBtn = await screen.findByRole('button', { name: /^revoke$/i });
-    await user.click(confirmBtn);
+    await user.click(within(dialog).getByRole('button', { name: /^revoke$/i }));
 
     expect(revokeCredential).toHaveBeenCalledWith('cred-to-revoke');
   });
@@ -329,31 +501,62 @@ describe('WorkersPage — Node credentials', () => {
     );
     const user = userEvent.setup();
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     const revokeIcon = await screen.findByRole('button', { name: /revoke credential/i });
     await user.click(revokeIcon);
 
-    const cancelBtn = await screen.findByRole('button', { name: /cancel/i });
-    await user.click(cancelBtn);
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
 
     expect(revokeCredential).not.toHaveBeenCalled();
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
-  it('hides the revoke action for an already-revoked credential', async () => {
+  it('DISABLES (rather than hides) the revoke action for an already-revoked credential', async () => {
     mockUseNodeCredentials.mockReturnValue(
       makeCredentialsHook({
         credentials: [makeCredential({ id: 'cred-revoked', revokedAt: '2026-07-10T00:00:00Z' })],
       }),
     );
 
-    render(<WorkersPage />, { wrapperOptions: { user: mockAdminUser } });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('Revoked')).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole('button', { name: /revoke credential/i })).not.toBeInTheDocument();
+    // The migration swapped "render nothing" for the contract's own per-row
+    // `disabled`, which keeps the control (and its tooltip) discoverable
+    // instead of silently vanishing.
+    expect(screen.getByRole('button', { name: /revoke credential/i })).toBeDisabled();
+  });
+
+  // =========================================================================
+  // Phone
+  // =========================================================================
+
+  describe('Phone layout (360px)', () => {
+    it('reaches deregister and revoke from cards', async () => {
+      setInitialContainerWidth(360);
+      mockUseWorkers.mockReturnValue(makeWorkersHook({ nodes: [makeNode()] }));
+      mockUseNodeCredentials.mockReturnValue(
+        makeCredentialsHook({ credentials: [makeCredential({ name: 'Doomed' })] }),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+
+      const tables = await screen.findAllByTestId('datatable');
+      tables.forEach((table) => expect(table).toHaveAttribute('data-layout', 'mobile'));
+
+      // On a card, a single row action collapses into the overflow menu.
+      await user.click(
+        await screen.findByRole('button', { name: 'Row actions for gpu-box-1' }),
+      );
+      expect(await screen.findByRole('menuitem', { name: /deregister node/i })).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/Admin/BackupPage.tsx
+++ b/apps/web/src/pages/Admin/BackupPage.tsx
@@ -4,13 +4,6 @@ import {
   Container,
   Typography,
   Box,
-  Paper,
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
-  Chip,
   CircularProgress,
   Alert,
   FormControl,
@@ -23,6 +16,9 @@ import {
 import { usePermissions } from '../../hooks/usePermissions';
 import { useCircles } from '../../hooks/useCircles';
 import { useBackup } from '../../hooks/useBackup';
+import type { BackupRun } from '../../services/backup';
+import { DataTable } from '../../components/datatable';
+import { BACKUP_RUNS_TABLE_ID, BACKUP_RUN_COLUMNS } from './backupTable';
 
 function BackupPageContent() {
   const { isAdmin } = usePermissions();
@@ -133,76 +129,24 @@ function BackupPageContent() {
         Recent Runs
       </Typography>
 
-      {runsError && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {runsError}
-        </Alert>
-      )}
-
-      {runsLoading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-          <CircularProgress />
-        </Box>
-      ) : (
-        <Paper variant="outlined">
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Scope</TableCell>
-                <TableCell align="right">Copied</TableCell>
-                <TableCell align="right">Skipped</TableCell>
-                <TableCell align="right">Failed</TableCell>
-                <TableCell>Started At</TableCell>
-                <TableCell>Completed</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {runs.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center">
-                    <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-                      No backup runs found
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                runs.map((run) => (
-                  <TableRow key={run.runId}>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
-                        {run.scope}
-                      </Typography>
-                    </TableCell>
-                    <TableCell align="right">
-                      <Typography variant="body2">{run.copied}</Typography>
-                    </TableCell>
-                    <TableCell align="right">
-                      <Typography variant="body2">{run.skipped}</Typography>
-                    </TableCell>
-                    <TableCell align="right">
-                      <Chip
-                        label={run.failed}
-                        size="small"
-                        color={run.failed > 0 ? 'error' : 'success'}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2">
-                        {new Date(run.startedAt).toLocaleString()}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2">
-                        {run.completedAt ? new Date(run.completedAt).toLocaleString() : '—'}
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </Paper>
-      )}
+      {/*
+        Rendered unconditionally with `loading` as a prop: the overlay draws
+        over rows that stay mounted, rather than swapping the whole table for a
+        spinner and losing scroll position on every refresh
+        (docs/specs/datatable.md §18.4).
+      */}
+      <DataTable<BackupRun>
+        columns={BACKUP_RUN_COLUMNS}
+        rows={runs}
+        rowId={(run) => run.runId}
+        tableId={BACKUP_RUNS_TABLE_ID}
+        ariaLabel="Backup runs"
+        density="compact"
+        loading={runsLoading}
+        error={runsError}
+        emptyState={<span>No backup runs found</span>}
+        csvExport={{ filename: 'backup-runs' }}
+      />
     </Container>
   );
 }

--- a/apps/web/src/pages/Admin/JobInsightsPage.tsx
+++ b/apps/web/src/pages/Admin/JobInsightsPage.tsx
@@ -8,12 +8,6 @@ import {
   CardContent,
   Alert,
   Link,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   useTheme,
 } from '@mui/material';
 import {
@@ -38,13 +32,14 @@ import { KpiSkeleton } from '../../components/insights/KpiSkeleton';
 import { ProportionBar } from '../../components/insights/ProportionBar';
 import { FreshnessPill } from '../../components/insights/FreshnessPill';
 import { formatDuration } from '../../utils/formatBytes';
-import type {
-  JobInsightsLiveByType,
-  JobInsightsHistoryByType,
-  JobInsightsEtaPerType,
-  JobLifetimeByType,
-} from '../../services/jobInsights';
 import { formatCompactNumber } from '../../utils/formatBytes';
+import { DataTable } from '../../components/datatable';
+import {
+  JOB_INSIGHTS_COLUMNS,
+  JOB_INSIGHTS_TABLE_ID,
+  buildPerTypeRows,
+  type PerTypeRow,
+} from './jobInsightsTable';
 
 // ---------------------------------------------------------------------------
 // Color palette for proportion bar segments
@@ -60,61 +55,6 @@ const SEGMENT_COLORS = [
   '#84cc16',
   '#f97316',
 ];
-
-// ---------------------------------------------------------------------------
-// Per-type row data (joined from three sources)
-// ---------------------------------------------------------------------------
-
-interface PerTypeRow {
-  type: string;
-  queued: number;
-  avgMs: number | null;
-  p95Ms: number | null;
-  throughputPerMin: number | null;
-  etcMs: number | null;
-  lifetimeTotal: number;
-}
-
-function buildPerTypeRows(
-  liveByType: JobInsightsLiveByType[],
-  historyByType: JobInsightsHistoryByType[],
-  etaPerType: JobInsightsEtaPerType[],
-  lifetimeByType: JobLifetimeByType[],
-): PerTypeRow[] {
-  // Build a map of all types
-  const allTypes = new Set<string>();
-  liveByType.forEach((r) => allTypes.add(r.type));
-  historyByType.forEach((r) => allTypes.add(r.type));
-  etaPerType.forEach((r) => allTypes.add(r.type));
-  lifetimeByType.forEach((r) => allTypes.add(r.type));
-
-  const rows: PerTypeRow[] = Array.from(allTypes).map((type) => {
-    const live = liveByType.find((r) => r.type === type);
-    const hist = historyByType.find((r) => r.type === type);
-    const eta = etaPerType.find((r) => r.type === type);
-    const life = lifetimeByType.find((r) => r.type === type);
-
-    const queued = (live?.pending ?? 0) + (live?.running ?? 0);
-
-    return {
-      type,
-      queued,
-      avgMs: hist?.avgMs ?? null,
-      p95Ms: hist?.p95Ms ?? null,
-      throughputPerMin: hist?.throughputPerMin ?? null,
-      etcMs: eta?.etcMs ?? null,
-      lifetimeTotal: life?.total ?? 0,
-    };
-  });
-
-  // Sort by queued descending, then type ascending
-  rows.sort((a, b) => {
-    if (b.queued !== a.queued) return b.queued - a.queued;
-    return a.type.localeCompare(b.type);
-  });
-
-  return rows;
-}
 
 // ---------------------------------------------------------------------------
 // Main content (admin-gated wrapper below)
@@ -343,72 +283,16 @@ function JobInsightsPageContent() {
                   Duration statistics and estimated completion times by job type
                 </Typography>
 
-                <TableContainer>
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Type</TableCell>
-                        <TableCell align="right">Queued</TableCell>
-                        <TableCell align="right">Avg Duration</TableCell>
-                        <TableCell align="right">p95</TableCell>
-                        <TableCell align="right">Throughput</TableCell>
-                        <TableCell align="right">ETC</TableCell>
-                        <TableCell align="right">All-time</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {perTypeRows.length === 0 ? (
-                        <TableRow>
-                          <TableCell colSpan={7} align="center" sx={{ py: 3, color: 'text.secondary' }}>
-                            No per-type data available
-                          </TableCell>
-                        </TableRow>
-                      ) : (
-                        perTypeRows.map((row) => (
-                          <TableRow key={row.type} hover>
-                            <TableCell>
-                              <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {row.type}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Typography variant="body2">
-                                {row.queued > 0 ? row.queued : '—'}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Typography variant="body2">
-                                {formatDuration(row.avgMs)}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Typography variant="body2">
-                                {formatDuration(row.p95Ms)}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Typography variant="body2">
-                                {row.throughputPerMin !== null && row.throughputPerMin > 0
-                                  ? `${row.throughputPerMin.toFixed(1)}/min`
-                                  : '—'}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Typography variant="body2">
-                                {formatDuration(row.etcMs)}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                {row.lifetimeTotal > 0 ? formatCompactNumber(row.lifetimeTotal) : '—'}
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                        ))
-                      )}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
+                <DataTable<PerTypeRow>
+                  columns={JOB_INSIGHTS_COLUMNS}
+                  rows={perTypeRows}
+                  rowId={(row) => row.type}
+                  tableId={JOB_INSIGHTS_TABLE_ID}
+                  ariaLabel="Per-type job breakdown"
+                  density="compact"
+                  emptyState={<span>No per-type data available</span>}
+                  csvExport={{ filename: 'job-insights-by-type' }}
+                />
 
                 {/* Tier 3 — ProportionBar */}
                 {proportionSegments.length > 0 && (

--- a/apps/web/src/pages/Admin/PublicSharesPage.tsx
+++ b/apps/web/src/pages/Admin/PublicSharesPage.tsx
@@ -1,26 +1,45 @@
+/**
+ * Admin → Public Sharing (`/admin/settings/sharing`).
+ *
+ * Migrated onto the shared DataTable in issue #259 (epic #238). This was the
+ * worst-affected surface after the Job Queue: on a phone the checkbox column and
+ * Preview were visible, Type and Items partially, and the Public URL plus the
+ * ENTIRE per-row action column — revoke, set expiration, delete — were off
+ * screen. The one thing you open this page on a phone to do was the one thing
+ * you could not reach.
+ *
+ * What the migration deleted: a hand-rolled 9-column `<Table>`, a bespoke
+ * selection model (`toggleSelect` / `toggleSelectAll` / `allSelected`), a
+ * hand-built bulk-action `Paper`, a `TablePagination` footer, and two of the
+ * three confirm dialogs.
+ *
+ * ## The tabs are the filter model, not a second filter surface
+ *
+ * The All / Active / Expired / Revoked strip stays (issue #259's decision), but
+ * it now writes into the table's own normalized filter model and reads the
+ * active tab back out of it (`./sharesTable.tsx`). The `status` column declares
+ * no `filterable`, so the generic "Add filter" picker never offers a second
+ * control for the same param.
+ *
+ * ## Permissions
+ *
+ * Unchanged: the page is Admin-gated (`shares:manage_any` is what the API
+ * enforces for `scope=all` and for the bulk endpoint).
+ */
+
 import { useState, useCallback, useMemo } from 'react';
 import { Navigate, Link as RouterLink } from 'react-router-dom';
 import {
   Box,
   Typography,
   Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TablePagination,
-  Chip,
   IconButton,
   Tooltip,
   Button,
   Stack,
-  Checkbox,
   CircularProgress,
   Alert,
   Snackbar,
-  Avatar,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -32,60 +51,33 @@ import {
   Link,
 } from '@mui/material';
 import {
-  ContentCopy as CopyIcon,
   Edit as EditIcon,
   Block as RevokeIcon,
   Delete as DeleteIcon,
   Public as PublicIcon,
-  Image as ImageIcon,
-  PhotoLibrary as AlbumIcon,
   Refresh as RefreshIcon,
 } from '@mui/icons-material';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useMediaShares } from '../../hooks/useMediaShares';
-import type { MediaShare, ShareStatus } from '../../types/sharing';
+import type { MediaShare } from '../../types/sharing';
+import {
+  DataTable,
+  type DataTableBulkAction,
+  type DataTableFilterModel,
+  type DataTableRowAction,
+} from '../../components/datatable';
+import {
+  SHARES_EMPTY_STATE,
+  SHARES_TABLE_ID,
+  buildShareColumns,
+  normalizeShareFilters,
+  statusFromFilters,
+  toShareQuery,
+  withStatusFilter,
+  type ShareStatusFilter,
+} from './sharesTable';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const STATUS_COLORS: Record<ShareStatus, 'success' | 'warning' | 'error'> = {
-  active: 'success',
-  expired: 'warning',
-  revoked: 'error',
-};
-
-const STATUS_LABELS: Record<ShareStatus, string> = {
-  active: 'Active',
-  expired: 'Expired',
-  revoked: 'Revoked',
-};
-
-function ShareStatusChip({ status }: { status: ShareStatus }) {
-  return (
-    <Chip
-      label={STATUS_LABELS[status]}
-      color={STATUS_COLORS[status]}
-      size="small"
-      variant="outlined"
-    />
-  );
-}
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return 'Never';
-  return new Date(iso).toLocaleString();
-}
-
-function formatDateShort(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return new Date(iso).toLocaleDateString();
-}
-
-function truncateUrl(url: string, maxLen = 48): string {
-  if (url.length <= maxLen) return url;
-  return url.slice(0, maxLen) + '…';
-}
+const DEFAULT_PAGE_SIZE = 20;
 
 // ---------------------------------------------------------------------------
 // Edit expiration dialog
@@ -160,7 +152,8 @@ function EditExpirationDialog({ share, onClose, onSave }: EditExpirationDialogPr
 }
 
 // ---------------------------------------------------------------------------
-// Confirm revoke dialog
+// Confirm revoke dialog (bulk only — the per-row revoke uses the DataTable's
+// own single confirm dialog, so there is exactly one implementation per gesture)
 // ---------------------------------------------------------------------------
 
 interface ConfirmRevokeDialogProps {
@@ -270,26 +263,19 @@ function BulkExpirationDialog({ open, onClose, onSave, count }: BulkExpirationDi
 }
 
 // ---------------------------------------------------------------------------
-// Status tab type
-// ---------------------------------------------------------------------------
-
-type StatusFilter = 'all' | ShareStatus;
-
-// ---------------------------------------------------------------------------
 // Main page content
 // ---------------------------------------------------------------------------
 
 function PublicSharesPageContent() {
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [page, setPage] = useState(0);
-  const [pageSize] = useState(20);
+  // --- Controlled table state (all of it lives HERE, above the table) --------
 
-  // Selection
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [filterModel, setFilterModel] = useState<DataTableFilterModel>([]);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
   // Dialogs
   const [editShare, setEditShare] = useState<MediaShare | null>(null);
-  const [revokeShare, setRevokeShare] = useState<MediaShare | null>(null);
   const [showBulkRevokeConfirm, setShowBulkRevokeConfirm] = useState(false);
   const [showBulkExpiration, setShowBulkExpiration] = useState(false);
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
@@ -297,55 +283,70 @@ function PublicSharesPageContent() {
   // Snackbar
   const [snack, setSnack] = useState<{ message: string; severity: 'success' | 'error' } | null>(null);
 
-  const hookParams = useMemo(() => ({
-    scope: 'all' as const,
-    status: statusFilter === 'all' ? undefined : statusFilter,
-    page: page + 1,
-    pageSize,
-  }), [statusFilter, page, pageSize]);
+  const query = useMemo(() => toShareQuery(filterModel), [filterModel]);
+  const statusFilter: ShareStatusFilter = statusFromFilters(filterModel);
 
-  const { shares, meta, isLoading, error, refetch, updateShare, revokeShare: revokeShareFn, bulkAction } = useMediaShares(hookParams);
+  const hookParams = useMemo(
+    () => ({
+      scope: 'all' as const,
+      status: query.status,
+      targetType: query.targetType,
+      page: page + 1, // the API is 1-based, the table 0-based
+      pageSize,
+    }),
+    [query.status, query.targetType, page, pageSize],
+  );
 
-  // Reset page when filter changes
-  const handleStatusChange = useCallback((_: React.SyntheticEvent, val: StatusFilter) => {
-    setStatusFilter(val);
+  const {
+    shares,
+    meta,
+    isLoading,
+    error,
+    refetch,
+    updateShare,
+    revokeShare: revokeShareFn,
+    bulkAction,
+  } = useMediaShares(hookParams);
+
+  // --- Filter model ----------------------------------------------------------
+
+  const applyFilters = useCallback((next: DataTableFilterModel) => {
+    setFilterModel(normalizeShareFilters(next));
+    // A new filter invalidates the current offset, and any selection made
+    // against rows that are about to be replaced.
     setPage(0);
     setSelectedIds(new Set());
   }, []);
 
-  // Selection
-  const allIds = useMemo(() => shares.map((s) => s.id), [shares]);
-  const allSelected = allIds.length > 0 && allIds.every((id) => selectedIds.has(id));
-  const someSelected = selectedIds.size > 0;
-
-  const toggleSelectAll = useCallback(() => {
-    if (allSelected) {
+  /** The tab strip writes straight into the table's own filter model. */
+  const handleStatusChange = useCallback(
+    (_: React.SyntheticEvent, value: ShareStatusFilter) => {
+      setFilterModel((current) => withStatusFilter(current, value));
+      setPage(0);
       setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(allIds));
-    }
-  }, [allSelected, allIds]);
+    },
+    [],
+  );
 
-  const toggleSelect = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
+  const handlePaginationChange = useCallback(
+    ({ page: nextPage, pageSize: nextPageSize }: { page: number; pageSize: number }) => {
+      setPage(nextPage);
+      setPageSize(nextPageSize);
+    },
+    [],
+  );
 
-  // Copy URL
-  const handleCopy = useCallback(async (url: string) => {
+  // --- Mutations -------------------------------------------------------------
+
+  const handleCopy = useCallback(async (share: MediaShare) => {
     try {
-      await navigator.clipboard.writeText(url);
+      await navigator.clipboard.writeText(share.publicUrl);
       setSnack({ message: 'Link copied to clipboard', severity: 'success' });
     } catch {
       setSnack({ message: 'Failed to copy link', severity: 'error' });
     }
   }, []);
 
-  // Edit expiration
   const handleUpdateExpiration = useCallback(async (id: string, expiresAt: string | null) => {
     try {
       await updateShare(id, { expiresAt });
@@ -356,19 +357,15 @@ function PublicSharesPageContent() {
     }
   }, [updateShare]);
 
-  // Revoke single
-  const handleRevokeSingle = useCallback(async () => {
-    if (!revokeShare) return;
+  const handleRevokeSingle = useCallback(async (share: MediaShare) => {
     try {
-      await revokeShareFn(revokeShare.id);
+      await revokeShareFn(share.id);
       setSnack({ message: 'Share revoked', severity: 'success' });
     } catch {
       setSnack({ message: 'Failed to revoke share', severity: 'error' });
-      throw new Error('Failed');
     }
-  }, [revokeShare, revokeShareFn]);
+  }, [revokeShareFn]);
 
-  // Bulk revoke
   const handleBulkRevoke = useCallback(async () => {
     try {
       const result = await bulkAction({ ids: Array.from(selectedIds), action: 'revoke' });
@@ -380,7 +377,6 @@ function PublicSharesPageContent() {
     }
   }, [bulkAction, selectedIds]);
 
-  // Bulk set expiration
   const handleBulkSetExpiration = useCallback(async (expiresAt: string | null) => {
     try {
       const result = await bulkAction({ ids: Array.from(selectedIds), action: 'set_expiration', expiresAt });
@@ -392,7 +388,6 @@ function PublicSharesPageContent() {
     }
   }, [bulkAction, selectedIds]);
 
-  // Bulk delete
   const handleBulkDelete = useCallback(async () => {
     try {
       const result = await bulkAction({ ids: Array.from(selectedIds), action: 'delete' });
@@ -403,6 +398,66 @@ function PublicSharesPageContent() {
       throw new Error('Failed');
     }
   }, [bulkAction, selectedIds]);
+
+  // --- Columns / actions -----------------------------------------------------
+
+  const columns = useMemo(
+    () => buildShareColumns({ onCopy: (share) => void handleCopy(share) }),
+    [handleCopy],
+  );
+
+  const rowActions = useMemo<DataTableRowAction<MediaShare>[]>(
+    () => [
+      {
+        id: 'edit-expiration',
+        label: 'Edit expiration',
+        icon: <EditIcon fontSize="small" />,
+        disabled: (share) => share.status === 'revoked',
+        onClick: (share) => setEditShare(share),
+      },
+      {
+        id: 'revoke',
+        label: 'Revoke',
+        icon: <RevokeIcon fontSize="small" />,
+        destructive: true,
+        disabled: (share) => share.status === 'revoked',
+        confirm: {
+          title: 'Revoke share?',
+          description:
+            'This will revoke the share link immediately. Anyone with this link will no longer be able to access the shared media.',
+          confirmLabel: 'Revoke',
+        },
+        onClick: (share) => void handleRevokeSingle(share),
+      },
+    ],
+    [handleRevokeSingle],
+  );
+
+  const bulkActions = useMemo<DataTableBulkAction[]>(
+    () => [
+      {
+        id: 'revoke',
+        label: 'Revoke',
+        icon: <RevokeIcon fontSize="small" />,
+        destructive: true,
+        onClick: () => setShowBulkRevokeConfirm(true),
+      },
+      {
+        id: 'set-expiration',
+        label: 'Set expiration',
+        icon: <EditIcon fontSize="small" />,
+        onClick: () => setShowBulkExpiration(true),
+      },
+      {
+        id: 'delete',
+        label: 'Delete',
+        icon: <DeleteIcon fontSize="small" />,
+        destructive: true,
+        onClick: () => setShowBulkDeleteConfirm(true),
+      },
+    ],
+    [],
+  );
 
   return (
     <Box sx={{ p: { xs: 2, md: 4 } }}>
@@ -419,8 +474,8 @@ function PublicSharesPageContent() {
       {/* Header */}
       <Stack direction="row" spacing={2} sx={{ mb: 3, alignItems: 'center' }}>
         <PublicIcon color="primary" sx={{ fontSize: 32 }} />
-        <Box sx={{ flex: 1 }}>
-          <Typography variant="h5" sx={{ fontWeight: 700 }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="h5" component="h1" sx={{ fontWeight: 700 }}>
             Public Sharing
           </Typography>
           <Typography variant="body2" color="text.secondary">
@@ -434,9 +489,17 @@ function PublicSharesPageContent() {
         </Tooltip>
       </Stack>
 
-      {/* Status filter tabs */}
+      {/* Status filter tabs — a quick-filter preset over the table's own filter
+          model (see ./sharesTable.tsx). `variant="scrollable"` keeps four tabs
+          inside 360px instead of pushing the document sideways. */}
       <Paper variant="outlined" sx={{ mb: 2 }}>
-        <Tabs value={statusFilter} onChange={handleStatusChange}>
+        <Tabs
+          value={statusFilter}
+          onChange={handleStatusChange}
+          variant="scrollable"
+          scrollButtons="auto"
+          allowScrollButtonsMobile
+        >
           <Tab label="All" value="all" />
           <Tab label="Active" value="active" />
           <Tab label="Expired" value="expired" />
@@ -444,227 +507,41 @@ function PublicSharesPageContent() {
         </Tabs>
       </Paper>
 
-      {/* Bulk action bar */}
-      {someSelected && (
-        <Paper
-          variant="outlined"
-          sx={{
-            mb: 2,
-            p: 1.5,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            backgroundColor: 'action.selected',
-          }}
-        >
-          <Typography variant="body2" sx={{ mr: 1, fontWeight: 500 }}>
-            {selectedIds.size} selected
-          </Typography>
-          <Button
-            size="small"
-            color="error"
-            startIcon={<RevokeIcon />}
-            onClick={() => setShowBulkRevokeConfirm(true)}
-          >
-            Revoke
-          </Button>
-          <Button
-            size="small"
-            startIcon={<EditIcon />}
-            onClick={() => setShowBulkExpiration(true)}
-          >
-            Set expiration
-          </Button>
-          <Button
-            size="small"
-            color="error"
-            startIcon={<DeleteIcon />}
-            onClick={() => setShowBulkDeleteConfirm(true)}
-          >
-            Delete
-          </Button>
-          <Button size="small" sx={{ ml: 'auto' }} onClick={() => setSelectedIds(new Set())}>
-            Clear selection
-          </Button>
-        </Paper>
-      )}
-
-      {/* Error */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Table */}
-      <TableContainer component={Paper} variant="outlined">
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell padding="checkbox">
-                <Checkbox
-                  checked={allSelected}
-                  indeterminate={someSelected && !allSelected}
-                  onChange={toggleSelectAll}
-                  disabled={shares.length === 0}
-                />
-              </TableCell>
-              <TableCell>Preview</TableCell>
-              <TableCell>Type</TableCell>
-              <TableCell>Items</TableCell>
-              <TableCell>Public URL</TableCell>
-              <TableCell>Expires</TableCell>
-              <TableCell>Status</TableCell>
-              <TableCell>Created</TableCell>
-              <TableCell align="right">Actions</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {isLoading && shares.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
-                  <CircularProgress size={24} />
-                </TableCell>
-              </TableRow>
-            ) : shares.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    No shares found.
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : (
-              shares.map((share) => (
-                <TableRow
-                  key={share.id}
-                  hover
-                  selected={selectedIds.has(share.id)}
-                >
-                  <TableCell padding="checkbox">
-                    <Checkbox
-                      checked={selectedIds.has(share.id)}
-                      onChange={() => toggleSelect(share.id)}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    {share.preview?.thumbnailUrl ? (
-                      <Avatar
-                        src={share.preview.thumbnailUrl}
-                        variant="rounded"
-                        sx={{ width: 40, height: 40 }}
-                      />
-                    ) : (
-                      <Avatar variant="rounded" sx={{ width: 40, height: 40, bgcolor: 'action.disabledBackground' }}>
-                        {share.targetType === 'album' ? (
-                          <AlbumIcon sx={{ fontSize: 20, color: 'text.disabled' }} />
-                        ) : (
-                          <ImageIcon sx={{ fontSize: 20, color: 'text.disabled' }} />
-                        )}
-                      </Avatar>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                      {share.targetType === 'album' ? (
-                        <AlbumIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-                      ) : (
-                        <ImageIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-                      )}
-                      <Typography variant="body2">
-                        {share.targetType === 'album' ? 'Album' : 'Photo'}
-                      </Typography>
-                    </Stack>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2">
-                      {share.targetType === 'album' && share.itemCount != null
-                        ? share.itemCount
-                        : '—'}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Tooltip title={share.publicUrl} arrow>
-                      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
-                        {truncateUrl(share.publicUrl)}
-                      </Typography>
-                    </Tooltip>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2">
-                      {formatDate(share.expiresAt)}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <ShareStatusChip status={share.status} />
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2">
-                      {formatDateShort(share.createdAt)}
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    <Stack direction="row" spacing={0.5} sx={{ justifyContent: 'flex-end' }}>
-                      <Tooltip title="Copy link">
-                        <IconButton size="small" onClick={() => handleCopy(share.publicUrl)}>
-                          <CopyIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                      <Tooltip title="Edit expiration">
-                        <span>
-                          <IconButton
-                            size="small"
-                            onClick={() => setEditShare(share)}
-                            disabled={share.status === 'revoked'}
-                          >
-                            <EditIcon fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                      <Tooltip title="Revoke">
-                        <span>
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={() => setRevokeShare(share)}
-                            disabled={share.status === 'revoked'}
-                          >
-                            <RevokeIcon fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </Stack>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </TableContainer>
-
-      {/* Pagination */}
-      {meta && (
-        <TablePagination
-          component="div"
-          count={meta.totalItems}
-          page={page}
-          rowsPerPage={pageSize}
-          rowsPerPageOptions={[pageSize]}
-          onPageChange={(_, p) => setPage(p)}
-        />
-      )}
+      {/*
+        Rendered unconditionally: `loading` is a prop so a refetch draws an
+        overlay over rows that stay mounted, rather than unmounting the
+        renderer and losing its expansion state (docs/specs/datatable.md §18.4).
+      */}
+      <DataTable<MediaShare>
+        columns={columns}
+        rows={shares}
+        rowId={(share) => share.id}
+        tableId={SHARES_TABLE_ID}
+        ariaLabel="Public shares"
+        density="compact"
+        loading={isLoading}
+        error={error}
+        emptyState={SHARES_EMPTY_STATE}
+        pagination={{
+          page,
+          pageSize,
+          total: meta?.totalItems ?? shares.length,
+          onPaginationChange: handlePaginationChange,
+          pageSizeOptions: [10, 20, 50, 100],
+        }}
+        filters={filterModel}
+        onFiltersChange={applyFilters}
+        selection={{ selectedIds, onSelectionChange: setSelectedIds }}
+        rowActions={rowActions}
+        bulkActions={bulkActions}
+        csvExport={{ filename: 'public-shares' }}
+      />
 
       {/* Dialogs */}
       <EditExpirationDialog
         share={editShare}
         onClose={() => setEditShare(null)}
         onSave={handleUpdateExpiration}
-      />
-
-      <ConfirmRevokeDialog
-        open={!!revokeShare}
-        onClose={() => setRevokeShare(null)}
-        onConfirm={handleRevokeSingle}
       />
 
       <ConfirmRevokeDialog

--- a/apps/web/src/pages/Admin/StorageProvidersPage.tsx
+++ b/apps/web/src/pages/Admin/StorageProvidersPage.tsx
@@ -1,11 +1,32 @@
-import { useEffect, useState } from 'react';
+/**
+ * Admin → Storage Providers (`/admin/settings/storage/providers`).
+ *
+ * Migrated onto the shared DataTable in issue #259 (epic #238). Two surfaces
+ * changed here:
+ *
+ *   1. **Provider rows.** The three stacked credential CARDS became one table
+ *      (`./storageProvidersTable.tsx`), with the credential form moved behind a
+ *      per-row "Configure…" dialog. The old layout made the reader scroll past
+ *      six text fields per provider to compare which one was active, which had a
+ *      bucket set, and which was even configured — the exact comparison a table
+ *      answers in one glance and a stack of forms never does. Every mutation is
+ *      unchanged: the same `saveCredentials` / `removeCredentials` /
+ *      `testProvider` calls, with the same "blank secret means keep the stored
+ *      one" semantics and the same pre-save test guard.
+ *   2. **Migration run history.** A hand-rolled seven-column `<Table>` became a
+ *      DataTable with `status` as a `primary` column (issue #259's decision).
+ *
+ * The active-provider radio group and the migration start form are NOT tables
+ * and are untouched.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
 import { Navigate, Link as RouterLink } from 'react-router-dom';
 import {
   Container,
   Box,
   Typography,
   Paper,
-  Chip,
   TextField,
   FormControlLabel,
   Switch,
@@ -19,11 +40,6 @@ import {
   Alert,
   Snackbar,
   LinearProgress,
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -37,292 +53,27 @@ import {
   CheckCircle as CheckCircleIcon,
   Error as ErrorIcon,
   Cloud as CloudIcon,
+  Settings as SettingsIcon,
+  NetworkCheck as TestIcon,
+  Delete as DeleteIcon,
 } from '@mui/icons-material';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useStorageProviders } from '../../hooks/useStorageProviders';
 import { useStorageMigration } from '../../hooks/useStorageMigration';
-import type { StorageProviderRow } from '../../services/storage-providers';
-
-// ---------------------------------------------------------------------------
-// Helper: human-readable provider label
-// ---------------------------------------------------------------------------
-
-function providerLabel(key: string): string {
-  switch (key) {
-    case 's3':
-      return 'AWS S3';
-    case 'r2':
-      return 'Cloudflare R2';
-    case 'local':
-      return 'Local Disk';
-    default:
-      return key.toUpperCase();
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helper: migration status chip
-// ---------------------------------------------------------------------------
-
-function StatusChip({ status }: { status: string }) {
-  const colorMap: Record<string, 'default' | 'warning' | 'info' | 'success' | 'error'> = {
-    pending: 'warning',
-    running: 'info',
-    completed: 'success',
-    failed: 'error',
-    cancelled: 'default',
-  };
-  return (
-    <Chip
-      label={status}
-      color={colorMap[status] ?? 'default'}
-      size="small"
-      variant="outlined"
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Provider card
-// ---------------------------------------------------------------------------
-
-interface ProviderCardProps {
-  providerConfig: StorageProviderRow;
-  isActive: boolean;
-  formState: ProviderFormState;
-  onFormChange: (key: string, field: string, value: string | boolean) => void;
-  onSave: (provider: string) => Promise<void>;
-  onRemove: (provider: string) => Promise<void>;
-  onTest: (provider: string) => Promise<void>;
-  testResult: { ok: boolean; bucket?: string; region?: string; endpoint?: string; error?: string } | null;
-  testLoading: boolean;
-}
-
-function ProviderCard({
-  providerConfig,
-  isActive,
-  formState,
-  onFormChange,
-  onSave,
-  onRemove,
-  onTest,
-  testResult,
-  testLoading,
-}: ProviderCardProps) {
-  const key = providerConfig.provider;
-  const isLocal = key === 'local';
-  const isR2 = key === 'r2';
-
-  return (
-    <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2, flexWrap: 'wrap' }}>
-        <Typography variant="h6">{providerLabel(key)}</Typography>
-        {isActive && (
-          <Chip label="Active" color="primary" size="small" />
-        )}
-        <Chip
-          label={providerConfig.enabled ? 'Enabled' : 'Disabled'}
-          color={providerConfig.enabled ? 'success' : 'default'}
-          size="small"
-          variant="outlined"
-        />
-        {providerConfig.configured && (
-          <Chip label="Configured" color="info" size="small" variant="outlined" />
-        )}
-      </Box>
-
-      {isLocal ? (
-        /* Local disk — no credential fields */
-        <Box>
-          <Alert severity="info" icon={false} sx={{ py: 0.5, mb: 2 }}>
-            No credentials required — files are stored on the server's local filesystem.
-          </Alert>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Button
-              variant="outlined"
-              size="small"
-              disabled={testLoading}
-              startIcon={testLoading ? <CircularProgress size={14} /> : undefined}
-              onClick={() => void onTest(key)}
-            >
-              Test connection
-            </Button>
-          </Stack>
-          {testResult != null && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}>
-              {testResult.ok ? (
-                <CheckCircleIcon color="success" fontSize="small" />
-              ) : (
-                <ErrorIcon color="error" fontSize="small" />
-              )}
-              <Typography
-                variant="body2"
-                color={testResult.ok ? 'success.main' : 'error.main'}
-              >
-                {testResult.ok ? 'Accessible' : (testResult.error ?? 'Test failed')}
-              </Typography>
-            </Box>
-          )}
-        </Box>
-      ) : (
-        <>
-          {/* Masked current secret */}
-          {providerConfig.configured && providerConfig.last4 && (
-            <TextField
-              label="Current Secret Access Key"
-              value={`••••••••${providerConfig.last4}`}
-              size="small"
-              fullWidth
-              disabled
-              sx={{ mb: 2 }}
-            />
-          )}
-
-          {/* Access Key ID */}
-          <TextField
-            label="Access Key ID"
-            size="small"
-            fullWidth
-            value={formState.accessKeyId ?? ''}
-            onChange={(e) => onFormChange(key, 'accessKeyId', e.target.value)}
-            placeholder={providerConfig.configured ? 'Leave blank to keep current' : 'Enter Access Key ID'}
-            sx={{ mb: 2 }}
-          />
-
-          {/* New Secret Access Key */}
-          <TextField
-            label="New Secret Access Key"
-            type="password"
-            size="small"
-            fullWidth
-            value={formState.secretAccessKey ?? ''}
-            onChange={(e) => onFormChange(key, 'secretAccessKey', e.target.value)}
-            placeholder={providerConfig.configured ? 'Leave blank to keep current secret' : 'Enter Secret Access Key'}
-            helperText={providerConfig.configured ? 'Leave blank to use the saved secret when testing or saving.' : undefined}
-            sx={{ mb: 2 }}
-          />
-
-          {/* Bucket */}
-          <TextField
-            label="Bucket"
-            size="small"
-            fullWidth
-            value={formState.bucket ?? ''}
-            onChange={(e) => onFormChange(key, 'bucket', e.target.value)}
-            placeholder="my-bucket"
-            sx={{ mb: 2 }}
-          />
-
-          {/* Region */}
-          <TextField
-            label="Region"
-            size="small"
-            fullWidth
-            value={formState.region ?? ''}
-            onChange={(e) => onFormChange(key, 'region', e.target.value)}
-            placeholder={isR2 ? 'auto' : 'us-east-1'}
-            sx={{ mb: 2 }}
-          />
-
-          {/* Endpoint (R2 requires it; S3 optional) */}
-          <TextField
-            label="Endpoint URL"
-            size="small"
-            fullWidth
-            value={formState.endpoint ?? ''}
-            onChange={(e) => onFormChange(key, 'endpoint', e.target.value)}
-            placeholder={
-              isR2
-                ? 'https://<account-id>.r2.cloudflarestorage.com'
-                : 'Leave blank for AWS default'
-            }
-            helperText={
-              isR2
-                ? 'Required for Cloudflare R2 — find this in the R2 dashboard.'
-                : 'Optional — set only for S3-compatible endpoints.'
-            }
-            required={isR2}
-            sx={{ mb: 2 }}
-          />
-
-          {/* Enabled toggle */}
-          <FormControlLabel
-            control={
-              <Switch
-                checked={formState.enabled ?? providerConfig.enabled}
-                onChange={(e) => onFormChange(key, 'enabled', e.target.checked)}
-              />
-            }
-            label="Enabled"
-            sx={{ mb: 2, display: 'block' }}
-          />
-
-          {/* Guard: provider requires credentials, not yet saved, and secret is blank */}
-          {providerConfig.requiresCredentials && !providerConfig.configured && !formState.secretAccessKey && (
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-              Enter the Secret Access Key to test before saving.
-            </Typography>
-          )}
-
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Button
-              variant="contained"
-              size="small"
-              onClick={() => void onSave(key)}
-            >
-              Save
-            </Button>
-            {providerConfig.configured && (
-              <Button
-                variant="outlined"
-                size="small"
-                color="error"
-                onClick={() => void onRemove(key)}
-              >
-                Remove
-              </Button>
-            )}
-            <Button
-              variant="outlined"
-              size="small"
-              disabled={
-                testLoading ||
-                (providerConfig.requiresCredentials && !providerConfig.configured && !formState.secretAccessKey)
-              }
-              title={
-                providerConfig.requiresCredentials && !providerConfig.configured && !formState.secretAccessKey
-                  ? 'Enter the Secret Access Key to test before saving'
-                  : undefined
-              }
-              startIcon={testLoading ? <CircularProgress size={14} /> : undefined}
-              onClick={() => void onTest(key)}
-            >
-              Test connection
-            </Button>
-          </Stack>
-
-          {testResult != null && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}>
-              {testResult.ok ? (
-                <CheckCircleIcon color="success" fontSize="small" />
-              ) : (
-                <ErrorIcon color="error" fontSize="small" />
-              )}
-              <Typography
-                variant="body2"
-                color={testResult.ok ? 'success.main' : 'error.main'}
-              >
-                {testResult.ok
-                  ? `Connected${testResult.bucket ? ` — bucket: ${testResult.bucket}` : ''}`
-                  : (testResult.error ?? 'Test failed')}
-              </Typography>
-            </Box>
-          )}
-        </>
-      )}
-    </Paper>
-  );
-}
+import type {
+  MigrationRun,
+  StorageProviderRow,
+  StorageTestResult,
+} from '../../services/storage-providers';
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
+import {
+  MIGRATION_RUN_COLUMNS,
+  MigrationStatusChip,
+  STORAGE_MIGRATIONS_TABLE_ID,
+  STORAGE_PROVIDERS_TABLE_ID,
+  buildStorageProviderColumns,
+  providerLabel,
+} from './storageProvidersTable';
 
 // ---------------------------------------------------------------------------
 // Per-provider form shape
@@ -348,6 +99,218 @@ function defaultFormState(row: StorageProviderRow): ProviderFormState {
     endpoint: row.endpoint ?? '',
     enabled: row.enabled,
   };
+}
+
+/**
+ * Whether a provider still needs a secret typed in before it can be tested.
+ *
+ * Unchanged rule, lifted verbatim out of the old card: a provider that requires
+ * credentials and has never been saved has nothing on the server to test with.
+ */
+function needsSecretBeforeTest(
+  row: StorageProviderRow,
+  form: ProviderFormState | undefined,
+): boolean {
+  return row.requiresCredentials && !row.configured && !form?.secretAccessKey;
+}
+
+// ---------------------------------------------------------------------------
+// Test result line (shared by the dialog and the local-disk row)
+// ---------------------------------------------------------------------------
+
+function TestResultLine({ result, local }: { result: StorageTestResult; local?: boolean }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}>
+      {result.ok ? (
+        <CheckCircleIcon color="success" fontSize="small" />
+      ) : (
+        <ErrorIcon color="error" fontSize="small" />
+      )}
+      <Typography variant="body2" color={result.ok ? 'success.main' : 'error.main'}>
+        {result.ok
+          ? local
+            ? 'Accessible'
+            : `Connected${result.bucket ? ` — bucket: ${result.bucket}` : ''}`
+          : (result.error ?? 'Test failed')}
+      </Typography>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Configure dialog — the credential form that used to be a card
+// ---------------------------------------------------------------------------
+
+interface ConfigureProviderDialogProps {
+  providerConfig: StorageProviderRow | null;
+  formState: ProviderFormState | undefined;
+  onFormChange: (key: string, field: string, value: string | boolean) => void;
+  onSave: (provider: string) => Promise<void>;
+  onTest: (provider: string) => Promise<void>;
+  testResult: StorageTestResult | null;
+  testLoading: boolean;
+  onClose: () => void;
+}
+
+function ConfigureProviderDialog({
+  providerConfig,
+  formState,
+  onFormChange,
+  onSave,
+  onTest,
+  testResult,
+  testLoading,
+  onClose,
+}: ConfigureProviderDialogProps) {
+  if (!providerConfig) {
+    return <Dialog open={false} onClose={onClose} />;
+  }
+
+  const key = providerConfig.provider;
+  const isLocal = key === 'local';
+  const isR2 = key === 'r2';
+  const form = formState ?? defaultFormState(providerConfig);
+  const testBlocked = needsSecretBeforeTest(providerConfig, form);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{providerLabel(key)}</DialogTitle>
+      <DialogContent>
+        {isLocal ? (
+          <Box sx={{ pt: 1 }}>
+            <Alert severity="info" icon={false} sx={{ py: 0.5, mb: 2 }}>
+              No credentials required — files are stored on the server&apos;s local filesystem.
+            </Alert>
+            {testResult != null && <TestResultLine result={testResult} local />}
+          </Box>
+        ) : (
+          <Box sx={{ pt: 1 }}>
+            {/* Masked current secret */}
+            {providerConfig.configured && providerConfig.last4 && (
+              <TextField
+                label="Current Secret Access Key"
+                value={`••••••••${providerConfig.last4}`}
+                size="small"
+                fullWidth
+                disabled
+                sx={{ mb: 2 }}
+              />
+            )}
+
+            <TextField
+              label="Access Key ID"
+              size="small"
+              fullWidth
+              value={form.accessKeyId ?? ''}
+              onChange={(e) => onFormChange(key, 'accessKeyId', e.target.value)}
+              placeholder={
+                providerConfig.configured ? 'Leave blank to keep current' : 'Enter Access Key ID'
+              }
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              label="New Secret Access Key"
+              type="password"
+              size="small"
+              fullWidth
+              value={form.secretAccessKey ?? ''}
+              onChange={(e) => onFormChange(key, 'secretAccessKey', e.target.value)}
+              placeholder={
+                providerConfig.configured
+                  ? 'Leave blank to keep current secret'
+                  : 'Enter Secret Access Key'
+              }
+              helperText={
+                providerConfig.configured
+                  ? 'Leave blank to use the saved secret when testing or saving.'
+                  : undefined
+              }
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              label="Bucket"
+              size="small"
+              fullWidth
+              value={form.bucket ?? ''}
+              onChange={(e) => onFormChange(key, 'bucket', e.target.value)}
+              placeholder="my-bucket"
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              label="Region"
+              size="small"
+              fullWidth
+              value={form.region ?? ''}
+              onChange={(e) => onFormChange(key, 'region', e.target.value)}
+              placeholder={isR2 ? 'auto' : 'us-east-1'}
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              label="Endpoint URL"
+              size="small"
+              fullWidth
+              value={form.endpoint ?? ''}
+              onChange={(e) => onFormChange(key, 'endpoint', e.target.value)}
+              placeholder={
+                isR2
+                  ? 'https://<account-id>.r2.cloudflarestorage.com'
+                  : 'Leave blank for AWS default'
+              }
+              helperText={
+                isR2
+                  ? 'Required for Cloudflare R2 — find this in the R2 dashboard.'
+                  : 'Optional — set only for S3-compatible endpoints.'
+              }
+              required={isR2}
+              sx={{ mb: 2 }}
+            />
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.enabled ?? providerConfig.enabled}
+                  onChange={(e) => onFormChange(key, 'enabled', e.target.checked)}
+                />
+              }
+              label="Enabled"
+              sx={{ mb: 2, display: 'block' }}
+            />
+
+            {testBlocked && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                Enter the Secret Access Key to test before saving.
+              </Typography>
+            )}
+
+            {testResult != null && <TestResultLine result={testResult} />}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ flexWrap: 'wrap', gap: 1, px: 3, pb: 2 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          disabled={testLoading || testBlocked}
+          title={testBlocked ? 'Enter the Secret Access Key to test before saving' : undefined}
+          startIcon={testLoading ? <CircularProgress size={14} /> : undefined}
+          onClick={() => void onTest(key)}
+        >
+          Test connection
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button onClick={onClose}>Close</Button>
+        {!isLocal && (
+          <Button variant="contained" size="small" onClick={() => void onSave(key)}>
+            Save
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -384,6 +347,9 @@ function StorageProvidersContent() {
 
   // Per-provider form state
   const [formMap, setFormMap] = useState<ProviderFormMap>({});
+
+  // The provider whose credential dialog is open
+  const [configureProvider, setConfigureProvider] = useState<string | null>(null);
 
   // Active provider radio selection
   const [activeProviderLocal, setActiveProviderLocal] = useState('');
@@ -470,12 +436,7 @@ function StorageProvidersContent() {
   };
 
   const handleRemove = async (provider: string) => {
-    if (
-      !window.confirm(
-        `Remove credentials for ${providerLabel(provider)}? This will disable this provider.`,
-      )
-    )
-      return;
+    setConfigureProvider(null);
     try {
       await removeCredentials(provider);
       setSuccessMessage(`${providerLabel(provider)} credentials removed`);
@@ -488,13 +449,20 @@ function StorageProvidersContent() {
   const handleTest = async (provider: string) => {
     const form = formMap[provider];
     try {
-      await testProvider(provider, {
+      const result = await testProvider(provider, {
         accessKeyId: form?.accessKeyId || undefined,
         secretAccessKey: form?.secretAccessKey || undefined,
         bucket: form?.bucket || undefined,
         region: form?.region || undefined,
         endpoint: form?.endpoint || undefined,
       });
+      // The dialog shows the result inline; a test launched from the row menu
+      // has nowhere to show it, so it also lands in the snackbar.
+      if (result.ok) {
+        setSuccessMessage(`${providerLabel(provider)} connection OK`);
+      } else {
+        setLocalError(result.error ?? `${providerLabel(provider)} test failed`);
+      }
     } catch {
       // result is captured inside testProvider
     }
@@ -535,6 +503,50 @@ function StorageProvidersContent() {
   };
 
   // ---------------------------------------------------------------------------
+  // Table wiring
+  // ---------------------------------------------------------------------------
+
+  const providerColumns = useMemo(
+    () => buildStorageProviderColumns(settings?.activeProvider),
+    [settings?.activeProvider],
+  );
+
+  const providerActions = useMemo<DataTableRowAction<StorageProviderRow>[]>(
+    () => [
+      {
+        id: 'configure',
+        label: 'Configure',
+        icon: <SettingsIcon fontSize="small" />,
+        onClick: (row) => setConfigureProvider(row.provider),
+      },
+      {
+        id: 'test',
+        label: 'Test connection',
+        icon: <TestIcon fontSize="small" />,
+        disabled: (row) =>
+          (testLoading[row.provider] ?? false) || needsSecretBeforeTest(row, formMap[row.provider]),
+        onClick: (row) => void handleTest(row.provider),
+      },
+      {
+        id: 'remove',
+        label: 'Remove',
+        icon: <DeleteIcon fontSize="small" />,
+        destructive: true,
+        disabled: (row) => !row.configured || row.provider === 'local',
+        confirm: {
+          title: 'Remove credentials?',
+          description: (row) =>
+            `Remove credentials for ${providerLabel(row.provider)}? This will disable this provider.`,
+          confirmLabel: 'Remove',
+        },
+        onClick: (row) => void handleRemove(row.provider),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [testLoading, formMap],
+  );
+
+  // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
 
@@ -557,6 +569,7 @@ function StorageProvidersContent() {
   const providerKeys = providers.map((p) => p.provider);
   const migrationInProgress =
     activeRun != null && (activeRun.status === 'pending' || activeRun.status === 'running');
+  const configureRow = providers.find((p) => p.provider === configureProvider) ?? null;
 
   return (
     <Container maxWidth="lg">
@@ -584,27 +597,25 @@ function StorageProvidersContent() {
         </Typography>
 
         {/* ------------------------------------------------------------------ */}
-        {/* Provider cards                                                      */}
+        {/* Provider rows                                                       */}
         {/* ------------------------------------------------------------------ */}
-        {providers.map((p) => (
-          <ProviderCard
-            key={p.provider}
-            providerConfig={p}
-            isActive={settings?.activeProvider === p.provider}
-            formState={formMap[p.provider] ?? defaultFormState(p)}
-            onFormChange={onFormChange}
-            onSave={handleSave}
-            onRemove={handleRemove}
-            onTest={handleTest}
-            testResult={testResults[p.provider] ?? null}
-            testLoading={testLoading[p.provider] ?? false}
-          />
-        ))}
+        <DataTable<StorageProviderRow>
+          columns={providerColumns}
+          rows={providers}
+          rowId={(row) => row.provider}
+          tableId={STORAGE_PROVIDERS_TABLE_ID}
+          ariaLabel="Storage providers"
+          density="compact"
+          loading={loading}
+          emptyState={<span>No storage providers available</span>}
+          rowActions={providerActions}
+          csvExport={{ filename: 'storage-providers' }}
+        />
 
         {/* ------------------------------------------------------------------ */}
         {/* Active provider selector                                            */}
         {/* ------------------------------------------------------------------ */}
-        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+        <Paper variant="outlined" sx={{ p: 3, mt: 3, mb: 2 }}>
           <Typography variant="h6" sx={{ mb: 0.5 }}>
             Active Provider for New Uploads
           </Typography>
@@ -664,7 +675,7 @@ function StorageProvidersContent() {
                 <Typography variant="body2" sx={{ fontWeight: 600 }}>
                   Migration in progress
                 </Typography>
-                <StatusChip status={activeRun.status} />
+                <MigrationStatusChip status={activeRun.status} />
               </Box>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                 {providerLabel(activeRun.sourceProvider)} → {providerLabel(activeRun.targetProvider)}
@@ -716,8 +727,9 @@ function StorageProvidersContent() {
           {!migrationInProgress && (
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ alignItems: 'flex-start' }}>
               <FormControl size="small" sx={{ minWidth: 160 }}>
-                <InputLabel>Source provider</InputLabel>
+                <InputLabel id="migration-source-label">Source provider</InputLabel>
                 <Select
+                  labelId="migration-source-label"
                   label="Source provider"
                   value={migSource}
                   onChange={(e) => setMigSource(e.target.value)}
@@ -732,8 +744,9 @@ function StorageProvidersContent() {
               </FormControl>
 
               <FormControl size="small" sx={{ minWidth: 160 }}>
-                <InputLabel>Target provider</InputLabel>
+                <InputLabel id="migration-target-label">Target provider</InputLabel>
                 <Select
+                  labelId="migration-target-label"
                   label="Target provider"
                   value={migTarget}
                   onChange={(e) => setMigTarget(e.target.value)}
@@ -773,77 +786,35 @@ function StorageProvidersContent() {
               <Typography variant="subtitle2" sx={{ mb: 1 }}>
                 Recent Migration Runs
               </Typography>
-              <Paper variant="outlined">
-                {runsLoading ? (
-                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
-                    <CircularProgress size={24} />
-                  </Box>
-                ) : (
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Route</TableCell>
-                        <TableCell>Status</TableCell>
-                        <TableCell align="right">Copied</TableCell>
-                        <TableCell align="right">Failed</TableCell>
-                        <TableCell align="right">Skipped</TableCell>
-                        <TableCell>Started</TableCell>
-                        <TableCell>Finished</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {runs.map((run) => (
-                        <TableRow key={run.id}>
-                          <TableCell>
-                            <Typography
-                              variant="body2"
-                              sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
-                            >
-                              {providerLabel(run.sourceProvider)} →{' '}
-                              {providerLabel(run.targetProvider)}
-                            </Typography>
-                          </TableCell>
-                          <TableCell>
-                            <StatusChip status={run.status} />
-                          </TableCell>
-                          <TableCell align="right">
-                            <Typography variant="body2">{run.migratedCount}</Typography>
-                          </TableCell>
-                          <TableCell align="right">
-                            <Chip
-                              label={run.failedCount}
-                              size="small"
-                              color={run.failedCount > 0 ? 'error' : 'default'}
-                              variant="outlined"
-                            />
-                          </TableCell>
-                          <TableCell align="right">
-                            <Typography variant="body2">{run.skippedCount}</Typography>
-                          </TableCell>
-                          <TableCell>
-                            <Typography variant="body2">
-                              {run.startedAt
-                                ? new Date(run.startedAt).toLocaleString()
-                                : '—'}
-                            </Typography>
-                          </TableCell>
-                          <TableCell>
-                            <Typography variant="body2">
-                              {run.finishedAt
-                                ? new Date(run.finishedAt).toLocaleString()
-                                : '—'}
-                            </Typography>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                )}
-              </Paper>
+              <DataTable<MigrationRun>
+                columns={MIGRATION_RUN_COLUMNS}
+                rows={runs}
+                rowId={(run) => run.id}
+                tableId={STORAGE_MIGRATIONS_TABLE_ID}
+                ariaLabel="Migration runs"
+                density="compact"
+                loading={runsLoading}
+                emptyState={<span>No migration runs yet</span>}
+                csvExport={{ filename: 'storage-migration-runs' }}
+              />
             </Box>
           )}
         </Paper>
       </Box>
+
+      {/* -------------------------------------------------------------------- */}
+      {/* Configure provider dialog (the old card, per row)                     */}
+      {/* -------------------------------------------------------------------- */}
+      <ConfigureProviderDialog
+        providerConfig={configureRow}
+        formState={configureProvider ? formMap[configureProvider] : undefined}
+        onFormChange={onFormChange}
+        onSave={handleSave}
+        onTest={handleTest}
+        testResult={configureProvider ? (testResults[configureProvider] ?? null) : null}
+        testLoading={configureProvider ? (testLoading[configureProvider] ?? false) : false}
+        onClose={() => setConfigureProvider(null)}
+      />
 
       {/* -------------------------------------------------------------------- */}
       {/* Confirmation dialog                                                   */}

--- a/apps/web/src/pages/Admin/TagsPage.tsx
+++ b/apps/web/src/pages/Admin/TagsPage.tsx
@@ -1,4 +1,22 @@
-import { useState, useEffect, useRef } from 'react';
+/**
+ * Admin → Tags (`/admin/settings/tagging`, embedded as {@link TagsContent}).
+ *
+ * Migrated onto the shared DataTable in issue #259 (epic #238): the hand-rolled
+ * three-column `<Table>`, its inline row-edit mode, and its `window.confirm`
+ * delete are gone. Renaming is now a small dialog (an inline `TextField` inside
+ * a grid cell has no card-layout equivalent, and the DataTable's card renderer
+ * is the whole point of the migration), and deleting routes through the row
+ * action's own confirmation.
+ *
+ * ## The bespoke CSV round trip stays, and the generic export is disabled
+ *
+ * `GET /api/tag-labels/export` emits `id,name` — the importer needs those ids to
+ * update or delete by row. Two export buttons producing different files, one of
+ * which cannot be re-imported, is worse than one, so this table passes
+ * `disableExport` (docs/specs/datatable.md §16.4) and keeps its own buttons.
+ */
+
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   Container,
@@ -10,20 +28,15 @@ import {
   Button,
   CircularProgress,
   Alert,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Switch,
   IconButton,
   Collapse,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import {
   Edit as EditIcon,
-  Save as SaveIcon,
-  Cancel as CancelIcon,
   Delete as DeleteIcon,
   Download as DownloadIcon,
   Upload as UploadIcon,
@@ -40,6 +53,12 @@ import {
   importTagLabels,
 } from '../../services/tagLabels';
 import type { TagLabel, ImportResult } from '../../services/tagLabels';
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
+import {
+  TAG_LABELS_PAGE_SIZE,
+  TAG_LABELS_TABLE_ID,
+  buildTagColumns,
+} from './tagsTable';
 
 // ---------------------------------------------------------------------------
 // Inner content (only rendered when user is admin)
@@ -55,13 +74,17 @@ export function TagsContent() {
   const [addName, setAddName] = useState('');
   const [addSaving, setAddSaving] = useState(false);
 
-  // Inline edit form
-  const [editId, setEditId] = useState<string | null>(null);
+  // Rename dialog
+  const [editLabel, setEditLabel] = useState<TagLabel | null>(null);
   const [editName, setEditName] = useState('');
   const [editSaving, setEditSaving] = useState(false);
 
   // Delete
   const [deletingSaving, setDeletingSaving] = useState<string | null>(null);
+
+  // Client-side pagination (the endpoint returns the whole vocabulary)
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(TAG_LABELS_PAGE_SIZE);
 
   // Export / import
   const [exporting, setExporting] = useState(false);
@@ -102,17 +125,17 @@ export function TagsContent() {
   };
 
   const startEdit = (label: TagLabel) => {
-    setEditId(label.id);
+    setEditLabel(label);
     setEditName(label.name);
   };
 
   const handleSaveEdit = async () => {
-    if (!editId) return;
+    if (!editLabel) return;
     setEditSaving(true);
     try {
-      const updated = await updateTagLabel(editId, { name: editName });
+      const updated = await updateTagLabel(editLabel.id, { name: editName });
       setLabels((prev) => prev.map((l) => (l.id === updated.id ? updated : l)));
-      setEditId(null);
+      setEditLabel(null);
     } catch (err) {
       setLabelsError(err instanceof Error ? err.message : 'Failed to save label');
     } finally {
@@ -130,7 +153,6 @@ export function TagsContent() {
   };
 
   const handleDeleteLabel = async (id: string) => {
-    if (!window.confirm('Delete this tag label? This cannot be undone.')) return;
     setDeletingSaving(id);
     try {
       await deleteTagLabel(id);
@@ -192,6 +214,61 @@ export function TagsContent() {
       setImporting(false);
     }
   };
+
+  // ---- Table ----
+
+  const columns = useMemo(
+    () =>
+      buildTagColumns({
+        onToggleEnabled: (label, enabled) => void handleToggleEnabled(label.id, enabled),
+      }),
+    // Built once, deliberately: `handleToggleEnabled` closes over nothing that
+    // changes — the `setLabels` / `setLabelsError` setters are stable and
+    // `updateTagLabel` is a module import — so a fresh column array per render
+    // would only churn every downstream `useMemo` keyed on `columns`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const rowActions = useMemo<DataTableRowAction<TagLabel>[]>(
+    () => [
+      {
+        id: 'rename',
+        label: 'Rename',
+        icon: <EditIcon fontSize="small" />,
+        onClick: (label) => startEdit(label),
+      },
+      {
+        id: 'delete',
+        label: 'Delete',
+        icon: <DeleteIcon fontSize="small" />,
+        destructive: true,
+        disabled: (label) => deletingSaving === label.id,
+        confirm: {
+          title: 'Delete tag label?',
+          description: (label) =>
+            `"${label.name}" will be removed from the vocabulary, along with every AI-applied instance of it. This cannot be undone.`,
+          confirmLabel: 'Delete',
+        },
+        onClick: (label) => void handleDeleteLabel(label.id),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [deletingSaving],
+  );
+
+  // The endpoint returns the whole vocabulary; the PAGE slices it, so the
+  // DataTable's "never paginate `rows` yourself" contract still holds.
+  const pageRows = useMemo(
+    () => labels.slice(page * pageSize, page * pageSize + pageSize),
+    [labels, page, pageSize],
+  );
+
+  // Deleting the last row of the last page would otherwise strand the user on
+  // an empty page with no way back except the footer's own arrows.
+  useEffect(() => {
+    if (page > 0 && page * pageSize >= labels.length) setPage(0);
+  }, [labels.length, page, pageSize]);
 
   return (
     <Container maxWidth="lg">
@@ -316,107 +393,66 @@ export function TagsContent() {
             <code>id</code> empty to create a new tag; set <code>delete=true</code> to remove by id.
           </Typography>
 
-          {/* Table */}
-          {labelsLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <CircularProgress />
-            </Box>
-          ) : (
-            <TableContainer sx={{ overflowX: 'auto' }}>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Name</TableCell>
-                    <TableCell>Enabled</TableCell>
-                    <TableCell align="right">Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {labels.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={3} align="center">
-                        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-                          No tag labels defined yet.
-                        </Typography>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {labels.map((label) =>
-                    editId === label.id ? (
-                      // Inline edit mode
-                      <TableRow key={label.id}>
-                        <TableCell>
-                          <TextField
-                            size="small"
-                            value={editName}
-                            onChange={(e) => setEditName(e.target.value)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') void handleSaveEdit();
-                              if (e.key === 'Escape') setEditId(null);
-                            }}
-                            autoFocus
-                          />
-                        </TableCell>
-                        <TableCell />
-                        <TableCell align="right">
-                          <IconButton
-                            size="small"
-                            onClick={() => void handleSaveEdit()}
-                            disabled={editSaving}
-                            aria-label="Save"
-                          >
-                            {editSaving ? <CircularProgress size={14} /> : <SaveIcon />}
-                          </IconButton>
-                          <IconButton
-                            size="small"
-                            onClick={() => setEditId(null)}
-                            aria-label="Cancel"
-                          >
-                            <CancelIcon />
-                          </IconButton>
-                        </TableCell>
-                      </TableRow>
-                    ) : (
-                      // Read mode
-                      <TableRow key={label.id}>
-                        <TableCell>{label.name}</TableCell>
-                        <TableCell>
-                          <Switch
-                            size="small"
-                            checked={label.enabled}
-                            onChange={(e) => void handleToggleEnabled(label.id, e.target.checked)}
-                            aria-label={`Toggle ${label.name}`}
-                          />
-                        </TableCell>
-                        <TableCell align="right">
-                          <IconButton
-                            size="small"
-                            onClick={() => startEdit(label)}
-                            aria-label={`Edit ${label.name}`}
-                          >
-                            <EditIcon />
-                          </IconButton>
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={() => void handleDeleteLabel(label.id)}
-                            disabled={deletingSaving === label.id}
-                            aria-label={`Delete ${label.name}`}
-                          >
-                            {deletingSaving === label.id ? (
-                              <CircularProgress size={14} />
-                            ) : (
-                              <DeleteIcon />
-                            )}
-                          </IconButton>
-                        </TableCell>
-                      </TableRow>
-                    ),
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
+          {/*
+            Rendered unconditionally with `loading` as a prop — see the module
+            docblock's reference to docs/specs/datatable.md §18.4.
+          */}
+          <DataTable<TagLabel>
+            columns={columns}
+            rows={pageRows}
+            rowId={(label) => label.id}
+            tableId={TAG_LABELS_TABLE_ID}
+            ariaLabel="Tag vocabulary"
+            density="compact"
+            loading={labelsLoading}
+            emptyState={<span>No tag labels defined yet.</span>}
+            pagination={{
+              page,
+              pageSize,
+              total: labels.length,
+              onPaginationChange: ({ page: nextPage, pageSize: nextPageSize }) => {
+                setPage(nextPage);
+                setPageSize(nextPageSize);
+              },
+              pageSizeOptions: [10, 25, 50, 100],
+            }}
+            rowActions={rowActions}
+            // The bespoke `id,name` CSV round trip above is this table's export.
+            disableExport
+          />
+
+          {/* Rename dialog — an inline TextField inside a grid cell has no
+              card-layout equivalent, so the edit affordance is a dialog now. */}
+          <Dialog open={!!editLabel} onClose={() => setEditLabel(null)} maxWidth="xs" fullWidth>
+            <DialogTitle>Rename tag label</DialogTitle>
+            <DialogContent>
+              <TextField
+                label="Label name"
+                size="small"
+                fullWidth
+                autoFocus
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleSaveEdit();
+                }}
+                sx={{ mt: 1 }}
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setEditLabel(null)} disabled={editSaving}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                onClick={() => void handleSaveEdit()}
+                disabled={editSaving || !editName.trim()}
+                startIcon={editSaving ? <CircularProgress size={14} /> : undefined}
+              >
+                Save
+              </Button>
+            </DialogActions>
+          </Dialog>
         </Paper>
 
       </Box>

--- a/apps/web/src/pages/Admin/WorkersPage.tsx
+++ b/apps/web/src/pages/Admin/WorkersPage.tsx
@@ -1,22 +1,38 @@
-import { useState, FormEvent } from 'react';
+/**
+ * Admin → Worker Nodes (`/admin/settings/nodes`).
+ *
+ * Migrated onto the shared DataTable in issue #259 (epic #238). Two hand-rolled
+ * tables went away here — an eleven-column fleet table and an eight-column node
+ * credentials table, both of which could only be read by scrolling the document
+ * sideways on anything narrower than a laptop, and both of which put their only
+ * destructive action (deregister / revoke) in the last column, i.e. the first
+ * thing to fall off a phone.
+ *
+ * Both are now `DataTableColumn[]` declarations in `./workersTable.tsx`, with
+ * `status` as a `primary` column so a card leads with "is this node up?"
+ * (issue #259's decision). Their two bespoke confirm dialogs are gone too: a
+ * row action's own `confirm` gives the same copy from one implementation.
+ *
+ * ## The auto-refresh contract
+ *
+ * `useWorkers` polls every 5 seconds, so both tables are rendered
+ * UNCONDITIONALLY with `loading` passed as a prop. Gating the render on
+ * `loading` would remount the renderer twelve times a minute and take its
+ * expansion state and the page's scroll offset with it
+ * (docs/specs/datatable.md §18.4).
+ */
+
+import { useCallback, useMemo, useState, FormEvent } from 'react';
 import { Navigate, Link as RouterLink } from 'react-router-dom';
 import {
   Container,
   Box,
   Typography,
   Paper,
-  Chip,
   Stack,
   Button,
-  CircularProgress,
   Alert,
   Snackbar,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Tooltip,
   IconButton,
   FormControlLabel,
@@ -24,7 +40,6 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  DialogContentText,
   DialogActions,
   Link,
   TextField,
@@ -38,9 +53,6 @@ import {
   Hub as HubIcon,
   Refresh as RefreshIcon,
   Delete as DeleteIcon,
-  CheckCircle as HealthyIcon,
-  Warning as StaleIcon,
-  Cancel as OfflineIcon,
   Add as AddIcon,
   ContentCopy as ContentCopyIcon,
   Check as CheckIcon,
@@ -48,163 +60,19 @@ import {
 import { usePermissions } from '../../hooks/usePermissions';
 import { useWorkers } from '../../hooks/useWorkers';
 import { useNodeCredentials } from '../../hooks/useNodeCredentials';
-import type { WorkerNodeDto, NodeStatus, NodeHealth } from '../../services/workers';
+import type { WorkerNodeDto } from '../../services/workers';
 import type {
   AdminNodeCredentialDto,
   CreatedNodeCredentialDto,
 } from '../../services/workers';
-import { relativeTime } from '../../utils/formatBytes';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const STATUS_COLORS: Record<NodeStatus, 'default' | 'success' | 'warning' | 'error'> = {
-  online: 'success',
-  draining: 'warning',
-  offline: 'default',
-  disabled: 'error',
-};
-
-function StatusChip({ status }: { status: NodeStatus }) {
-  return (
-    <Chip
-      label={status}
-      color={STATUS_COLORS[status] ?? 'default'}
-      size="small"
-      variant="outlined"
-    />
-  );
-}
-
-const HEALTH_META: Record<
-  NodeHealth,
-  { color: 'success' | 'warning' | 'error'; label: string; Icon: typeof HealthyIcon }
-> = {
-  healthy: { color: 'success', label: 'Healthy', Icon: HealthyIcon },
-  stale: { color: 'warning', label: 'Stale', Icon: StaleIcon },
-  offline: { color: 'error', label: 'Offline', Icon: OfflineIcon },
-};
-
-/** Heartbeat-freshness pill driven by the server-derived `health` field. */
-function HeartbeatPill({ node }: { node: WorkerNodeDto }) {
-  const meta = HEALTH_META[node.health] ?? HEALTH_META.offline;
-  const rel = node.lastHeartbeatAt ? relativeTime(node.lastHeartbeatAt) : 'never';
-  return (
-    <Tooltip
-      title={
-        node.lastHeartbeatAt
-          ? `Last heartbeat ${new Date(node.lastHeartbeatAt).toLocaleString()}`
-          : 'No heartbeat recorded'
-      }
-      arrow
-    >
-      <Chip
-        icon={<meta.Icon />}
-        label={`${meta.label} · ${rel}`}
-        color={meta.color}
-        size="small"
-        variant="outlined"
-        sx={{ cursor: 'help' }}
-      />
-    </Tooltip>
-  );
-}
-
-const MAX_TYPE_CHIPS = 3;
-
-/** Renders eligible job types as small chips, truncating with a "+N" overflow chip. */
-function EligibleTypes({ types }: { types: string[] }) {
-  if (!types || types.length === 0) {
-    return (
-      <Typography variant="body2" color="text.disabled">
-        —
-      </Typography>
-    );
-  }
-  const shown = types.slice(0, MAX_TYPE_CHIPS);
-  const overflow = types.length - shown.length;
-  return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-      {shown.map((t) => (
-        <Chip key={t} label={t} size="small" variant="outlined" />
-      ))}
-      {overflow > 0 && (
-        <Tooltip title={types.slice(MAX_TYPE_CHIPS).join(', ')} arrow>
-          <Chip label={`+${overflow}`} size="small" variant="outlined" sx={{ cursor: 'help' }} />
-        </Tooltip>
-      )}
-    </Box>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Confirm delete dialog
-// ---------------------------------------------------------------------------
-
-interface ConfirmDeleteDialogProps {
-  open: boolean;
-  node: WorkerNodeDto;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-function ConfirmDeleteDialog({ open, node, onConfirm, onCancel }: ConfirmDeleteDialogProps) {
-  return (
-    <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
-      <DialogTitle>Deregister worker node?</DialogTitle>
-      <DialogContent>
-        <DialogContentText>
-          Node <strong>{node.name}</strong> ({node.hostname}) will be removed from the fleet. Any
-          jobs it currently holds are released back to the queue. This cannot be undone.
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onCancel}>Cancel</Button>
-        <Button onClick={onConfirm} color="error" variant="contained">
-          Deregister
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Confirm revoke credential dialog
-// ---------------------------------------------------------------------------
-
-interface ConfirmRevokeCredentialDialogProps {
-  open: boolean;
-  credential: AdminNodeCredentialDto;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-function ConfirmRevokeCredentialDialog({
-  open,
-  credential,
-  onConfirm,
-  onCancel,
-}: ConfirmRevokeCredentialDialogProps) {
-  return (
-    <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
-      <DialogTitle>Revoke credential?</DialogTitle>
-      <DialogContent>
-        <DialogContentText>
-          Revoking is immediate. The worker using token{' '}
-          <strong>{credential.tokenPrefix}…</strong> (named <strong>{credential.name}</strong>)
-          will lose access right away. This cannot be undone.
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onCancel}>Cancel</Button>
-        <Button onClick={onConfirm} color="error" variant="contained">
-          Revoke
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
+import {
+  NODE_CREDENTIALS_TABLE_ID,
+  WORKER_NODES_TABLE_ID,
+  buildNodeCredentialColumns,
+  buildWorkerNodeColumns,
+  isCredentialRevoked,
+} from './workersTable';
 
 // ---------------------------------------------------------------------------
 // Create node credential dialog
@@ -433,49 +301,95 @@ function WorkersPageContent() {
 
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [deleteDialog, setDeleteDialog] = useState<WorkerNodeDto | null>(null);
   const [mutating, setMutating] = useState(false);
 
   const [credentialMutating, setCredentialMutating] = useState(false);
   const [createCredentialDialogOpen, setCreateCredentialDialogOpen] = useState(false);
-  const [revokeCredentialDialog, setRevokeCredentialDialog] =
-    useState<AdminNodeCredentialDto | null>(null);
   const [revealedToken, setRevealedToken] = useState<string | null>(null);
 
-  const handleDelete = async () => {
-    if (!deleteDialog) return;
-    const node = deleteDialog;
-    setDeleteDialog(null);
-    setMutating(true);
-    try {
-      await deleteWorker(node.id);
-      setSuccessMessage(`Node "${node.name}" deregistered`);
-    } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : 'Failed to deregister node');
-    } finally {
-      setMutating(false);
-    }
-  };
+  const handleDelete = useCallback(
+    async (node: WorkerNodeDto) => {
+      setMutating(true);
+      try {
+        await deleteWorker(node.id);
+        setSuccessMessage(`Node "${node.name}" deregistered`);
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : 'Failed to deregister node');
+      } finally {
+        setMutating(false);
+      }
+    },
+    [deleteWorker],
+  );
 
   const handleCredentialCreated = (created: CreatedNodeCredentialDto) => {
     setSuccessMessage(`Credential "${created.name}" created`);
     setRevealedToken(created.token);
   };
 
-  const handleRevokeCredential = async () => {
-    if (!revokeCredentialDialog) return;
-    const credential = revokeCredentialDialog;
-    setRevokeCredentialDialog(null);
-    setCredentialMutating(true);
-    try {
-      await revokeCredential(credential.id);
-      setSuccessMessage(`Credential "${credential.name}" revoked`);
-    } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : 'Failed to revoke credential');
-    } finally {
-      setCredentialMutating(false);
-    }
-  };
+  const handleRevokeCredential = useCallback(
+    async (credential: AdminNodeCredentialDto) => {
+      setCredentialMutating(true);
+      try {
+        await revokeCredential(credential.id);
+        setSuccessMessage(`Credential "${credential.name}" revoked`);
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : 'Failed to revoke credential');
+      } finally {
+        setCredentialMutating(false);
+      }
+    },
+    [revokeCredential],
+  );
+
+  // --- Columns + row actions -------------------------------------------------
+
+  const nodeColumns = useMemo(() => buildWorkerNodeColumns(), []);
+  const credentialColumns = useMemo(() => buildNodeCredentialColumns(), []);
+
+  const nodeActions = useMemo<DataTableRowAction<WorkerNodeDto>[]>(
+    () => [
+      {
+        id: 'deregister',
+        label: 'Deregister node',
+        icon: <DeleteIcon fontSize="small" />,
+        destructive: true,
+        disabled: () => mutating,
+        confirm: {
+          title: 'Deregister worker node?',
+          description: (node) =>
+            `Node ${node.name} (${node.hostname}) will be removed from the fleet. Any jobs it currently holds are released back to the queue. This cannot be undone.`,
+          confirmLabel: 'Deregister',
+        },
+        onClick: (node) => void handleDelete(node),
+      },
+    ],
+    [mutating, handleDelete],
+  );
+
+  const credentialActions = useMemo<DataTableRowAction<AdminNodeCredentialDto>[]>(
+    () => [
+      {
+        id: 'revoke',
+        label: 'Revoke credential',
+        icon: <DeleteIcon fontSize="small" />,
+        destructive: true,
+        // An already-revoked credential has nothing left to revoke; the old
+        // table hid the button entirely, which is unreachable-by-keyboard
+        // equivalent to disabling it — the DataTable keeps the control present
+        // with its tooltip and marks it disabled instead.
+        disabled: (credential) => credentialMutating || isCredentialRevoked(credential),
+        confirm: {
+          title: 'Revoke credential?',
+          description: (credential) =>
+            `Revoking is immediate. The worker using token ${credential.tokenPrefix}… (named ${credential.name}) will lose access right away. This cannot be undone.`,
+          confirmLabel: 'Revoke',
+        },
+        onClick: (credential) => void handleRevokeCredential(credential),
+      },
+    ],
+    [credentialMutating, handleRevokeCredential],
+  );
 
   return (
     <Container maxWidth="xl">
@@ -532,126 +446,20 @@ function WorkersPageContent() {
           </Stack>
         </Paper>
 
-        {/* Error */}
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            {error}
-          </Alert>
-        )}
-
         {/* Nodes table */}
-        <Paper variant="outlined">
-          {loading && nodes.length === 0 ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <CircularProgress size={28} />
-            </Box>
-          ) : (
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Node</TableCell>
-                    <TableCell>Platform</TableCell>
-                    <TableCell>CLI Version</TableCell>
-                    <TableCell>Status</TableCell>
-                    <TableCell>Heartbeat</TableCell>
-                    <TableCell>Eligible Types</TableCell>
-                    <TableCell align="center">Concurrency</TableCell>
-                    <TableCell align="center">Running</TableCell>
-                    <TableCell align="center">Succeeded</TableCell>
-                    <TableCell align="center">Failed</TableCell>
-                    <TableCell align="right">Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {nodes.length === 0 ? (
-                    <TableRow>
-                      <TableCell
-                        colSpan={11}
-                        align="center"
-                        sx={{ py: 4, color: 'text.secondary' }}
-                      >
-                        No worker nodes registered
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    nodes.map((node) => (
-                      <TableRow key={node.id} hover>
-                        <TableCell sx={{ maxWidth: 220 }}>
-                          <Typography variant="body2" noWrap>
-                            {node.name}
-                          </Typography>
-                          <Typography
-                            variant="caption"
-                            sx={{ color: 'text.secondary', display: 'block' }}
-                            noWrap
-                          >
-                            {node.hostname}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Typography variant="body2" color="text.secondary" noWrap>
-                            {node.platform}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Typography variant="body2" color="text.secondary" noWrap>
-                            {node.cliVersion}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <StatusChip status={node.status} />
-                        </TableCell>
-                        <TableCell>
-                          <HeartbeatPill node={node} />
-                        </TableCell>
-                        <TableCell sx={{ maxWidth: 240 }}>
-                          <EligibleTypes types={node.eligibleTypes} />
-                        </TableCell>
-                        <TableCell align="center">
-                          <Typography variant="body2">{node.concurrency}</Typography>
-                        </TableCell>
-                        <TableCell align="center">
-                          <Typography variant="body2" color="info.main">
-                            {node.jobCounts.running}
-                          </Typography>
-                        </TableCell>
-                        <TableCell align="center">
-                          <Typography variant="body2" color="success.main">
-                            {node.jobCounts.succeeded}
-                          </Typography>
-                        </TableCell>
-                        <TableCell align="center">
-                          <Typography
-                            variant="body2"
-                            color={node.jobCounts.failed > 0 ? 'error.main' : 'text.secondary'}
-                          >
-                            {node.jobCounts.failed}
-                          </Typography>
-                        </TableCell>
-                        <TableCell align="right">
-                          <Tooltip title="Deregister node">
-                            <span>
-                              <IconButton
-                                size="small"
-                                aria-label="Deregister node"
-                                color="error"
-                                disabled={mutating}
-                                onClick={() => setDeleteDialog(node)}
-                              >
-                                <DeleteIcon fontSize="small" />
-                              </IconButton>
-                            </span>
-                          </Tooltip>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </Paper>
+        <DataTable<WorkerNodeDto>
+          columns={nodeColumns}
+          rows={nodes}
+          rowId={(node) => node.id}
+          tableId={WORKER_NODES_TABLE_ID}
+          ariaLabel="Worker nodes"
+          density="compact"
+          loading={loading}
+          error={error}
+          emptyState={<span>No worker nodes registered</span>}
+          rowActions={nodeActions}
+          csvExport={{ filename: 'worker-nodes' }}
+        />
 
         {/* Node credentials section */}
         <Box sx={{ mt: 5 }}>
@@ -684,142 +492,21 @@ function WorkersPageContent() {
             </Button>
           </Box>
 
-          {credentialsError && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {credentialsError}
-            </Alert>
-          )}
-
-          <Paper variant="outlined">
-            {credentialsLoading && credentials.length === 0 ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                <CircularProgress size={28} />
-              </Box>
-            ) : (
-              <TableContainer>
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Name</TableCell>
-                      <TableCell>Prefix</TableCell>
-                      <TableCell>Owner</TableCell>
-                      <TableCell>Created</TableCell>
-                      <TableCell>Last used</TableCell>
-                      <TableCell>Expires</TableCell>
-                      <TableCell>Status</TableCell>
-                      <TableCell align="right">Actions</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {credentials.length === 0 ? (
-                      <TableRow>
-                        <TableCell colSpan={8} align="center" sx={{ py: 4, color: 'text.secondary' }}>
-                          No node credentials yet
-                        </TableCell>
-                      </TableRow>
-                    ) : (
-                      credentials.map((cred) => {
-                        const isExpired =
-                          !!cred.expiresAt && new Date(cred.expiresAt) < new Date();
-                        const isRevoked = !!cred.revokedAt;
-                        return (
-                          <TableRow key={cred.id} hover>
-                            <TableCell sx={{ maxWidth: 220 }}>
-                              <Typography variant="body2" noWrap>
-                                {cred.name}
-                              </Typography>
-                            </TableCell>
-                            <TableCell>
-                              <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                                {cred.tokenPrefix}…
-                              </Typography>
-                            </TableCell>
-                            <TableCell>
-                              <Typography variant="body2" color="text.secondary" noWrap>
-                                {cred.ownerEmail}
-                              </Typography>
-                            </TableCell>
-                            <TableCell>
-                              <Typography variant="body2" color="text.secondary" noWrap>
-                                {relativeTime(cred.createdAt)}
-                              </Typography>
-                            </TableCell>
-                            <TableCell>
-                              <Typography variant="body2" color="text.secondary" noWrap>
-                                {cred.lastUsedAt ? relativeTime(cred.lastUsedAt) : '—'}
-                              </Typography>
-                            </TableCell>
-                            <TableCell>
-                              {cred.expiresAt ? (
-                                <Typography
-                                  variant="body2"
-                                  color={isExpired ? 'error.main' : 'text.secondary'}
-                                  noWrap
-                                >
-                                  {new Date(cred.expiresAt).toLocaleDateString()}
-                                </Typography>
-                              ) : (
-                                <Typography variant="body2" color="text.secondary">
-                                  Never
-                                </Typography>
-                              )}
-                            </TableCell>
-                            <TableCell>
-                              <Chip
-                                label={isRevoked ? 'Revoked' : isExpired ? 'Expired' : 'Active'}
-                                color={isRevoked ? 'default' : isExpired ? 'warning' : 'success'}
-                                size="small"
-                                variant="outlined"
-                              />
-                            </TableCell>
-                            <TableCell align="right">
-                              {!isRevoked && (
-                                <Tooltip title="Revoke credential">
-                                  <span>
-                                    <IconButton
-                                      size="small"
-                                      aria-label="Revoke credential"
-                                      color="error"
-                                      disabled={credentialMutating}
-                                      onClick={() => setRevokeCredentialDialog(cred)}
-                                    >
-                                      <DeleteIcon fontSize="small" />
-                                    </IconButton>
-                                  </span>
-                                </Tooltip>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })
-                    )}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            )}
-          </Paper>
+          <DataTable<AdminNodeCredentialDto>
+            columns={credentialColumns}
+            rows={credentials}
+            rowId={(credential) => credential.id}
+            tableId={NODE_CREDENTIALS_TABLE_ID}
+            ariaLabel="Node credentials"
+            density="compact"
+            loading={credentialsLoading}
+            error={credentialsError}
+            emptyState={<span>No node credentials yet</span>}
+            rowActions={credentialActions}
+            csvExport={{ filename: 'node-credentials' }}
+          />
         </Box>
       </Box>
-
-      {/* Confirm delete dialog */}
-      {deleteDialog && (
-        <ConfirmDeleteDialog
-          open
-          node={deleteDialog}
-          onConfirm={() => void handleDelete()}
-          onCancel={() => setDeleteDialog(null)}
-        />
-      )}
-
-      {/* Confirm revoke credential dialog */}
-      {revokeCredentialDialog && (
-        <ConfirmRevokeCredentialDialog
-          open
-          credential={revokeCredentialDialog}
-          onConfirm={() => void handleRevokeCredential()}
-          onCancel={() => setRevokeCredentialDialog(null)}
-        />
-      )}
 
       {/* Create node credential dialog */}
       <CreateNodeCredentialDialog

--- a/apps/web/src/pages/Admin/backupTable.tsx
+++ b/apps/web/src/pages/Admin/backupTable.tsx
@@ -1,0 +1,150 @@
+/**
+ * Admin Backup — the run-history DataTable declaration (issue #259).
+ *
+ * ## Status is derived, and it is `primary`
+ *
+ * `GET /api/admin/backup/runs` returns no status field — a run is described by
+ * its counters and its timestamps. The one question an operator scans this list
+ * for ("did it work?") is therefore computed here, once, in
+ * {@link backupRunStatus}, rather than being re-derived by every reader:
+ *
+ *   - `failed > 0`        → **Failed**
+ *   - no `completedAt`    → **Running**
+ *   - otherwise           → **Succeeded**
+ *
+ * Issue #259 decided this leads the card on a phone, so it is a `primary`
+ * column beside the scope.
+ *
+ * ## No pagination, sort or filter
+ *
+ * The endpoint returns the recent runs as a plain array with no query params, so
+ * none of the three server-side controls is declared (§4).
+ */
+
+import { Chip, Typography } from '@mui/material';
+import type { DataTableColumn } from '../../components/datatable';
+import type { BackupRun } from '../../services/backup';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export const BACKUP_RUNS_TABLE_ID = 'admin-backup-runs';
+
+// ---------------------------------------------------------------------------
+// Derived status
+// ---------------------------------------------------------------------------
+
+export type BackupRunStatus = 'Succeeded' | 'Failed' | 'Running';
+
+export function backupRunStatus(run: BackupRun): BackupRunStatus {
+  if (run.failed > 0) return 'Failed';
+  if (!run.completedAt) return 'Running';
+  return 'Succeeded';
+}
+
+const STATUS_COLORS: Record<BackupRunStatus, 'success' | 'error' | 'info'> = {
+  Succeeded: 'success',
+  Failed: 'error',
+  Running: 'info',
+};
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+/**
+ * The seven run columns.
+ *
+ * Priorities:
+ *   - primary   — Scope, Status
+ *   - secondary — Copied, Failed, Started At
+ *   - detail    — Skipped, Completed
+ */
+export const BACKUP_RUN_COLUMNS: DataTableColumn<BackupRun>[] = [
+  // --- primary --------------------------------------------------------------
+  {
+    id: 'scope',
+    label: 'Scope',
+    priority: 'primary',
+    value: (run) => run.scope,
+    render: (run) => (
+      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }} noWrap>
+        {run.scope}
+      </Typography>
+    ),
+    minWidth: 160,
+    flex: 1,
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    priority: 'primary',
+    value: backupRunStatus,
+    render: (run) => {
+      const status = backupRunStatus(run);
+      return <Chip label={status} color={STATUS_COLORS[status]} size="small" variant="outlined" />;
+    },
+    width: 130,
+  },
+
+  // --- secondary ------------------------------------------------------------
+  {
+    id: 'copied',
+    label: 'Copied',
+    priority: 'secondary',
+    align: 'right',
+    value: (run) => run.copied,
+    width: 100,
+  },
+  {
+    id: 'failed',
+    label: 'Failed',
+    priority: 'secondary',
+    align: 'right',
+    value: (run) => run.failed,
+    render: (run) => (
+      <Chip label={run.failed} size="small" color={run.failed > 0 ? 'error' : 'success'} />
+    ),
+    width: 100,
+  },
+  {
+    id: 'startedAt',
+    label: 'Started At',
+    priority: 'secondary',
+    value: (run) => run.startedAt,
+    render: (run) => (
+      <Typography variant="body2" noWrap>
+        {formatTimestamp(run.startedAt)}
+      </Typography>
+    ),
+    minWidth: 180,
+  },
+
+  // --- detail ---------------------------------------------------------------
+  {
+    id: 'skipped',
+    label: 'Skipped',
+    priority: 'detail',
+    align: 'right',
+    value: (run) => run.skipped,
+    width: 110,
+  },
+  {
+    id: 'completedAt',
+    label: 'Completed',
+    priority: 'detail',
+    value: (run) => run.completedAt ?? null,
+    render: (run) => (
+      <Typography variant="body2" noWrap>
+        {formatTimestamp(run.completedAt)}
+      </Typography>
+    ),
+    minWidth: 180,
+  },
+];

--- a/apps/web/src/pages/Admin/jobInsightsTable.tsx
+++ b/apps/web/src/pages/Admin/jobInsightsTable.tsx
@@ -1,0 +1,186 @@
+/**
+ * Job Queue Insights — the per-type DataTable declaration (issue #259).
+ *
+ * The row model is a JOIN of four independent per-type arrays the insights
+ * endpoint returns (`live.byType`, `history.byType`, `eta.perType`,
+ * `lifetime.byType`), so {@link buildPerTypeRows} lives here beside the columns
+ * that read it — the two are one contract and were previously buried mid-page.
+ *
+ * ## No pagination, no filters, no sort
+ *
+ * `GET /api/admin/jobs/insights` is a single on-demand aggregate: it returns
+ * every job type in one payload, unpaginated, with no query params beyond
+ * `windowDays`. There is nothing for a server-side page/filter/sort control to
+ * talk to, so none is declared — the `sortable`-defaults-to-false rule (§4)
+ * applied to a whole table. The row count is bounded by the number of enrichment
+ * job types (~30), comfortably under the MIT DataGrid's 100-row page ceiling.
+ */
+
+import { Typography } from '@mui/material';
+import type { DataTableColumn } from '../../components/datatable';
+import { formatCompactNumber, formatDuration } from '../../utils/formatBytes';
+import type {
+  JobInsightsLiveByType,
+  JobInsightsHistoryByType,
+  JobInsightsEtaPerType,
+  JobLifetimeByType,
+} from '../../services/jobInsights';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export const JOB_INSIGHTS_TABLE_ID = 'admin-job-insights';
+
+// ---------------------------------------------------------------------------
+// Row model
+// ---------------------------------------------------------------------------
+
+export interface PerTypeRow {
+  type: string;
+  queued: number;
+  avgMs: number | null;
+  p95Ms: number | null;
+  throughputPerMin: number | null;
+  etcMs: number | null;
+  lifetimeTotal: number;
+}
+
+/**
+ * Join the four per-type arrays into one row per job type, ordered by backlog
+ * (queued descending) then alphabetically — the order an operator scans in.
+ */
+export function buildPerTypeRows(
+  liveByType: JobInsightsLiveByType[],
+  historyByType: JobInsightsHistoryByType[],
+  etaPerType: JobInsightsEtaPerType[],
+  lifetimeByType: JobLifetimeByType[],
+): PerTypeRow[] {
+  const allTypes = new Set<string>();
+  liveByType.forEach((r) => allTypes.add(r.type));
+  historyByType.forEach((r) => allTypes.add(r.type));
+  etaPerType.forEach((r) => allTypes.add(r.type));
+  lifetimeByType.forEach((r) => allTypes.add(r.type));
+
+  const rows: PerTypeRow[] = Array.from(allTypes).map((type) => {
+    const live = liveByType.find((r) => r.type === type);
+    const hist = historyByType.find((r) => r.type === type);
+    const eta = etaPerType.find((r) => r.type === type);
+    const life = lifetimeByType.find((r) => r.type === type);
+
+    const queued = (live?.pending ?? 0) + (live?.running ?? 0);
+
+    return {
+      type,
+      queued,
+      avgMs: hist?.avgMs ?? null,
+      p95Ms: hist?.p95Ms ?? null,
+      throughputPerMin: hist?.throughputPerMin ?? null,
+      etcMs: eta?.etcMs ?? null,
+      lifetimeTotal: life?.total ?? 0,
+    };
+  });
+
+  rows.sort((a, b) => {
+    if (b.queued !== a.queued) return b.queued - a.queued;
+    return a.type.localeCompare(b.type);
+  });
+
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+function numberCell(text: string, muted = false) {
+  return (
+    <Typography variant="body2" sx={muted ? { color: 'text.secondary' } : undefined}>
+      {text}
+    </Typography>
+  );
+}
+
+/** Throughput, as the page has always rendered it: `"12.4/min"`, else an em dash. */
+export function formatThroughput(perMin: number | null): string {
+  return perMin !== null && perMin > 0 ? `${perMin.toFixed(1)}/min` : '—';
+}
+
+/**
+ * The seven per-type columns.
+ *
+ * Priorities:
+ *   - primary   — Type, Queued  (the backlog question a card must answer first)
+ *   - secondary — Avg Duration, ETC
+ *   - detail    — p95, Throughput, All-time
+ */
+export const JOB_INSIGHTS_COLUMNS: DataTableColumn<PerTypeRow>[] = [
+  {
+    id: 'type',
+    label: 'Type',
+    priority: 'primary',
+    value: (row) => row.type,
+    render: (row) => (
+      <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
+        {row.type}
+      </Typography>
+    ),
+    minWidth: 200,
+    flex: 1.2,
+  },
+  {
+    id: 'queued',
+    label: 'Queued',
+    priority: 'primary',
+    align: 'right',
+    value: (row) => row.queued,
+    render: (row) => numberCell(row.queued > 0 ? String(row.queued) : '—'),
+    width: 110,
+  },
+  {
+    id: 'avgMs',
+    label: 'Avg Duration',
+    priority: 'secondary',
+    align: 'right',
+    value: (row) => row.avgMs,
+    render: (row) => numberCell(formatDuration(row.avgMs)),
+    width: 140,
+  },
+  {
+    id: 'etcMs',
+    label: 'ETC',
+    priority: 'secondary',
+    align: 'right',
+    value: (row) => row.etcMs,
+    render: (row) => numberCell(formatDuration(row.etcMs)),
+    width: 120,
+  },
+  {
+    id: 'p95Ms',
+    label: 'p95',
+    priority: 'detail',
+    align: 'right',
+    value: (row) => row.p95Ms,
+    render: (row) => numberCell(formatDuration(row.p95Ms)),
+    width: 110,
+  },
+  {
+    id: 'throughputPerMin',
+    label: 'Throughput',
+    priority: 'detail',
+    align: 'right',
+    value: (row) => row.throughputPerMin,
+    render: (row) => numberCell(formatThroughput(row.throughputPerMin)),
+    width: 130,
+  },
+  {
+    id: 'lifetimeTotal',
+    label: 'All-time',
+    priority: 'detail',
+    align: 'right',
+    value: (row) => row.lifetimeTotal,
+    render: (row) =>
+      numberCell(row.lifetimeTotal > 0 ? formatCompactNumber(row.lifetimeTotal) : '—', true),
+    width: 120,
+  },
+];

--- a/apps/web/src/pages/Admin/sharesTable.tsx
+++ b/apps/web/src/pages/Admin/sharesTable.tsx
@@ -1,0 +1,391 @@
+/**
+ * Public Sharing — the DataTable declaration and its query mapping (issue #259).
+ *
+ * Split out of `PublicSharesPage.tsx` for the same reason `jobsTable.tsx` was
+ * split out of `JobsPage.tsx` (docs/specs/datatable.md §18): the column set and
+ * the pure model → query-param mapping are the two halves worth testing in
+ * isolation.
+ *
+ * ## The status tabs ARE the filter model
+ *
+ * Issue #259 decided the All / Active / Expired / Revoked tab strip stays — it
+ * is the fastest control for the one triage question this page exists to answer.
+ * So the tabs are not a second filter surface sitting beside the table's own:
+ * they *write into the same normalized filter model* the DataTable is handed
+ * ({@link withStatusFilter}), and the table reads the active tab back out of it
+ * ({@link statusFromFilters}).
+ *
+ * The `status` column therefore deliberately declares **no `filterable`**. A
+ * column that is filterable appears in the generic "Add filter" picker, and two
+ * controls writing the same param is exactly the drift the old page had between
+ * its tabs and its per-row state. The chip strip still shows the active status
+ * filter, and removing that chip is the same gesture as selecting the "All" tab
+ * — one model, one source of truth.
+ *
+ * `targetType` IS generically filterable: `GET /api/shares` accepts it, and no
+ * bespoke control competes for it.
+ *
+ * ## The public URL never renders in full
+ *
+ * A share token is a bearer credential for the media behind it. The column
+ * renders a truncated URL plus an explicit copy button (the only way to get the
+ * whole thing), and is `exportable: false` so it can never leave the app through
+ * a CSV — docs/specs/datatable.md §16.6.
+ *
+ * ## Nothing is `sortable`
+ *
+ * `GET /api/shares` takes no `sortBy`/`sortOrder`, so no column opts in and the
+ * page passes no `sort` config, per the `sortable`-defaults-to-false rule (§4).
+ */
+
+import type { ReactNode } from 'react';
+import { Avatar, Box, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import {
+  ContentCopy as CopyIcon,
+  Image as ImageIcon,
+  PhotoLibrary as AlbumIcon,
+} from '@mui/icons-material';
+import type {
+  DataTableColumn,
+  DataTableFilterModel,
+} from '../../components/datatable';
+import type { MediaShare, ShareStatus, ShareTargetType } from '../../types/sharing';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Persistence key for the user's column/density choices
+ * (`user_settings.dataTables['admin-shares']`).
+ */
+export const SHARES_TABLE_ID = 'admin-shares';
+
+/** The status-tab values. `'all'` is the absence of a status filter. */
+export type ShareStatusFilter = 'all' | ShareStatus;
+
+export const SHARE_STATUSES: ShareStatus[] = ['active', 'expired', 'revoked'];
+
+const STATUS_COLORS: Record<ShareStatus, 'success' | 'warning' | 'error'> = {
+  active: 'success',
+  expired: 'warning',
+  revoked: 'error',
+};
+
+const STATUS_LABELS: Record<ShareStatus, string> = {
+  active: 'Active',
+  expired: 'Expired',
+  revoked: 'Revoked',
+};
+
+const TARGET_LABELS: Record<ShareTargetType, string> = {
+  media_item: 'Photo',
+  album: 'Album',
+};
+
+// ---------------------------------------------------------------------------
+// Cell helpers
+// ---------------------------------------------------------------------------
+
+function ShareStatusChip({ status }: { status: ShareStatus }) {
+  return (
+    <Chip
+      label={STATUS_LABELS[status]}
+      color={STATUS_COLORS[status]}
+      size="small"
+      variant="outlined"
+    />
+  );
+}
+
+export function formatShareDate(iso: string | null | undefined): string {
+  if (!iso) return 'Never';
+  return new Date(iso).toLocaleString();
+}
+
+function formatShareDateShort(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString();
+}
+
+/** Clip a share URL for display. The full value is only ever reachable via copy. */
+export function truncateShareUrl(url: string, maxLen = 32): string {
+  if (url.length <= maxLen) return url;
+  return `${url.slice(0, maxLen)}…`;
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+export interface ShareColumnHandlers {
+  /** Copies the share's public URL. Wired to the in-cell copy button. */
+  onCopy: (share: MediaShare) => void;
+}
+
+/** The first 8 characters of a share's record id — its human handle. */
+export function shortShareId(id: string): string {
+  return id.slice(0, 8);
+}
+
+/**
+ * The eight share columns.
+ *
+ * Priorities:
+ *   - primary   — Share, Type, Status  (a card leads with "a1b2c3d4 Album Revoked")
+ *   - secondary — Preview, Items, Public URL, Expires
+ *   - detail    — Created
+ *
+ * `Share` leads deliberately: the first `primary` column is what names every
+ * per-row control ("Select a1b2c3d4", "Row actions for a1b2c3d4",
+ * docs/specs/datatable.md §17.6), and it is the only column here with
+ * row-unique values — naming twenty checkboxes "Photo" would make the table
+ * unnavigable by screen reader. It is the share RECORD id (what the bulk
+ * endpoint takes), never the token.
+ */
+export function buildShareColumns({
+  onCopy,
+}: ShareColumnHandlers): DataTableColumn<MediaShare>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'id',
+      label: 'Share',
+      priority: 'primary',
+      value: (share) => shortShareId(share.id),
+      render: (share) => (
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          {shortShareId(share.id)}
+        </Typography>
+      ),
+      width: 120,
+      hideable: false,
+    },
+    {
+      id: 'targetType',
+      label: 'Type',
+      priority: 'primary',
+      value: (share) => TARGET_LABELS[share.targetType],
+      render: (share) => (
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+          {share.targetType === 'album' ? (
+            <AlbumIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+          ) : (
+            <ImageIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+          )}
+          <Typography variant="body2">{TARGET_LABELS[share.targetType]}</Typography>
+        </Stack>
+      ),
+      filterable: ['is'],
+      filterType: 'enum',
+      enumValues: [
+        { value: 'media_item', label: 'Photo' },
+        { value: 'album', label: 'Album' },
+      ],
+      width: 130,
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      priority: 'primary',
+      value: (share) => share.status,
+      render: (share) => <ShareStatusChip status={share.status} />,
+      // Deliberately NOT `filterable`: the tab strip owns this filter (see the
+      // module docblock). `filterType`/`enumValues` are still declared so the
+      // chip the tabs produce reads "Status is Active", not "status is active".
+      filterType: 'enum',
+      enumValues: SHARE_STATUSES.map((status) => ({
+        value: status,
+        label: STATUS_LABELS[status],
+      })),
+      width: 120,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'preview',
+      label: 'Preview',
+      priority: 'secondary',
+      // A thumbnail has no scalar worth writing to a CSV.
+      exportable: false,
+      render: (share) =>
+        share.preview?.thumbnailUrl ? (
+          <Avatar
+            src={share.preview.thumbnailUrl}
+            alt=""
+            variant="rounded"
+            sx={{ width: 40, height: 40 }}
+          />
+        ) : (
+          <Avatar
+            variant="rounded"
+            sx={{ width: 40, height: 40, bgcolor: 'action.disabledBackground' }}
+          >
+            {share.targetType === 'album' ? (
+              <AlbumIcon sx={{ fontSize: 20, color: 'text.disabled' }} />
+            ) : (
+              <ImageIcon sx={{ fontSize: 20, color: 'text.disabled' }} />
+            )}
+          </Avatar>
+        ),
+      width: 90,
+      hideable: true,
+    },
+    {
+      id: 'itemCount',
+      label: 'Items',
+      priority: 'secondary',
+      align: 'right',
+      value: (share) =>
+        share.targetType === 'album' && share.itemCount != null ? share.itemCount : null,
+      width: 90,
+    },
+    {
+      id: 'publicUrl',
+      label: 'Public URL',
+      priority: 'secondary',
+      // NEVER exported: the token in this URL is a bearer credential for the
+      // media behind it (docs/specs/datatable.md §16.6).
+      exportable: false,
+      render: (share) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+          <Typography
+            variant="body2"
+            sx={{ fontFamily: 'monospace', fontSize: '0.75rem', minWidth: 0 }}
+            noWrap
+          >
+            {truncateShareUrl(share.publicUrl)}
+          </Typography>
+          <Tooltip title="Copy link">
+            <IconButton
+              size="small"
+              aria-label={`Copy link for ${TARGET_LABELS[share.targetType]} share`}
+              onClick={() => onCopy(share)}
+            >
+              <CopyIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      ),
+      minWidth: 220,
+      flex: 1.2,
+    },
+    {
+      id: 'expiresAt',
+      label: 'Expires',
+      priority: 'secondary',
+      value: (share) => share.expiresAt,
+      render: (share) => (
+        <Typography variant="body2" noWrap>
+          {formatShareDate(share.expiresAt)}
+        </Typography>
+      ),
+      minWidth: 170,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'createdAt',
+      label: 'Created',
+      priority: 'detail',
+      value: (share) => share.createdAt,
+      render: (share) => (
+        <Typography variant="body2" noWrap>
+          {formatShareDateShort(share.createdAt)}
+        </Typography>
+      ),
+      minWidth: 130,
+    },
+  ];
+}
+
+/** The empty-state node, shared by the page and its tests. */
+export const SHARES_EMPTY_STATE: ReactNode = <span>No shares found.</span>;
+
+// ---------------------------------------------------------------------------
+// Model ⇄ status tab
+// ---------------------------------------------------------------------------
+
+/** Read the active status tab back out of the filter model. */
+export function statusFromFilters(model: DataTableFilterModel): ShareStatusFilter {
+  for (let index = model.length - 1; index >= 0; index -= 1) {
+    const filter = model[index];
+    if (filter.columnId !== 'status' || filter.operator !== 'is') continue;
+    const raw = Array.isArray(filter.value) ? filter.value[0] : filter.value;
+    const value = raw == null ? '' : String(raw);
+    if ((SHARE_STATUSES as string[]).includes(value)) return value as ShareStatus;
+  }
+  return 'all';
+}
+
+/**
+ * Write a status tab selection into the model.
+ *
+ * `'all'` REMOVES the status entry rather than encoding an "all" value — the
+ * absence of the filter is what the endpoint means by "every status", exactly
+ * as `processedWithin` handles it on the job queue (§18.1).
+ */
+export function withStatusFilter(
+  model: DataTableFilterModel,
+  status: ShareStatusFilter,
+): DataTableFilterModel {
+  const withoutStatus = model.filter((filter) => filter.columnId !== 'status');
+  if (status === 'all') return withoutStatus;
+  return [...withoutStatus, { columnId: 'status', operator: 'is', value: status }];
+}
+
+// ---------------------------------------------------------------------------
+// Model → query params
+// ---------------------------------------------------------------------------
+
+/** The subset of `useMediaShares` params the filter model produces. */
+export interface ShareFilterQuery {
+  status?: ShareStatus;
+  targetType?: ShareTargetType;
+}
+
+/**
+ * Reduce an emitted model to one this endpoint can answer: at most one filter
+ * per column, last one wins (every param here is single-valued).
+ */
+export function normalizeShareFilters(model: DataTableFilterModel): DataTableFilterModel {
+  const claimed = new Set<string>();
+  const out: DataTableFilterModel = [];
+  for (let index = model.length - 1; index >= 0; index -= 1) {
+    const filter = model[index];
+    if (claimed.has(filter.columnId)) continue;
+    claimed.add(filter.columnId);
+    out.unshift(filter);
+  }
+  return out.length === model.length ? model : out;
+}
+
+/**
+ * Map the normalized filter model onto `GET /api/shares` query params.
+ *
+ * Unknown columns, operators and enum values are ignored rather than forwarded:
+ * a filter restored from a stale URL should drop, not produce a 400.
+ */
+export function toShareQuery(model: DataTableFilterModel): ShareFilterQuery {
+  const query: ShareFilterQuery = {};
+
+  for (const filter of model) {
+    if (filter.operator !== 'is') continue;
+    const raw = Array.isArray(filter.value) ? filter.value[0] : filter.value;
+    if (raw === null || raw === undefined || raw === '') continue;
+    const value = String(raw);
+
+    switch (filter.columnId) {
+      case 'status':
+        if ((SHARE_STATUSES as string[]).includes(value)) query.status = value as ShareStatus;
+        break;
+      case 'targetType':
+        if (value === 'media_item' || value === 'album') query.targetType = value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return query;
+}

--- a/apps/web/src/pages/Admin/storageProvidersTable.tsx
+++ b/apps/web/src/pages/Admin/storageProvidersTable.tsx
@@ -1,0 +1,308 @@
+/**
+ * Storage Providers — the two DataTable declarations for
+ * `/admin/settings/storage/providers` (issue #259).
+ *
+ *   - {@link buildStorageProviderColumns} — one row per configurable provider
+ *     (`admin-storage-providers`)
+ *   - {@link MIGRATION_RUN_COLUMNS} — the copy-migration run history
+ *     (`admin-storage-migrations`)
+ *
+ * ## Status is `primary` on both
+ *
+ * Issue #259's decision. For a provider that is the four-way
+ * Active / Enabled / Disabled / Not configured state ({@link providerState});
+ * for a run it is the server's own `status` enum. Both lead the card on a phone.
+ *
+ * ## The secret is never exported
+ *
+ * The API only ever returns the last four characters of a stored secret, and
+ * even that is `exportable: false` — a masked credential fragment has no
+ * business in a spreadsheet in a Downloads folder
+ * (docs/specs/datatable.md §16.6).
+ */
+
+import { Box, Chip, Typography } from '@mui/material';
+import type { DataTableColumn } from '../../components/datatable';
+import type { MigrationRun, StorageProviderRow } from '../../services/storage-providers';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export const STORAGE_PROVIDERS_TABLE_ID = 'admin-storage-providers';
+export const STORAGE_MIGRATIONS_TABLE_ID = 'admin-storage-migrations';
+
+// ---------------------------------------------------------------------------
+// Provider helpers
+// ---------------------------------------------------------------------------
+
+/** Human-readable provider label. Unknown keys fall back to their uppercase id. */
+export function providerLabel(key: string): string {
+  switch (key) {
+    case 's3':
+      return 'AWS S3';
+    case 'r2':
+      return 'Cloudflare R2';
+    case 'local':
+      return 'Local Disk';
+    default:
+      return key.toUpperCase();
+  }
+}
+
+export type ProviderState = 'Active' | 'Enabled' | 'Disabled' | 'Not configured';
+
+/**
+ * The one question this table exists to answer, in priority order: is this the
+ * provider new uploads go to, is it usable at all, and is it even set up?
+ */
+export function providerState(
+  row: StorageProviderRow,
+  activeProvider: string | undefined,
+): ProviderState {
+  if (row.provider === activeProvider) return 'Active';
+  if (!row.configured) return 'Not configured';
+  return row.enabled ? 'Enabled' : 'Disabled';
+}
+
+const PROVIDER_STATE_COLORS: Record<ProviderState, 'primary' | 'success' | 'default'> = {
+  Active: 'primary',
+  Enabled: 'success',
+  Disabled: 'default',
+  'Not configured': 'default',
+};
+
+/** The masked secret the API exposes, or an em dash. */
+export function maskedSecret(row: StorageProviderRow): string | null {
+  return row.last4 ? `••••••••${row.last4}` : null;
+}
+
+// ---------------------------------------------------------------------------
+// Provider columns
+// ---------------------------------------------------------------------------
+
+/**
+ * The seven provider columns.
+ *
+ * Priorities:
+ *   - primary   — Provider, Status
+ *   - secondary — Bucket, Region
+ *   - detail    — Endpoint, Secret, Updated
+ *
+ * @param activeProvider the `storage.activeProvider` system setting, which is
+ *   what makes one row's status "Active" rather than merely "Enabled".
+ */
+export function buildStorageProviderColumns(
+  activeProvider: string | undefined,
+): DataTableColumn<StorageProviderRow>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'provider',
+      label: 'Provider',
+      priority: 'primary',
+      value: (row) => providerLabel(row.provider),
+      minWidth: 160,
+      flex: 1,
+    },
+    {
+      id: 'state',
+      label: 'Status',
+      priority: 'primary',
+      value: (row) => providerState(row, activeProvider),
+      render: (row) => {
+        const state = providerState(row, activeProvider);
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+            <Chip
+              label={state}
+              color={PROVIDER_STATE_COLORS[state]}
+              size="small"
+              variant={state === 'Active' ? 'filled' : 'outlined'}
+            />
+            {row.configured && (
+              <Chip label="Configured" color="info" size="small" variant="outlined" />
+            )}
+          </Box>
+        );
+      },
+      minWidth: 190,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'bucket',
+      label: 'Bucket',
+      priority: 'secondary',
+      value: (row) => row.bucket,
+      truncate: true,
+      minWidth: 150,
+    },
+    {
+      id: 'region',
+      label: 'Region',
+      priority: 'secondary',
+      value: (row) => row.region,
+      width: 130,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'endpoint',
+      label: 'Endpoint',
+      priority: 'detail',
+      value: (row) => row.endpoint,
+      truncate: true,
+      minWidth: 200,
+      flex: 1,
+    },
+    {
+      id: 'last4',
+      label: 'Secret',
+      priority: 'detail',
+      // Never leaves the app through a CSV, masked or not.
+      exportable: false,
+      value: (row) => maskedSecret(row),
+      render: (row) => (
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }} color="text.secondary">
+          {maskedSecret(row) ?? '—'}
+        </Typography>
+      ),
+      width: 150,
+    },
+    {
+      id: 'updatedAt',
+      label: 'Updated',
+      priority: 'detail',
+      value: (row) => row.updatedAt ?? null,
+      render: (row) => (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {row.updatedAt ? new Date(row.updatedAt).toLocaleString() : '—'}
+        </Typography>
+      ),
+      minWidth: 160,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Migration run columns
+// ---------------------------------------------------------------------------
+
+const RUN_STATUS_COLORS: Record<string, 'default' | 'warning' | 'info' | 'success' | 'error'> = {
+  pending: 'warning',
+  running: 'info',
+  completed: 'success',
+  failed: 'error',
+  cancelled: 'default',
+};
+
+/** The migration-status chip, shared with the in-flight progress panel. */
+export function MigrationStatusChip({ status }: { status: string }) {
+  return (
+    <Chip
+      label={status}
+      color={RUN_STATUS_COLORS[status] ?? 'default'}
+      size="small"
+      variant="outlined"
+    />
+  );
+}
+
+/** `"Local Disk → AWS S3"` — the scalar behind the Route column. */
+export function migrationRoute(run: MigrationRun): string {
+  return `${providerLabel(run.sourceProvider)} → ${providerLabel(run.targetProvider)}`;
+}
+
+/**
+ * The seven run columns.
+ *
+ * Priorities:
+ *   - primary   — Route, Status
+ *   - secondary — Copied, Failed
+ *   - detail    — Skipped, Started, Finished
+ */
+export const MIGRATION_RUN_COLUMNS: DataTableColumn<MigrationRun>[] = [
+  // --- primary --------------------------------------------------------------
+  {
+    id: 'route',
+    label: 'Route',
+    priority: 'primary',
+    value: migrationRoute,
+    render: (run) => (
+      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }} noWrap>
+        {migrationRoute(run)}
+      </Typography>
+    ),
+    minWidth: 200,
+    flex: 1,
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    priority: 'primary',
+    value: (run) => run.status,
+    render: (run) => <MigrationStatusChip status={run.status} />,
+    width: 130,
+  },
+
+  // --- secondary ------------------------------------------------------------
+  {
+    id: 'migratedCount',
+    label: 'Copied',
+    priority: 'secondary',
+    align: 'right',
+    value: (run) => run.migratedCount,
+    width: 100,
+  },
+  {
+    id: 'failedCount',
+    label: 'Failed',
+    priority: 'secondary',
+    align: 'right',
+    value: (run) => run.failedCount,
+    render: (run) => (
+      <Chip
+        label={run.failedCount}
+        size="small"
+        color={run.failedCount > 0 ? 'error' : 'default'}
+        variant="outlined"
+      />
+    ),
+    width: 100,
+  },
+
+  // --- detail ---------------------------------------------------------------
+  {
+    id: 'skippedCount',
+    label: 'Skipped',
+    priority: 'detail',
+    align: 'right',
+    value: (run) => run.skippedCount,
+    width: 110,
+  },
+  {
+    id: 'startedAt',
+    label: 'Started',
+    priority: 'detail',
+    value: (run) => run.startedAt,
+    render: (run) => (
+      <Typography variant="body2" noWrap>
+        {run.startedAt ? new Date(run.startedAt).toLocaleString() : '—'}
+      </Typography>
+    ),
+    minWidth: 180,
+  },
+  {
+    id: 'finishedAt',
+    label: 'Finished',
+    priority: 'detail',
+    value: (run) => run.finishedAt,
+    render: (run) => (
+      <Typography variant="body2" noWrap>
+        {run.finishedAt ? new Date(run.finishedAt).toLocaleString() : '—'}
+      </Typography>
+    ),
+    minWidth: 180,
+  },
+];

--- a/apps/web/src/pages/Admin/tagsTable.tsx
+++ b/apps/web/src/pages/Admin/tagsTable.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tag vocabulary — the DataTable declaration for the Tags admin surface
+ * (issue #259).
+ *
+ * ## The generic CSV export is DISABLED on this table
+ *
+ * `GET /api/tag-labels/export` / `POST /api/tag-labels/import` are a round trip:
+ * the exported file carries the `id` column the importer needs to update or
+ * delete a row. A generic column-visibility-shaped CSV would look like the same
+ * file and silently fail to re-import, so the page passes `disableExport` and
+ * keeps its own two buttons (docs/specs/datatable.md §16.4).
+ *
+ * ## Pagination is client-side, and that is not a contract violation
+ *
+ * `GET /api/tag-labels` returns the entire vocabulary in one response — there is
+ * no server-side page to ask for. The DataTable still never slices `rows`; the
+ * PAGE slices, exactly as it owns every other piece of controlled state. The
+ * paging exists at all because a vocabulary is user-grown and the MIT DataGrid
+ * throws above 100 rows on one page.
+ */
+
+import { Switch, Typography } from '@mui/material';
+import type { DataTableColumn } from '../../components/datatable';
+import type { TagLabel } from '../../services/tagLabels';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export const TAG_LABELS_TABLE_ID = 'admin-tag-labels';
+
+/** Rows per page for the client-side slice. */
+export const TAG_LABELS_PAGE_SIZE = 25;
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+export interface TagColumnHandlers {
+  /** Flips a label's `enabled` flag. Wired to the in-cell switch. */
+  onToggleEnabled: (label: TagLabel, enabled: boolean) => void;
+}
+
+/**
+ * The three tag columns.
+ *
+ * Priorities:
+ *   - primary   — Name
+ *   - secondary — Enabled (the switch, live in the cell AND on the card)
+ *   - detail    — Updated
+ */
+export function buildTagColumns({
+  onToggleEnabled,
+}: TagColumnHandlers): DataTableColumn<TagLabel>[] {
+  return [
+    {
+      id: 'name',
+      label: 'Name',
+      priority: 'primary',
+      value: (label) => label.name,
+      minWidth: 200,
+      flex: 1,
+    },
+    {
+      id: 'enabled',
+      label: 'Enabled',
+      priority: 'secondary',
+      // The scalar the CSV would carry if this table exported one; it does not
+      // (see the module docblock), but the switch still needs a value behind it
+      // for the card's label/value pair to make sense.
+      value: (label) => (label.enabled ? 'true' : 'false'),
+      render: (label) => (
+        <Switch
+          size="small"
+          checked={label.enabled}
+          onChange={(event) => onToggleEnabled(label, event.target.checked)}
+          // On the INPUT, not the root span: MUI v9 spreads bare props onto the
+          // wrapper, which carries no role, leaving the `switch` element itself
+          // nameless to assistive tech.
+          slotProps={{ input: { 'aria-label': `Toggle ${label.name}` } }}
+        />
+      ),
+      width: 120,
+    },
+    {
+      id: 'updatedAt',
+      label: 'Updated',
+      priority: 'detail',
+      value: (label) => label.updatedAt,
+      render: (label) => (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {label.updatedAt ? new Date(label.updatedAt).toLocaleDateString() : '—'}
+        </Typography>
+      ),
+      minWidth: 140,
+    },
+  ];
+}

--- a/apps/web/src/pages/Admin/workersTable.tsx
+++ b/apps/web/src/pages/Admin/workersTable.tsx
@@ -1,0 +1,386 @@
+/**
+ * Worker Nodes — the two DataTable declarations for `/admin/settings/nodes`
+ * (issue #259).
+ *
+ * The page hosts two unrelated row types and therefore two independent tables,
+ * each with its own `tableId` so a user's column/density choice on one does not
+ * leak into the other:
+ *
+ *   - {@link buildWorkerNodeColumns} — the fleet (`admin-nodes`)
+ *   - {@link buildNodeCredentialColumns} — the durable `nod_` credentials
+ *     (`admin-node-credentials`)
+ *
+ * ## Status is `primary` on both
+ *
+ * Issue #259's decision: on a phone the card headline must answer "is this node
+ * up?" / "is this token still valid?" before anything else. So `status` (nodes)
+ * and the derived credential state both lead their card, beside the name.
+ *
+ * ## Nothing is `sortable` or `filterable`
+ *
+ * `GET /admin/nodes` and `GET /admin/nodes/credentials` return the whole list
+ * with no query params at all — no page, no sort, no filter. Declaring any of
+ * those would paint a control the server cannot honour (§4).
+ */
+
+import { Box, Chip, Tooltip, Typography } from '@mui/material';
+import {
+  CheckCircle as HealthyIcon,
+  Warning as StaleIcon,
+  Cancel as OfflineIcon,
+} from '@mui/icons-material';
+import type { DataTableColumn } from '../../components/datatable';
+import type {
+  AdminNodeCredentialDto,
+  NodeHealth,
+  NodeStatus,
+  WorkerNodeDto,
+} from '../../services/workers';
+import { relativeTime } from '../../utils/formatBytes';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export const WORKER_NODES_TABLE_ID = 'admin-nodes';
+export const NODE_CREDENTIALS_TABLE_ID = 'admin-node-credentials';
+
+// ---------------------------------------------------------------------------
+// Node cell helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_COLORS: Record<NodeStatus, 'default' | 'success' | 'warning' | 'error'> = {
+  online: 'success',
+  draining: 'warning',
+  offline: 'default',
+  disabled: 'error',
+};
+
+function StatusChip({ status }: { status: NodeStatus }) {
+  return (
+    <Chip label={status} color={STATUS_COLORS[status] ?? 'default'} size="small" variant="outlined" />
+  );
+}
+
+const HEALTH_META: Record<
+  NodeHealth,
+  { color: 'success' | 'warning' | 'error'; label: string; Icon: typeof HealthyIcon }
+> = {
+  healthy: { color: 'success', label: 'Healthy', Icon: HealthyIcon },
+  stale: { color: 'warning', label: 'Stale', Icon: StaleIcon },
+  offline: { color: 'error', label: 'Offline', Icon: OfflineIcon },
+};
+
+/** Heartbeat-freshness pill driven by the server-derived `health` field. */
+function HeartbeatPill({ node }: { node: WorkerNodeDto }) {
+  const meta = HEALTH_META[node.health] ?? HEALTH_META.offline;
+  const rel = node.lastHeartbeatAt ? relativeTime(node.lastHeartbeatAt) : 'never';
+  return (
+    <Tooltip
+      title={
+        node.lastHeartbeatAt
+          ? `Last heartbeat ${new Date(node.lastHeartbeatAt).toLocaleString()}`
+          : 'No heartbeat recorded'
+      }
+      arrow
+    >
+      <Chip
+        icon={<meta.Icon />}
+        label={`${meta.label} · ${rel}`}
+        color={meta.color}
+        size="small"
+        variant="outlined"
+        sx={{ cursor: 'help' }}
+      />
+    </Tooltip>
+  );
+}
+
+const MAX_TYPE_CHIPS = 3;
+
+/** Eligible job types as chips, truncated with a "+N" overflow chip. */
+function EligibleTypes({ types }: { types: string[] }) {
+  if (!types || types.length === 0) {
+    return (
+      <Typography variant="body2" color="text.disabled">
+        —
+      </Typography>
+    );
+  }
+  const shown = types.slice(0, MAX_TYPE_CHIPS);
+  const overflow = types.length - shown.length;
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+      {shown.map((t) => (
+        <Chip key={t} label={t} size="small" variant="outlined" />
+      ))}
+      {overflow > 0 && (
+        <Tooltip title={types.slice(MAX_TYPE_CHIPS).join(', ')} arrow>
+          <Chip label={`+${overflow}`} size="small" variant="outlined" sx={{ cursor: 'help' }} />
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Worker node columns
+// ---------------------------------------------------------------------------
+
+/**
+ * The eleven fleet columns.
+ *
+ * Priorities:
+ *   - primary   — Node, Status
+ *   - secondary — Heartbeat, Running, Failed
+ *   - detail    — Platform, CLI version, Eligible types, Concurrency, Succeeded
+ */
+export function buildWorkerNodeColumns(): DataTableColumn<WorkerNodeDto>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'name',
+      label: 'Node',
+      priority: 'primary',
+      value: (node) => node.name,
+      render: (node) => (
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="body2" noWrap>
+            {node.name}
+          </Typography>
+          <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }} noWrap>
+            {node.hostname}
+          </Typography>
+        </Box>
+      ),
+      minWidth: 180,
+      flex: 1.2,
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      priority: 'primary',
+      value: (node) => node.status,
+      render: (node) => <StatusChip status={node.status} />,
+      width: 120,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'health',
+      label: 'Heartbeat',
+      priority: 'secondary',
+      value: (node) => node.health,
+      render: (node) => <HeartbeatPill node={node} />,
+      minWidth: 180,
+    },
+    {
+      id: 'running',
+      label: 'Running',
+      priority: 'secondary',
+      align: 'center',
+      value: (node) => node.jobCounts.running,
+      render: (node) => (
+        <Typography variant="body2" color="info.main">
+          {node.jobCounts.running}
+        </Typography>
+      ),
+      width: 110,
+    },
+    {
+      id: 'failed',
+      label: 'Failed',
+      priority: 'secondary',
+      align: 'center',
+      value: (node) => node.jobCounts.failed,
+      render: (node) => (
+        <Typography
+          variant="body2"
+          color={node.jobCounts.failed > 0 ? 'error.main' : 'text.secondary'}
+        >
+          {node.jobCounts.failed}
+        </Typography>
+      ),
+      width: 110,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'succeeded',
+      label: 'Succeeded',
+      priority: 'detail',
+      align: 'center',
+      value: (node) => node.jobCounts.succeeded,
+      render: (node) => (
+        <Typography variant="body2" color="success.main">
+          {node.jobCounts.succeeded}
+        </Typography>
+      ),
+      width: 120,
+    },
+    {
+      id: 'platform',
+      label: 'Platform',
+      priority: 'detail',
+      value: (node) => node.platform,
+      minWidth: 130,
+    },
+    {
+      id: 'cliVersion',
+      label: 'CLI Version',
+      priority: 'detail',
+      value: (node) => node.cliVersion,
+      width: 130,
+    },
+    {
+      id: 'eligibleTypes',
+      label: 'Eligible Types',
+      priority: 'detail',
+      value: (node) => (node.eligibleTypes ?? []).join(', '),
+      render: (node) => <EligibleTypes types={node.eligibleTypes} />,
+      minWidth: 200,
+      flex: 1,
+    },
+    {
+      id: 'concurrency',
+      label: 'Concurrency',
+      priority: 'detail',
+      align: 'center',
+      value: (node) => node.concurrency,
+      width: 130,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Node credential helpers + columns
+// ---------------------------------------------------------------------------
+
+export function isCredentialExpired(credential: AdminNodeCredentialDto): boolean {
+  return !!credential.expiresAt && new Date(credential.expiresAt) < new Date();
+}
+
+export function isCredentialRevoked(credential: AdminNodeCredentialDto): boolean {
+  return !!credential.revokedAt;
+}
+
+/** `Revoked` | `Expired` | `Active` — the scalar the Status column sorts/exports. */
+export function credentialState(credential: AdminNodeCredentialDto): string {
+  if (isCredentialRevoked(credential)) return 'Revoked';
+  if (isCredentialExpired(credential)) return 'Expired';
+  return 'Active';
+}
+
+/**
+ * The eight credential columns.
+ *
+ * Priorities:
+ *   - primary   — Name, Status
+ *   - secondary — Prefix, Owner, Expires
+ *   - detail    — Created, Last used
+ *
+ * The token PREFIX is all this endpoint ever returns (the raw token is shown
+ * exactly once, at creation), so there is no secret to keep out of a CSV here —
+ * unlike the share URL on the Public Sharing table.
+ */
+export function buildNodeCredentialColumns(): DataTableColumn<AdminNodeCredentialDto>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'name',
+      label: 'Name',
+      priority: 'primary',
+      value: (credential) => credential.name,
+      minWidth: 160,
+      flex: 1,
+    },
+    {
+      id: 'state',
+      label: 'Status',
+      priority: 'primary',
+      value: credentialState,
+      render: (credential) => {
+        const revoked = isCredentialRevoked(credential);
+        const expired = isCredentialExpired(credential);
+        return (
+          <Chip
+            label={credentialState(credential)}
+            color={revoked ? 'default' : expired ? 'warning' : 'success'}
+            size="small"
+            variant="outlined"
+          />
+        );
+      },
+      width: 120,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'tokenPrefix',
+      label: 'Prefix',
+      priority: 'secondary',
+      value: (credential) => credential.tokenPrefix,
+      render: (credential) => (
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          {credential.tokenPrefix}…
+        </Typography>
+      ),
+      width: 140,
+    },
+    {
+      id: 'ownerEmail',
+      label: 'Owner',
+      priority: 'secondary',
+      value: (credential) => credential.ownerEmail,
+      truncate: true,
+      minWidth: 180,
+    },
+    {
+      id: 'expiresAt',
+      label: 'Expires',
+      priority: 'secondary',
+      value: (credential) => credential.expiresAt,
+      render: (credential) =>
+        credential.expiresAt ? (
+          <Typography
+            variant="body2"
+            color={isCredentialExpired(credential) ? 'error.main' : 'text.secondary'}
+            noWrap
+          >
+            {new Date(credential.expiresAt).toLocaleDateString()}
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            Never
+          </Typography>
+        ),
+      minWidth: 130,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'createdAt',
+      label: 'Created',
+      priority: 'detail',
+      value: (credential) => credential.createdAt,
+      render: (credential) => (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {relativeTime(credential.createdAt)}
+        </Typography>
+      ),
+      minWidth: 140,
+    },
+    {
+      id: 'lastUsedAt',
+      label: 'Last used',
+      priority: 'detail',
+      value: (credential) => credential.lastUsedAt,
+      render: (credential) => (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {credential.lastUsedAt ? relativeTime(credential.lastUsedAt) : '—'}
+        </Typography>
+      ),
+      minWidth: 140,
+    },
+  ];
+}

--- a/docs/specs/datatable.md
+++ b/docs/specs/datatable.md
@@ -6,7 +6,10 @@ density and per-user layout persistence shipped (issue #255, §14–§15); row
 virtualization + CSV export shipped (issue #256, §16); accessibility contract,
 keyboard model and the shared conformance suite shipped (issue #257, §17);
 pilot migration — Job Queue — shipped, adding `filterOnly` to the contract
-(issue #258, §18) — all of epic #238
+(issue #258, §18); identity-and-access tables (Users, Allowlist, Personal Access
+Tokens, Circle members/invites) migrated, establishing the `exportable: false`
+secret-material rule and the gate-the-action-array rule (issue #260, §13.1) —
+all of epic #238
 **Location:** `apps/web/src/components/datatable/`,
 `apps/api/src/common/schemas/settings.schema.ts` (persistence schema)
 **Spec owner:** frontend
@@ -1261,11 +1264,74 @@ one at a time.
 The **pilot is `JobsPage`** (#258, §18) — deliberately not the easiest table but
 the worst-affected one, so the contract met its hardest case before fifteen
 pages depended on it. It found one real gap (`filterOnly`, §18.1) and produced
-three rules every later migration should follow (§18.2–§18.4). The rest follow:
+three rules every later migration should follow (§18.2–§18.4).
 
-1. `AllowlistTable` — plain columns, pagination, one row action.
-2. `UserList` — adds rich cells (avatar, role chips) and a multi-action menu.
-3. The storage-migration, shares, and node tables.
+**Migrated so far:**
+
+| Table | `tableId` | Columns module | Issue |
+| ----- | --------- | -------------- | ----- |
+| Job Queue | `admin-jobs` | `pages/Admin/jobsTable.tsx` | #258 (pilot) |
+| Users | `admin-users` | `components/admin/usersTable.tsx` | #260 |
+| Allowlist | `admin-allowlist` | `components/admin/allowlistColumns.tsx` | #260 |
+| Personal Access Tokens | `settings-pats` | `components/settings/patTable.tsx` | #260 |
+| Circle members / invites | `circle-members` / `circle-invites` | `pages/Circles/circleMembersTable.tsx` | #260 |
+| Public Sharing | `admin-shares` | `pages/Admin/sharesTable.tsx` | #259 |
+| Job Insights (per-type) | `admin-job-insights` | `pages/Admin/jobInsightsTable.tsx` | #259 |
+| Worker nodes / node credentials | `admin-nodes` / `admin-node-credentials` | `pages/Admin/workersTable.tsx` | #259 |
+| Storage providers / migration runs | `admin-storage-providers` / `admin-storage-migrations` | `pages/Admin/storageProvidersTable.tsx` | #259 |
+| Backup runs | `admin-backup-runs` | `pages/Admin/backupTable.tsx` | #259 |
+| Tag vocabulary | `admin-tag-labels` | `pages/Admin/tagsTable.tsx` | #259 |
+
+Still to come: the remaining media surfaces.
+
+### 13.1 Decisions from the admin-operations batch (#259)
+
+Six surfaces at once, and five of them settled a question the pilot had not:
+
+- **A quick-filter preset can BE the filter model.** Public Sharing keeps its
+  All / Active / Expired / Revoked tab strip, but the tabs now write into the
+  table's own `filters` model and read the active tab back out of it
+  (`statusFromFilters` / `withStatusFilter`). The `status` column deliberately
+  declares **no `filterable`**, so the generic "Add filter" picker never offers a
+  second control for the same param — and because `filters` is controlled, the
+  chip the tabs produce is removable, which returns the strip to "All". One
+  model, one source of truth, two entry points.
+- **`exportable: false` is for material, not just secrets.** The share
+  `publicUrl` column renders truncated with an explicit copy button and is kept
+  out of every CSV: the token in it is a bearer credential for the media behind
+  it (§16.6). The masked `••••••••last4` on Storage Providers is excluded on the
+  same reasoning even though it is already redacted.
+- **Declare a row-unique `primary` column, or every control is called the same
+  thing.** Public Sharing's natural leading column was Type — which reads
+  "Photo" on twenty consecutive rows, and therefore names twenty checkboxes
+  "Select Photo" (§17.6). It leads with a short share id instead. Worth checking
+  on any table whose obvious headline is a category rather than an identity.
+- **A per-row `disabled` replaces "render nothing".** The old node-credentials
+  table hid its revoke button on an already-revoked row. The contract has no
+  per-row hide, and does not need one: `disabled: (row) => …` keeps the control
+  (and its tooltip) discoverable instead of silently vanishing.
+- **Client-side pagination is legal; client-side FILTERING is not.** Tag labels
+  and the per-type job-insights rows arrive in one unpaginated response, so the
+  *page* slices them and hands the table one page. That respects §5.1 exactly —
+  the table still never slices `rows` — while keeping the vocabulary under the
+  MIT DataGrid's 100-row page ceiling. The §10.1 prohibition is about filtering a
+  server-paginated result, which neither of these is.
+- **`disableExport` earns its keep.** Tags keeps the bespoke
+  `GET /api/tag-labels/export` ⇄ `POST /api/tag-labels/import` round trip: the
+  exported file carries the `id` column the importer needs, so a generic
+  visibility-shaped CSV would look like the same file and silently fail to
+  re-import.
+- **An editable cell is a card-layout problem.** Tags' inline row edit (a
+  `TextField` spliced into the name cell) has no card equivalent, so it became a
+  rename dialog; its `window.confirm` delete became the row action's own
+  `confirm`. Storage Providers went further: the three stacked credential CARDS
+  became one table plus a per-row "Configure…" dialog holding the same form and
+  the same save / test / remove calls.
+- **MUI gotcha, worth one line:** `<Switch aria-label="…">` puts the label on
+  the wrapper span, not on the `role="switch"` input, leaving the control
+  nameless to assistive tech. Use
+  `slotProps={{ input: { 'aria-label': … } }}` for a switch rendered inside a
+  cell.
 
 Each migration should delete the hand-rolled `Table`/`TablePagination`/`Menu`
 block wholesale rather than wrapping it, and should declare `value` on every
@@ -1274,6 +1340,31 @@ without a second pass, and should declare `filterable` / `filterType` /
 `searchable` for the fields its endpoint can actually filter and search on —
 replacing that page's bespoke filter controls (JobsPage's Status/Type/Processed
 selects, Public Sharing's status tabs) as part of the same migration.
+
+### 13.1 Two invariants the identity-and-access group (#260) established
+
+Both apply to every later migration, not just to those four tables.
+
+**Secret material declares `exportable: false`.** CSV export writes a column's
+`value` scalar for every row on the page (§16.4), and a downloaded file outlives
+the session that produced it. A column carrying token material — a PAT prefix, a
+share token, a node credential, an API key — therefore opts out of export
+explicitly, even when the value on screen is already masked. §16.6 is why this is
+a *narrowing* control rather than the only barrier: an export can never reach a
+field the list response did not already contain, so forgetting the flag leaks
+nothing new, but the flag is what keeps material the user can see from becoming
+material the user can forward. `settings-pats` sets it on `tokenPrefix`.
+
+**A permission gate belongs on the action ARRAY, never on a rendered control.**
+The pre-migration pages hid a whole `<TableCell>` or swapped a `<Select>` for
+text when the caller lacked a permission — a grid-shaped gate that a card
+renderer would have had to reimplement, and therefore could quietly have got
+wrong. Build `rowActions` from the caller's permissions (and gate an inline
+editor inside the column's `render`, which every renderer uses verbatim, §3), and
+the gate holds in the grid, in the tablet row expander and on a phone card at
+once. An action a caller may not perform is then absent from the DOM entirely
+rather than merely off-screen. Each migrated surface's tests assert this in
+*both* renderers.
 
 ---
 


### PR DESCRIPTION
## Summary

Six admin surfaces migrated onto the shared DataTable. **Public Sharing** was the second-worst case after the Job Queue and the one most likely to be needed away from a desk — the one thing you'd open it on a phone to do (revoke a share) was the one thing off-screen.

## Type of Change

- [x] Refactoring (no functional changes)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Relates to #238
Fixes #259

## Changes Made

| Surface | `tableId` | Columns module |
|---|---|---|
| Public Sharing | `admin-shares` | `pages/Admin/sharesTable.tsx` |
| Job Insights (per-type) | `admin-job-insights` | `pages/Admin/jobInsightsTable.tsx` |
| Worker nodes / credentials | `admin-nodes` / `admin-node-credentials` | `pages/Admin/workersTable.tsx` |
| Storage providers / migration runs | `admin-storage-providers` / `admin-storage-migrations` | `pages/Admin/storageProvidersTable.tsx` |
| Backup runs | `admin-backup-runs` | `pages/Admin/backupTable.tsx` |
| Tag vocabulary | `admin-tag-labels` | `pages/Admin/tagsTable.tsx` |

**Per the issue's decided requirements:**
- **Public Sharing keeps its status tabs.** They now write into the table's own `filters` model and read the active tab back out of it, and the `status` column declares no `filterable` — so the generic picker never offers a second control for the same param. Because `filters` is controlled, removing the chip the tabs produce returns the strip to "All". One model, two entry points. `shares:manage_any` gating unchanged.
- **The public token/URL renders truncated with an explicit copy button** and is `exportable: false` — the token in it is a bearer credential for the media behind it.
- **Tags keeps its bespoke CSV round-trip** with `disableExport` set, so there are never two export buttons in two different formats (the bespoke export carries the `id` column the importer needs).
- **Status is `primary`** on Worker Nodes, Storage Providers, and Backup, so it leads the card on a phone.

### Decisions worth a reviewer's attention

- **⚠️ Storage Providers' credential cards became table rows + a per-row Configure dialog.** The biggest judgement call: the issue lists "provider rows" as a target, but a credential form is not a table. The rows are now a table and the form moved verbatim into a Configure dialog; row actions are Configure / Test connection / Remove, with the pre-save "enter the secret first" guard preserved as `disabled`. **Every mutation call is byte-identical.** If you'd rather have kept the cards, this is the one part to revert.
- **Declare a row-unique `primary` column, or every control is called the same thing.** Public Sharing's natural headline was Type — which reads "Photo" on twenty consecutive rows and would therefore name twenty checkboxes "Select Photo". It leads with a short share record id instead (not the token). Recorded in the spec as a check for future migrations.
- **A per-row `disabled` replaces "render nothing".** The node-credentials revoke button used to vanish on an already-revoked row; it is now disabled, so the control and its tooltip stay discoverable. One existing test was inverted to match.
- **Client-side pagination is legal; client-side filtering is not.** Tag labels and the per-type insights rows arrive in one unpaginated response, so the *page* slices them and hands the table one page — the table still never slices `rows`. The prohibition is about filtering a server-paginated result, which neither of these is.

### Two incidental a11y fixes found on the way

- `<Switch aria-label>` puts the accessible name on the wrapper span, not the `role="switch"` input — the Tags cell switch now uses `slotProps={{ input: { 'aria-label': … } }}`.
- The storage-migration Source/Target selects had unlabelled comboboxes; added `labelId`.

## Testing

- [x] Unit tests pass (`npm test`) — full web suite **198 files / 4118 tests passed**
- [x] Type checks pass (`npm run typecheck`) — zero errors, also clean under `--noUnusedLocals`
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

Per-page tests cover column definitions and page-specific behaviour only; table mechanics come from the shared conformance suite. Two pages gained their first tests (Tags: 14, the Workers fleet table: 21).

One earlier full run had a single failure — `StorageProvidersPage > saves credentials with the typed values`, a 10 s vitest timeout from `user.type` re-rendering two DataGrids per keystroke while a concurrent suite ran. Fixed by using `fireEvent.change` for the two long typed strings. Not a product bug.

**No shared-component change was needed** — the contract as shipped in #252–#258 covered all six tables, including `disableExport` behaving exactly as anticipated. That is the pilot doing its job.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The spec's §13 migration table and the new §13.1 in this PR cover **both** this batch and #260's (merged in #281) — the two were migrated concurrently and their doc edits interleave in the same file, so they land together here rather than being split artificially.

Next and last: **#261**, the workflow and run-detail tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE)_