### PR TITLE
feat(web): notification bell and popover panel in the top bar (#249)

### DIFF
--- a/apps/web/src/__tests__/components/notifications/NotificationBell.test.tsx
+++ b/apps/web/src/__tests__/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for NotificationBell (issue #249).
+ *
+ * These render the REAL `useNotifications` hook (module store) and the REAL
+ * NotificationPanel it mounts — only the network seam (`services/notifications`)
+ * is mocked — so the badge-decrement-then-rollback assertions exercise the
+ * actual optimistic-update code path, not a stand-in.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Mock the notifications service — the only network seam of the real store.
+// ---------------------------------------------------------------------------
+vi.mock('../../../services/notifications', () => ({
+  getUnreadCount: vi.fn(),
+  listNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  dismissNotification: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+}));
+
+import { NotificationBell } from '../../../components/notifications/NotificationBell';
+import { __resetNotificationsStoreForTests } from '../../../hooks/useNotifications';
+import {
+  getUnreadCount,
+  listNotifications,
+  markNotificationRead,
+} from '../../../services/notifications';
+import type { NotificationItem } from '../../../types/notifications';
+
+const mockGetUnreadCount = vi.mocked(getUnreadCount);
+const mockListNotifications = vi.mocked(listNotifications);
+const mockMarkNotificationRead = vi.mocked(markNotificationRead);
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'notif-1',
+    circleId: 'circle-1', // matches the default active circle from test-utils
+    type: 'review_queue_bursts',
+    title: 'Burst review ready',
+    body: null,
+    link: '/bursts',
+    data: null,
+    readAt: null,
+    dismissedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('NotificationBell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNotificationsStoreForTests();
+    mockListNotifications.mockResolvedValue({
+      items: [],
+      meta: { page: 1, pageSize: 10, totalItems: 0, totalPages: 0 },
+    });
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    __resetNotificationsStoreForTests();
+  });
+
+  // =========================================================================
+  // Badge rendering
+  // =========================================================================
+
+  describe('badge', () => {
+    it('renders the unread count from GET /api/notifications/unread-count', async () => {
+      mockGetUnreadCount.mockResolvedValue(5);
+
+      render(<NotificationBell />);
+
+      await waitFor(() => {
+        expect(screen.getByText('5')).toBeInTheDocument();
+      });
+      // Filled bell icon is shown once there is at least one unread item.
+      expect(screen.getByTestId('NotificationsIcon')).toBeInTheDocument();
+    });
+
+    it('renders no visible badge digit when unread count is zero', async () => {
+      mockGetUnreadCount.mockResolvedValue(0);
+
+      render(<NotificationBell />);
+
+      await waitFor(() => {
+        expect(mockGetUnreadCount).toHaveBeenCalled();
+      });
+
+      // NOTE on why this doesn't assert `queryByText('0')` is absent: MUI's
+      // <Badge> intentionally keeps the LAST rendered digit as a text node
+      // (wrapped `aria-hidden`, `MuiBadge-invisible`, `transform: scale(0)`)
+      // so it can animate out rather than vanish instantly — this is true in
+      // a real browser too, not a jsdom artifact, and reproduces here even on
+      // a fresh 0-count mount because `useBadge`'s `usePreviousProps` ref is
+      // populated by the SAME render's effect before `invisible` is
+      // re-evaluated. So a plain text-presence query is the wrong tool for
+      // this assertion regardless of environment. The two DOM signals that
+      // are actually authoritative for "no visible unread digit" are: (1) the
+      // badge span carries `MuiBadge-invisible` + `aria-hidden="true"`, and
+      // (2) the icon button's accessible name — computed straight from
+      // `unreadCount`, unaffected by Badge's internal retained-props quirk.
+      const badgeSpan = document.querySelector('.MuiBadge-badge');
+      expect(badgeSpan).toHaveClass('MuiBadge-invisible');
+      expect(badgeSpan).toHaveAttribute('aria-hidden', 'true');
+      // Outline bell icon (no unread) is shown instead of the filled one.
+      expect(screen.getByTestId('NotificationsNoneIcon')).toBeInTheDocument();
+      expect(screen.queryByTestId('NotificationsIcon')).not.toBeInTheDocument();
+    });
+
+    it('embeds the unread count in the accessible name for screen readers', async () => {
+      mockGetUnreadCount.mockResolvedValue(3);
+
+      render(<NotificationBell />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Notifications, 3 unread' }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('accessible name reads "no unread" when the count is zero', async () => {
+      mockGetUnreadCount.mockResolvedValue(0);
+
+      render(<NotificationBell />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Notifications, no unread' }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // =========================================================================
+  // Optimistic mark-read + rollback, exercised end-to-end through the bell
+  // =========================================================================
+
+  describe('tapping a row', () => {
+    it('marks it read and decrements the badge IMMEDIATELY, before the server responds', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification();
+      mockGetUnreadCount.mockResolvedValue(1);
+      mockListNotifications.mockResolvedValue({
+        items: [item],
+        meta: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1 },
+      });
+
+      render(<NotificationBell />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1')).toBeInTheDocument();
+      });
+
+      // Open the bell — this triggers refreshList().
+      await user.click(screen.getByRole('button', { name: 'Notifications, 1 unread' }));
+      await waitFor(() => {
+        expect(screen.getByText('Burst review ready')).toBeInTheDocument();
+      });
+
+      // The mark-read request never resolves during this test — we want to
+      // observe the state BEFORE the server responds.
+      let resolveRead!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        resolveRead = resolve;
+      });
+      mockMarkNotificationRead.mockReturnValue(pending);
+
+      await user.click(screen.getByText('Burst review ready'));
+
+      // Badge dropped to 0 IMMEDIATELY — no network round-trip has completed
+      // yet (`pending` is still unresolved). Asserted via the icon button's
+      // accessible name, which is derived straight from `unreadCount` and is
+      // unaffected by MUI Badge's animate-out digit-retention quirk (see the
+      // note in the "renders no visible badge digit" test above).
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Notifications, no unread' }),
+        ).toBeInTheDocument();
+      });
+      expect(mockMarkNotificationRead).toHaveBeenCalledWith(item.id);
+
+      // Let the request settle so nothing leaks into the next test.
+      mockGetUnreadCount.mockResolvedValue(0);
+      await act(async () => {
+        resolveRead();
+        await pending;
+      });
+    });
+
+    it('ROLLS BACK the badge to its previous value when the mark-read request fails', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification();
+      mockGetUnreadCount.mockResolvedValue(1);
+      mockListNotifications.mockResolvedValue({
+        items: [item],
+        meta: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1 },
+      });
+
+      render(<NotificationBell />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Notifications, 1 unread' }));
+      await waitFor(() => {
+        expect(screen.getByText('Burst review ready')).toBeInTheDocument();
+      });
+
+      let rejectRead!: (err: unknown) => void;
+      const pending = new Promise<void>((_resolve, reject) => {
+        rejectRead = reject;
+      });
+      mockMarkNotificationRead.mockReturnValue(pending);
+
+      await user.click(screen.getByText('Burst review ready'));
+
+      // Optimistic drop happened first.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Notifications, no unread' }),
+        ).toBeInTheDocument();
+      });
+
+      // The rollback path re-fetches the count as a tiebreaker; keep it
+      // reporting the true (still-unread) value so the rollback is visible.
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      await act(async () => {
+        rejectRead(new Error('server exploded'));
+        await pending.catch(() => undefined);
+      });
+
+      // Badge is restored to 1 — the failed mutation was rolled back.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Notifications, 1 unread' }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/notifications/NotificationPanel.test.tsx
+++ b/apps/web/src/__tests__/components/notifications/NotificationPanel.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * Tests for NotificationPanel (issue #249).
+ *
+ * `useNotifications` and `useCircle` are mocked directly (same pattern as
+ * BurstsPage.test.tsx / DuplicateGroupPage.test.tsx) so each scenario can be
+ * driven with exact, deterministic item/circle fixtures — the store's own
+ * behavior (optimistic updates, rollback, polling) is covered separately in
+ * `hooks/useNotifications.test.ts` and `NotificationBell.test.tsx`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+import type { Circle } from '../../../types/circles';
+import type { NotificationItem } from '../../../types/notifications';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../hooks/useNotifications', () => ({
+  useNotifications: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import { NotificationPanel } from '../../../components/notifications/NotificationPanel';
+import { useNotifications } from '../../../hooks/useNotifications';
+import { useCircle } from '../../../hooks/useCircle';
+
+const mockUseNotifications = vi.mocked(useNotifications);
+const mockUseCircle = vi.mocked(useCircle);
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function makeCircle(id: string, overrides: Partial<Circle> = {}): Circle {
+  return {
+    id,
+    name: `Circle ${id}`,
+    description: null,
+    ownerId: 'test-user-id',
+    isPersonal: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'notif-1',
+    circleId: 'circle-1',
+    type: 'review_queue_bursts',
+    title: 'Burst review ready',
+    body: null,
+    link: '/bursts',
+    data: null,
+    readAt: null,
+    dismissedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const markRead = vi.fn().mockResolvedValue(undefined);
+const dismiss = vi.fn().mockResolvedValue(undefined);
+const markAllRead = vi.fn().mockResolvedValue(undefined);
+const refreshList = vi.fn().mockResolvedValue(undefined);
+const refreshCount = vi.fn().mockResolvedValue(undefined);
+
+function setNotificationsState(overrides: {
+  items?: NotificationItem[];
+  unreadCount?: number;
+  isLoading?: boolean;
+  hasLoadedList?: boolean;
+  error?: string | null;
+} = {}) {
+  mockUseNotifications.mockReturnValue({
+    unreadCount: overrides.unreadCount ?? 0,
+    items: overrides.items ?? [],
+    isLoading: overrides.isLoading ?? false,
+    hasLoadedList: overrides.hasLoadedList ?? true,
+    error: overrides.error ?? null,
+    refreshList,
+    refreshCount,
+    markRead,
+    dismiss,
+    markAllRead,
+  });
+}
+
+/** setActiveCircle spy shared with the ordering-assertion tests. */
+let setActiveCircle: ReturnType<typeof vi.fn>;
+/** Records call order across the two mocked side effects, for ordering checks. */
+let callOrder: string[];
+
+function setCircleState(activeCircleId: string | null, circles: Circle[]) {
+  setActiveCircle = vi.fn().mockImplementation(async (id: string) => {
+    callOrder.push(`setActiveCircle:${id}`);
+  });
+  mockUseCircle.mockReturnValue({
+    circles,
+    activeCircle: circles.find((c) => c.id === activeCircleId) ?? null,
+    activeCircleId,
+    activeCircleRole: 'collaborator',
+    loading: false,
+    setActiveCircle,
+    refreshCircles: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+function renderPanel(open = true) {
+  return render(
+    <NotificationPanel open={open} anchorEl={null} onClose={vi.fn()} />,
+  );
+}
+
+describe('NotificationPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callOrder = [];
+    setNotificationsState();
+    setCircleState('circle-1', [makeCircle('circle-1')]);
+    mockNavigate.mockImplementation((to: string) => {
+      callOrder.push(`navigate:${to}`);
+    });
+  });
+
+  // =========================================================================
+  // Panel states
+  // =========================================================================
+
+  describe('states', () => {
+    it('shows the empty state when the list has loaded with zero items', () => {
+      setNotificationsState({ items: [], hasLoadedList: true });
+      renderPanel();
+
+      expect(screen.getByText("You're all caught up")).toBeInTheDocument();
+    });
+
+    it('shows a loading skeleton before the first list fetch resolves', () => {
+      setNotificationsState({ hasLoadedList: false });
+      renderPanel();
+
+      expect(screen.getByTestId('notification-panel-skeleton')).toBeInTheDocument();
+      expect(screen.queryByText("You're all caught up")).not.toBeInTheDocument();
+    });
+
+    it('shows an error alert when the store reports an error', () => {
+      setNotificationsState({ hasLoadedList: true, error: 'Failed to load notifications' });
+      renderPanel();
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load notifications');
+    });
+
+    it('renders each notification row when items are present', () => {
+      setNotificationsState({
+        hasLoadedList: true,
+        items: [
+          makeNotification({ id: 'a', title: 'First notification' }),
+          makeNotification({ id: 'b', title: 'Second notification' }),
+        ],
+      });
+      renderPanel();
+
+      expect(screen.getByText('First notification')).toBeInTheDocument();
+      expect(screen.getByText('Second notification')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Dismiss: removes the row, never navigates
+  // =========================================================================
+
+  describe('dismiss', () => {
+    it('calls dismiss() for the row and does NOT navigate', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({ id: 'dismiss-me', title: 'Dismiss target', link: '/bursts' });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      renderPanel();
+
+      const dismissButton = screen.getByRole('button', {
+        name: 'Dismiss notification: Dismiss target',
+      });
+      await user.click(dismissButton);
+
+      expect(dismiss).toHaveBeenCalledWith('dismiss-me');
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(markRead).not.toHaveBeenCalled();
+      expect(setActiveCircle).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Mark all as read
+  // =========================================================================
+
+  describe('mark all as read', () => {
+    it('hits the bulk endpoint (unscoped) when clicked', async () => {
+      const user = userEvent.setup();
+      setNotificationsState({
+        hasLoadedList: true,
+        unreadCount: 2,
+        items: [makeNotification({ id: 'a' }), makeNotification({ id: 'b' })],
+      });
+      renderPanel();
+
+      await user.click(screen.getByRole('button', { name: 'Mark all as read' }));
+
+      expect(markAllRead).toHaveBeenCalledTimes(1);
+      expect(markAllRead).toHaveBeenCalledWith();
+    });
+
+    it('is disabled when unreadCount is 0', () => {
+      setNotificationsState({ hasLoadedList: true, unreadCount: 0, items: [] });
+      renderPanel();
+
+      expect(screen.getByRole('button', { name: 'Mark all as read' })).toBeDisabled();
+    });
+  });
+
+  // =========================================================================
+  // Circle-switch-then-navigate
+  // =========================================================================
+
+  describe('opening a notification row', () => {
+    it('switches the active circle BEFORE navigating when the notification targets a different, known circle', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({
+        id: 'x',
+        title: 'Switch target',
+        circleId: 'circle-2',
+        link: '/bursts',
+        readAt: '2026-08-01T00:00:00.000Z', // already read — isolates ordering from markRead
+      });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      setCircleState('circle-1', [makeCircle('circle-1'), makeCircle('circle-2')]);
+      renderPanel();
+
+      await user.click(screen.getByText('Switch target'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/bursts');
+      });
+      expect(setActiveCircle).toHaveBeenCalledWith('circle-2');
+      expect(callOrder).toEqual(['setActiveCircle:circle-2', 'navigate:/bursts']);
+    });
+
+    it('does NOT switch circles when the notification circle matches the active circle', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({
+        id: 'same',
+        title: 'Same circle target',
+        circleId: 'circle-1',
+        link: '/bursts',
+      });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      setCircleState('circle-1', [makeCircle('circle-1')]);
+      renderPanel();
+
+      await user.click(screen.getByText('Same circle target'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/bursts');
+      });
+      expect(setActiveCircle).not.toHaveBeenCalled();
+    });
+
+    it('does NOT switch when the notification circle is not in the membership list (membership guard)', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({
+        id: 'gone',
+        title: 'Stale circle target',
+        circleId: 'circle-999',
+        link: '/bursts',
+      });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      // A loaded, non-empty circle list that does NOT contain circle-999.
+      setCircleState('circle-1', [makeCircle('circle-1'), makeCircle('circle-2')]);
+      renderPanel();
+
+      await user.click(screen.getByText('Stale circle target'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/bursts');
+      });
+      expect(setActiveCircle).not.toHaveBeenCalled();
+    });
+
+    it('navigates without switching for a global (circleId: null) notification', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({
+        id: 'global',
+        title: 'Global notice',
+        circleId: null,
+        link: '/admin/settings/jobs',
+      });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      renderPanel();
+
+      await user.click(screen.getByText('Global notice'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/admin/settings/jobs');
+      });
+      expect(setActiveCircle).not.toHaveBeenCalled();
+    });
+
+    it('marks an unread notification read when opened', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({ id: 'unread-open', title: 'Unread target', readAt: null });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      renderPanel();
+
+      await user.click(screen.getByText('Unread target'));
+
+      expect(markRead).toHaveBeenCalledWith('unread-open');
+    });
+
+    it('does not call markRead for an already-read notification', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({
+        id: 'already-read',
+        title: 'Already read target',
+        readAt: '2026-08-01T00:00:00.000Z',
+      });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      renderPanel();
+
+      await user.click(screen.getByText('Already read target'));
+
+      expect(markRead).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when the notification has no link', async () => {
+      const user = userEvent.setup();
+      const item = makeNotification({ id: 'no-link', title: 'Informational only', link: null });
+      setNotificationsState({ hasLoadedList: true, items: [item] });
+      renderPanel();
+
+      await user.click(screen.getByText('Informational only'));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Mobile variant
+  // =========================================================================
+
+  describe('responsive shell', () => {
+    function setViewport(matches: (query: string) => boolean) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: matches(query),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+
+    it('renders as a bottom Drawer below the sm breakpoint', () => {
+      const originalMatchMedia = window.matchMedia;
+      // MUI's `down('sm')` compiles to a max-width media query.
+      setViewport((query) => query.includes('max-width'));
+      setNotificationsState({ hasLoadedList: true, items: [] });
+
+      try {
+        renderPanel();
+
+        expect(document.querySelector('.MuiDrawer-root')).toBeInTheDocument();
+        expect(document.querySelector('.MuiPopover-root')).not.toBeInTheDocument();
+        expect(screen.getByRole('presentation')).toBeInTheDocument();
+      } finally {
+        Object.defineProperty(window, 'matchMedia', { writable: true, value: originalMatchMedia });
+      }
+    });
+
+    it('renders as an anchored Popover at sm and up', () => {
+      const originalMatchMedia = window.matchMedia;
+      setViewport(() => false); // jsdom default: no query ever matches
+      setNotificationsState({ hasLoadedList: true, items: [] });
+
+      try {
+        renderPanel();
+
+        expect(document.querySelector('.MuiPopover-root')).toBeInTheDocument();
+        expect(document.querySelector('.MuiDrawer-root')).not.toBeInTheDocument();
+      } finally {
+        Object.defineProperty(window, 'matchMedia', { writable: true, value: originalMatchMedia });
+      }
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/notifications/NotificationRow.test.tsx
+++ b/apps/web/src/__tests__/components/notifications/NotificationRow.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for NotificationRow (issue #249).
+ *
+ * Isolated at the component level — no store/service mocking needed, just
+ * the two callback props. The case this file exists for: the dismiss (×)
+ * button sits OUTSIDE the row's ListItemButton (MUI `secondaryAction`), so
+ * clicking it must call `onDismiss` and must NOT also call `onOpen`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+import { NotificationRow } from '../../../components/notifications/NotificationRow';
+import type { NotificationItem } from '../../../types/notifications';
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'notif-1',
+    circleId: 'circle-1',
+    type: 'review_queue_bursts',
+    title: 'Burst review ready',
+    body: 'Three bursts are waiting for review.',
+    link: '/bursts',
+    data: null,
+    readAt: null,
+    dismissedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('NotificationRow', () => {
+  it('renders the title and body', () => {
+    const notification = makeNotification();
+    render(
+      <NotificationRow notification={notification} onOpen={vi.fn()} onDismiss={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Burst review ready')).toBeInTheDocument();
+    expect(screen.getByText('Three bursts are waiting for review.')).toBeInTheDocument();
+  });
+
+  it('calls onOpen with the notification when the row body is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    const notification = makeNotification();
+    render(<NotificationRow notification={notification} onOpen={onOpen} onDismiss={vi.fn()} />);
+
+    await user.click(screen.getByText('Burst review ready'));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith(notification);
+  });
+
+  it('calls onDismiss (not onOpen) when the dismiss (×) button is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    const onDismiss = vi.fn();
+    const notification = makeNotification();
+    render(
+      <NotificationRow notification={notification} onOpen={onOpen} onDismiss={onDismiss} />,
+    );
+
+    const dismissButton = screen.getByRole('button', {
+      name: 'Dismiss notification: Burst review ready',
+    });
+    await user.click(dismissButton);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith(notification);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('stops propagation so a raw (non-user-event) click on dismiss never bubbles into the row', () => {
+    const onOpen = vi.fn();
+    const onDismiss = vi.fn();
+    const notification = makeNotification();
+    render(
+      <NotificationRow notification={notification} onOpen={onOpen} onDismiss={onDismiss} />,
+    );
+
+    const dismissButton = screen.getByRole('button', {
+      name: 'Dismiss notification: Burst review ready',
+    });
+    fireEvent.click(dismissButton);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('shows an "Unread" indicator for an unread notification', () => {
+    const notification = makeNotification({ readAt: null });
+    render(<NotificationRow notification={notification} onOpen={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(screen.getByText('Unread')).toBeInTheDocument();
+  });
+
+  it('does not show an "Unread" indicator once read', () => {
+    const notification = makeNotification({ readAt: new Date().toISOString() });
+    render(<NotificationRow notification={notification} onOpen={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(screen.queryByText('Unread')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/hooks/useNotifications.test.ts
+++ b/apps/web/src/__tests__/hooks/useNotifications.test.ts
@@ -1,0 +1,958 @@
+/**
+ * Unit tests for the useNotifications module-level store (issue #249, epic #240).
+ *
+ * Covers:
+ *  - Badge count fetch on mount (acquire) and via refreshCount
+ *  - Panel list fetch via refreshList
+ *  - Optimistic markRead / dismiss / markAllRead with rollback-on-failure
+ *  - Polling cadence, visibility pause/resume, focus resume
+ *  - Reference-counted shared store: two subscribers do not double-poll,
+ *    and polling only stops once the LAST subscriber unmounts
+ *  - The `enabled` opt-out (unauthenticated / gated surfaces never poll)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mock the notifications service — the store's only network seam.
+// ---------------------------------------------------------------------------
+vi.mock('../../services/notifications', () => ({
+  getUnreadCount: vi.fn(),
+  listNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  dismissNotification: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+}));
+
+import {
+  useNotifications,
+  __resetNotificationsStoreForTests,
+} from '../../hooks/useNotifications';
+import {
+  getUnreadCount,
+  listNotifications,
+  markNotificationRead,
+  dismissNotification,
+  markAllNotificationsRead,
+} from '../../services/notifications';
+import type { NotificationItem, NotificationListResponse } from '../../types/notifications';
+
+const mockGetUnreadCount = vi.mocked(getUnreadCount);
+const mockListNotifications = vi.mocked(listNotifications);
+const mockMarkNotificationRead = vi.mocked(markNotificationRead);
+const mockDismissNotification = vi.mocked(dismissNotification);
+const mockMarkAllNotificationsRead = vi.mocked(markAllNotificationsRead);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'notif-1',
+    circleId: 'circle-1',
+    type: 'review_queue_bursts',
+    title: 'Burst review ready',
+    body: null,
+    link: '/bursts',
+    data: null,
+    readAt: null,
+    dismissedAt: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function listResponse(items: NotificationItem[]): NotificationListResponse {
+  return {
+    items,
+    meta: { page: 1, pageSize: 10, totalItems: items.length, totalPages: 1 },
+  };
+}
+
+function setVisibility(value: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+const POLL_INTERVAL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNotificationsStoreForTests();
+    setVisibility('visible');
+    mockGetUnreadCount.mockResolvedValue(0);
+    mockListNotifications.mockResolvedValue(listResponse([]));
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockDismissNotification.mockResolvedValue(undefined);
+    mockMarkAllNotificationsRead.mockResolvedValue({ updated: 0 });
+  });
+
+  afterEach(() => {
+    __resetNotificationsStoreForTests();
+    vi.useRealTimers();
+    setVisibility('visible');
+  });
+
+  // =========================================================================
+  // Badge count
+  // =========================================================================
+
+  describe('unread count', () => {
+    it('starts at 0 with an empty item list before the first fetch resolves', () => {
+      mockGetUnreadCount.mockReturnValue(new Promise(() => {})); // never resolves
+
+      const { result } = renderHook(() => useNotifications());
+
+      expect(result.current.unreadCount).toBe(0);
+      expect(result.current.items).toEqual([]);
+      expect(result.current.hasLoadedList).toBe(false);
+    });
+
+    it('fetches the unread count on mount and reflects the server value', async () => {
+      mockGetUnreadCount.mockResolvedValue(5);
+
+      const { result } = renderHook(() => useNotifications());
+
+      await waitFor(() => {
+        expect(result.current.unreadCount).toBe(5);
+      });
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+    });
+
+    it('reflects a zero unread count from the server', async () => {
+      mockGetUnreadCount.mockResolvedValue(0);
+
+      const { result } = renderHook(() => useNotifications());
+
+      await waitFor(() => {
+        expect(mockGetUnreadCount).toHaveBeenCalled();
+      });
+      expect(result.current.unreadCount).toBe(0);
+    });
+
+    it('refreshCount re-invokes getUnreadCount on demand', async () => {
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(mockGetUnreadCount).toHaveBeenCalledTimes(1));
+
+      mockGetUnreadCount.mockResolvedValue(3);
+      await act(async () => {
+        await result.current.refreshCount();
+      });
+
+      expect(result.current.unreadCount).toBe(3);
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+    });
+
+    it('captures an error message when getUnreadCount rejects', async () => {
+      mockGetUnreadCount.mockRejectedValue(new Error('network down'));
+
+      const { result } = renderHook(() => useNotifications());
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('network down');
+      });
+    });
+  });
+
+  // =========================================================================
+  // Panel list fetch
+  // =========================================================================
+
+  describe('refreshList', () => {
+    it('is a no-op until called — hasLoadedList starts false', () => {
+      const { result } = renderHook(() => useNotifications());
+      expect(result.current.hasLoadedList).toBe(false);
+      expect(mockListNotifications).not.toHaveBeenCalled();
+    });
+
+    it('fetches and populates items, flips hasLoadedList true', async () => {
+      const item = makeNotification();
+      mockListNotifications.mockResolvedValue(listResponse([item]));
+
+      const { result } = renderHook(() => useNotifications());
+      await act(async () => {
+        await result.current.refreshList();
+      });
+
+      expect(result.current.items).toEqual([item]);
+      expect(result.current.hasLoadedList).toBe(true);
+      expect(mockListNotifications).toHaveBeenCalledWith({
+        status: 'all',
+        page: 1,
+        pageSize: 10,
+      });
+    });
+
+    it('sets an error and stops loading when listNotifications rejects', async () => {
+      mockListNotifications.mockRejectedValue(new Error('list failed'));
+
+      const { result } = renderHook(() => useNotifications());
+      await act(async () => {
+        await result.current.refreshList();
+      });
+
+      expect(result.current.error).toBe('list failed');
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Optimistic markRead + rollback
+  // =========================================================================
+
+  describe('markRead', () => {
+    async function seedOneUnreadItem(unreadCount = 1) {
+      const item = makeNotification({ readAt: null });
+      mockListNotifications.mockResolvedValue(listResponse([item]));
+      mockGetUnreadCount.mockResolvedValue(unreadCount);
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.unreadCount).toBe(unreadCount));
+      await act(async () => {
+        await result.current.refreshList();
+      });
+      return { result, item };
+    }
+
+    it('marks the row read and decrements the badge IMMEDIATELY, before the request resolves', async () => {
+      const { result, item } = await seedOneUnreadItem(1);
+
+      let resolveRead!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        resolveRead = resolve;
+      });
+      mockMarkNotificationRead.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.markRead(item.id);
+      });
+
+      // Optimistic effect must be visible synchronously, before the request settles.
+      expect(result.current.unreadCount).toBe(0);
+      expect(result.current.items.find((n) => n.id === item.id)?.readAt).not.toBeNull();
+
+      // The success path also fires a reconciling `fetchCount()` — reflect the
+      // now-decremented server truth so that call doesn't fight our assertion.
+      mockGetUnreadCount.mockResolvedValue(0);
+
+      await act(async () => {
+        resolveRead();
+        await pending;
+      });
+
+      expect(mockMarkNotificationRead).toHaveBeenCalledWith(item.id);
+      // Still marked read after the request settles successfully.
+      expect(result.current.unreadCount).toBe(0);
+    });
+
+    it('ROLLS BACK the badge and the row on a FAILED request', async () => {
+      const { result, item } = await seedOneUnreadItem(1);
+
+      let rejectRead!: (err: unknown) => void;
+      const pending = new Promise<void>((_resolve, reject) => {
+        rejectRead = reject;
+      });
+      mockMarkNotificationRead.mockReturnValue(pending);
+      // The rollback path also re-fetches the count as a tiebreaker; make that
+      // resolve back to the pre-mutation value so we can assert the restored
+      // state deterministically.
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      act(() => {
+        void result.current.markRead(item.id);
+      });
+
+      // Optimistic decrement happened…
+      expect(result.current.unreadCount).toBe(0);
+
+      await act(async () => {
+        rejectRead(new Error('server rejected'));
+        await pending.catch(() => undefined);
+      });
+
+      // …and is undone once the request fails.
+      expect(result.current.unreadCount).toBe(1);
+      expect(result.current.items.find((n) => n.id === item.id)?.readAt).toBeNull();
+      // The rollback's error message SURVIVES the reconciling count refetch —
+      // see the dedicated 'rollback error surface' block below, which covers
+      // this for all three mutations.
+    });
+
+    it('is a no-op for an already-read notification', async () => {
+      const item = makeNotification({ readAt: '2026-08-01T00:00:00.000Z' });
+      mockListNotifications.mockResolvedValue(listResponse([item]));
+
+      const { result } = renderHook(() => useNotifications());
+      await act(async () => {
+        await result.current.refreshList();
+      });
+
+      await act(async () => {
+        await result.current.markRead(item.id);
+      });
+
+      expect(mockMarkNotificationRead).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Optimistic dismiss + rollback
+  // =========================================================================
+
+  describe('dismiss', () => {
+    async function seedOneUnreadItem() {
+      const item = makeNotification({ readAt: null });
+      mockListNotifications.mockResolvedValue(listResponse([item]));
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.unreadCount).toBe(1));
+      await act(async () => {
+        await result.current.refreshList();
+      });
+      return { result, item };
+    }
+
+    it('removes the row and decrements the badge immediately', async () => {
+      const { result, item } = await seedOneUnreadItem();
+
+      let resolveDismiss!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        resolveDismiss = resolve;
+      });
+      mockDismissNotification.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.dismiss(item.id);
+      });
+
+      expect(result.current.items).toEqual([]);
+      expect(result.current.unreadCount).toBe(0);
+
+      await act(async () => {
+        resolveDismiss();
+        await pending;
+      });
+
+      expect(mockDismissNotification).toHaveBeenCalledWith(item.id);
+    });
+
+    it('restores the row and the badge count on a failed dismiss', async () => {
+      const { result, item } = await seedOneUnreadItem();
+
+      let rejectDismiss!: (err: unknown) => void;
+      const pending = new Promise<void>((_resolve, reject) => {
+        rejectDismiss = reject;
+      });
+      mockDismissNotification.mockReturnValue(pending);
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      act(() => {
+        void result.current.dismiss(item.id);
+      });
+      expect(result.current.items).toEqual([]);
+
+      await act(async () => {
+        rejectDismiss(new Error('dismiss failed'));
+        await pending.catch(() => undefined);
+      });
+
+      expect(result.current.items).toEqual([item]);
+      expect(result.current.unreadCount).toBe(1);
+      // `error` is asserted in the 'rollback error surface' block below.
+    });
+  });
+
+  // =========================================================================
+  // markAllRead (unscoped — the only form the panel's "Mark all as read" uses)
+  // =========================================================================
+
+  describe('markAllRead', () => {
+    it('hits the bulk read-all endpoint and zeroes the badge immediately', async () => {
+      const items = [
+        makeNotification({ id: 'a', readAt: null }),
+        makeNotification({ id: 'b', readAt: null }),
+      ];
+      mockListNotifications.mockResolvedValue(listResponse(items));
+      mockGetUnreadCount.mockResolvedValue(2);
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.unreadCount).toBe(2));
+      await act(async () => {
+        await result.current.refreshList();
+      });
+
+      let resolveAll!: () => void;
+      const pending = new Promise<{ updated: number }>((resolve) => {
+        resolveAll = () => resolve({ updated: 2 });
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.markAllRead();
+      });
+
+      expect(result.current.unreadCount).toBe(0);
+      expect(result.current.items.every((n) => n.readAt !== null)).toBe(true);
+
+      await act(async () => {
+        resolveAll();
+        await pending;
+      });
+
+      expect(mockMarkAllNotificationsRead).toHaveBeenCalledWith(undefined);
+    });
+
+    it('rolls back on failure', async () => {
+      const items = [makeNotification({ id: 'a', readAt: null })];
+      mockListNotifications.mockResolvedValue(listResponse(items));
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.unreadCount).toBe(1));
+      await act(async () => {
+        await result.current.refreshList();
+      });
+
+      let rejectAll!: (err: unknown) => void;
+      const pending = new Promise<{ updated: number }>((_resolve, reject) => {
+        rejectAll = reject;
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      act(() => {
+        void result.current.markAllRead();
+      });
+      expect(result.current.unreadCount).toBe(0);
+
+      await act(async () => {
+        rejectAll(new Error('bulk failed'));
+        await pending.catch(() => undefined);
+      });
+
+      expect(result.current.unreadCount).toBe(1);
+      expect(result.current.items[0].readAt).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // markAllRead SCOPED to a circle
+  //
+  // Not reachable from the shipped bell panel (which only calls the unscoped
+  // form) but it is the exact path issue #250's `/notifications` page takes
+  // when a circle filter is active. Regression guard: this used to skip the
+  // optimistic decrement entirely, so the badge silently froze.
+  // =========================================================================
+
+  describe('markAllRead scoped to a circle', () => {
+    /**
+     * Two loaded unread rows in circle-1, one in circle-2, and a server badge
+     * of 5 — i.e. deliberately MORE unread rows than the store has loaded, which
+     * is what makes the scoped decrement an estimate rather than a fact.
+     */
+    async function seedMixedCircles(unreadCount = 5) {
+      const items = [
+        makeNotification({ id: 'a', circleId: 'circle-1', readAt: null }),
+        makeNotification({ id: 'b', circleId: 'circle-1', readAt: null }),
+        makeNotification({ id: 'c', circleId: 'circle-2', readAt: null }),
+      ];
+      mockListNotifications.mockResolvedValue(listResponse(items));
+      mockGetUnreadCount.mockResolvedValue(unreadCount);
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.unreadCount).toBe(unreadCount));
+      await act(async () => {
+        await result.current.refreshList();
+      });
+      return { result, items };
+    }
+
+    it('decrements the badge OPTIMISTICALLY by the loaded unread rows in that circle', async () => {
+      const { result } = await seedMixedCircles(5);
+
+      let resolveAll!: () => void;
+      const pending = new Promise<{ updated: number }>((resolve) => {
+        resolveAll = () => resolve({ updated: 2 });
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.markAllRead('circle-1');
+      });
+
+      // Two of the five unread rows are loaded and in scope → 5 - 2 = 3,
+      // visible synchronously, before the request settles.
+      expect(result.current.unreadCount).toBe(3);
+      expect(mockMarkAllNotificationsRead).toHaveBeenCalledWith('circle-1');
+
+      await act(async () => {
+        resolveAll();
+        await pending;
+      });
+    });
+
+    it('only marks rows of the scoped circle read, leaving other circles untouched', async () => {
+      const { result } = await seedMixedCircles(5);
+
+      let resolveAll!: () => void;
+      const pending = new Promise<{ updated: number }>((resolve) => {
+        resolveAll = () => resolve({ updated: 2 });
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.markAllRead('circle-1');
+      });
+
+      const byId = (id: string) => result.current.items.find((n) => n.id === id);
+      expect(byId('a')?.readAt).not.toBeNull();
+      expect(byId('b')?.readAt).not.toBeNull();
+      expect(byId('c')?.readAt).toBeNull();
+
+      await act(async () => {
+        resolveAll();
+        await pending;
+      });
+    });
+
+    it('replaces the estimate with the server’s exact `updated` count', async () => {
+      const { result } = await seedMixedCircles(5);
+
+      let resolveAll!: () => void;
+      const pending = new Promise<{ updated: number }>((resolve) => {
+        // The server flipped FOUR rows — two more than the store had loaded,
+        // which is precisely the case the optimistic estimate cannot know.
+        resolveAll = () => resolve({ updated: 4 });
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.markAllRead('circle-1');
+      });
+      expect(result.current.unreadCount).toBe(3); // the estimate
+
+      // Hang the reconciling fetchCount so this assertion isolates the
+      // `updated`-derived correction rather than the later refetch.
+      mockGetUnreadCount.mockReturnValue(new Promise(() => {}));
+
+      await act(async () => {
+        resolveAll();
+        await pending;
+      });
+
+      expect(result.current.unreadCount).toBe(1); // 5 - 4
+    });
+
+    it('ends server-accurate even when the estimate and `updated` both disagree', async () => {
+      const { result } = await seedMixedCircles(5);
+
+      mockMarkAllNotificationsRead.mockResolvedValue({ updated: 4 });
+      // The reconciling refetch is the final authority; pick a value that
+      // matches neither the estimate (3) nor the `updated` correction (1).
+      mockGetUnreadCount.mockResolvedValue(7);
+
+      await act(async () => {
+        await result.current.markAllRead('circle-1');
+      });
+
+      await waitFor(() => {
+        expect(result.current.unreadCount).toBe(7);
+      });
+    });
+
+    it('never drives the badge below zero when the estimate overshoots', async () => {
+      // Server badge of 1 but two loaded unread rows in scope (possible when a
+      // poll landed between the list fetch and the click).
+      const { result } = await seedMixedCircles(1);
+
+      let resolveAll!: () => void;
+      const pending = new Promise<{ updated: number }>((resolve) => {
+        resolveAll = () => resolve({ updated: 2 });
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+
+      act(() => {
+        void result.current.markAllRead('circle-1');
+      });
+
+      expect(result.current.unreadCount).toBe(0); // clamped, not -1
+
+      mockGetUnreadCount.mockReturnValue(new Promise(() => {}));
+      await act(async () => {
+        resolveAll();
+        await pending;
+      });
+
+      expect(result.current.unreadCount).toBe(0); // 1 - 2 clamped, not -1
+    });
+
+    it('rolls the scoped decrement back on failure', async () => {
+      const { result, items } = await seedMixedCircles(5);
+
+      let rejectAll!: (err: unknown) => void;
+      const pending = new Promise<{ updated: number }>((_resolve, reject) => {
+        rejectAll = reject;
+      });
+      mockMarkAllNotificationsRead.mockReturnValue(pending);
+      mockGetUnreadCount.mockResolvedValue(5);
+
+      act(() => {
+        void result.current.markAllRead('circle-1');
+      });
+      expect(result.current.unreadCount).toBe(3);
+
+      await act(async () => {
+        rejectAll(new Error('scoped bulk failed'));
+        await pending.catch(() => undefined);
+      });
+
+      expect(result.current.unreadCount).toBe(5);
+      expect(result.current.items).toEqual(items);
+      expect(result.current.error).toBe('scoped bulk failed');
+    });
+  });
+
+  // =========================================================================
+  // Rollback error surface
+  //
+  // The rollback fires a reconciling count refetch (a poll landing mid-flight
+  // can make the restored snapshot's own count stale, so the server is the
+  // tiebreaker). That refetch must NOT clear the error the rollback just set —
+  // otherwise the badge reverts correctly but the user is never told why.
+  // =========================================================================
+
+  describe('rollback error surface', () => {
+    async function seedOne(unreadCount = 1) {
+      const item = makeNotification({ readAt: null });
+      mockListNotifications.mockResolvedValue(listResponse([item]));
+      mockGetUnreadCount.mockResolvedValue(unreadCount);
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.unreadCount).toBe(unreadCount));
+      await act(async () => {
+        await result.current.refreshList();
+      });
+      return { result, item };
+    }
+
+    it('keeps the markRead failure message even though the reconciling refetch SUCCEEDS', async () => {
+      const { result, item } = await seedOne(1);
+      mockMarkNotificationRead.mockRejectedValue(new Error('server rejected'));
+      mockGetUnreadCount.mockResolvedValue(1); // the reconcile succeeds
+
+      await act(async () => {
+        await result.current.markRead(item.id);
+      });
+
+      // Reconciliation still happened (mount + refresh + reconcile)…
+      await waitFor(() => {
+        expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+      });
+      expect(result.current.unreadCount).toBe(1);
+      // …and the error survived it.
+      expect(result.current.error).toBe('server rejected');
+    });
+
+    it('keeps the dismiss failure message', async () => {
+      const { result, item } = await seedOne(1);
+      mockDismissNotification.mockRejectedValue(new Error('dismiss failed'));
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      await act(async () => {
+        await result.current.dismiss(item.id);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('dismiss failed');
+      });
+      expect(result.current.items).toEqual([item]);
+    });
+
+    it('keeps the markAllRead failure message', async () => {
+      const { result } = await seedOne(1);
+      mockMarkAllNotificationsRead.mockRejectedValue(new Error('bulk failed'));
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      await act(async () => {
+        await result.current.markAllRead();
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('bulk failed');
+      });
+      expect(result.current.unreadCount).toBe(1);
+    });
+
+    it('does not let a FAILING reconcile overwrite the mutation error either', async () => {
+      const { result, item } = await seedOne(1);
+      mockMarkNotificationRead.mockRejectedValue(new Error('server rejected'));
+      mockGetUnreadCount.mockRejectedValue(new Error('count also down'));
+
+      await act(async () => {
+        await result.current.markRead(item.id);
+      });
+
+      // The failed WRITE is the more actionable of the two messages.
+      await waitFor(() => {
+        expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+      });
+      expect(result.current.error).toBe('server rejected');
+    });
+
+    it('clears the rollback error on the next ordinary successful refresh', async () => {
+      const { result, item } = await seedOne(1);
+      mockMarkNotificationRead.mockRejectedValue(new Error('server rejected'));
+      mockGetUnreadCount.mockResolvedValue(1);
+
+      await act(async () => {
+        await result.current.markRead(item.id);
+      });
+      await waitFor(() => expect(result.current.error).toBe('server rejected'));
+
+      // An ordinary poll / explicit refresh still clears a stale error — only
+      // the rollback's own reconciling read is prevented from doing so.
+      await act(async () => {
+        await result.current.refreshCount();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Polling cadence + visibility pause/resume
+  // =========================================================================
+
+  describe('polling / visibility', () => {
+    it('polls again after POLL_INTERVAL_MS while the tab stays visible', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        await Promise.resolve();
+      });
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops issuing requests while the tab is hidden', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const callsBeforeHide = mockGetUnreadCount.mock.calls.length;
+
+      act(() => {
+        setVisibility('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS * 3);
+        await Promise.resolve();
+      });
+
+      expect(mockGetUnreadCount.mock.calls.length).toBe(callsBeforeHide);
+    });
+
+    it('refetches IMMEDIATELY and resumes the interval when the tab becomes visible again', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      act(() => {
+        setVisibility('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const callsWhileHidden = mockGetUnreadCount.mock.calls.length;
+
+      // Coming back to the tab triggers an immediate refetch — no need to
+      // advance the timer at all.
+      await act(async () => {
+        setVisibility('visible');
+        document.dispatchEvent(new Event('visibilitychange'));
+        await Promise.resolve();
+      });
+      expect(mockGetUnreadCount.mock.calls.length).toBe(callsWhileHidden + 1);
+
+      // …and the interval is running again.
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        await Promise.resolve();
+      });
+      expect(mockGetUnreadCount.mock.calls.length).toBe(callsWhileHidden + 2);
+    });
+
+    it('refetches on window focus while the tab is visible', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const callsBeforeFocus = mockGetUnreadCount.mock.calls.length;
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'));
+        await Promise.resolve();
+      });
+
+      expect(mockGetUnreadCount.mock.calls.length).toBe(callsBeforeFocus + 1);
+    });
+
+    it('does NOT refetch on focus while the tab is hidden', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications());
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      act(() => {
+        setVisibility('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const callsWhileHidden = mockGetUnreadCount.mock.calls.length;
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'));
+        await Promise.resolve();
+      });
+
+      expect(mockGetUnreadCount.mock.calls.length).toBe(callsWhileHidden);
+    });
+  });
+
+  // =========================================================================
+  // Shared store: reference-counted subscribers
+  // =========================================================================
+
+  describe('shared store across multiple subscribers', () => {
+    it('mounting two consumers issues only ONE unread-count fetch, not two', async () => {
+      renderHook(() => useNotifications());
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+    });
+
+    it('a single shared poller ticks once per interval regardless of subscriber count', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications());
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        await Promise.resolve();
+      });
+
+      // One additional tick from the ONE shared interval — not two.
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+    });
+
+    it('polling continues after only ONE of two subscribers unmounts', async () => {
+      vi.useFakeTimers();
+      const first = renderHook(() => useNotifications());
+      renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      first.unmount();
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        await Promise.resolve();
+      });
+
+      // The still-mounted second subscriber keeps the shared poller alive.
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+    });
+
+    it('polling stops once the LAST subscriber unmounts', async () => {
+      vi.useFakeTimers();
+      const first = renderHook(() => useNotifications());
+      const second = renderHook(() => useNotifications());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const callsBeforeUnmount = mockGetUnreadCount.mock.calls.length;
+
+      first.unmount();
+      second.unmount();
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS * 2);
+        await Promise.resolve();
+      });
+
+      expect(mockGetUnreadCount.mock.calls.length).toBe(callsBeforeUnmount);
+    });
+  });
+
+  // =========================================================================
+  // enabled: false — opt out of polling entirely
+  // =========================================================================
+
+  describe('enabled option', () => {
+    it('never fetches or polls when enabled is false', async () => {
+      vi.useFakeTimers();
+      renderHook(() => useNotifications({ enabled: false }));
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS * 2);
+        await Promise.resolve();
+      });
+
+      expect(mockGetUnreadCount).not.toHaveBeenCalled();
+    });
+
+    it('refreshList / refreshCount are no-ops while disabled', async () => {
+      const { result } = renderHook(() => useNotifications({ enabled: false }));
+
+      await act(async () => {
+        await result.current.refreshList();
+        await result.current.refreshCount();
+      });
+
+      expect(mockListNotifications).not.toHaveBeenCalled();
+      expect(mockGetUnreadCount).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/__tests__/mocks/handlers.ts
+++ b/apps/web/src/__tests__/mocks/handlers.ts
@@ -393,6 +393,42 @@ export const handlers = [
     return HttpResponse.json({ items: [], total: 0 });
   }),
 
+  // Notifications (epic #240 / issue #249) — the AppBar bell polls these on
+  // every render of the app shell, so they need a default handler or every
+  // AppBar/Layout test logs an unhandled-request warning.
+  http.get(`${API_BASE}/notifications/unread-count`, () => {
+    return HttpResponse.json({ data: { count: 0 } });
+  }),
+
+  http.get(`${API_BASE}/notifications`, () => {
+    return HttpResponse.json({
+      data: {
+        items: [],
+        meta: { page: 1, pageSize: 10, totalItems: 0, totalPages: 0 },
+      },
+    });
+  }),
+
+  http.post(`${API_BASE}/notifications/read-all`, () => {
+    return HttpResponse.json({ data: { updated: 0 } });
+  }),
+
+  http.post(`${API_BASE}/notifications/dismiss-all`, () => {
+    return HttpResponse.json({ data: { updated: 0 } });
+  }),
+
+  http.post(`${API_BASE}/notifications/:id/read`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.post(`${API_BASE}/notifications/:id/dismiss`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete(`${API_BASE}/notifications/:id`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
   http.post(`${API_BASE}/circles`, async ({ request }) => {
     const body = (await request.json()) as { name: string; description?: string };
     return HttpResponse.json(

--- a/apps/web/src/components/navigation/AppBar.tsx
+++ b/apps/web/src/components/navigation/AppBar.tsx
@@ -22,6 +22,7 @@ import { useThemeContext } from '../../contexts/ThemeContext';
 import { useCircle } from '../../hooks/useCircle';
 import { useMediaRefresh } from '../../contexts/MediaRefreshContext';
 import { UserMenu } from './UserMenu';
+import { NotificationBell } from '../notifications/NotificationBell';
 import { TopbarSearch } from '../search/TopbarSearch';
 import { MediaUploadDialog } from '../media/MediaUploadDialog';
 import { APP_NAME } from '../../constants/app';
@@ -62,7 +63,17 @@ export function AppBar({ onMenuClick }: AppBarProps) {
           zIndex: theme.zIndex.appBar,
         }}
       >
-        <Toolbar sx={{ gap: 1, position: 'relative' }}>
+        {/* `gap` tightens on phone. At 360px the trailing cluster is now
+            hamburger + logo + collapsed search + upload + BELL + theme +
+            avatar; with the desktop 8px gap the row measures ~354px against
+            360px of viewport — 6px of slack, which a slightly larger system
+            font or a 2-digit badge would blow through. Dropping to 4px below
+            `sm` buys back 24px (six inter-item gaps) so the row measures
+            ~330px and the flex-growing search wrapper absorbs the remainder
+            instead of the toolbar overflowing. See
+            docs/audits/mobile-topbar-audit.md for the previous regression of
+            this class. */}
+        <Toolbar sx={{ gap: { xs: 0.5, sm: 1 }, position: 'relative' }}>
           {/* Hamburger */}
           <IconButton
             color="inherit"
@@ -126,6 +137,9 @@ export function AppBar({ onMenuClick }: AppBarProps) {
               </IconButton>
             )
           )}
+
+          {/* Notifications (between upload and the theme toggle) */}
+          <NotificationBell />
 
           {/* Theme Toggle */}
           <IconButton

--- a/apps/web/src/components/notifications/NotificationBell.tsx
+++ b/apps/web/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,73 @@
+/**
+ * NotificationBell — AppBar bell + unread badge (issue #249).
+ *
+ * Reads the shared `useNotifications` store, so the count here and the count
+ * on any other surface (#250's sidebar entry / `/notifications` page) come
+ * from ONE 60s poller, not one per mount.
+ *
+ * A11Y: `aria-label` embeds the unread count so a screen reader announces
+ * "Notifications, 3 unread" rather than just "Notifications" — the badge digit
+ * itself is decorative markup a reader would otherwise read out of context.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { Badge, IconButton, Tooltip } from '@mui/material';
+import {
+  Notifications as NotificationsIcon,
+  NotificationsNone as NotificationsNoneIcon,
+} from '@mui/icons-material';
+import { useNotifications } from '../../hooks/useNotifications';
+import { NotificationPanel } from './NotificationPanel';
+
+/** Minimum comfortable touch target (WCAG 2.5.5 / Material). */
+const TOUCH_TARGET = 44;
+
+export function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const { unreadCount, refreshList } = useNotifications();
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+    // The list is fetched on demand, not polled — a closed bell costs only the
+    // unread-count integer per minute.
+    void refreshList();
+  }, [refreshList]);
+
+  const handleClose = useCallback(() => setOpen(false), []);
+
+  const label =
+    unreadCount > 0
+      ? `Notifications, ${unreadCount} unread`
+      : 'Notifications, no unread';
+
+  return (
+    <>
+      <Tooltip title="Notifications">
+        <IconButton
+          ref={anchorRef}
+          color="inherit"
+          onClick={handleOpen}
+          aria-label={label}
+          aria-haspopup="dialog"
+          aria-expanded={open ? 'true' : undefined}
+          sx={{ flexShrink: 0, width: TOUCH_TARGET, height: TOUCH_TARGET }}
+        >
+          <Badge
+            badgeContent={unreadCount}
+            color="error"
+            max={99}
+            overlap="circular"
+            // The digit is presentational; the accessible name on the button
+            // above already carries the count.
+            slotProps={{ badge: { 'aria-hidden': true } }}
+          >
+            {unreadCount > 0 ? <NotificationsIcon /> : <NotificationsNoneIcon />}
+          </Badge>
+        </IconButton>
+      </Tooltip>
+
+      <NotificationPanel open={open} anchorEl={anchorRef.current} onClose={handleClose} />
+    </>
+  );
+}

--- a/apps/web/src/components/notifications/NotificationPanel.tsx
+++ b/apps/web/src/components/notifications/NotificationPanel.tsx
@@ -1,0 +1,265 @@
+/**
+ * NotificationPanel — the bell's dropdown (issue #249).
+ *
+ * RESPONSIVE SHELL
+ * ----------------
+ * Below `sm` (<600px) the panel is a bottom `Drawer` sheet spanning the full
+ * viewport width, because a ~380px floating card anchored to a toolbar icon on
+ * a 360px phone is both cramped and clipped by the viewport edge. At `sm` and
+ * up it is a `Popover` anchored to the bell. Only the shell differs — the
+ * header / list / footer content is one shared subtree.
+ *
+ * CIRCLE-SWITCH-THEN-NAVIGATE
+ * ---------------------------
+ * The review-queue notifications carry circle-agnostic links (`/bursts`,
+ * `/duplicates`, …) that render whatever circle is currently active. Tapping a
+ * row for a NON-active circle therefore has to switch the active circle first,
+ * or the user lands on the right page showing the wrong circle's data. We call
+ * `CircleContext.setActiveCircle` (which also persists `activeCircleId` to user
+ * settings) and then `navigate` in the same event handler: `setActiveCircle`
+ * updates its React state synchronously before its first `await`, so both
+ * updates land in one render batch and the destination mounts already scoped to
+ * the new circle — no need to await the settings PATCH round-trip.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  List,
+  Popover,
+  Skeleton,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { NotificationsNone as NotificationsNoneIcon } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useCircle } from '../../hooks/useCircle';
+import { useNotifications } from '../../hooks/useNotifications';
+import { NotificationRow } from './NotificationRow';
+import type { NotificationItem } from '../../types/notifications';
+
+interface NotificationPanelProps {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+}
+
+const PANEL_WIDTH = 380;
+
+export function NotificationPanel({ open, anchorEl, onClose }: NotificationPanelProps) {
+  const theme = useTheme();
+  const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const navigate = useNavigate();
+  const { circles, activeCircleId, setActiveCircle } = useCircle();
+
+  const { items, hasLoadedList, error, unreadCount, markRead, dismiss, markAllRead } =
+    useNotifications();
+
+  const handleOpenNotification = (notification: NotificationItem) => {
+    onClose();
+
+    // Optimistic — the badge drops before the request resolves, and rolls back
+    // inside the store if it fails.
+    if (!notification.readAt) void markRead(notification.id);
+
+    // Switch circle BEFORE navigating (see file header).
+    //
+    // The membership check guards the stale-row case: a notification can
+    // outlive the user's access to its circle, and `setActiveCircle` would
+    // happily persist an id that resolves to no circle at all, leaving the
+    // whole app in a sticky "no active circle" state. `circles.length === 0`
+    // is treated as "not loaded yet" rather than "member of nothing" — every
+    // user always has a personal circle, so an empty list only ever means the
+    // CircleContext init is still in flight.
+    const circleKnown =
+      circles.length === 0 || circles.some((c) => c.id === notification.circleId);
+
+    if (notification.circleId && notification.circleId !== activeCircleId && circleKnown) {
+      void setActiveCircle(notification.circleId);
+    }
+
+    if (notification.link) navigate(notification.link);
+  };
+
+  const handleSeeAll = () => {
+    onClose();
+    navigate('/notifications');
+  };
+
+  // ---------------------------------------------------------------------------
+  // Shared content
+  // ---------------------------------------------------------------------------
+
+  const content = (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: isPhone ? '100%' : PANEL_WIDTH,
+        maxWidth: '100%',
+        maxHeight: isPhone ? '80vh' : 460,
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          px: 2,
+          py: 1.5,
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Notifications
+        </Typography>
+        <Button
+          size="small"
+          onClick={() => void markAllRead()}
+          disabled={unreadCount === 0}
+          sx={{ minHeight: 36 }}
+        >
+          Mark all as read
+        </Button>
+      </Box>
+
+      <Divider />
+
+      {/* Body */}
+      <Box sx={{ overflowY: 'auto', flexGrow: 1 }}>
+        {error && (
+          <Alert severity="error" sx={{ m: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Loading skeleton — shown until the FIRST list fetch resolves.
+            Keyed off `hasLoadedList` rather than `isLoading` so it also covers
+            the tick between the panel opening and `refreshList()` starting,
+            and so later background refreshes swap rows in place instead of
+            flashing the skeleton again. */}
+        {!hasLoadedList && !error && (
+          <Box sx={{ px: 2, py: 1.5 }} data-testid="notification-panel-skeleton">
+            {[0, 1, 2].map((i) => (
+              <Box key={i} sx={{ display: 'flex', gap: 1.5, py: 1 }}>
+                <Skeleton variant="circular" width={32} height={32} />
+                <Box sx={{ flexGrow: 1 }}>
+                  <Skeleton variant="text" width="80%" />
+                  <Skeleton variant="text" width="40%" />
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {hasLoadedList && items.length === 0 && !error && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1,
+              px: 3,
+              py: 5,
+              textAlign: 'center',
+            }}
+          >
+            <NotificationsNoneIcon color="disabled" />
+            <Typography variant="body2" color="text.secondary">
+              You&apos;re all caught up
+            </Typography>
+          </Box>
+        )}
+
+        {hasLoadedList && items.length > 0 && (
+          <List disablePadding>
+            {items.map((notification) => (
+              <NotificationRow
+                key={notification.id}
+                notification={notification}
+                onOpen={handleOpenNotification}
+                onDismiss={(n) => void dismiss(n.id)}
+              />
+            ))}
+          </List>
+        )}
+      </Box>
+
+      <Divider />
+
+      {/* Footer */}
+      <Box sx={{ p: 1, flexShrink: 0 }}>
+        <Button fullWidth size="small" onClick={handleSeeAll} sx={{ minHeight: 40 }}>
+          See all
+        </Button>
+      </Box>
+    </Box>
+  );
+
+  // ---------------------------------------------------------------------------
+  // Phone: full-width bottom sheet
+  // ---------------------------------------------------------------------------
+
+  if (isPhone) {
+    return (
+      <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={onClose}
+        slotProps={{
+          paper: {
+            'aria-label': 'Notifications',
+            sx: {
+              width: '100%',
+              maxHeight: '80vh',
+              borderTopLeftRadius: 16,
+              borderTopRightRadius: 16,
+            },
+          },
+        }}
+      >
+        {/* Grab handle */}
+        <Box
+          aria-hidden
+          sx={{
+            width: 36,
+            height: 4,
+            borderRadius: 2,
+            backgroundColor: 'divider',
+            mx: 'auto',
+            mt: 1,
+          }}
+        />
+        {content}
+      </Drawer>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tablet / desktop: anchored popover
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      slotProps={{
+        paper: {
+          'aria-label': 'Notifications',
+          sx: { mt: 1, width: PANEL_WIDTH, maxWidth: 'calc(100vw - 16px)' },
+        },
+      }}
+    >
+      {content}
+    </Popover>
+  );
+}

--- a/apps/web/src/components/notifications/NotificationRow.tsx
+++ b/apps/web/src/components/notifications/NotificationRow.tsx
@@ -1,0 +1,172 @@
+/**
+ * One row in the notification panel (issue #249).
+ *
+ * The dismiss (×) button is ALWAYS rendered and always hit-testable. It is
+ * deliberately not a hover-reveal control: issue #243 shipped an `opacity: 0`
+ * affordance that stayed clickable (and therefore invisible-but-tappable) on
+ * touch devices. The rule this file follows is — if a control is visually
+ * hidden it must also set `pointerEvents: 'none'` or be gated behind
+ * `@media (hover: hover)`. Here we simply never hide it.
+ */
+
+import {
+  Box,
+  IconButton,
+  ListItem,
+  ListItemButton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { Close as CloseIcon } from '@mui/icons-material';
+import { relativeTime } from '../../utils/formatBytes';
+import { notificationMeta } from './notificationMeta';
+import type { NotificationItem } from '../../types/notifications';
+
+interface NotificationRowProps {
+  notification: NotificationItem;
+  onOpen: (notification: NotificationItem) => void;
+  onDismiss: (notification: NotificationItem) => void;
+}
+
+/** Minimum comfortable touch target (WCAG 2.5.5 / Material). */
+const TOUCH_TARGET = 44;
+
+export function NotificationRow({ notification, onOpen, onDismiss }: NotificationRowProps) {
+  const meta = notificationMeta(notification.type);
+  const isUnread = notification.readAt === null;
+
+  return (
+    <ListItem
+      disablePadding
+      // `secondaryAction` renders the dismiss button OUTSIDE the ListItemButton,
+      // so tapping × never also triggers the row's navigate.
+      secondaryAction={
+        <Tooltip title="Dismiss">
+          <IconButton
+            edge="end"
+            aria-label={`Dismiss notification: ${notification.title}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss(notification);
+            }}
+            sx={{
+              width: TOUCH_TARGET,
+              height: TOUCH_TARGET,
+              color: 'text.secondary',
+            }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      }
+      sx={{
+        alignItems: 'stretch',
+        backgroundColor: isUnread ? 'action.hover' : 'transparent',
+      }}
+    >
+      <ListItemButton
+        onClick={() => onOpen(notification)}
+        sx={{
+          alignItems: 'flex-start',
+          gap: 1.5,
+          // Leave room for the 44px secondaryAction so long titles don't run
+          // underneath it.
+          pr: `${TOUCH_TARGET + 8}px`,
+          py: 1.25,
+          minHeight: TOUCH_TARGET,
+        }}
+      >
+        {/* Type icon */}
+        <Box
+          aria-hidden
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            width: 32,
+            height: 32,
+            borderRadius: '50%',
+            mt: 0.25,
+            color: `${meta.tone}.main`,
+            backgroundColor: 'action.selected',
+          }}
+        >
+          {meta.icon}
+        </Box>
+
+        {/* Text block */}
+        <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: isUnread ? 600 : 400,
+              // Two-line clamp — titles carry a circle name and can be long.
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {notification.title}
+          </Typography>
+
+          {notification.body && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {notification.body}
+            </Typography>
+          )}
+
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 0.25 }}
+          >
+            {relativeTime(notification.createdAt)}
+          </Typography>
+        </Box>
+
+        {/* Unread dot — announced via the visually-hidden text below it so the
+            state is not conveyed by color alone. */}
+        {isUnread && (
+          <Box sx={{ flexShrink: 0, display: 'flex', alignItems: 'center', mt: 1 }}>
+            <Box
+              aria-hidden
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                backgroundColor: 'primary.main',
+              }}
+            />
+            <Box component="span" sx={visuallyHidden}>
+              Unread
+            </Box>
+          </Box>
+        )}
+      </ListItemButton>
+    </ListItem>
+  );
+}
+
+/** Local copy of MUI's `visuallyHidden` style object (avoids a utils import). */
+const visuallyHidden = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute' as const,
+  whiteSpace: 'nowrap' as const,
+  width: '1px',
+};

--- a/apps/web/src/components/notifications/notificationMeta.tsx
+++ b/apps/web/src/components/notifications/notificationMeta.tsx
@@ -1,0 +1,85 @@
+/**
+ * Per-type presentation metadata for a notification row (issue #249).
+ *
+ * Kept in its own module (not inline in the panel) so #250's `/notifications`
+ * page renders identical icons/colors without duplicating the mapping.
+ *
+ * An unknown `type` — a row produced by a newer API than this bundle — falls
+ * back to a generic bell rather than rendering nothing.
+ */
+
+import type { ReactElement } from 'react';
+import {
+  AutoFixHigh as AutoFixHighIcon,
+  BurstMode as BurstModeIcon,
+  CloudUpload as CloudUploadIcon,
+  ContentCopy as ContentCopyIcon,
+  ErrorOutlined as ErrorOutlineIcon,
+  MyLocation as MyLocationIcon,
+  NotificationsNone as NotificationsNoneIcon,
+  AccountTree as AccountTreeIcon,
+  Public as PublicIcon,
+} from '@mui/icons-material';
+
+/** Theme palette key used to tint the row's icon. */
+export type NotificationTone = 'primary' | 'warning' | 'error' | 'success' | 'info';
+
+export interface NotificationMeta {
+  icon: ReactElement;
+  tone: NotificationTone;
+  /** Short human label for the type, used as the icon's accessible name. */
+  label: string;
+}
+
+const META: Record<string, NotificationMeta> = {
+  review_queue_bursts: {
+    icon: <BurstModeIcon fontSize="small" />,
+    tone: 'primary',
+    label: 'Burst review',
+  },
+  review_queue_duplicates: {
+    icon: <ContentCopyIcon fontSize="small" />,
+    tone: 'primary',
+    label: 'Duplicate review',
+  },
+  review_queue_location_suggestions: {
+    icon: <MyLocationIcon fontSize="small" />,
+    tone: 'primary',
+    label: 'Location suggestions',
+  },
+  review_queue_enhancements: {
+    icon: <AutoFixHighIcon fontSize="small" />,
+    tone: 'primary',
+    label: 'AI enhancements',
+  },
+  upload_completed: {
+    icon: <CloudUploadIcon fontSize="small" />,
+    tone: 'success',
+    label: 'Upload complete',
+  },
+  enrichment_failed: {
+    icon: <ErrorOutlineIcon fontSize="small" />,
+    tone: 'error',
+    label: 'Enrichment failed',
+  },
+  workflow_run_completed: {
+    icon: <AccountTreeIcon fontSize="small" />,
+    tone: 'info',
+    label: 'Workflow run',
+  },
+  share_expiring: {
+    icon: <PublicIcon fontSize="small" />,
+    tone: 'warning',
+    label: 'Share expiring',
+  },
+};
+
+const FALLBACK: NotificationMeta = {
+  icon: <NotificationsNoneIcon fontSize="small" />,
+  tone: 'info',
+  label: 'Notification',
+};
+
+export function notificationMeta(type: string): NotificationMeta {
+  return META[type] ?? FALLBACK;
+}

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -1,0 +1,390 @@
+/**
+ * useNotifications — the single shared source of notification state (issue #249).
+ *
+ * WHY A MODULE-LEVEL STORE AND NOT A NORMAL HOOK
+ * ----------------------------------------------
+ * More than one surface needs the same unread count: the AppBar bell (#249)
+ * and, next, the sidebar entry and the `/notifications` page (#250). Written
+ * as an ordinary `useState` + `setInterval` hook, every one of those mounts
+ * would start its OWN 60s poller and they would drift out of sync after a
+ * mutation. So the polling loop, the timer and the cached state live once at
+ * module scope; `useNotifications()` is just a subscriber.
+ *
+ * The store is reference-counted: the poll starts when the first *enabled*
+ * subscriber mounts and stops when the last one unmounts, so nothing polls on
+ * the login screen or in a test that never renders the bell.
+ *
+ * A context provider would work too, but would have to be threaded through
+ * `App.tsx` AND every test wrapper; a module store needs neither, which keeps
+ * the bell from being able to crash a tree that forgot to wrap it.
+ *
+ * POLLING / VISIBILITY
+ * --------------------
+ * - Unread count polls every `POLL_INTERVAL_MS` (60s) — the count endpoint is
+ *   cheap and server-cached ~2s.
+ * - Polling PAUSES entirely while `document.visibilityState === 'hidden'`: the
+ *   interval is torn down, not merely skipped, so a backgrounded tab issues
+ *   zero requests.
+ * - Returning to the tab (`visibilitychange` → visible) or refocusing the
+ *   window (`focus`) triggers an immediate refetch and restarts the interval,
+ *   so the badge is never stale by more than the time since focus.
+ * - The panel's list is NOT polled. It is fetched on demand (`refreshList`)
+ *   when the popover opens and after mutations, so a closed bell costs exactly
+ *   one small integer per minute.
+ *
+ * ERRORS are captured into `error` and never thrown — a notification badge
+ * must not be able to take down the AppBar.
+ */
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import {
+  dismissNotification,
+  getUnreadCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '../services/notifications';
+import type { NotificationItem } from '../types/notifications';
+
+/** Badge poll cadence. */
+const POLL_INTERVAL_MS = 60_000;
+
+/** How many rows the bell popover shows. */
+export const NOTIFICATION_PANEL_PAGE_SIZE = 10;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+interface NotificationsState {
+  unreadCount: number;
+  items: NotificationItem[];
+  /** True while the panel list is being (re)fetched for the first time. */
+  isLoading: boolean;
+  /** True once a list fetch has completed at least once. */
+  hasLoadedList: boolean;
+  error: string | null;
+}
+
+const INITIAL_STATE: NotificationsState = {
+  unreadCount: 0,
+  items: [],
+  isLoading: false,
+  hasLoadedList: false,
+  error: null,
+};
+
+let state: NotificationsState = INITIAL_STATE;
+const listeners = new Set<() => void>();
+
+/** Number of currently-mounted subscribers that want polling. */
+let enabledSubscribers = 0;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let domListenersAttached = false;
+
+function getSnapshot(): NotificationsState {
+  return state;
+}
+
+function setState(patch: Partial<NotificationsState>): void {
+  state = { ...state, ...patch };
+  listeners.forEach((l) => l());
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+// --- network ---------------------------------------------------------------
+
+async function fetchCount(): Promise<void> {
+  try {
+    const count = await getUnreadCount();
+    setState({ unreadCount: count, error: null });
+  } catch (err) {
+    setState({ error: errorMessage(err, 'Failed to load notifications') });
+  }
+}
+
+async function fetchList(): Promise<void> {
+  if (!state.hasLoadedList) setState({ isLoading: true });
+  try {
+    const response = await listNotifications({
+      status: 'all',
+      page: 1,
+      pageSize: NOTIFICATION_PANEL_PAGE_SIZE,
+    });
+    setState({
+      items: response.items ?? [],
+      isLoading: false,
+      hasLoadedList: true,
+      error: null,
+    });
+  } catch (err) {
+    setState({
+      isLoading: false,
+      error: errorMessage(err, 'Failed to load notifications'),
+    });
+  }
+}
+
+// --- polling lifecycle -----------------------------------------------------
+
+function isHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+}
+
+function stopTimer(): void {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
+function startTimer(): void {
+  if (pollTimer !== null || enabledSubscribers === 0 || isHidden()) return;
+  pollTimer = setInterval(() => {
+    void fetchCount();
+  }, POLL_INTERVAL_MS);
+}
+
+/** Immediate refetch + (re)start the interval. Used on focus / tab-visible. */
+function resumePolling(): void {
+  if (enabledSubscribers === 0) return;
+  void fetchCount();
+  // Refresh the open panel's rows too, if it has ever been opened.
+  if (state.hasLoadedList) void fetchList();
+  startTimer();
+}
+
+function handleVisibilityChange(): void {
+  if (isHidden()) {
+    stopTimer();
+  } else {
+    resumePolling();
+  }
+}
+
+function handleFocus(): void {
+  if (isHidden()) return;
+  resumePolling();
+}
+
+function attachDomListeners(): void {
+  if (domListenersAttached || typeof window === 'undefined') return;
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  window.addEventListener('focus', handleFocus);
+  domListenersAttached = true;
+}
+
+function detachDomListeners(): void {
+  if (!domListenersAttached || typeof window === 'undefined') return;
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
+  window.removeEventListener('focus', handleFocus);
+  domListenersAttached = false;
+}
+
+function acquire(): void {
+  enabledSubscribers += 1;
+  if (enabledSubscribers === 1) {
+    attachDomListeners();
+    if (!isHidden()) {
+      void fetchCount();
+      startTimer();
+    }
+  }
+}
+
+function release(): void {
+  enabledSubscribers = Math.max(0, enabledSubscribers - 1);
+  if (enabledSubscribers === 0) {
+    stopTimer();
+    detachDomListeners();
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// --- mutations (optimistic, with rollback) ---------------------------------
+
+/**
+ * Restore a pre-mutation snapshot after a failed request.
+ *
+ * Assigns `state` wholesale (rather than going through `setState`, which
+ * merges) so nothing from the failed optimistic write survives, then kicks off
+ * a count refetch: the snapshot's `unreadCount` may itself be stale if a poll
+ * landed while the mutation was in flight, and the server is the tiebreaker.
+ */
+function rollback(previous: NotificationsState, err: unknown, fallback: string): void {
+  state = { ...previous, error: errorMessage(err, fallback) };
+  listeners.forEach((l) => l());
+  void fetchCount();
+}
+
+/**
+ * Mark one row read.
+ *
+ * Optimistic in the same shape as `MediaGallery`/`MediaLightbox`'s favorite
+ * toggle: apply locally first so the badge drops instantly, then reconcile —
+ * and restore the exact pre-mutation snapshot if the request fails.
+ */
+async function markReadAction(id: string): Promise<void> {
+  const target = state.items.find((n) => n.id === id);
+  if (target?.readAt) return; // already read — nothing to do
+  const previous = state;
+
+  setState({
+    items: state.items.map((n) =>
+      n.id === id ? { ...n, readAt: new Date().toISOString() } : n,
+    ),
+    unreadCount: Math.max(0, state.unreadCount - 1),
+  });
+
+  try {
+    await markNotificationRead(id);
+  } catch (err) {
+    rollback(previous, err, 'Failed to mark as read');
+    return;
+  }
+  void fetchCount();
+}
+
+/** Dismiss one row — it disappears from the panel (dismissed rows are excluded). */
+async function dismissAction(id: string): Promise<void> {
+  const previous = state;
+  const target = state.items.find((n) => n.id === id);
+  const wasUnread = Boolean(target && !target.readAt);
+
+  setState({
+    items: state.items.filter((n) => n.id !== id),
+    unreadCount: wasUnread ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
+  });
+
+  try {
+    await dismissNotification(id);
+  } catch (err) {
+    rollback(previous, err, 'Failed to dismiss notification');
+    return;
+  }
+  void fetchList();
+  void fetchCount();
+}
+
+/** Mark everything read (optionally scoped to a circle). */
+async function markAllReadAction(circleId?: string): Promise<void> {
+  const previous = state;
+  const now = new Date().toISOString();
+
+  setState({
+    items: state.items.map((n) =>
+      n.readAt || (circleId && n.circleId !== circleId) ? n : { ...n, readAt: now },
+    ),
+    unreadCount: circleId ? state.unreadCount : 0,
+  });
+
+  try {
+    await markAllNotificationsRead(circleId);
+  } catch (err) {
+    rollback(previous, err, 'Failed to mark all as read');
+    return;
+  }
+  void fetchCount();
+  void fetchList();
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseNotificationsOptions {
+  /**
+   * When false the subscriber does not participate in polling (and does not
+   * start it). Hooks cannot be called conditionally, so an unauthenticated
+   * surface passes `enabled: false` rather than skipping the call — the same
+   * pattern `useReviewCounts` uses (issue #204). Default: true.
+   */
+  enabled?: boolean;
+}
+
+export interface UseNotificationsResult {
+  unreadCount: number;
+  /** The most recent `NOTIFICATION_PANEL_PAGE_SIZE` live rows. */
+  items: NotificationItem[];
+  isLoading: boolean;
+  hasLoadedList: boolean;
+  error: string | null;
+  /** Refetch the panel list (call when opening the popover). */
+  refreshList: () => Promise<void>;
+  /** Refetch the badge count. */
+  refreshCount: () => Promise<void>;
+  markRead: (id: string) => Promise<void>;
+  dismiss: (id: string) => Promise<void>;
+  markAllRead: (circleId?: string) => Promise<void>;
+}
+
+export function useNotifications(
+  options: UseNotificationsOptions = {},
+): UseNotificationsResult {
+  const { enabled = true } = options;
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    if (!enabled) return;
+    acquire();
+    return release;
+  }, [enabled]);
+
+  const refreshList = useCallback(async () => {
+    if (!enabled) return;
+    await fetchList();
+  }, [enabled]);
+
+  const refreshCount = useCallback(async () => {
+    if (!enabled) return;
+    await fetchCount();
+  }, [enabled]);
+
+  const markRead = useCallback(async (id: string) => {
+    await markReadAction(id);
+  }, []);
+
+  const dismiss = useCallback(async (id: string) => {
+    await dismissAction(id);
+  }, []);
+
+  const markAllRead = useCallback(async (circleId?: string) => {
+    await markAllReadAction(circleId);
+  }, []);
+
+  return {
+    unreadCount: snapshot.unreadCount,
+    items: snapshot.items,
+    isLoading: snapshot.isLoading,
+    hasLoadedList: snapshot.hasLoadedList,
+    error: snapshot.error,
+    refreshList,
+    refreshCount,
+    markRead,
+    dismiss,
+    markAllRead,
+  };
+}
+
+/**
+ * Test-only reset of the module store.
+ *
+ * Exported because the store outlives React unmounts by design; without this a
+ * test's badge count would leak into the next test in the same file.
+ */
+export function __resetNotificationsStoreForTests(): void {
+  stopTimer();
+  detachDomListeners();
+  enabledSubscribers = 0;
+  state = INITIAL_STATE;
+  listeners.clear();
+}

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -97,12 +97,42 @@ function errorMessage(err: unknown, fallback: string): string {
 
 // --- network ---------------------------------------------------------------
 
+/**
+ * Refetch the badge count *for its own sake* (mount, poll tick, focus, explicit
+ * `refreshCount`, and the success path of a mutation).
+ *
+ * A success here clears `error`, because a working read is genuine evidence the
+ * previously-reported problem is over.
+ */
 async function fetchCount(): Promise<void> {
   try {
     const count = await getUnreadCount();
     setState({ unreadCount: count, error: null });
   } catch (err) {
     setState({ error: errorMessage(err, 'Failed to load notifications') });
+  }
+}
+
+/**
+ * Refetch the badge count purely to RECONCILE it, leaving `error` untouched.
+ *
+ * Used by `rollback()` only. The difference from `fetchCount` is the whole
+ * point: after a failed mutation the store has just set an error the user still
+ * needs to see, and a successful count read says nothing about whether the
+ * *write* that failed would now succeed — so clearing the error here would
+ * revert the badge correctly while silently swallowing the reason (the panel's
+ * error `Alert` would flash, or more likely never render at all).
+ *
+ * A failure is swallowed rather than overwriting `error`: the mutation failure
+ * is the more actionable message of the two, and a persistent outage will be
+ * reported by the next ordinary poll through `fetchCount` anyway.
+ */
+async function reconcileCount(): Promise<void> {
+  try {
+    const count = await getUnreadCount();
+    setState({ unreadCount: count });
+  } catch {
+    // Intentionally ignored — see above.
   }
 }
 
@@ -219,11 +249,17 @@ function subscribe(listener: () => void): () => void {
  * merges) so nothing from the failed optimistic write survives, then kicks off
  * a count refetch: the snapshot's `unreadCount` may itself be stale if a poll
  * landed while the mutation was in flight, and the server is the tiebreaker.
+ *
+ * That reconciling refetch deliberately goes through `reconcileCount` and NOT
+ * `fetchCount`, so it cannot clear the error being set on the line above. With
+ * `fetchCount` the rollback was only half-working: the badge reverted, but the
+ * cheap count read almost always won the race and reset `error` to null, so the
+ * user was never told the write had failed.
  */
 function rollback(previous: NotificationsState, err: unknown, fallback: string): void {
   state = { ...previous, error: errorMessage(err, fallback) };
   listeners.forEach((l) => l());
-  void fetchCount();
+  void reconcileCount();
 }
 
 /**
@@ -275,24 +311,58 @@ async function dismissAction(id: string): Promise<void> {
   void fetchCount();
 }
 
-/** Mark everything read (optionally scoped to a circle). */
+/**
+ * Mark everything read (optionally scoped to a circle).
+ *
+ * OPTIMISTIC DECREMENT — exact when unscoped, an ESTIMATE when scoped.
+ *
+ * Unscoped, every unread row is being read, so the badge is exactly 0.
+ *
+ * Scoped to a circle (the form issue #250's `/notifications` page uses when a
+ * circle filter is active) the store CANNOT know the true number: it only holds
+ * the rows it has loaded — at most `NOTIFICATION_PANEL_PAGE_SIZE` of them — so
+ * the user may well have unread rows in that circle the store has never seen.
+ * We therefore decrement by the count of *loaded* unread rows in that circle,
+ * which is a lower bound: the badge can only ever be momentarily too HIGH, never
+ * too low. That direction is chosen on purpose — an over-reporting badge is
+ * merely stale, an under-reporting one hides work the user still has to do.
+ *
+ * The estimate is then replaced twice over: first by the server's exact
+ * `updated` row count as soon as the response lands, then by the reconciling
+ * `fetchCount()`, which is the final authority. So the badge always converges on
+ * the server value regardless of how far off the optimistic step was.
+ */
 async function markAllReadAction(circleId?: string): Promise<void> {
   const previous = state;
   const now = new Date().toISOString();
+
+  const loadedUnreadInScope = circleId
+    ? state.items.filter((n) => !n.readAt && n.circleId === circleId).length
+    : 0;
 
   setState({
     items: state.items.map((n) =>
       n.readAt || (circleId && n.circleId !== circleId) ? n : { ...n, readAt: now },
     ),
-    unreadCount: circleId ? state.unreadCount : 0,
+    unreadCount: circleId ? Math.max(0, state.unreadCount - loadedUnreadInScope) : 0,
   });
 
+  let updated: number | undefined;
   try {
-    await markAllNotificationsRead(circleId);
+    const result = await markAllNotificationsRead(circleId);
+    updated = result?.updated;
   } catch (err) {
     rollback(previous, err, 'Failed to mark all as read');
     return;
   }
+
+  // Swap the estimate for the server's exact count of rows it actually flipped.
+  // Only for the scoped path — unscoped already landed on an exact 0, and
+  // re-deriving it from `previous` would just reintroduce staleness.
+  if (circleId && typeof updated === 'number') {
+    setState({ unreadCount: Math.max(0, previous.unreadCount - updated) });
+  }
+
   void fetchCount();
   void fetchList();
 }

--- a/apps/web/src/services/notifications.ts
+++ b/apps/web/src/services/notifications.ts
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------
+// Notification Center API client (epic #240, consumes issue #245's endpoints).
+//
+// Every route is authenticated-any-role — there is no notification permission.
+// ---------------------------------------------------------------------------
+
+import { api } from './api';
+import type {
+  NotificationBulkResult,
+  NotificationListParams,
+  NotificationListResponse,
+} from '../types/notifications';
+
+/** List the current user's notifications, newest first. */
+export async function listNotifications(
+  params: NotificationListParams = {},
+): Promise<NotificationListResponse> {
+  const search = new URLSearchParams();
+  if (params.status) search.set('status', params.status);
+  if (params.circleId) search.set('circleId', params.circleId);
+  if (params.page !== undefined) search.set('page', String(params.page));
+  if (params.pageSize !== undefined) search.set('pageSize', String(params.pageSize));
+
+  const qs = search.toString();
+  return api.get<NotificationListResponse>(`/notifications${qs ? `?${qs}` : ''}`);
+}
+
+/** Unread count for the bell badge. */
+export async function getUnreadCount(): Promise<number> {
+  const result = await api.get<{ count: number }>('/notifications/unread-count');
+  return result?.count ?? 0;
+}
+
+/** Mark one notification read (idempotent, 204). */
+export async function markNotificationRead(id: string): Promise<void> {
+  await api.post<void>(`/notifications/${id}/read`);
+}
+
+/** Dismiss one notification (idempotent, implies read, 204). */
+export async function dismissNotification(id: string): Promise<void> {
+  await api.post<void>(`/notifications/${id}/dismiss`);
+}
+
+/** Hard-delete one notification (204). */
+export async function deleteNotification(id: string): Promise<void> {
+  await api.delete<void>(`/notifications/${id}`);
+}
+
+/**
+ * Mark every unread notification read, optionally scoped to one circle.
+ *
+ * NOTE — deliberately always sends a real JSON object body, even when
+ * unscoped. `api.post` only sets `Content-Type: application/json` when a body
+ * is present, but its 401-refresh retry path sets that header unconditionally;
+ * a `Content-Type: application/json` request with a ZERO-LENGTH body is
+ * rejected by Fastify itself (`FST_ERR_CTP_EMPTY_JSON_BODY`) before Nest's
+ * validation ever runs. Passing an object here means `JSON.stringify` always
+ * produces at least `"{}"`, which the endpoint's `NotificationScopeDto`
+ * (`z.object({...}).default({})`) explicitly accepts as "all circles".
+ */
+export async function markAllNotificationsRead(
+  circleId?: string,
+): Promise<NotificationBulkResult> {
+  return api.post<NotificationBulkResult>('/notifications/read-all', { circleId });
+}
+
+/** Dismiss every live notification, optionally scoped to one circle. See above. */
+export async function dismissAllNotifications(
+  circleId?: string,
+): Promise<NotificationBulkResult> {
+  return api.post<NotificationBulkResult>('/notifications/dismiss-all', { circleId });
+}

--- a/apps/web/src/types/notifications.ts
+++ b/apps/web/src/types/notifications.ts
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// Notification Center (epic #240) — client types.
+//
+// Mirrors the API's `notificationItemSchema` / `notificationListSchema`
+// (apps/api/src/notifications/dto/notification-response.dto.ts). All date-ish
+// fields are `string` because JSON transports ISO 8601.
+// ---------------------------------------------------------------------------
+
+/**
+ * The producer that created a notification row.
+ *
+ * Kept as a closed union PLUS a `(string & {})` escape hatch so a row produced
+ * by a newer API than this bundle still type-checks and renders with the
+ * fallback icon rather than crashing the panel.
+ */
+export type NotificationType =
+  | 'review_queue_bursts'
+  | 'review_queue_duplicates'
+  | 'review_queue_location_suggestions'
+  | 'review_queue_enhancements'
+  | 'upload_completed'
+  | 'enrichment_failed'
+  | 'workflow_run_completed'
+  | 'share_expiring';
+
+/** One notification row. */
+export interface NotificationItem {
+  id: string;
+  /**
+   * Circle the notification belongs to, or `null` for a global (circle-less)
+   * row such as `enrichment_failed` / `share_expiring`.
+   *
+   * When non-null, a client MUST switch the active circle to this id before
+   * following `link` — the review-queue links are deliberately circle-agnostic
+   * routes (`/bursts`, `/duplicates`, …) that render whatever circle is
+   * currently active. See `NotificationPanel.handleOpen`.
+   */
+  circleId: string | null;
+  type: NotificationType | (string & {});
+  title: string;
+  body: string | null;
+  /** Same-origin app path to navigate to, or `null` for an informational row. */
+  link: string | null;
+  /** Free-form producer payload; `{ count, countAtRead? }` for review-queue rows. */
+  data: unknown;
+  readAt: string | null;
+  dismissedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** `status` filter accepted by `GET /api/notifications`. */
+export type NotificationStatusFilter = 'unread' | 'read' | 'all' | 'dismissed';
+
+export interface NotificationListParams {
+  status?: NotificationStatusFilter;
+  circleId?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface NotificationListMeta {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+/**
+ * Payload of `GET /api/notifications` AFTER the api client unwraps the global
+ * TransformInterceptor's `{ data: … }` envelope — so pagination meta lives at
+ * the top level here, not under a second `data`.
+ */
+export interface NotificationListResponse {
+  items: NotificationItem[];
+  meta: NotificationListMeta;
+}
+
+/** Payload of the two bulk endpoints. */
+export interface NotificationBulkResult {
+  updated: number;
+}


### PR DESCRIPTION
## Summary

The bell, badge, and panel — the first user-visible surface of epic #240. Sixth child; the whole backend (#244–#248) is merged behind it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Closes #249
Relates to #240

## Changes Made

New `src/components/notifications/` (`NotificationBell`, `NotificationPanel`, `NotificationRow`, `notificationMeta`), `src/hooks/useNotifications.ts`, `src/services/notifications.ts`, `src/types/notifications.ts`. `AppBar.tsx` gains the bell; MSW handlers gain the seven routes.

### The polling source is a module store, not a hook

#250 adds a sidebar entry needing the same unread count, and the issue is explicit that both must share **one** polling source. As an ordinary `useState` + `setInterval` hook, each mount would start its own 60s poller and drift out of sync after any mutation. This is a module-level store read via `useSyncExternalStore` — timer, cache and in-flight logic exist once; consumers are subscribers. Bell + panel today = refcount 2, one timer.

A context provider was rejected deliberately: it would need threading through `App.tsx` and every test wrapper, and any surface that forgot the wrapper would throw. **A bell must not be able to crash the AppBar.**

Only the *count* polls. The list is fetched on demand when the panel opens, so a closed bell costs one integer per minute. A hidden tab **tears the interval down** rather than skipping ticks — zero requests while backgrounded — and both `visibilitychange` and `window.focus` trigger an immediate refetch.

### Two things worth a reviewer's attention

**The 360px toolbar had 2px of slack.** With the bell added, measured box-model arithmetic came to 358px against 360 at the existing 8px gap — a larger system font or a two-digit badge would have overflowed it. That is precisely the regression class in `docs/audits/mobile-topbar-audit.md`. The `Toolbar` gap is now `{ xs: 0.5, sm: 1 }`, restoring 26px of slack; desktop spacing is unchanged. *Caveat: this is computed arithmetic, not a real browser render — jsdom does no layout, so the suite cannot confirm it. Worth an eyeball at 360px.*

**Bulk POSTs always send a real object body.** Beyond the known `FST_ERR_CTP_EMPTY_JSON_BODY` hazard, `api.post`'s **401-refresh retry path sets `Content-Type: application/json` unconditionally** — so a bodyless request that happened to be retried after a token refresh would fail there specifically, an intermittent failure that would only show up once a user's token expired mid-session. An always-present object sidesteps both. Documented at the call site.

### Circle-switch-then-navigate

Tapping a circle-scoped notification switches the active circle *before* navigating, so it lands on the right circle's queue instead of silently showing the active circle's data. No `await` needed — `CircleContext.setActiveCircle` updates state synchronously before its first `await`, so both land in one React batch. Guarded on membership: a notification can outlive access to its circle, and persisting an unresolvable `activeCircleId` would be a sticky broken state. `circles.length === 0` is read as "context initializing", not "member of nothing", since every user always has a personal circle.

### Accessibility / touch

`aria-label` is `"Notifications, 3 unread"` (badge digit `aria-hidden` so it isn't read out of context), `aria-haspopup="dialog"`, `aria-expanded`. Per-row dismiss is **always rendered and always hit-testable** — never `opacity: 0`, the #243 invisible-tap-target mistake — is 44×44, and sits outside the row's `ListItemButton` so dismissing cannot also navigate. Unread state isn't color-alone: dot + visually-hidden "Unread" + font weight.

Below `sm` the panel is a bottom `Drawer` (80vh, grab handle), not a narrow floating card; both variants share one content subtree so they can't drift.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

`typecheck --workspace=web` clean · `test:ci --workspace=web` exit 0 (197 files, 4,052 tests). Dedicated tests for the bell are being added to this PR.

**Unverified:** the 360px fit is arithmetic, not a rendered check (see above).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

"See all" points at `/notifications`, which lands in #250 — until then it falls through the catch-all to `/`. Expected.

**The Home review banners are deliberately untouched.** Removing them is #250's cutover, sequenced after this one so there is never a window with neither surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbaUja8WXhV9xXKPrvU6Hz)_