### PR TITLE
feat(web): migrate workflow and run-detail tables to the shared DataTable

### DIFF
--- a/apps/web/src/__tests__/components/workflows/admin/WorkflowRunsDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/workflows/admin/WorkflowRunsDrawer.test.tsx
@@ -1,26 +1,48 @@
 /**
- * RTL tests for WorkflowRunsDrawer (issue #143 — Workflows Phase 5 admin UI).
+ * RTL tests for WorkflowRunsDrawer — post-#261 (the shared-DataTable migration,
+ * epic #238).
  *
- * Purely presentational and props-driven — the parent owns fetching runs for
- * the selected workflow and the cancel-confirm flow — so these tests
- * exercise it directly with no mocked hooks or network layer.
+ * ## This file carries the epic's container-query acceptance case
  *
- * Covers:
- *   - Closed state renders nothing meaningful; open state shows the heading
- *     and workflow name.
- *   - Loading / error / empty states.
- *   - Row rendering: status chip, matched/succeeded/failed counts.
- *   - Admin-cancel action: the Cancel button is offered only for non-terminal
- *     runs, calls onCancel with the run, is disabled while canCancel is
- *     false or while that specific run is mid-cancel (cancellingRunId).
- *   - Close button calls onClose.
+ * `docs/specs/datatable.md` §7.2 states the rule this drawer exists to prove:
+ * the renderer switch measures the table's OWN CONTAINER, never the viewport.
+ * The drawer is ~570px of content on a 1440px desktop, so the correct rendering
+ * is the CARD layout — a viewport media query would hand it the full desktop
+ * grid and reintroduce horizontal scrolling on a desktop, which is the exact
+ * defect epic #238 exists to remove.
+ *
+ * `installLayoutStubs()` pins `window.matchMedia` to a FIXED 1440px viewport,
+ * so every viewport media query in the tree answers "desktop". A `mobile`
+ * result therefore CANNOT have come from an accidental viewport match — it can
+ * only have come from the container measurement. That is what makes the
+ * assertion below meaningful rather than incidental.
+ *
+ * Scope note (§17.8 / §18.5): table mechanics live in
+ * `runDataTableConformanceSuite` and are not re-tested here.
  */
-import { describe, it, expect, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  VIEWPORT_WIDTH,
+} from '../../../../components/datatable/__tests__/testUtils/layoutStubs';
 import { WorkflowRunsDrawer } from '../../../../components/workflows/admin/WorkflowRunsDrawer';
+import {
+  buildWorkflowRunColumns,
+  shortRunId,
+} from '../../../../components/workflows/admin/workflowRunsColumns';
 import type { AdminWorkflowRun } from '../../../../services/adminWorkflows';
+import { api } from '../../../../services/api';
+
+/**
+ * The drawer's real content width on a desktop: a 620px paper minus `p: 3`
+ * (24px) on each side. Comfortably under the component's 600px container
+ * threshold, which is why this table draws cards.
+ */
+const DRAWER_CONTENT_WIDTH = 620 - 48;
 
 function makeRun(overrides: Partial<AdminWorkflowRun> = {}): AdminWorkflowRun {
   return {
@@ -60,7 +82,88 @@ const baseProps = {
   onClose: vi.fn(),
 };
 
+beforeAll(() => {
+  installLayoutStubs();
+});
+
 describe('WorkflowRunsDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Every test in this file renders at the drawer's REAL content width.
+    resetContainerWidth(DRAWER_CONTENT_WIDTH);
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
+  });
+
+  // =========================================================================
+  // Container-driven layout — issue #261's named acceptance case
+  // =========================================================================
+
+  describe('narrow container on a wide viewport (issue #261)', () => {
+    it('renders CARDS in the drawer even though the viewport is a 1440px desktop', async () => {
+      render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun()]} />);
+
+      // The viewport really is a desktop — this is what makes the assertion
+      // below about the CONTAINER rather than about the window.
+      expect(VIEWPORT_WIDTH).toBe(1440);
+      expect(window.matchMedia('(min-width:1200px)').matches).toBe(true);
+
+      const table = await screen.findByTestId('datatable');
+      expect(table).toHaveAttribute('data-layout', 'mobile');
+      expect(table).toHaveAttribute('data-renderer', 'mobile');
+
+      // …and the card list, not a grid, is what was actually drawn.
+      expect(screen.getByRole('list', { name: /workflow run history/i })).toBeInTheDocument();
+      expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    });
+
+    it('never lets the drawer scroll sideways: the table is width-contained', async () => {
+      render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun()]} />);
+
+      const table = await screen.findByTestId('datatable');
+      const styles = window.getComputedStyle(table);
+      expect(styles.maxWidth).toBe('100%');
+      expect(styles.minWidth).toBe('0px');
+    });
+
+    it('switches to the GRID when the same table is given a desktop-width container', async () => {
+      // The mirror image of the first case: nothing about this component pins a
+      // layout — only the measured width decides.
+      resetContainerWidth(1400);
+      render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun()]} />);
+
+      const table = await screen.findByTestId('datatable');
+      expect(table).toHaveAttribute('data-layout', 'desktop');
+      expect(screen.getByRole('grid', { name: /workflow run history/i })).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Column definitions (pure)
+  // =========================================================================
+
+  describe('column definitions', () => {
+    const columns = buildWorkflowRunColumns();
+
+    it('leads with the row-unique run id so per-row controls are nameable', () => {
+      const firstPrimary = columns.find((column) => column.priority === 'primary')!;
+      expect(firstPrimary.id).toBe('id');
+      expect(firstPrimary.value!(makeRun({ id: 'abcdefgh-1234' }))).toBe('abcdefgh');
+    });
+
+    it('makes status a PRIMARY column so it lands in the card headline', () => {
+      expect(columns.find((column) => column.id === 'status')!.priority).toBe('primary');
+    });
+
+    it('declares no sortable column — the endpoint accepts no sortBy', () => {
+      expect(columns.some((column) => column.sortable)).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Header / states
+  // =========================================================================
+
   describe('open/closed and header', () => {
     it('shows the "Run history" heading and workflow name when open', () => {
       render(<WorkflowRunsDrawer {...baseProps} runs={[]} />);
@@ -87,10 +190,18 @@ describe('WorkflowRunsDrawer', () => {
   });
 
   describe('loading / error / empty states', () => {
-    it('shows a loading spinner when loading with no runs yet', () => {
+    it('shows a loading overlay when loading with no runs yet', async () => {
       render(<WorkflowRunsDrawer {...baseProps} runs={[]} loading />);
 
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(await screen.findByTestId('datatable-loading-overlay')).toBeInTheDocument();
+    });
+
+    it('keeps the runs on screen during a background refresh', async () => {
+      // The #261 loading contract: `loading` is a prop, never a gate.
+      render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun({ id: 'run-keepme' })]} loading />);
+
+      expect(await screen.findByText(shortRunId('run-keepme'))).toBeInTheDocument();
+      expect(screen.getByTestId('datatable-loading-overlay')).toBeInTheDocument();
     });
 
     it('shows the error message in an Alert', () => {
@@ -99,58 +210,92 @@ describe('WorkflowRunsDrawer', () => {
       expect(screen.getByText('Failed to load runs')).toBeInTheDocument();
     });
 
-    it('shows "No runs for this workflow yet." when runs is empty and not loading', () => {
+    it('shows "No runs for this workflow yet." when runs is empty and not loading', async () => {
       render(<WorkflowRunsDrawer {...baseProps} runs={[]} />);
 
-      expect(screen.getByText(/no runs for this workflow yet/i)).toBeInTheDocument();
+      expect(await screen.findByText(/no runs for this workflow yet/i)).toBeInTheDocument();
     });
   });
 
   describe('row rendering', () => {
-    it('renders the status chip and matched/succeeded/failed counts', () => {
+    it('renders the status chip and matched/succeeded/failed counts', async () => {
       const run = makeRun({ matchedCount: 100, succeededCount: 30, failedCount: 10 });
       render(<WorkflowRunsDrawer {...baseProps} runs={[run]} />);
 
-      expect(screen.getByText('Running')).toBeInTheDocument();
-      expect(screen.getByText('100')).toBeInTheDocument();
-      expect(screen.getByText('30')).toBeInTheDocument();
-      expect(screen.getByText('10')).toBeInTheDocument();
+      const card = await screen.findByTestId('datatable-card');
+      expect(within(card).getByText('Running')).toBeInTheDocument();
+      expect(within(card).getByText('100')).toBeInTheDocument();
+      expect(within(card).getByText('30')).toBeInTheDocument();
+      expect(within(card).getByText('10')).toBeInTheDocument();
     });
   });
 
+  // =========================================================================
+  // Admin-cancel action
+  // =========================================================================
+
   describe('admin-cancel action', () => {
-    it('offers a Cancel button for a non-terminal (running) run', () => {
+    async function openRowMenu(user: ReturnType<typeof userEvent.setup>, id = 'run-1') {
+      await user.click(
+        await screen.findByRole('button', { name: `Row actions for ${shortRunId(id)}` }),
+      );
+    }
+
+    it('offers an enabled Cancel action for a non-terminal (running) run', async () => {
+      const user = userEvent.setup();
       render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun({ status: 'running' })]} />);
 
-      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+      await openRowMenu(user);
+
+      expect(screen.getByRole('menuitem', { name: /cancel run/i })).not.toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
 
-    it('does not offer a Cancel button for a terminal (completed) run — shows "—" instead', () => {
+    it('disables Cancel for a terminal (completed) run', async () => {
+      // #259's rule: a per-row `disabled` replaces "render nothing", so the
+      // control stays discoverable instead of silently becoming an em dash.
+      const user = userEvent.setup();
       render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun({ status: 'completed' })]} />);
 
-      expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
-      expect(screen.getByText('—')).toBeInTheDocument();
+      await openRowMenu(user);
+
+      expect(screen.getByRole('menuitem', { name: /cancel run/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
 
-    it('does not offer a Cancel button for an awaiting_approval run — treated as non-terminal, still cancellable', () => {
-      render(<WorkflowRunsDrawer {...baseProps} runs={[makeRun({ status: 'awaiting_approval' })]} />);
+    it('keeps Cancel enabled for an awaiting_approval run — not a terminal status', async () => {
+      const user = userEvent.setup();
+      render(
+        <WorkflowRunsDrawer {...baseProps} runs={[makeRun({ status: 'awaiting_approval' })]} />,
+      );
 
-      // awaiting_approval is NOT in the terminal set, so Cancel is still offered.
-      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+      await openRowMenu(user);
+
+      expect(screen.getByRole('menuitem', { name: /cancel run/i })).not.toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
 
-    it('calls onCancel with the run when Cancel is clicked', async () => {
+    it('calls onCancel with the run when Cancel is chosen', async () => {
       const user = userEvent.setup();
       const onCancel = vi.fn();
       const run = makeRun({ status: 'running' });
       render(<WorkflowRunsDrawer {...baseProps} runs={[run]} onCancel={onCancel} />);
 
-      await user.click(screen.getByRole('button', { name: /cancel/i }));
+      await openRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /cancel run/i }));
 
       expect(onCancel).toHaveBeenCalledWith(run);
     });
 
-    it('disables Cancel when canCancel is false (missing jobs:write)', () => {
+    it('omits the Cancel action entirely without jobs:write', async () => {
+      // The permission gate is on the action ARRAY (§13.1), so it is absent
+      // from the DOM rather than present-but-inert — in every renderer.
       render(
         <WorkflowRunsDrawer
           {...baseProps}
@@ -159,29 +304,49 @@ describe('WorkflowRunsDrawer', () => {
         />,
       );
 
-      expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+      expect(await screen.findByTestId('datatable-card')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: `Row actions for ${shortRunId('run-1')}` }),
+      ).not.toBeInTheDocument();
     });
 
-    it('disables Cancel for the specific run currently being cancelled', () => {
-      const run = makeRun({ id: 'run-target', status: 'running' });
+    it('disables Cancel for the specific run currently being cancelled', async () => {
+      const user = userEvent.setup();
       render(
-        <WorkflowRunsDrawer {...baseProps} runs={[run]} cancellingRunId="run-target" />,
+        <WorkflowRunsDrawer
+          {...baseProps}
+          runs={[makeRun({ id: 'run-target', status: 'running' })]}
+          cancellingRunId="run-target"
+        />,
       );
 
-      expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+      await openRowMenu(user, 'run-target');
+
+      expect(screen.getByRole('menuitem', { name: /cancel run/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
 
-    it('does not disable Cancel for a different run while another run is mid-cancel', () => {
-      const runA = makeRun({ id: 'run-a', status: 'running' });
-      const runB = makeRun({ id: 'run-b', status: 'running' });
+    it('does not disable Cancel for a different run while another run is mid-cancel', async () => {
+      const user = userEvent.setup();
       render(
-        <WorkflowRunsDrawer {...baseProps} runs={[runA, runB]} cancellingRunId="run-a" />,
+        <WorkflowRunsDrawer
+          {...baseProps}
+          runs={[
+            makeRun({ id: 'run-aaaa', status: 'running' }),
+            makeRun({ id: 'run-bbbb', status: 'running' }),
+          ]}
+          cancellingRunId="run-aaaa"
+        />,
       );
 
-      const buttons = screen.getAllByRole('button', { name: /cancel/i });
-      expect(buttons).toHaveLength(2);
-      expect(buttons[0]).toBeDisabled(); // run-a: mid-cancel
-      expect(buttons[1]).toBeEnabled(); // run-b: unaffected
+      await openRowMenu(user, 'run-bbbb');
+
+      expect(screen.getByRole('menuitem', { name: /cancel run/i })).not.toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
   });
 });

--- a/apps/web/src/__tests__/components/workflows/admin/WorkflowsOversightTable.test.tsx
+++ b/apps/web/src/__tests__/components/workflows/admin/WorkflowsOversightTable.test.tsx
@@ -1,26 +1,38 @@
 /**
- * RTL tests for WorkflowsOversightTable (issue #143 — Workflows Phase 5 admin UI).
+ * RTL tests for WorkflowsOversightTable — post-#261 (the shared-DataTable
+ * migration, epic #238).
  *
- * Purely presentational and props-driven — the parent owns fetching,
- * pagination, and the row-action handlers — so these tests exercise it
- * directly with no mocked hooks or network layer.
+ * Scope note, per docs/specs/datatable.md §17.8 / §18.5: TABLE MECHANICS are a
+ * property of the shared component and are covered end to end by
+ * `runDataTableConformanceSuite` — pagination/sort/selection round-trips, the
+ * negative "never filters rows locally" test, loading/empty/error overlays,
+ * column visibility and density, CSV escaping, the issue #243
+ * invisible-but-tappable sweep, and axe in both renderers and both themes.
+ * None of that is re-tested here.
  *
- * Covers:
- *   - Empty state and loading state.
- *   - Row rendering: circle/name/subject/trigger/enabled chip/last-run/totals.
- *   - Row actions: "Runs" always calls onViewRuns; "Disable" calls onDisable
- *     only when canManage and the workflow is currently enabled.
- *   - Disable button disabled states (no permission / already disabled) via
- *     the Tooltip title, since MUI disables the inner button but keeps the
- *     Tooltip wrapper interactive.
- *   - Pagination callbacks (onPageChange / onPageSizeChange).
+ * What IS here is what this migration could break:
+ *   - the column set: what each priority band renders, and that the row-unique
+ *     column leads (so per-row controls are nameable, §17.6),
+ *   - the row actions and their PERMISSION gate, which #261 moved from a
+ *     disabled button onto the action ARRAY (§13.1),
+ *   - the loading contract: rows stay on screen during a background refresh,
+ *   - the pagination callbacks the parent still owns.
  */
-import { describe, it, expect, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+} from '../../../../components/datatable/__tests__/testUtils/layoutStubs';
 import { WorkflowsOversightTable } from '../../../../components/workflows/admin/WorkflowsOversightTable';
+import {
+  buildWorkflowOversightColumns,
+  lastRunSummary,
+} from '../../../../components/workflows/admin/workflowsOversightColumns';
 import type { AdminWorkflowListItem } from '../../../../services/adminWorkflows';
+import { api } from '../../../../services/api';
 
 function makeItem(overrides: Partial<AdminWorkflowListItem> = {}): AdminWorkflowListItem {
   return {
@@ -52,63 +64,130 @@ const baseProps = {
   onViewRuns: vi.fn(),
 };
 
-describe('WorkflowsOversightTable', () => {
-  describe('empty and loading states', () => {
-    it('shows "No workflows found." when items is empty and not loading', () => {
-      render(<WorkflowsOversightTable {...baseProps} items={[]} totalItems={0} />);
+/** The row-scoped accessible-name suffix: the first `primary` column's value. */
+const ROW = 'Screenshot cleanup';
 
-      expect(screen.getByText(/no workflows found/i)).toBeInTheDocument();
+beforeAll(() => {
+  // jsdom performs no layout, so MUI X measures a 0×0 viewport and renders zero
+  // rows without these. Same recipe every DataTable suite uses.
+  installLayoutStubs();
+});
+
+describe('WorkflowsOversightTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetContainerWidth(1400); // desktop layout unless a test says otherwise
+    // The layout-persistence hook reads/writes `/user-settings` (§15).
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
+  });
+
+  // =========================================================================
+  // Column definitions (pure)
+  // =========================================================================
+
+  describe('column definitions', () => {
+    const columns = buildWorkflowOversightColumns();
+    const byId = (id: string) => columns.find((column) => column.id === id)!;
+
+    it('leads with a row-unique primary column so per-row controls are nameable', () => {
+      const firstPrimary = columns.find((column) => column.priority === 'primary')!;
+      expect(firstPrimary.id).toBe('name');
+      expect(firstPrimary.value!(makeItem())).toBe('Screenshot cleanup');
     });
 
-    it('shows a loading spinner instead of the empty state while loading with no items yet', () => {
+    it('makes the enabled/disabled state a PRIMARY column, not a detail one', () => {
+      expect(byId('enabled').priority).toBe('primary');
+      expect(byId('enabled').value!(makeItem({ enabled: false }))).toBe('Disabled');
+    });
+
+    it('declares no sortable column — the endpoint accepts no sortBy', () => {
+      expect(columns.some((column) => column.sortable)).toBe(false);
+    });
+
+    it('summarises the last run as a scalar for export and truncation', () => {
+      expect(lastRunSummary(makeItem())).toBeNull();
+      expect(
+        lastRunSummary(
+          makeItem({
+            lastRun: {
+              status: 'completed_with_errors',
+              triggerType: 'manual',
+              createdAt: new Date().toISOString(),
+              finishedAt: new Date().toISOString(),
+              matchedCount: 20,
+              processedCount: 20,
+              succeededCount: 15,
+              failedCount: 5,
+              skippedCount: 2,
+            },
+          } as Partial<AdminWorkflowListItem>),
+        ),
+      ).toBe('15 ok · 5 failed · 2 skipped');
+    });
+  });
+
+  // =========================================================================
+  // Rendering
+  // =========================================================================
+
+  describe('empty and loading states', () => {
+    it('shows "No workflows found." when items is empty and not loading', async () => {
+      render(<WorkflowsOversightTable {...baseProps} items={[]} totalItems={0} />);
+
+      expect(await screen.findByText(/no workflows found/i)).toBeInTheDocument();
+    });
+
+    it('shows a loading overlay instead of the empty state while loading with no items yet', async () => {
       render(<WorkflowsOversightTable {...baseProps} items={[]} totalItems={0} loading />);
 
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(await screen.findByTestId('datatable-loading-overlay')).toBeInTheDocument();
       expect(screen.queryByText(/no workflows found/i)).not.toBeInTheDocument();
     });
 
-    it('renders existing rows even while a background refresh is loading', () => {
+    it('keeps existing rows on screen while a background refresh is loading', async () => {
+      // The #261 regression this guards: the pre-migration table swapped itself
+      // for a spinner, which unmounted the renderer on every refetch.
       render(<WorkflowsOversightTable {...baseProps} items={[makeItem()]} loading />);
 
-      expect(screen.getByText('Screenshot cleanup')).toBeInTheDocument();
-      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      expect(await screen.findByText('Screenshot cleanup')).toBeInTheDocument();
+      expect(screen.getByTestId('datatable-loading-overlay')).toBeInTheDocument();
     });
   });
 
   describe('row rendering', () => {
-    it('renders circle name, workflow name, subject, trigger, and an Enabled chip', () => {
+    it('renders circle name, workflow name, subject, trigger, and an Enabled chip', async () => {
       render(<WorkflowsOversightTable {...baseProps} items={[makeItem()]} />);
 
-      expect(screen.getByText('Family circle')).toBeInTheDocument();
-      expect(screen.getByText('Screenshot cleanup')).toBeInTheDocument();
-      expect(screen.getByText('Media item')).toBeInTheDocument();
-      expect(screen.getByText('Manual')).toBeInTheDocument();
-      // "Enabled" also appears as a column header, so a live row must add a
-      // SECOND match (the status chip) — getAllByText avoids a false negative.
-      expect(screen.getAllByText('Enabled')).toHaveLength(2);
+      const grid = await screen.findByRole('grid', { name: /all workflows/i });
+      expect(await within(grid).findByText('Screenshot cleanup')).toBeInTheDocument();
+      expect(within(grid).getByText('Family circle')).toBeInTheDocument();
+      expect(within(grid).getByText('Media item')).toBeInTheDocument();
+      expect(within(grid).getByText('Manual')).toBeInTheDocument();
+      expect(within(grid).getByText('Enabled')).toBeInTheDocument();
     });
 
-    it('renders a Disabled chip for a disabled workflow', () => {
+    it('renders a Disabled chip for a disabled workflow', async () => {
       render(<WorkflowsOversightTable {...baseProps} items={[makeItem({ enabled: false })]} />);
 
-      expect(screen.getByText('Disabled')).toBeInTheDocument();
-      // Only the column header remains — no chip renders the word "Enabled".
-      expect(screen.getAllByText('Enabled')).toHaveLength(1);
+      const grid = await screen.findByRole('grid', { name: /all workflows/i });
+      expect(await within(grid).findByText('Disabled')).toBeInTheDocument();
+      expect(within(grid).queryByText('Enabled')).not.toBeInTheDocument();
     });
 
-    it('renders "—" for a null circle', () => {
+    it('renders "—" for a null circle', async () => {
       render(<WorkflowsOversightTable {...baseProps} items={[makeItem({ circle: null })]} />);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      expect(await screen.findByText('—')).toBeInTheDocument();
     });
 
-    it('renders "Never run" when lastRun is null', () => {
+    it('renders "Never run" when lastRun is null', async () => {
       render(<WorkflowsOversightTable {...baseProps} items={[makeItem({ lastRun: null })]} />);
 
-      expect(screen.getByText(/never run/i)).toBeInTheDocument();
+      expect(await screen.findByText(/never run/i)).toBeInTheDocument();
     });
 
-    it('renders the last-run status chip and succeeded/failed counts', () => {
+    it('renders the last-run status chip and succeeded/failed counts', async () => {
       const item = makeItem({
         lastRun: {
           status: 'completed_with_errors',
@@ -121,16 +200,16 @@ describe('WorkflowsOversightTable', () => {
           failedCount: 5,
           skippedCount: 0,
         },
-      });
+      } as Partial<AdminWorkflowListItem>);
 
       render(<WorkflowsOversightTable {...baseProps} items={[item]} />);
 
-      expect(screen.getByText('Completed with errors')).toBeInTheDocument();
+      expect(await screen.findByText('Completed with errors')).toBeInTheDocument();
       expect(screen.getByText(/15 ok/)).toBeInTheDocument();
       expect(screen.getByText(/5 failed/)).toBeInTheDocument();
     });
 
-    it('renders formatted matched/actioned totals', () => {
+    it('renders formatted matched/actioned totals', async () => {
       render(
         <WorkflowsOversightTable
           {...baseProps}
@@ -138,24 +217,33 @@ describe('WorkflowsOversightTable', () => {
         />,
       );
 
-      expect(screen.getByText('2,481')).toBeInTheDocument();
+      expect(await screen.findByText('2,481')).toBeInTheDocument();
       expect(screen.getByText('2,000')).toBeInTheDocument();
     });
   });
 
+  // =========================================================================
+  // Row actions + permission gating
+  // =========================================================================
+
   describe('row actions', () => {
-    it('calls onViewRuns with the workflow when "Runs" is clicked', async () => {
+    async function openRowMenu(user: ReturnType<typeof userEvent.setup>) {
+      await user.click(await screen.findByRole('button', { name: `Row actions for ${ROW}` }));
+    }
+
+    it('calls onViewRuns with the workflow when "Runs" is chosen', async () => {
       const user = userEvent.setup();
       const onViewRuns = vi.fn();
       const item = makeItem();
       render(<WorkflowsOversightTable {...baseProps} items={[item]} onViewRuns={onViewRuns} />);
 
-      await user.click(screen.getByRole('button', { name: /runs/i }));
+      await openRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /runs/i }));
 
       expect(onViewRuns).toHaveBeenCalledWith(item);
     });
 
-    it('calls onDisable with the workflow when "Disable" is clicked (canManage + enabled)', async () => {
+    it('calls onDisable with the workflow when "Disable" is chosen (canManage + enabled)', async () => {
       const user = userEvent.setup();
       const onDisable = vi.fn();
       const item = makeItem({ enabled: true });
@@ -163,12 +251,18 @@ describe('WorkflowsOversightTable', () => {
         <WorkflowsOversightTable {...baseProps} items={[item]} canManage onDisable={onDisable} />,
       );
 
-      await user.click(screen.getByRole('button', { name: /disable/i }));
+      await openRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /disable/i }));
 
       expect(onDisable).toHaveBeenCalledWith(item);
     });
 
-    it('disables the Disable button when canManage is false', () => {
+    it('omits the Disable action entirely without system_settings:write', async () => {
+      // #261 moved the permission gate from a disabled button onto the action
+      // ARRAY (docs/specs/datatable.md §13.1), so the action a caller may not
+      // perform is absent from the DOM rather than merely inert — and it is
+      // absent in EVERY renderer, not just the grid.
+      const user = userEvent.setup();
       render(
         <WorkflowsOversightTable
           {...baseProps}
@@ -177,10 +271,34 @@ describe('WorkflowsOversightTable', () => {
         />,
       );
 
-      expect(screen.getByRole('button', { name: /disable/i })).toBeDisabled();
+      // One action left, so the control is a bare icon button, not a menu.
+      expect(await screen.findByRole('button', { name: `Runs for ${ROW}` })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: `Row actions for ${ROW}` }),
+      ).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: `Runs for ${ROW}` }));
+      expect(screen.queryByRole('menuitem', { name: /disable/i })).not.toBeInTheDocument();
     });
 
-    it('disables the Disable button when the workflow is already disabled', () => {
+    it('omits the Disable action in the CARD renderer too, without the permission', async () => {
+      resetContainerWidth(400); // a phone-width container
+      render(
+        <WorkflowsOversightTable
+          {...baseProps}
+          items={[makeItem({ enabled: true })]}
+          canManage={false}
+        />,
+      );
+
+      const user = userEvent.setup();
+      // On a card the actions control is ALWAYS a menu, even for one action.
+      await user.click(await screen.findByRole('button', { name: `Row actions for ${ROW}` }));
+      expect(screen.getByRole('menuitem', { name: /runs/i })).toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: /disable/i })).not.toBeInTheDocument();
+    });
+
+    it('disables (but keeps) the Disable action for an already-disabled workflow', async () => {
+      const user = userEvent.setup();
       render(
         <WorkflowsOversightTable
           {...baseProps}
@@ -189,18 +307,51 @@ describe('WorkflowsOversightTable', () => {
         />,
       );
 
-      expect(screen.getByRole('button', { name: /disable/i })).toBeDisabled();
+      await openRowMenu(user);
+      expect(screen.getByRole('menuitem', { name: /disable/i })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
     });
   });
 
+  // =========================================================================
+  // Pagination (the parent still owns the state)
+  // =========================================================================
+
   describe('pagination', () => {
-    it('renders TablePagination reflecting totalItems/page/pageSize', () => {
+    it('reflects totalItems/page/pageSize in the footer', async () => {
       render(
-        <WorkflowsOversightTable {...baseProps} items={[makeItem()]} totalItems={57} page={1} pageSize={25} />,
+        <WorkflowsOversightTable
+          {...baseProps}
+          items={[makeItem()]}
+          totalItems={57}
+          page={1}
+          pageSize={25}
+        />,
       );
 
-      // MUI TablePagination renders "26–50 of 57" for page=1 (0-based), pageSize=25.
-      expect(screen.getByText(/26.50 of 57/)).toBeInTheDocument();
+      // page=1 (0-based) × 25 → "26–50 of 57".
+      expect(await screen.findByText(/26.50 of 57/)).toBeInTheDocument();
+    });
+
+    it('calls onPageChange when the next-page control is used', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+      render(
+        <WorkflowsOversightTable
+          {...baseProps}
+          items={[makeItem()]}
+          totalItems={57}
+          page={0}
+          pageSize={25}
+          onPageChange={onPageChange}
+        />,
+      );
+
+      await user.click(await screen.findByRole('button', { name: /go to next page/i }));
+
+      expect(onPageChange).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/apps/web/src/__tests__/pages/Reviews/ReviewRunPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Reviews/ReviewRunPage.test.tsx
@@ -27,9 +27,16 @@
  * real network.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { act, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../../components/datatable/__tests__/testUtils/layoutStubs';
+import { api } from '../../../services/api';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -147,11 +154,21 @@ function makeItemsHook(overrides: Partial<ItemsHookReturn> = {}): ItemsHookRetur
   } as ItemsHookReturn;
 }
 
+beforeAll(() => {
+  // The failed-items table is a DataTable (#261); jsdom performs no layout, so
+  // both the container-width hook and MUI X measure 0×0 without these.
+  installLayoutStubs();
+});
+
 describe('ReviewRunPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400); // desktop layout unless a test says otherwise
     mockUseCircle.mockReturnValue(makeCircleContext());
     mockUseReviewRunItems.mockReturnValue(makeItemsHook());
+    // The table's layout-persistence hook reads/writes `/user-settings` (§15).
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
   });
 
   afterEach(() => {
@@ -482,7 +499,7 @@ describe('ReviewRunPage', () => {
       expect(screen.getByText('Geocode failed')).toBeInTheDocument();
     });
 
-    it('links a failed burst item back to its own group page', () => {
+    it('links a failed burst item back to its own group page', async () => {
       mockUseReviewRun.mockReturnValue(
         makeRunHook({
           run: makeRun({
@@ -516,8 +533,9 @@ describe('ReviewRunPage', () => {
       render(<ReviewRunPage />);
 
       // With no media row, the subject id is the label (truncated).
-      expect(screen.getByText('bg-42')).toBeInTheDocument();
-      screen.getByRole('button', { name: 'View' }).click();
+      expect(await screen.findByText('bg-42')).toBeInTheDocument();
+      // One row action, so it is a bare icon button named after its row (§17.6).
+      await userEvent.setup().click(screen.getByRole('button', { name: 'View for bg-42' }));
       expect(mockNavigate).toHaveBeenCalledWith('/bursts/bg-42');
     });
 
@@ -638,6 +656,115 @@ describe('ReviewRunPage', () => {
         vi.advanceTimersByTime(10000);
       });
       expect(fetchRun).toHaveBeenCalledTimes(callsAfterMount);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Live updates must not disturb the user (issue #261)
+  // -------------------------------------------------------------------------
+  //
+  // Every run page polls its detail endpoint, so `run` — and, on a refetch,
+  // `items` — are BRAND NEW OBJECTS on every tick. The failure mode this guards
+  // is the one docs/specs/datatable.md §18.4 names: gating the table on
+  // `loading` (`{!loading && <TableContainer>…}`, which is exactly what these
+  // three pages did before #261) remounts the renderer on every tick and takes
+  // card/row expansion state and the page's scroll offset with it.
+  describe('live updates do not disturb the failed-items table', () => {
+    function terminalRunWithFailures() {
+      return makeRun({
+        subjectType: 'burst_group',
+        action: 'resolve_archive',
+        status: 'completed_with_errors',
+        matchedCount: 10,
+        processedCount: 10,
+        succeededCount: 8,
+        failedCount: 2,
+      });
+    }
+
+    /** Fresh objects with the SAME ids — what one poll tick actually produces. */
+    function failedItems() {
+      return [
+        {
+          id: 'ri-1',
+          subjectType: 'burst_group' as const,
+          subjectId: 'bg-11111',
+          status: 'failed' as const,
+          error: 'Resolve failed',
+          updatedAt: new Date().toISOString(),
+          media: {
+            type: 'photo',
+            capturedAt: null,
+            filename: 'broken-one.jpg',
+            width: 10,
+            height: 10,
+          },
+          thumbnailUrl: null,
+        },
+        {
+          id: 'ri-2',
+          subjectType: 'burst_group' as const,
+          subjectId: 'bg-22222',
+          status: 'failed' as const,
+          error: 'Resolve failed',
+          updatedAt: new Date().toISOString(),
+          media: {
+            type: 'photo',
+            capturedAt: null,
+            filename: 'broken-two.jpg',
+            width: 10,
+            height: 10,
+          },
+          thumbnailUrl: null,
+        },
+      ];
+    }
+
+    it('preserves an expanded card and the table itself across a poll tick', async () => {
+      const user = userEvent.setup();
+      // A phone-width CONTAINER, so the card layout (and therefore its
+      // "More details" region) is what is on screen.
+      setInitialContainerWidth(400);
+      mockUseReviewRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseReviewRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+
+      const { rerender } = render(<ReviewRunPage />);
+
+      const table = await screen.findByTestId('datatable');
+      await user.click(
+        await screen.findByRole('button', { name: 'More details for broken-one.jpg' }),
+      );
+      expect(screen.getByTestId('datatable-card-detail-region')).toBeInTheDocument();
+
+      // One poll tick: a new run object and new item objects, same ids.
+      mockUseReviewRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseReviewRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+      rerender(<ReviewRunPage />);
+
+      // The renderer was never unmounted…
+      expect(screen.getByTestId('datatable')).toBe(table);
+      // …so the expansion the user opened is still open…
+      expect(screen.getByTestId('datatable-card-detail-region')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Hide details for broken-one.jpg' }),
+      ).toBeInTheDocument();
+      // …and both rows are still on screen.
+      expect(screen.getByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByText('broken-two.jpg')).toBeInTheDocument();
+    });
+
+    it('keeps the rows rendered while a refetch is in flight', async () => {
+      mockUseReviewRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseReviewRunItems.mockReturnValue(
+        makeItemsHook({ items: failedItems(), isLoading: true }),
+      );
+
+      render(<ReviewRunPage />);
+
+      // `loading` is a PROP — an overlay over live rows, never a replacement
+      // for the table.
+      expect(await screen.findByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByTestId('datatable-loading-overlay')).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/pages/Trash/TrashEmptyRunPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Trash/TrashEmptyRunPage.test.tsx
@@ -22,9 +22,16 @@
  * including its stricter circle_admin cancel gate.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { act, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../../components/datatable/__tests__/testUtils/layoutStubs';
+import { api } from '../../../services/api';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -139,11 +146,21 @@ function makeItemsHook(overrides: Partial<ItemsHookReturn> = {}): ItemsHookRetur
   } as ItemsHookReturn;
 }
 
+beforeAll(() => {
+  // The failed-items table is a DataTable (#261); jsdom performs no layout, so
+  // both the container-width hook and MUI X measure 0×0 without these.
+  installLayoutStubs();
+});
+
 describe('TrashEmptyRunPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400); // desktop layout unless a test says otherwise
     mockUseCircle.mockReturnValue(makeCircleContext());
     mockUseTrashEmptyRunItems.mockReturnValue(makeItemsHook());
+    // The table's layout-persistence hook reads/writes `/user-settings` (§15).
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
   });
 
   afterEach(() => {
@@ -380,6 +397,116 @@ describe('TrashEmptyRunPage', () => {
         vi.advanceTimersByTime(10000);
       });
       expect(fetchRun).toHaveBeenCalledTimes(callsAfterMount);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Live updates must not disturb the user (issue #261)
+  // -------------------------------------------------------------------------
+  //
+  // The page polls its run endpoint, so `run` and (on a refetch) `items` are
+  // brand-new objects on every tick. Gating the table on `loading` — which this
+  // page did before #261 — would remount the renderer each time and take card
+  // expansion state and the scroll offset with it (docs/specs/datatable.md
+  // §18.4).
+  describe('live updates do not disturb the failed-items table', () => {
+    function terminalRunWithFailures() {
+      return makeRun({
+        status: 'completed_with_errors',
+        matchedCount: 10,
+        processedCount: 10,
+        succeededCount: 8,
+        failedCount: 2,
+      });
+    }
+
+    /** Fresh objects with the SAME ids — what one poll tick actually produces. */
+    function failedItems() {
+      return [
+        {
+          id: 'ri-1',
+          mediaItemId: 'm-1',
+          status: 'failed' as const,
+          error: 'Hard-delete failed',
+          updatedAt: new Date().toISOString(),
+          media: {
+            type: 'photo',
+            capturedAt: null,
+            filename: 'broken-one.jpg',
+            width: 10,
+            height: 10,
+          },
+          thumbnailUrl: null,
+        },
+        {
+          id: 'ri-2',
+          mediaItemId: 'm-2',
+          status: 'failed' as const,
+          error: 'Hard-delete failed',
+          updatedAt: new Date().toISOString(),
+          media: {
+            type: 'photo',
+            capturedAt: null,
+            filename: 'broken-two.jpg',
+            width: 10,
+            height: 10,
+          },
+          thumbnailUrl: null,
+        },
+      ];
+    }
+
+    it('preserves an expanded card and the table itself across a poll tick', async () => {
+      const user = userEvent.setup();
+      setInitialContainerWidth(400); // card layout, so "More details" exists
+      mockUseTrashEmptyRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseTrashEmptyRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+
+      const { rerender } = render(<TrashEmptyRunPage />);
+
+      const table = await screen.findByTestId('datatable');
+      await user.click(
+        await screen.findByRole('button', { name: 'More details for broken-one.jpg' }),
+      );
+      expect(screen.getByTestId('datatable-card-detail-region')).toBeInTheDocument();
+
+      mockUseTrashEmptyRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseTrashEmptyRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+      rerender(<TrashEmptyRunPage />);
+
+      expect(screen.getByTestId('datatable')).toBe(table);
+      expect(screen.getByTestId('datatable-card-detail-region')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Hide details for broken-one.jpg' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByText('broken-two.jpg')).toBeInTheDocument();
+    });
+
+    it('keeps the rows rendered while a refetch is in flight', async () => {
+      mockUseTrashEmptyRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseTrashEmptyRunItems.mockReturnValue(
+        makeItemsHook({ items: failedItems(), isLoading: true }),
+      );
+
+      render(<TrashEmptyRunPage />);
+
+      expect(await screen.findByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByTestId('datatable-loading-overlay')).toBeInTheDocument();
+    });
+
+    it('links a failed item to its media, from a row-named action', async () => {
+      mockUseTrashEmptyRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseTrashEmptyRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+
+      render(<TrashEmptyRunPage />);
+
+      // One row action → a bare icon button named after its row (§17.6).
+      await userEvent
+        .setup()
+        .click(await screen.findByRole('button', { name: 'View for broken-one.jpg' }));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/media?item=m-1');
     });
   });
 });

--- a/apps/web/src/__tests__/pages/Workflows/WorkflowRunPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Workflows/WorkflowRunPage.test.tsx
@@ -22,10 +22,16 @@
  * not disturb it.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { act, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../../components/datatable/__tests__/testUtils/layoutStubs';
+import { api } from '../../../services/api';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -197,13 +203,23 @@ function makeMutationsHook(overrides: Partial<MutationsHookReturn> = {}): Mutati
   } as MutationsHookReturn;
 }
 
+beforeAll(() => {
+  // The failed-items table is a DataTable (#261); jsdom performs no layout, so
+  // both the container-width hook and MUI X measure 0×0 without these.
+  installLayoutStubs();
+});
+
 describe('WorkflowRunPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetContainerWidth(1400); // desktop layout unless a test says otherwise
     mockUseCircle.mockReturnValue(makeCircleContext());
     mockUsePermissions.mockReturnValue(makePermissions());
     mockUseWorkflowRunItems.mockReturnValue(makeItemsHook());
     mockUseWorkflowMutations.mockReturnValue(makeMutationsHook());
+    // The table's layout-persistence hook reads/writes `/user-settings` (§15).
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
   });
 
   afterEach(() => {
@@ -407,6 +423,88 @@ describe('WorkflowRunPage', () => {
         vi.advanceTimersByTime(10000);
       });
       expect(fetchRun).toHaveBeenCalledTimes(callsAfterMount);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Live updates must not disturb the user (issue #261)
+  // -------------------------------------------------------------------------
+  //
+  // The page polls its run endpoint, so `run` and (on a refetch) `items` are
+  // brand-new objects on every tick. Gating the table on `loading` — which this
+  // page did before #261 — would remount the renderer each time and take card
+  // expansion state and the scroll offset with it (docs/specs/datatable.md
+  // §18.4).
+  describe('live updates do not disturb the failed-items table', () => {
+    function terminalRunWithFailures() {
+      return makeRun({
+        status: 'completed_with_errors',
+        matchedCount: 10,
+        processedCount: 10,
+        succeededCount: 8,
+        failedCount: 2,
+      });
+    }
+
+    /** Fresh objects with the SAME ids — what one poll tick actually produces. */
+    function failedItems() {
+      return [
+        makeItem('broken-one', { status: 'failed', error: 'Move to trash failed' }),
+        makeItem('broken-two', { status: 'failed', error: 'Move to trash failed' }),
+      ];
+    }
+
+    it('preserves an expanded card and the table itself across a poll tick', async () => {
+      const user = userEvent.setup();
+      setInitialContainerWidth(400); // card layout, so "More details" exists
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseWorkflowRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+
+      const { rerender } = render(<WorkflowRunPage />);
+
+      const table = await screen.findByTestId('datatable');
+      await user.click(
+        await screen.findByRole('button', { name: 'More details for broken-one.jpg' }),
+      );
+      expect(screen.getByTestId('datatable-card-detail-region')).toBeInTheDocument();
+
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseWorkflowRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+      rerender(<WorkflowRunPage />);
+
+      expect(screen.getByTestId('datatable')).toBe(table);
+      expect(screen.getByTestId('datatable-card-detail-region')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Hide details for broken-one.jpg' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByText('broken-two.jpg')).toBeInTheDocument();
+    });
+
+    it('keeps the rows rendered while a refetch is in flight', async () => {
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseWorkflowRunItems.mockReturnValue(
+        makeItemsHook({ items: failedItems(), isLoading: true }),
+      );
+
+      render(<WorkflowRunPage />);
+
+      expect(await screen.findByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByTestId('datatable-loading-overlay')).toBeInTheDocument();
+    });
+
+    it('links a failed item to its media, from a row-named action', async () => {
+      mockUseWorkflowRun.mockReturnValue(makeRunHook({ run: terminalRunWithFailures() }));
+      mockUseWorkflowRunItems.mockReturnValue(makeItemsHook({ items: failedItems() }));
+
+      render(<WorkflowRunPage />);
+
+      // One row action → a bare icon button named after its row (§17.6).
+      await userEvent
+        .setup()
+        .click(await screen.findByRole('button', { name: 'View for broken-one.jpg' }));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/media?item=broken-one');
     });
   });
 });

--- a/apps/web/src/__tests__/pages/WorkflowsSettingsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/WorkflowsSettingsPage.test.tsx
@@ -171,6 +171,20 @@ function makeRun(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/**
+ * Open a workflow row's overflow menu.
+ *
+ * Post-#261 the oversight table's row actions live in the shared DataTable's
+ * `MoreVert` menu, named after the row's first `primary` column value
+ * (docs/specs/datatable.md §17.6) — not as two bare buttons in a trailing cell.
+ */
+async function openWorkflowRowMenu(
+  user: ReturnType<typeof userEvent.setup>,
+  rowLabel = 'Screenshot cleanup',
+) {
+  await user.click(await screen.findByRole('button', { name: `Row actions for ${rowLabel}` }));
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -497,7 +511,8 @@ describe('WorkflowsSettingsPage', () => {
 
       await waitFor(() => expect(screen.getByText('Screenshot cleanup')).toBeInTheDocument());
 
-      await user.click(screen.getByRole('button', { name: /^disable$/i }));
+      await openWorkflowRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /^disable$/i }));
 
       const dialog = await screen.findByRole('dialog');
       expect(within(dialog).getByText(/disable workflow\?/i)).toBeInTheDocument();
@@ -517,7 +532,8 @@ describe('WorkflowsSettingsPage', () => {
 
       await waitFor(() => expect(screen.getByText('Screenshot cleanup')).toBeInTheDocument());
 
-      await user.click(screen.getByRole('button', { name: /^disable$/i }));
+      await openWorkflowRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /^disable$/i }));
       const dialog = await screen.findByRole('dialog');
       await user.click(within(dialog).getByRole('button', { name: /^cancel$/i }));
 
@@ -530,7 +546,8 @@ describe('WorkflowsSettingsPage', () => {
 
       await waitFor(() => expect(screen.getByText('Screenshot cleanup')).toBeInTheDocument());
 
-      await user.click(screen.getByRole('button', { name: /runs/i }));
+      await openWorkflowRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /^runs$/i }));
 
       await waitFor(() => {
         expect(mockListRuns).toHaveBeenCalledWith(
@@ -550,10 +567,13 @@ describe('WorkflowsSettingsPage', () => {
       render(<WorkflowsSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
 
       await waitFor(() => expect(screen.getByText('Screenshot cleanup')).toBeInTheDocument());
-      await user.click(screen.getByRole('button', { name: /runs/i }));
+      await openWorkflowRowMenu(user);
+      await user.click(screen.getByRole('menuitem', { name: /^runs$/i }));
       await waitFor(() => expect(screen.getByRole('heading', { name: /run history/i })).toBeInTheDocument());
 
-      await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+      // Cancel is the drawer table's ONLY row action, so it renders as a bare
+      // icon button named after its row (the run's short id) — §17.6.
+      await user.click(await screen.findByRole('button', { name: 'Cancel run for run-1' }));
 
       const dialog = await screen.findByRole('dialog');
       expect(within(dialog).getByText(/cancel this run\?/i)).toBeInTheDocument();

--- a/apps/web/src/components/runs/runItemsTable.tsx
+++ b/apps/web/src/components/runs/runItemsTable.tsx
@@ -1,0 +1,207 @@
+/**
+ * Run-item tables — the shared DataTable declaration (issue #261, epic #238).
+ *
+ * Three pages render "the items this run could not process": the workflow run
+ * page, the generic review-run page, and the empty-trash run page. Before this
+ * migration each one hand-rolled the *same* three-column
+ * `<TableContainer><Table size="small">` block plus a `<Pagination>` footer, so
+ * all three scrolled sideways on a phone and all three had to be fixed
+ * separately. They now share one column declaration.
+ *
+ * ## Why one module rather than three column files
+ *
+ * The three item types are structurally the same row — `types/runs.ts`'s
+ * {@link BaseRunItem} is exactly the intersection the API already guarantees
+ * (`id`, `status`, `error`, `updatedAt`, `media`, `thumbnailUrl`). Only two
+ * things genuinely differ per queue: what a row is *called* (a filename, or a
+ * burst-group id when the subject has no media row) and where "View" goes. Both
+ * are parameters.
+ *
+ * ## Priorities
+ *
+ *   - primary   — Subject (thumbnail + label), Status
+ *   - secondary — Error, Captured
+ *   - detail    — Item id
+ *
+ * `status` is `primary` deliberately: it is the signal every one of these
+ * surfaces exists to convey (`matched` / `applied` / `failed` / `skipped`), so
+ * it belongs in the card headline rather than folded behind "More details".
+ *
+ * The signed thumbnail rides **inside the Subject column's `render`** rather
+ * than in a column of its own. A column's `render` is used verbatim by every
+ * layout (docs/specs/datatable.md §3), so this puts the thumbnail in the card's
+ * headline area — while keeping the column's `value` a real scalar (the label),
+ * which is what names every per-row control (§17.6) and what a CSV export
+ * writes. A thumbnail-only column would have neither.
+ *
+ * ## Nothing is `sortable`, nothing is `filterable`
+ *
+ * `GET /workflow-runs/:id/items`, `GET /review-runs/:id/items` and
+ * `GET /trash-empty-runs/:id/items` accept `status`, `page` and `pageSize` and
+ * nothing else — no `sortBy`, no free-text search. Per the
+ * `sortable`-defaults-to-false rule (§4) no column opts in, and the pages pass
+ * no `sort` config. `status` is not offered as a generic filter either: the
+ * page pins it to `failed` for the "failed items" surface, and a second control
+ * writing the same param is the drift §13.1 warns about.
+ */
+
+import type { ReactNode } from 'react';
+import { Avatar, Box, Chip, Stack, Typography } from '@mui/material';
+import { BrokenImage as BrokenImageIcon } from '@mui/icons-material';
+import type { DataTableColumn } from '../datatable';
+import type { BaseRunItem, RunItemStatus } from '../../types/runs';
+import { formatCaptureDate } from '../../utils/runFormat';
+
+// ---------------------------------------------------------------------------
+// Status presentation
+// ---------------------------------------------------------------------------
+
+const ITEM_STATUS_COLORS: Record<
+  RunItemStatus,
+  'default' | 'info' | 'success' | 'warning' | 'error'
+> = {
+  matched: 'default',
+  processing: 'info',
+  excluded: 'default',
+  applied: 'success',
+  partially_applied: 'warning',
+  deleted: 'success',
+  failed: 'error',
+  skipped: 'default',
+};
+
+/** Title-cased, space-separated label for a run-item status. */
+export function runItemStatusLabel(status: RunItemStatus): string {
+  const words = status.split('_');
+  return words
+    .map((word, index) =>
+      index === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word,
+    )
+    .join(' ');
+}
+
+function RunItemStatusChip({ status }: { status: RunItemStatus }) {
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      label={runItemStatusLabel(status)}
+      color={ITEM_STATUS_COLORS[status] ?? 'default'}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+export interface RunItemColumnOptions<Item extends BaseRunItem> {
+  /**
+   * Header/field label for the leading column — "File" for media-backed runs,
+   * "Subject" where a row may be a burst or duplicate group instead.
+   */
+  subjectLabel: string;
+  /**
+   * The row's human handle. Also the column's `value`, so it is what names the
+   * row's checkbox and its action control (docs/specs/datatable.md §17.6) and
+   * what a CSV export writes.
+   */
+  itemLabel: (item: Item) => string;
+}
+
+export function buildRunItemColumns<Item extends BaseRunItem>({
+  subjectLabel,
+  itemLabel,
+}: RunItemColumnOptions<Item>): DataTableColumn<Item>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'subject',
+      label: subjectLabel,
+      priority: 'primary',
+      value: (item) => itemLabel(item),
+      render: (item) => {
+        const label = itemLabel(item);
+        return (
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+            <Avatar
+              variant="rounded"
+              src={item.thumbnailUrl ?? undefined}
+              alt=""
+              sx={{ width: 36, height: 36, flexShrink: 0, bgcolor: 'action.hover' }}
+            >
+              <BrokenImageIcon sx={{ fontSize: 18, color: 'text.disabled' }} />
+            </Avatar>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="body2" noWrap title={label}>
+                {label}
+              </Typography>
+            </Box>
+          </Stack>
+        );
+      },
+      minWidth: 200,
+      flex: 1.2,
+      // A thumbnail has no scalar; the label is the scalar, and it is exported.
+      hideable: false,
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      priority: 'primary',
+      value: (item) => item.status,
+      render: (item) => <RunItemStatusChip status={item.status} />,
+      width: 150,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'error',
+      label: 'Error',
+      priority: 'secondary',
+      value: (item) => item.error,
+      // One line + tooltip on the grid; a tap-to-expand value on a card. This
+      // is what stops a stack trace turning every row into a five-line block.
+      truncate: true,
+      render: (item) => (
+        <Typography variant="body2" color="error">
+          {item.error ?? 'Unknown error'}
+        </Typography>
+      ),
+      minWidth: 200,
+      flex: 2,
+    },
+    {
+      id: 'capturedAt',
+      label: 'Captured',
+      priority: 'secondary',
+      value: (item) => item.media?.capturedAt ?? null,
+      render: (item) => (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {formatCaptureDate(item.media?.capturedAt ?? null)}
+        </Typography>
+      ),
+      minWidth: 130,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'id',
+      label: 'Item ID',
+      priority: 'detail',
+      value: (item) => item.id,
+      render: (item) => (
+        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+          {item.id.slice(0, 8)}
+        </Typography>
+      ),
+      width: 140,
+    },
+  ];
+}
+
+/** Default page size for every run-item table. */
+export const RUN_ITEMS_PAGE_SIZE = 25;
+
+/** The empty-state node, shared by all three run-item tables. */
+export const RUN_ITEMS_EMPTY_STATE: ReactNode = <span>No items to show.</span>;

--- a/apps/web/src/components/workflows/admin/WorkflowRunsDrawer.tsx
+++ b/apps/web/src/components/workflows/admin/WorkflowRunsDrawer.tsx
@@ -1,38 +1,49 @@
+/**
+ * Admin workflow-runs drawer (issue #143; migrated onto the shared DataTable in
+ * issue #261, epic #238).
+ *
+ * Presentational: the parent owns fetching runs for the selected workflow and
+ * the cancel-confirm flow.
+ *
+ * ## Why this one table proves the container-query work (#253)
+ *
+ * The drawer is 620px wide on a desktop and its content ~570px after padding —
+ * on a 1440px viewport. If the shared component switched layouts on
+ * `useMediaQuery` it would render the full desktop grid in here and reintroduce
+ * horizontal scrolling on a desktop, which is the exact defect epic #238 exists
+ * to remove. It measures its own wrapper instead, so this table resolves to the
+ * CARD layout while the oversight table behind the drawer stays a grid. See
+ * `./workflowRunsColumns.tsx` and docs/specs/datatable.md §7.2.
+ *
+ * No `mobileBreakpoint` override is needed or wanted: the default 600px
+ * container threshold already produces cards at this drawer's width, and
+ * hard-coding a layout here would be the viewport assumption in another form.
+ *
+ * ## Permission gating is on the ACTION ARRAY
+ *
+ * `canCancel` (Admin + `jobs:write`) decides whether the Cancel action EXISTS,
+ * per docs/specs/datatable.md §13.1 — not whether a rendered button is inert.
+ * Whether a given run is terminal, or is the one currently being cancelled, is
+ * per-row state and stays a `disabled` predicate.
+ */
+
+import { useMemo } from 'react';
 import {
   Drawer,
   Box,
   Typography,
   IconButton,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Chip,
-  Button,
-  CircularProgress,
   Alert,
-  Tooltip,
   Divider,
 } from '@mui/material';
 import { Close as CloseIcon, Stop as StopIcon } from '@mui/icons-material';
 import type { AdminWorkflowRun } from '../../../services/adminWorkflows';
+import { isTerminalRunStatus } from '../../../utils/workflowFormat';
+import { DataTable, type DataTableRowAction } from '../../datatable';
 import {
-  runStatusColor,
-  runStatusLabel,
-  isTerminalRunStatus,
-  formatRelativeTime,
-  formatCount,
-} from '../../../utils/workflowFormat';
-
-// ---------------------------------------------------------------------------
-// Admin workflow-runs drawer (issue #143).
-//
-// Presentational: the parent owns fetching runs for the selected workflow and
-// the cancel-confirm flow. Cancel is offered on non-terminal runs only, and
-// only when `canCancel` (Admin + jobs:write).
-// ---------------------------------------------------------------------------
+  WORKFLOW_RUNS_TABLE_ID,
+  buildWorkflowRunColumns,
+} from './workflowRunsColumns';
 
 interface WorkflowRunsDrawerProps {
   open: boolean;
@@ -57,6 +68,22 @@ export function WorkflowRunsDrawer({
   onCancel,
   onClose,
 }: WorkflowRunsDrawerProps) {
+  const columns = useMemo(() => buildWorkflowRunColumns(), []);
+
+  const rowActions = useMemo<DataTableRowAction<AdminWorkflowRun>[]>(() => {
+    if (!canCancel) return [];
+    return [
+      {
+        id: 'cancel',
+        label: 'Cancel run',
+        icon: <StopIcon fontSize="small" />,
+        destructive: true,
+        disabled: (run) => isTerminalRunStatus(run.status) || cancellingRunId === run.id,
+        onClick: onCancel,
+      },
+    ];
+  }, [canCancel, cancellingRunId, onCancel]);
+
   return (
     <Drawer
       anchor="right"
@@ -64,7 +91,7 @@ export function WorkflowRunsDrawer({
       onClose={onClose}
       slotProps={{ paper: { sx: { width: { xs: '100%', sm: 620 }, maxWidth: '100%' } } }}
     >
-      <Box sx={{ p: 3 }}>
+      <Box sx={{ p: 3, minWidth: 0 }}>
         <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: 1 }}>
           <Box>
             <Typography variant="h6" sx={{ fontWeight: 700 }}>
@@ -87,84 +114,24 @@ export function WorkflowRunsDrawer({
           </Alert>
         )}
 
-        {loading && runs.length === 0 ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-            <CircularProgress size={28} />
-          </Box>
-        ) : runs.length === 0 ? (
-          <Typography variant="body2" color="text.secondary" sx={{ py: 3, textAlign: 'center' }}>
-            No runs for this workflow yet.
-          </Typography>
-        ) : (
-          <TableContainer sx={{ overflowX: 'auto' }}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Status</TableCell>
-                  <TableCell>Started</TableCell>
-                  <TableCell align="right">Matched</TableCell>
-                  <TableCell align="right">Actioned</TableCell>
-                  <TableCell align="right">Failed</TableCell>
-                  <TableCell align="right">Action</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {runs.map((run) => {
-                  const terminal = isTerminalRunStatus(run.status);
-                  return (
-                    <TableRow key={run.id} hover>
-                      <TableCell>
-                        <Chip
-                          size="small"
-                          label={runStatusLabel(run.status)}
-                          color={runStatusColor(run.status)}
-                          variant="outlined"
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="caption" color="text.secondary">
-                          {formatRelativeTime(run.startedAt ?? run.createdAt)}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="right">{formatCount(run.matchedCount)}</TableCell>
-                      <TableCell align="right">{formatCount(run.succeededCount)}</TableCell>
-                      <TableCell align="right">{formatCount(run.failedCount)}</TableCell>
-                      <TableCell align="right">
-                        {terminal ? (
-                          <Typography variant="caption" color="text.disabled">
-                            —
-                          </Typography>
-                        ) : (
-                          <Tooltip
-                            title={canCancel ? 'Cancel this run' : 'Requires jobs:write'}
-                          >
-                            <span>
-                              <Button
-                                size="small"
-                                color="error"
-                                startIcon={
-                                  cancellingRunId === run.id ? (
-                                    <CircularProgress size={14} />
-                                  ) : (
-                                    <StopIcon />
-                                  )
-                                }
-                                disabled={!canCancel || cancellingRunId === run.id}
-                                onClick={() => onCancel(run)}
-                              >
-                                Cancel
-                              </Button>
-                            </span>
-                          </Tooltip>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        )}
+        {/*
+          Rendered UNCONDITIONALLY: `loading` is a prop, never a gate
+          (docs/specs/datatable.md §18.4). The drawer refetches this list after
+          every cancel, and swapping the table for a spinner would throw away
+          card expansion state and the drawer's scroll offset each time.
+        */}
+        <DataTable<AdminWorkflowRun>
+          columns={columns}
+          rows={runs}
+          rowId={(run) => run.id}
+          tableId={WORKFLOW_RUNS_TABLE_ID}
+          ariaLabel="Workflow run history"
+          density="compact"
+          loading={loading}
+          emptyState={<span>No runs for this workflow yet.</span>}
+          rowActions={rowActions}
+          csvExport={{ filename: 'workflow-runs' }}
+        />
       </Box>
     </Drawer>
   );

--- a/apps/web/src/components/workflows/admin/WorkflowsOversightTable.tsx
+++ b/apps/web/src/components/workflows/admin/WorkflowsOversightTable.tsx
@@ -1,50 +1,43 @@
-import {
-  Card,
-  CardContent,
-  Box,
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TablePagination,
-  Chip,
-  Stack,
-  Button,
-  Tooltip,
-  CircularProgress,
-} from '@mui/material';
+/**
+ * Workflows oversight table (issue #143; migrated onto the shared DataTable in
+ * issue #261, epic #238).
+ *
+ * Every workflow across all circles. Still props-driven for testability: the
+ * parent owns fetching, pagination state, and the row-action handlers.
+ *
+ * What #261 replaced: a hand-rolled nine-column `<Table>` inside a
+ * `<TableContainer sx={{ overflowX: 'auto' }}>` plus a `<TablePagination>`
+ * footer — i.e. the pattern where a desktop-shaped grid is made "responsive" by
+ * letting it scroll sideways. It is now one `DataTableColumn[]`
+ * (`./workflowsOversightColumns.tsx`) rendered by the shared component, which
+ * picks grid-vs-cards from ITS OWN CONTAINER width (§7.2). That matters here
+ * even on a desktop: this table sits inside a `Container maxWidth="lg"` card, so
+ * its container is ~1050px and it resolves to the tablet layout — the three
+ * `detail` columns fold into a row expander rather than being squeezed.
+ *
+ * ## Permission gating is on the ACTION ARRAY, not on a rendered control
+ *
+ * The pre-migration table always rendered a "Disable" button and merely
+ * disabled it when the caller lacked `system_settings:write`. Per
+ * docs/specs/datatable.md §13.1 (#260) a permission gate belongs on the array,
+ * so an action a caller may not perform is absent from the DOM in every
+ * renderer at once rather than present-but-inert in one of them. `canManage`
+ * therefore decides whether the action EXISTS; whether the workflow is already
+ * disabled is per-row state and stays a `disabled` predicate (#259's rule).
+ */
+
+import { Card, CardContent, Typography } from '@mui/material';
 import {
   Block as BlockIcon,
   History as HistoryIcon,
 } from '@mui/icons-material';
+import { useMemo } from 'react';
 import type { AdminWorkflowListItem } from '../../../services/adminWorkflows';
+import { DataTable, type DataTableRowAction } from '../../datatable';
 import {
-  triggerLabel,
-  runStatusColor,
-  runStatusLabel,
-  formatRelativeTime,
-  formatCount,
-} from '../../../utils/workflowFormat';
-import type { WorkflowSubjectType } from '../../../types/workflows';
-
-// ---------------------------------------------------------------------------
-// Workflows oversight table (issue #143).
-//
-// Every workflow across all circles. Props-driven for testability: the parent
-// owns fetching, pagination, and the row-action handlers. Disable / cancel are
-// gated by `canManage` (Admin + system_settings:write for disable).
-// ---------------------------------------------------------------------------
-
-const SUBJECT_LABELS: Record<WorkflowSubjectType, string> = {
-  media_item: 'Media item',
-};
-
-function subjectLabel(subject: WorkflowSubjectType): string {
-  return SUBJECT_LABELS[subject] ?? subject;
-}
+  WORKFLOWS_OVERSIGHT_TABLE_ID,
+  buildWorkflowOversightColumns,
+} from './workflowsOversightColumns';
 
 interface WorkflowsOversightTableProps {
   items: AdminWorkflowListItem[];
@@ -71,6 +64,33 @@ export function WorkflowsOversightTable({
   onDisable,
   onViewRuns,
 }: WorkflowsOversightTableProps) {
+  const columns = useMemo(() => buildWorkflowOversightColumns(), []);
+
+  const rowActions = useMemo<DataTableRowAction<AdminWorkflowListItem>[]>(() => {
+    const actions: DataTableRowAction<AdminWorkflowListItem>[] = [
+      {
+        id: 'runs',
+        label: 'Runs',
+        icon: <HistoryIcon fontSize="small" />,
+        onClick: onViewRuns,
+      },
+    ];
+    // Absent, not disabled, without the permission — see the module docblock.
+    if (canManage) {
+      actions.push({
+        id: 'disable',
+        label: 'Disable',
+        icon: <BlockIcon fontSize="small" />,
+        destructive: true,
+        // Per-ROW state, which is what `disabled` is for: the control stays
+        // discoverable on an already-disabled workflow instead of vanishing.
+        disabled: (item) => !item.enabled,
+        onClick: onDisable,
+      });
+    }
+    return actions;
+  }, [canManage, onDisable, onViewRuns]);
+
   return (
     <Card variant="outlined" sx={{ borderRadius: 2 }}>
       <CardContent sx={{ p: 3 }}>
@@ -81,144 +101,40 @@ export function WorkflowsOversightTable({
           Every workflow across all circles, newest first.
         </Typography>
 
-        <TableContainer sx={{ overflowX: 'auto' }}>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Circle</TableCell>
-                <TableCell>Name</TableCell>
-                <TableCell>Subject</TableCell>
-                <TableCell>Trigger</TableCell>
-                <TableCell>Enabled</TableCell>
-                <TableCell>Last run</TableCell>
-                <TableCell align="right">Matched</TableCell>
-                <TableCell align="right">Actioned</TableCell>
-                <TableCell align="right">Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {loading && items.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
-              ) : items.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={9} align="center" sx={{ py: 3, color: 'text.secondary' }}>
-                    No workflows found.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                items.map((wf) => (
-                  <TableRow key={wf.id} hover>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                        {wf.circle?.name ?? '—'}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                        {wf.name}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2">{subjectLabel(wf.subjectType)}</Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2">{triggerLabel(wf.trigger)}</Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Chip
-                        size="small"
-                        label={wf.enabled ? 'Enabled' : 'Disabled'}
-                        color={wf.enabled ? 'success' : 'default'}
-                        variant={wf.enabled ? 'filled' : 'outlined'}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      {wf.lastRun ? (
-                        <Stack spacing={0.5} sx={{ minWidth: 150 }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <Chip
-                              size="small"
-                              label={runStatusLabel(wf.lastRun.status)}
-                              color={runStatusColor(wf.lastRun.status)}
-                              variant="outlined"
-                            />
-                            <Typography variant="caption" color="text.secondary">
-                              {formatRelativeTime(wf.lastRun.finishedAt ?? wf.lastRun.createdAt)}
-                            </Typography>
-                          </Box>
-                          <Typography variant="caption" color="text.secondary">
-                            {formatCount(wf.lastRun.succeededCount)} ok
-                            {wf.lastRun.failedCount > 0
-                              ? ` · ${formatCount(wf.lastRun.failedCount)} failed`
-                              : ''}
-                            {wf.lastRun.skippedCount > 0
-                              ? ` · ${formatCount(wf.lastRun.skippedCount)} skipped`
-                              : ''}
-                          </Typography>
-                        </Stack>
-                      ) : (
-                        <Typography variant="body2" color="text.secondary">
-                          Never run
-                        </Typography>
-                      )}
-                    </TableCell>
-                    <TableCell align="right">
-                      <Typography variant="body2">{formatCount(wf.totals.matched)}</Typography>
-                    </TableCell>
-                    <TableCell align="right">
-                      <Typography variant="body2">{formatCount(wf.totals.actioned)}</Typography>
-                    </TableCell>
-                    <TableCell align="right">
-                      <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
-                        <Button
-                          size="small"
-                          startIcon={<HistoryIcon />}
-                          onClick={() => onViewRuns(wf)}
-                        >
-                          Runs
-                        </Button>
-                        <Tooltip
-                          title={
-                            !canManage
-                              ? 'Requires system_settings:write'
-                              : !wf.enabled
-                                ? 'Already disabled'
-                                : 'Force-disable this workflow'
-                          }
-                        >
-                          <span>
-                            <Button
-                              size="small"
-                              color="error"
-                              startIcon={<BlockIcon />}
-                              disabled={!canManage || !wf.enabled}
-                              onClick={() => onDisable(wf)}
-                            >
-                              Disable
-                            </Button>
-                          </span>
-                        </Tooltip>
-                      </Stack>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-
-        <TablePagination
-          component="div"
-          count={totalItems}
-          page={page}
-          onPageChange={(_, next) => onPageChange(next)}
-          rowsPerPage={pageSize}
-          onRowsPerPageChange={(e) => onPageSizeChange(parseInt(e.target.value, 10))}
-          rowsPerPageOptions={[10, 25, 50]}
+        {/*
+          Rendered UNCONDITIONALLY: `loading` is a prop, never a gate. Swapping
+          the table out for a spinner unmounts the renderer and takes row/card
+          expansion state (and the page's scroll offset) with it —
+          docs/specs/datatable.md §18.4.
+        */}
+        <DataTable<AdminWorkflowListItem>
+          columns={columns}
+          rows={items}
+          rowId={(item) => item.id}
+          tableId={WORKFLOWS_OVERSIGHT_TABLE_ID}
+          ariaLabel="All workflows"
+          density="compact"
+          loading={loading}
+          emptyState={<span>No workflows found.</span>}
+          pagination={{
+            page,
+            pageSize,
+            total: totalItems,
+            // The parent keeps `page` and `pageSize` as two separate setters,
+            // and its `onPageSizeChange` already resets the offset — so a
+            // size change must NOT also emit a page change, or the two would
+            // race and the reset would be clobbered.
+            onPaginationChange: ({ page: nextPage, pageSize: nextPageSize }) => {
+              if (nextPageSize !== pageSize) {
+                onPageSizeChange(nextPageSize);
+                return;
+              }
+              if (nextPage !== page) onPageChange(nextPage);
+            },
+            pageSizeOptions: [10, 25, 50],
+          }}
+          rowActions={rowActions}
+          csvExport={{ filename: 'workflows' }}
         />
       </CardContent>
     </Card>

--- a/apps/web/src/components/workflows/admin/workflowRunsColumns.tsx
+++ b/apps/web/src/components/workflows/admin/workflowRunsColumns.tsx
@@ -1,0 +1,125 @@
+/**
+ * Admin workflow-runs drawer — the DataTable column declaration (issue #261,
+ * epic #238).
+ *
+ * ## This table is the epic's container-query proof case
+ *
+ * The drawer is 620px wide on a desktop (`slotProps.paper`), which leaves its
+ * content ~570px after padding — on a 1440px viewport. A viewport media query
+ * would hand that a full desktop grid and it would be unusable; the shared
+ * component measures its OWN wrapper with a `ResizeObserver`, so it resolves to
+ * the CARD layout here while the same component renders a grid on the page
+ * behind the drawer. That is exactly the scenario docs/specs/datatable.md §7.2
+ * describes, and `WorkflowRunsDrawer.test.tsx` asserts it with `matchMedia`
+ * pinned to 1440px so a `mobile` result can only have come from the container
+ * measurement.
+ *
+ * ## Priorities
+ *
+ *   - primary   — Run (short id), Status
+ *   - secondary — Started, Matched, Actioned, Failed
+ *
+ * `Run` leads rather than `Status`, even though status is the signal an admin
+ * scans for, because the first `primary` column names every per-row control
+ * (§17.6) and half a dozen runs of one workflow are routinely all "Running".
+ * `Status` is the second primary, so it still lands in the card headline.
+ *
+ * Nothing is `sortable` (`GET /api/admin/workflow-runs` accepts no `sortBy`)
+ * and nothing is `filterable` (the drawer is already scoped to one workflow).
+ */
+
+import { Chip, Typography } from '@mui/material';
+import type { AdminWorkflowRun } from '../../../services/adminWorkflows';
+import {
+  runStatusColor,
+  runStatusLabel,
+  formatRelativeTime,
+  formatCount,
+} from '../../../utils/workflowFormat';
+import type { DataTableColumn } from '../../datatable';
+
+/**
+ * Persistence key for the user's column/density choices
+ * (`user_settings.dataTables['admin-workflow-runs']`).
+ */
+export const WORKFLOW_RUNS_TABLE_ID = 'admin-workflow-runs';
+
+/** A run's human handle — the first 8 characters of its id. */
+export function shortRunId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export function buildWorkflowRunColumns(): DataTableColumn<AdminWorkflowRun>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'id',
+      label: 'Run',
+      priority: 'primary',
+      value: (run) => shortRunId(run.id),
+      render: (run) => (
+        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+          {shortRunId(run.id)}
+        </Typography>
+      ),
+      width: 120,
+      hideable: false,
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      priority: 'primary',
+      value: (run) => run.status,
+      render: (run) => (
+        <Chip
+          size="small"
+          label={runStatusLabel(run.status)}
+          color={runStatusColor(run.status)}
+          variant="outlined"
+        />
+      ),
+      width: 170,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'startedAt',
+      label: 'Started',
+      priority: 'secondary',
+      value: (run) => run.startedAt ?? run.createdAt,
+      render: (run) => (
+        <Typography variant="caption" color="text.secondary">
+          {formatRelativeTime(run.startedAt ?? run.createdAt)}
+        </Typography>
+      ),
+      minWidth: 150,
+    },
+    {
+      id: 'matchedCount',
+      label: 'Matched',
+      priority: 'secondary',
+      align: 'right',
+      value: (run) => run.matchedCount,
+      render: (run) => <Typography variant="body2">{formatCount(run.matchedCount)}</Typography>,
+      width: 110,
+    },
+    {
+      id: 'succeededCount',
+      label: 'Actioned',
+      priority: 'secondary',
+      align: 'right',
+      value: (run) => run.succeededCount,
+      render: (run) => <Typography variant="body2">{formatCount(run.succeededCount)}</Typography>,
+      width: 110,
+    },
+    {
+      id: 'failedCount',
+      label: 'Failed',
+      priority: 'secondary',
+      align: 'right',
+      value: (run) => run.failedCount,
+      render: (run) => <Typography variant="body2">{formatCount(run.failedCount)}</Typography>,
+      width: 110,
+    },
+  ];
+}

--- a/apps/web/src/components/workflows/admin/workflowsOversightColumns.tsx
+++ b/apps/web/src/components/workflows/admin/workflowsOversightColumns.tsx
@@ -1,0 +1,199 @@
+/**
+ * Workflow oversight — the DataTable column declaration (issue #261, epic #238).
+ *
+ * Split out of `WorkflowsOversightTable.tsx` for the reason every migration
+ * since the pilot has (docs/specs/datatable.md §18): the column set is the half
+ * worth testing on its own, and keeping it out of the component keeps the
+ * component down to "hand the shared table its props".
+ *
+ * ## Priorities
+ *
+ *   - primary   — Workflow (name), Status (enabled/disabled)
+ *   - secondary — Circle, Trigger, Last run
+ *   - detail    — Subject, Matched (lifetime), Actioned (lifetime)
+ *
+ * `name` leads because it is the only row-unique column here: the first
+ * `primary` column names every per-row control ("Row actions for Screenshot
+ * cleanup", §17.6), and leading with Circle or Subject would name a dozen
+ * controls "Family circle" or "Media item" (§13.1's row-unique rule).
+ *
+ * `enabled` is `primary` because enabled-vs-disabled is the state this page
+ * exists to change — the same reasoning that makes `status` primary on every
+ * other migrated surface.
+ *
+ * ## Nothing is `sortable` or `filterable`
+ *
+ * `GET /api/admin/workflows` accepts `circleId`, `trigger` and `enabled`, but
+ * the page has never surfaced a control for any of them and adding three is a
+ * feature, not a migration. It accepts no `sortBy` at all, so per the
+ * `sortable`-defaults-to-false rule (§4) no column opts in and the component
+ * passes no `sort` config, rather than painting headers that would silently do
+ * nothing.
+ */
+
+import { Box, Chip, Stack, Typography } from '@mui/material';
+import type { AdminWorkflowListItem } from '../../../services/adminWorkflows';
+import {
+  triggerLabel,
+  runStatusColor,
+  runStatusLabel,
+  formatRelativeTime,
+  formatCount,
+} from '../../../utils/workflowFormat';
+import type { WorkflowSubjectType } from '../../../types/workflows';
+import type { DataTableColumn } from '../../datatable';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Persistence key for the user's column/density choices
+ * (`user_settings.dataTables['admin-workflows']`). Chosen here and never
+ * derived from the route — it must survive a URL change.
+ */
+export const WORKFLOWS_OVERSIGHT_TABLE_ID = 'admin-workflows';
+
+const SUBJECT_LABELS: Record<WorkflowSubjectType, string> = {
+  media_item: 'Media item',
+};
+
+export function subjectLabel(subject: WorkflowSubjectType): string {
+  return SUBJECT_LABELS[subject] ?? subject;
+}
+
+/** One-line summary of a workflow's most recent run, or null when never run. */
+export function lastRunSummary(item: AdminWorkflowListItem): string | null {
+  const run = item.lastRun;
+  if (!run) return null;
+  const parts = [`${formatCount(run.succeededCount)} ok`];
+  if (run.failedCount > 0) parts.push(`${formatCount(run.failedCount)} failed`);
+  if (run.skippedCount > 0) parts.push(`${formatCount(run.skippedCount)} skipped`);
+  return parts.join(' · ');
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+export function buildWorkflowOversightColumns(): DataTableColumn<AdminWorkflowListItem>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'name',
+      label: 'Workflow',
+      priority: 'primary',
+      value: (item) => item.name,
+      render: (item) => (
+        <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap title={item.name}>
+          {item.name}
+        </Typography>
+      ),
+      minWidth: 180,
+      flex: 1.2,
+      // The row's identity: hiding it would leave every per-row control named
+      // after the row id instead (§17.6).
+      hideable: false,
+    },
+    {
+      id: 'enabled',
+      label: 'Status',
+      priority: 'primary',
+      value: (item) => (item.enabled ? 'Enabled' : 'Disabled'),
+      render: (item) => (
+        <Chip
+          size="small"
+          label={item.enabled ? 'Enabled' : 'Disabled'}
+          color={item.enabled ? 'success' : 'default'}
+          variant={item.enabled ? 'filled' : 'outlined'}
+        />
+      ),
+      width: 130,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'circle',
+      label: 'Circle',
+      priority: 'secondary',
+      value: (item) => item.circle?.name ?? null,
+      render: (item) => (
+        <Typography variant="body2" sx={{ color: 'text.secondary' }} noWrap>
+          {item.circle?.name ?? '—'}
+        </Typography>
+      ),
+      minWidth: 140,
+    },
+    {
+      id: 'trigger',
+      label: 'Trigger',
+      priority: 'secondary',
+      value: (item) => triggerLabel(item.trigger),
+      width: 140,
+    },
+    {
+      id: 'lastRun',
+      label: 'Last run',
+      priority: 'secondary',
+      // The scalar behind the cell — what a CSV export writes and what the
+      // truncation tooltip would reveal.
+      value: (item) => lastRunSummary(item),
+      render: (item) =>
+        item.lastRun ? (
+          <Stack spacing={0.5} sx={{ minWidth: 0, py: 0.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              <Chip
+                size="small"
+                label={runStatusLabel(item.lastRun.status)}
+                color={runStatusColor(item.lastRun.status)}
+                variant="outlined"
+              />
+              <Typography variant="caption" color="text.secondary">
+                {formatRelativeTime(item.lastRun.finishedAt ?? item.lastRun.createdAt)}
+              </Typography>
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              {lastRunSummary(item)}
+            </Typography>
+          </Stack>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            Never run
+          </Typography>
+        ),
+      minWidth: 200,
+      flex: 1.4,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'subjectType',
+      label: 'Subject',
+      priority: 'detail',
+      value: (item) => subjectLabel(item.subjectType),
+      width: 140,
+    },
+    {
+      id: 'matched',
+      label: 'Matched',
+      priority: 'detail',
+      align: 'right',
+      value: (item) => item.totals.matched,
+      render: (item) => (
+        <Typography variant="body2">{formatCount(item.totals.matched)}</Typography>
+      ),
+      width: 120,
+    },
+    {
+      id: 'actioned',
+      label: 'Actioned',
+      priority: 'detail',
+      align: 'right',
+      value: (item) => item.totals.actioned,
+      render: (item) => (
+        <Typography variant="body2">{formatCount(item.totals.actioned)}</Typography>
+      ),
+      width: 120,
+    },
+  ];
+}

--- a/apps/web/src/pages/Reviews/ReviewRunPage.tsx
+++ b/apps/web/src/pages/Reviews/ReviewRunPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -9,16 +9,11 @@ import {
   Card,
   CardContent,
   Snackbar,
-  Pagination,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Link,
 } from '@mui/material';
-import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import {
+  ArrowBack as ArrowBackIcon,
+  Visibility as VisibilityIcon,
+} from '@mui/icons-material';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useCircle } from '../../hooks/useCircle';
 import { useReviewRun } from '../../hooks/useReviewRun';
@@ -28,16 +23,33 @@ import { cancelReviewRun } from '../../services/reviewRuns';
 import RunProgressPanel from '../../components/runs/RunProgressPanel';
 import type { RunTerminalSummary } from '../../components/runs/RunProgressPanel';
 import {
-  formatCaptureDate,
+  RUN_ITEMS_EMPTY_STATE,
+  RUN_ITEMS_PAGE_SIZE,
+  buildRunItemColumns,
+} from '../../components/runs/runItemsTable';
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
+import {
   formatCount,
   formatRelativeTime,
   isTerminalRunStatus,
   runStatusColor,
   runStatusLabel,
 } from '../../utils/runFormat';
-import type { ReviewRunDetail, ReviewRunItem } from '../../types/reviewRuns';
+import type {
+  ReviewRunAction,
+  ReviewRunDetail,
+  ReviewRunItem,
+  ReviewRunSubject,
+} from '../../types/reviewRuns';
 
-const ITEMS_PAGE_SIZE = 24;
+/**
+ * Persistence key for the failed-items table's column/density choices
+ * (`user_settings.dataTables['review-run-items']`, docs/specs/datatable.md
+ * §15). ONE id across all three review queues: the table is the same table with
+ * the same columns whichever queue produced the run, so a user who widens the
+ * Error column while reviewing bursts should find it widened for duplicates.
+ */
+export const REVIEW_RUN_ITEMS_TABLE_ID = 'review-run-items';
 
 // ---------------------------------------------------------------------------
 // Generic review-run page (issue #190), shared by all three review queues.
@@ -46,6 +58,13 @@ const ITEMS_PAGE_SIZE = 24;
 // so bursts, duplicates and location suggestions render the identical panel
 // with the right nouns, the right success-tile label, and the right links back
 // into their own queue.
+//
+// Issue #261 (epic #238) replaced the hand-rolled failed-items
+// `<TableContainer>` + `<Pagination>` block with the shared DataTable
+// (`components/runs/runItemsTable.tsx`). Two rules matter on a page that polls:
+// the table is rendered UNCONDITIONALLY with `loading` as a prop, and every
+// memo/effect around it keys on SCALARS rather than on the `run` object the
+// poll replaces each tick. See docs/specs/datatable.md §13.2 / §18.4.
 // ---------------------------------------------------------------------------
 
 interface ReviewRunPresentation {
@@ -74,10 +93,21 @@ function isBelowThresholdAction(run: ReviewRunDetail): boolean {
   return run.action === 'dismiss' || run.action === 'reject';
 }
 
-function describeReviewRun(run: ReviewRunDetail): ReviewRunPresentation {
-  const dismissing = run.action === 'dismiss';
+/**
+ * Derive the per-queue wording and links.
+ *
+ * Takes the two discriminators rather than the whole run so a `useMemo` over it
+ * can depend on scalars — the run object itself is replaced on every poll tick,
+ * and keying on it would rebuild the row-action array (and every control's
+ * identity with it) twice a second.
+ */
+function describeReviewRun(
+  subjectType: ReviewRunSubject,
+  action: ReviewRunAction,
+): ReviewRunPresentation {
+  const dismissing = action === 'dismiss';
 
-  switch (run.subjectType) {
+  switch (subjectType) {
     case 'burst_group':
       return {
         title: dismissing ? 'Dismiss burst groups' : 'Resolve burst groups',
@@ -108,7 +138,7 @@ function describeReviewRun(run: ReviewRunDetail): ReviewRunPresentation {
       };
     case 'location_suggestion':
     default: {
-      const rejecting = run.action === 'reject';
+      const rejecting = action === 'reject';
       return {
         title: rejecting ? 'Bulk reject locations' : 'Bulk accept locations',
         backPath: '/location-suggestions',
@@ -190,7 +220,9 @@ export default function ReviewRunPage() {
     fetchItems,
   } = useReviewRunItems();
 
-  const [failedPage, setFailedPage] = useState(1);
+  // ZERO-based (the DataTable convention); converted at the fetch boundary.
+  const [failedPage, setFailedPage] = useState(0);
+  const [failedPageSize, setFailedPageSize] = useState(RUN_ITEMS_PAGE_SIZE);
   const [isCancelling, setIsCancelling] = useState(false);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -209,15 +241,20 @@ export default function ReviewRunPage() {
   useRunPolling({ runId, status: run?.status, onPoll: fetchRun });
 
   // Load the failed-item table once the run is terminal and has failures.
+  //
+  // Keyed on the two SCALARS this depends on, never on `run` itself: the
+  // run-detail poll hands back a fresh object every tick, and depending on that
+  // identity would refetch the item page — and reset the table with it.
   const terminal = run ? isTerminalRunStatus(run.status) : false;
+  const failedCount = run?.failedCount ?? 0;
   useEffect(() => {
-    if (!runId || !run || !terminal || run.failedCount <= 0) return;
+    if (!runId || !terminal || failedCount <= 0) return;
     void fetchItems(runId, {
       status: 'failed',
-      page: failedPage,
-      pageSize: ITEMS_PAGE_SIZE,
+      page: failedPage + 1, // the API is 1-based, the table 0-based
+      pageSize: failedPageSize,
     });
-  }, [runId, run, terminal, failedPage, fetchItems]);
+  }, [runId, terminal, failedCount, failedPage, failedPageSize, fetchItems]);
 
   const handleCancel = useCallback(async () => {
     if (!runId) return;
@@ -232,6 +269,42 @@ export default function ReviewRunPage() {
       setIsCancelling(false);
     }
   }, [runId, fetchRun]);
+
+  // --- Failed-items table ----------------------------------------------------
+  //
+  // Both memos live ABOVE the early returns (hooks must) and are keyed on
+  // scalars a poll cannot churn, so the column and action arrays keep their
+  // identity across ticks. That, plus rendering the table unconditionally with
+  // `loading` as a prop, is what keeps a refresh from disturbing the user
+  // (docs/specs/datatable.md §18.4).
+
+  const subjectType = run?.subjectType;
+  const action = run?.action;
+
+  const failedItemColumns = useMemo(
+    () =>
+      buildRunItemColumns<ReviewRunItem>({
+        // "Subject", not "File": a burst/duplicate row is a GROUP, and may have
+        // no media row at all — `itemLabel` falls back to the subject id.
+        subjectLabel: 'Subject',
+        itemLabel,
+      }),
+    [],
+  );
+
+  const failedItemActions = useMemo<DataTableRowAction<ReviewRunItem>[]>(() => {
+    if (!subjectType || !action) return [];
+    const { subjectLink, backPath } = describeReviewRun(subjectType, action);
+    return [
+      {
+        id: 'view',
+        label: 'View',
+        icon: <VisibilityIcon fontSize="small" />,
+        onClick: (item) =>
+          navigate((item.subjectId ? subjectLink(item.subjectId) : null) ?? backPath),
+      },
+    ];
+  }, [navigate, subjectType, action]);
 
   // First-load spinner (only when we have no run yet).
   if (!run && isLoading) {
@@ -253,7 +326,7 @@ export default function ReviewRunPage() {
     );
   }
 
-  const presentation = describeReviewRun(run);
+  const presentation = describeReviewRun(run.subjectType, run.action);
   const thresholdLabel = `${isBelowThresholdAction(run) ? '<' : '≥'} ${run.threshold}%`;
 
   return (
@@ -308,76 +381,31 @@ export default function ReviewRunPage() {
               <Typography variant="subtitle2" sx={{ mb: 1.5 }}>
                 {presentation.failedTitle} ({formatCount(run.failedCount)})
               </Typography>
-              {itemsLoading && items.length === 0 ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                  <CircularProgress size={28} />
-                </Box>
-              ) : (
-                <>
-                  <TableContainer sx={{ overflowX: 'auto' }}>
-                    <Table size="small">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>Subject</TableCell>
-                          <TableCell>Error</TableCell>
-                          <TableCell align="right">Review</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {items.map((item) => {
-                          const subjectId = item.subjectId;
-                          const href = subjectId
-                            ? presentation.subjectLink(subjectId)
-                            : null;
-                          return (
-                            <TableRow key={item.id}>
-                              <TableCell sx={{ maxWidth: 220 }}>
-                                <Typography
-                                  variant="body2"
-                                  noWrap
-                                  title={item.media?.filename ?? subjectId ?? undefined}
-                                >
-                                  {itemLabel(item)}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary">
-                                  {formatCaptureDate(item.media?.capturedAt ?? null)}
-                                </Typography>
-                              </TableCell>
-                              <TableCell sx={{ maxWidth: 360 }}>
-                                <Typography variant="body2" color="error">
-                                  {item.error ?? 'Unknown error'}
-                                </Typography>
-                              </TableCell>
-                              <TableCell align="right">
-                                <Link
-                                  component="button"
-                                  type="button"
-                                  variant="body2"
-                                  onClick={() =>
-                                    navigate(href ?? presentation.backPath)
-                                  }
-                                >
-                                  View
-                                </Link>
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                  {itemsMeta && itemsMeta.totalPages > 1 && (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-                      <Pagination
-                        count={itemsMeta.totalPages}
-                        page={failedPage}
-                        onChange={(_, p) => setFailedPage(p)}
-                        size="small"
-                      />
-                    </Box>
-                  )}
-                </>
-              )}
+              {/*
+                Rendered UNCONDITIONALLY — `loading` is a prop, never a gate.
+                docs/specs/datatable.md §18.4.
+              */}
+              <DataTable<ReviewRunItem>
+                columns={failedItemColumns}
+                rows={items}
+                rowId={(item) => item.id}
+                tableId={REVIEW_RUN_ITEMS_TABLE_ID}
+                ariaLabel={presentation.failedTitle}
+                density="compact"
+                loading={itemsLoading}
+                emptyState={RUN_ITEMS_EMPTY_STATE}
+                pagination={{
+                  page: failedPage,
+                  pageSize: failedPageSize,
+                  total: itemsMeta?.totalItems ?? items.length,
+                  onPaginationChange: ({ page: nextPage, pageSize: nextSize }) => {
+                    setFailedPage(nextPage);
+                    setFailedPageSize(nextSize);
+                  },
+                }}
+                rowActions={failedItemActions}
+                csvExport={{ filename: 'review-run-failed-items' }}
+              />
             </CardContent>
           </Card>
         )}

--- a/apps/web/src/pages/Trash/TrashEmptyRunPage.tsx
+++ b/apps/web/src/pages/Trash/TrashEmptyRunPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -9,16 +9,11 @@ import {
   Card,
   CardContent,
   Snackbar,
-  Pagination,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Link,
 } from '@mui/material';
-import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import {
+  ArrowBack as ArrowBackIcon,
+  Visibility as VisibilityIcon,
+} from '@mui/icons-material';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useCircle } from '../../hooks/useCircle';
 import { useTrashEmptyRun } from '../../hooks/useTrashEmptyRun';
@@ -28,16 +23,26 @@ import { cancelTrashEmptyRun } from '../../services/trashEmptyRuns';
 import RunProgressPanel from '../../components/runs/RunProgressPanel';
 import type { RunTerminalSummary } from '../../components/runs/RunProgressPanel';
 import {
-  formatCaptureDate,
+  RUN_ITEMS_EMPTY_STATE,
+  RUN_ITEMS_PAGE_SIZE,
+  buildRunItemColumns,
+} from '../../components/runs/runItemsTable';
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
+import {
   formatCount,
   formatRelativeTime,
   isTerminalRunStatus,
   runStatusColor,
   runStatusLabel,
 } from '../../utils/runFormat';
-import type { TrashEmptyRunDetail } from '../../types/trashEmptyRuns';
+import type { TrashEmptyRunDetail, TrashEmptyRunItem } from '../../types/trashEmptyRuns';
 
-const ITEMS_PAGE_SIZE = 24;
+/**
+ * Persistence key for the failed-items table's column/density choices
+ * (`user_settings.dataTables['trash-empty-run-items']`,
+ * docs/specs/datatable.md §15).
+ */
+export const TRASH_EMPTY_RUN_ITEMS_TABLE_ID = 'trash-empty-run-items';
 
 // ---------------------------------------------------------------------------
 // Empty-trash run page.
@@ -46,6 +51,13 @@ const ITEMS_PAGE_SIZE = 24;
 // shared run pieces (issue #190) — `useRunPolling` + `RunProgressPanel` —
 // so this page only owns the empty-trash wording, its circle_admin cancel
 // gate, and the failed-item table.
+//
+// Issue #261 (epic #238) replaced that last hand-rolled `<TableContainer>` +
+// `<Pagination>` block with the shared DataTable
+// (`components/runs/runItemsTable.tsx`). Two rules matter on a page that polls:
+// the table is rendered UNCONDITIONALLY with `loading` as a prop, and the
+// effect/memos around it key on SCALARS rather than on the `run` object the
+// poll replaces each tick. See docs/specs/datatable.md §13.2 / §18.4.
 // ---------------------------------------------------------------------------
 
 /** Severity + message for a terminal run status. */
@@ -92,7 +104,9 @@ export default function TrashEmptyRunPage() {
     fetchItems,
   } = useTrashEmptyRunItems();
 
-  const [failedPage, setFailedPage] = useState(1);
+  // ZERO-based (the DataTable convention); converted at the fetch boundary.
+  const [failedPage, setFailedPage] = useState(0);
+  const [failedPageSize, setFailedPageSize] = useState(RUN_ITEMS_PAGE_SIZE);
   const [isCancelling, setIsCancelling] = useState(false);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -111,15 +125,48 @@ export default function TrashEmptyRunPage() {
   useRunPolling({ runId, status: run?.status, onPoll: fetchRun });
 
   // Load the failed-item table once the run is terminal and has failures.
+  //
+  // Keyed on the two SCALARS this depends on, never on `run` itself: the
+  // run-detail poll hands back a fresh object every tick, and depending on that
+  // identity would refetch the item page — and reset the table with it.
   const terminal = run ? isTerminalRunStatus(run.status) : false;
+  const failedCount = run?.failedCount ?? 0;
   useEffect(() => {
-    if (!runId || !run || !terminal || run.failedCount <= 0) return;
+    if (!runId || !terminal || failedCount <= 0) return;
     void fetchItems(runId, {
       status: 'failed',
-      page: failedPage,
-      pageSize: ITEMS_PAGE_SIZE,
+      page: failedPage + 1, // the API is 1-based, the table 0-based
+      pageSize: failedPageSize,
     });
-  }, [runId, run, terminal, failedPage, fetchItems]);
+  }, [runId, terminal, failedCount, failedPage, failedPageSize, fetchItems]);
+
+  // --- Failed-items table ----------------------------------------------------
+  //
+  // Keyed on nothing a poll can churn, so the column and action arrays keep
+  // their identity across ticks. That, plus rendering the table unconditionally
+  // with `loading` as a prop, is what keeps a refresh from disturbing the user
+  // (docs/specs/datatable.md §18.4).
+
+  const failedItemColumns = useMemo(
+    () =>
+      buildRunItemColumns<TrashEmptyRunItem>({
+        subjectLabel: 'File',
+        itemLabel: (item) => item.media?.filename ?? 'Untitled',
+      }),
+    [],
+  );
+
+  const failedItemActions = useMemo<DataTableRowAction<TrashEmptyRunItem>[]>(
+    () => [
+      {
+        id: 'view',
+        label: 'View',
+        icon: <VisibilityIcon fontSize="small" />,
+        onClick: (item) => navigate(`/media?item=${item.mediaItemId}`),
+      },
+    ],
+    [navigate],
+  );
 
   const handleCancel = useCallback(async () => {
     if (!runId) return;
@@ -209,68 +256,31 @@ export default function TrashEmptyRunPage() {
               <Typography variant="subtitle2" sx={{ mb: 1.5 }}>
                 Failed items ({formatCount(run.failedCount)})
               </Typography>
-              {itemsLoading && items.length === 0 ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                  <CircularProgress size={28} />
-                </Box>
-              ) : (
-                <>
-                  <TableContainer sx={{ overflowX: 'auto' }}>
-                    <Table size="small">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>File</TableCell>
-                          <TableCell>Error</TableCell>
-                          <TableCell align="right">Item</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {items.map((item) => (
-                          <TableRow key={item.id}>
-                            <TableCell sx={{ maxWidth: 220 }}>
-                              <Typography
-                                variant="body2"
-                                noWrap
-                                title={item.media?.filename ?? undefined}
-                              >
-                                {item.media?.filename ?? 'Untitled'}
-                              </Typography>
-                              <Typography variant="caption" color="text.secondary">
-                                {formatCaptureDate(item.media?.capturedAt ?? null)}
-                              </Typography>
-                            </TableCell>
-                            <TableCell sx={{ maxWidth: 360 }}>
-                              <Typography variant="body2" color="error">
-                                {item.error ?? 'Unknown error'}
-                              </Typography>
-                            </TableCell>
-                            <TableCell align="right">
-                              <Link
-                                component="button"
-                                type="button"
-                                variant="body2"
-                                onClick={() => navigate(`/media?item=${item.mediaItemId}`)}
-                              >
-                                View
-                              </Link>
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                  {itemsMeta && itemsMeta.totalPages > 1 && (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-                      <Pagination
-                        count={itemsMeta.totalPages}
-                        page={failedPage}
-                        onChange={(_, p) => setFailedPage(p)}
-                        size="small"
-                      />
-                    </Box>
-                  )}
-                </>
-              )}
+              {/*
+                Rendered UNCONDITIONALLY — `loading` is a prop, never a gate.
+                docs/specs/datatable.md §18.4.
+              */}
+              <DataTable<TrashEmptyRunItem>
+                columns={failedItemColumns}
+                rows={items}
+                rowId={(item) => item.id}
+                tableId={TRASH_EMPTY_RUN_ITEMS_TABLE_ID}
+                ariaLabel="Failed items"
+                density="compact"
+                loading={itemsLoading}
+                emptyState={RUN_ITEMS_EMPTY_STATE}
+                pagination={{
+                  page: failedPage,
+                  pageSize: failedPageSize,
+                  total: itemsMeta?.totalItems ?? items.length,
+                  onPaginationChange: ({ page: nextPage, pageSize: nextSize }) => {
+                    setFailedPage(nextPage);
+                    setFailedPageSize(nextSize);
+                  },
+                }}
+                rowActions={failedItemActions}
+                csvExport={{ filename: 'empty-trash-failed-items' }}
+              />
             </CardContent>
           </Card>
         )}

--- a/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
+++ b/apps/web/src/pages/Workflows/WorkflowRunPage.tsx
@@ -1,3 +1,18 @@
+/**
+ * Workflow run detail — approval preview, live progress, and failed items.
+ *
+ * Issue #261 (epic #238) replaced the hand-rolled failed-items
+ * `<TableContainer>` + `<Pagination>` block with the shared DataTable
+ * (`components/runs/runItemsTable.tsx`). Two rules matter on a page that polls
+ * its run every 2s: the table is rendered UNCONDITIONALLY with `loading` as a
+ * prop, and the effect/memos around it key on SCALARS rather than on the `run`
+ * object the poll replaces each tick. See docs/specs/datatable.md §13.2 / §18.4.
+ *
+ * The `awaiting_approval` exclusion GRID is deliberately untouched: it is a
+ * thumbnail picker with per-tile checkboxes, not a data table, and it already
+ * reflows through MUI's own `Grid` breakpoints.
+ */
+
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   Box,
@@ -18,18 +33,12 @@ import {
   List,
   ListItem,
   ListItemText,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Link,
   Tooltip,
 } from '@mui/material';
 import {
   BrokenImage as BrokenImageIcon,
   ArrowBack as ArrowBackIcon,
+  Visibility as VisibilityIcon,
 } from '@mui/icons-material';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useCircle } from '../../hooks/useCircle';
@@ -40,6 +49,12 @@ import { useWorkflowMutations } from '../../hooks/useWorkflowMutations';
 import { useRunPolling } from '../../hooks/useRunPolling';
 import RunProgressPanel from '../../components/runs/RunProgressPanel';
 import type { RunTerminalSummary } from '../../components/runs/RunProgressPanel';
+import {
+  RUN_ITEMS_EMPTY_STATE,
+  RUN_ITEMS_PAGE_SIZE,
+  buildRunItemColumns,
+} from '../../components/runs/runItemsTable';
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
 import {
   runStatusColor,
   runStatusLabel,
@@ -55,6 +70,13 @@ import type { WorkflowRunDetail, WorkflowRunItem } from '../../types/workflows';
 
 const ITEMS_PAGE_SIZE = 24;
 const MAX_EXCLUSIONS = 500;
+
+/**
+ * Persistence key for the failed-items table's column/density choices
+ * (`user_settings.dataTables['workflow-run-items']`, docs/specs/datatable.md
+ * §15). Chosen here and never derived from the route.
+ */
+export const WORKFLOW_RUN_ITEMS_TABLE_ID = 'workflow-run-items';
 
 // ---------------------------------------------------------------------------
 // Run item tile — thumbnail + filename + capture date, optional exclude checkbox
@@ -184,7 +206,10 @@ export default function WorkflowRunPage() {
   const [excluded, setExcluded] = useState<Set<string>>(new Set());
   const [confirmText, setConfirmText] = useState('');
   const [itemsPage, setItemsPage] = useState(1);
-  const [failedPage, setFailedPage] = useState(1);
+  // The failed-items DataTable is server-paginated: `failedPage` is ZERO-based
+  // (the component's convention) and converted at the fetch boundary.
+  const [failedPage, setFailedPage] = useState(0);
+  const [failedPageSize, setFailedPageSize] = useState(RUN_ITEMS_PAGE_SIZE);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
@@ -215,15 +240,21 @@ export default function WorkflowRunPage() {
   }, [runId, run?.status, itemsPage, fetchItems]);
 
   // Load the failed-item table once the run is terminal and has failures.
+  //
+  // Keyed on the two SCALARS this depends on, never on `run` itself: the
+  // run-detail poll hands back a fresh object every tick, and depending on that
+  // identity would refetch the item page — and with it reset the table — twice
+  // a second.
   const isTerminal = run ? isTerminalRunStatus(run.status) : false;
+  const failedCount = run?.failedCount ?? 0;
   useEffect(() => {
-    if (!runId || !run || !isTerminal || run.failedCount <= 0) return;
+    if (!runId || !isTerminal || failedCount <= 0) return;
     void fetchItems(runId, {
       status: 'failed',
-      page: failedPage,
-      pageSize: ITEMS_PAGE_SIZE,
+      page: failedPage + 1, // the API is 1-based, the table 0-based
+      pageSize: failedPageSize,
     });
-  }, [runId, run, isTerminal, failedPage, fetchItems]);
+  }, [runId, isTerminal, failedCount, failedPage, failedPageSize, fetchItems]);
 
   const effectiveMatched = useMemo(
     () => (run ? Math.max(0, run.matchedCount - excluded.size) : 0),
@@ -284,6 +315,34 @@ export default function WorkflowRunPage() {
       setErrorMsg(err instanceof Error ? err.message : 'Failed to cancel run');
     }
   }, [runId, cancelRun, fetchRun]);
+
+  // --- Failed-items table ----------------------------------------------------
+  //
+  // Both memos are keyed on nothing that a poll can change, so the column array
+  // and the action array keep their identity across ticks — the second half of
+  // the "a refresh must not disturb the user" contract (§18.4). The first half
+  // is that the table below is rendered UNCONDITIONALLY.
+
+  const failedItemColumns = useMemo(
+    () =>
+      buildRunItemColumns<WorkflowRunItem>({
+        subjectLabel: 'File',
+        itemLabel: (item) => item.media?.filename ?? 'Untitled',
+      }),
+    [],
+  );
+
+  const failedItemActions = useMemo<DataTableRowAction<WorkflowRunItem>[]>(
+    () => [
+      {
+        id: 'view',
+        label: 'View',
+        icon: <VisibilityIcon fontSize="small" />,
+        onClick: (item) => navigate(`/media?item=${item.mediaItemId}`),
+      },
+    ],
+    [navigate],
+  );
 
   // First-load spinner (only when we have no run yet).
   if (!run && isLoading) {
@@ -390,64 +449,34 @@ export default function WorkflowRunPage() {
                     </Tooltip>
                   )}
                 </Box>
-                {itemsLoading && items.length === 0 ? (
-                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                    <CircularProgress size={28} />
-                  </Box>
-                ) : (
-                  <>
-                    <TableContainer sx={{ overflowX: 'auto' }}>
-                      <Table size="small">
-                        <TableHead>
-                          <TableRow>
-                            <TableCell>File</TableCell>
-                            <TableCell>Error</TableCell>
-                            <TableCell align="right">Item</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {items.map((item) => (
-                            <TableRow key={item.id}>
-                              <TableCell sx={{ maxWidth: 220 }}>
-                                <Typography variant="body2" noWrap title={item.media?.filename ?? undefined}>
-                                  {item.media?.filename ?? 'Untitled'}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary">
-                                  {formatCaptureDate(item.media?.capturedAt ?? null)}
-                                </Typography>
-                              </TableCell>
-                              <TableCell sx={{ maxWidth: 360 }}>
-                                <Typography variant="body2" color="error">
-                                  {item.error ?? 'Unknown error'}
-                                </Typography>
-                              </TableCell>
-                              <TableCell align="right">
-                                <Link
-                                  component="button"
-                                  type="button"
-                                  variant="body2"
-                                  onClick={() => navigate(`/media?item=${item.mediaItemId}`)}
-                                >
-                                  View
-                                </Link>
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                    {itemsMeta && itemsMeta.totalPages > 1 && (
-                      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-                        <Pagination
-                          count={itemsMeta.totalPages}
-                          page={failedPage}
-                          onChange={(_, p) => setFailedPage(p)}
-                          size="small"
-                        />
-                      </Box>
-                    )}
-                  </>
-                )}
+                {/*
+                  Rendered UNCONDITIONALLY — `loading` is a prop, never a gate.
+                  Swapping the table for a spinner (as this page did before
+                  #261) unmounts the renderer on every refetch and takes card /
+                  row expansion state and the page's scroll offset with it.
+                  docs/specs/datatable.md §18.4.
+                */}
+                <DataTable<WorkflowRunItem>
+                  columns={failedItemColumns}
+                  rows={items}
+                  rowId={(item) => item.id}
+                  tableId={WORKFLOW_RUN_ITEMS_TABLE_ID}
+                  ariaLabel="Failed workflow run items"
+                  density="compact"
+                  loading={itemsLoading}
+                  emptyState={RUN_ITEMS_EMPTY_STATE}
+                  pagination={{
+                    page: failedPage,
+                    pageSize: failedPageSize,
+                    total: itemsMeta?.totalItems ?? items.length,
+                    onPaginationChange: ({ page: nextPage, pageSize: nextSize }) => {
+                      setFailedPage(nextPage);
+                      setFailedPageSize(nextSize);
+                    },
+                  }}
+                  rowActions={failedItemActions}
+                  csvExport={{ filename: 'workflow-run-failed-items' }}
+                />
               </CardContent>
             </Card>
           )}

--- a/docs/specs/datatable.md
+++ b/docs/specs/datatable.md
@@ -8,8 +8,12 @@ keyboard model and the shared conformance suite shipped (issue #257, §17);
 pilot migration — Job Queue — shipped, adding `filterOnly` to the contract
 (issue #258, §18); identity-and-access tables (Users, Allowlist, Personal Access
 Tokens, Circle members/invites) migrated, establishing the `exportable: false`
-secret-material rule and the gate-the-action-array rule (issue #260, §13.1) —
-all of epic #238
+secret-material rule and the gate-the-action-array rule (issue #260, §13.1);
+workflow oversight, the workflow-runs drawer and the three run-item tables
+migrated — the FINAL migration, proving the container-driven layout switch
+against the drawer case and the no-remount-under-poll rule against three polling
+pages (issue #261, §13.2) — all of epic #238. **No raw page-level table
+implementation remains** (§13).
 **Location:** `apps/web/src/components/datatable/`,
 `apps/api/src/common/schemas/settings.schema.ts` (persistence schema)
 **Spec owner:** frontend
@@ -1281,8 +1285,30 @@ three rules every later migration should follow (§18.2–§18.4).
 | Storage providers / migration runs | `admin-storage-providers` / `admin-storage-migrations` | `pages/Admin/storageProvidersTable.tsx` | #259 |
 | Backup runs | `admin-backup-runs` | `pages/Admin/backupTable.tsx` | #259 |
 | Tag vocabulary | `admin-tag-labels` | `pages/Admin/tagsTable.tsx` | #259 |
+| Workflow oversight (cross-circle) | `admin-workflows` | `components/workflows/admin/workflowsOversightColumns.tsx` | #261 |
+| Workflow runs drawer | `admin-workflow-runs` | `components/workflows/admin/workflowRunsColumns.tsx` | #261 |
+| Workflow run items (failed) | `workflow-run-items` | `components/runs/runItemsTable.tsx` | #261 |
+| Review run items (failed) | `review-run-items` | `components/runs/runItemsTable.tsx` | #261 |
+| Empty-trash run items (failed) | `trash-empty-run-items` | `components/runs/runItemsTable.tsx` | #261 |
 
-Still to come: the remaining media surfaces.
+**Nothing is still to come — the migration is complete.** #261 was the last one,
+and it closes the epic's "no raw page-level `TableContainer` remains" criterion.
+A grep for `TableContainer` across `apps/web/src` now returns exactly one
+component, and it is deliberately out of scope:
+
+| File | Why it is not a DataTable |
+| ---- | ------------------------- |
+| `components/review/MemberComparison.tsx` | A member-comparison **matrix**, not a data table. Its columns are the group's *members* (so the column count grows with the data, which is the one dimension a phone does not have) and its rows are *attributes* — the transpose of the row-per-record model this contract is built on. It already carries its own responsive story: an attribute matrix at `md` and up, one card per member below, both derived from a single model. Ruled out of scope by epic #234's issue #239 and left that way. |
+
+Every other match is prose — this spec, and the module docblocks of the pages
+that describe what they replaced.
+
+**This component is now the required pattern for any new table in this app.**
+A new list surface declares `DataTableColumn[]` and renders `DataTable`; it does
+not hand-roll a `Table` / `TablePagination` / `Menu` block. That is the epic's
+durable outcome: the class of defect it was filed for — a desktop-shaped grid
+made "responsive" by letting the document scroll sideways — cannot recur one
+page at a time, because there is no longer a per-page place for it to live.
 
 ### 13.1 Decisions from the admin-operations batch (#259)
 
@@ -1365,6 +1391,79 @@ the gate holds in the grid, in the tablet row expander and on a phone card at
 once. An action a caller may not perform is then absent from the DOM entirely
 rather than merely off-screen. Each migrated surface's tests assert this in
 *both* renderers.
+
+### 13.2 The final migration — run tables and the drawer (#261)
+
+Five surfaces, and the two things the issue was emphatic about are the two the
+component had shipped but never had proved against a real page.
+
+**The Workflow runs drawer IS the container-query acceptance case.** §7.2 has
+described the scenario since #253 — "a DataTable inside the Workflow runs drawer
+is 400px wide on a 1440px desktop" — using this exact table as its example.
+#261 is where that stopped being an illustration: the drawer's paper is 620px
+with `p: 3`, so its content is ~572px, and the correct rendering on a full
+desktop is the **card** layout. A `useMediaQuery` switch would hand it the
+desktop grid and reintroduce horizontal scrolling *on a desktop*, which is the
+defect the whole epic exists to remove.
+
+`WorkflowRunsDrawer.test.tsx` proves it the only way that means anything: the
+shared `installLayoutStubs()` pins `window.matchMedia` to a **fixed 1440px
+viewport**, so every viewport query in the tree answers "desktop" and a `mobile`
+result can only have come from the container measurement. The suite asserts the
+full chain at the drawer's real content width — `data-layout="mobile"`,
+`data-renderer="mobile"`, a `role="list"` card list, **no** `role="grid"` — plus
+the mirror image at 1400px, where the same component with the same props draws
+the grid. Nothing in the component pins a layout, and deliberately no
+`mobileBreakpoint` override is passed: hard-coding one here would be the
+viewport assumption wearing a different hat.
+
+**Every one of these tables is downstream of a poll, so §18.4 is the whole
+migration.** The three run pages poll their detail endpoint every 2s
+(`useRunPolling`), and all three did exactly what the pilot's old page did —
+`{itemsLoading && items.length === 0 ? <spinner/> : <TableContainer>…}`. Under a
+poll that remounts the renderer and takes card/row expansion and the page's
+scroll offset with it. All five tables now render **unconditionally** with
+`loading` as a prop.
+
+Two page-level rules complete it here, and both are new consequences of a poll
+that hands back whole objects rather than rows:
+
+- **Refetch effects key on SCALARS, never on `run`.** Every run page's
+  failed-items effect used to depend on the `run` object. The poll replaces that
+  object every tick even when nothing changed, so the effect refired twice a
+  second and refetched the item page — resetting the table underneath the user
+  regardless of how the table was mounted. They now depend on
+  `run?.status`-derived `terminal` and `run?.failedCount`.
+- **`describeReviewRun` takes the two discriminators, not the run.** Making it
+  `(subjectType, action)` is what lets `ReviewRunPage`'s row-action `useMemo`
+  depend on scalars, so the action array — and therefore every control's
+  identity — survives a tick. Same shape as the pilot's "memoize `columns` on
+  the job-type SET, not on `stats`".
+
+Each run page asserts this directly: expand a card, re-render with a brand-new
+run object and brand-new item objects carrying the same ids, and the table's own
+DOM node is `toBe` the same node, the expanded detail region is still open, and
+both rows are still on screen. A second test asserts rows stay rendered while
+`loading` is `true` — the overlay draws *over* live rows.
+
+Three smaller decisions worth keeping:
+
+- **A thumbnail belongs inside the leading column's `render`, not in a column of
+  its own.** The run-item tables carry signed thumbnails, and the card headline
+  is built from `primary` columns — but a thumbnail-only column has no `value`,
+  which would make it useless as the row's accessible name (§17.6) and empty in
+  a CSV. `components/runs/runItemsTable.tsx` renders an avatar + label together
+  in one `primary` column whose `value` is the label. The thumbnail lands in the
+  headline; the scalar stays real.
+- **One column module for three pages.** `BaseRunItem` (`types/runs.ts`) is
+  already the exact intersection the three run-items endpoints guarantee, so the
+  workflow, review and empty-trash tables share one `buildRunItemColumns` with
+  two parameters — what a row is *called*, and where "View" goes. Three
+  `tableId`s, one declaration. `status` is `primary` on all of them, per the
+  issue: it is the signal these surfaces exist to convey.
+- **`RunProgressPanel`'s layout is untouched.** All three tables live inside the
+  panel's `children` slot, still wrapped in the same outlined `Card` +
+  `CardContent`; only the contents of that card changed.
 
 ---
 


### PR DESCRIPTION
## Summary

The final migration of epic #238. Five tables that share a characteristic none of the earlier groups had: **they render inside constrained containers and they update while you are looking at them.**

This closes the epic's headline criterion — no raw page-level `TableContainer` remains.

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues

Relates to #238
Fixes #261

## Changes Made

| Surface | `tableId` |
|---|---|
| Workflow oversight | `admin-workflows` |
| Workflow runs drawer | `admin-workflow-runs` |
| Workflow run items | `workflow-run-items` |
| Review run items | `review-run-items` |
| Trash-empty run items | `trash-empty-run-items` |

All three run-item tables share one column builder (`components/runs/runItemsTable.tsx`). `BaseRunItem` is already the exact intersection the three endpoints guarantee, so only two things are parameters: what a row is *called*, and where "View" goes.

### 1. Container-driven breakpoints — the proof case

The drawer is why #253 measures the container rather than the viewport. The test pins `window.matchMedia` to a **fixed 1440 px viewport**, so a `mobile` result provably cannot have come from an accidental viewport match, then asserts the whole chain at the drawer's real content width:

```js
expect(window.matchMedia('(min-width:1200px)').matches).toBe(true);
expect(table).toHaveAttribute('data-layout', 'mobile');
expect(screen.queryByRole('grid')).not.toBeInTheDocument();
```

Plus the mirror image at 1400 px, where the same component with the same props draws the grid — so the assertion is about the measurement, not a hard-coded layout.

### 2. The poll fix needed a second half nobody had written down

The pilot (#258) found that rendering the table only after a fetch settles makes every poll tick remount the renderer. That fix was necessary here but **not sufficient**: all three run pages' refetch effects depended on the whole `run` object, which the 2 s poll replaces every tick — so the list reset twice a second regardless of how it was mounted. They now key on `terminal` + `failedCount` scalars. (Same reason `describeReviewRun` now takes `(subjectType, action)` instead of the run — it's what lets the row-action `useMemo` depend on scalars.) Recorded in the spec as §13.2.

### Decisions worth a reviewer's attention

- **Permission gating moved from a disabled button onto the action array**, per the invariant #260 established for "every later migration". `canManage` / `canCancel` now decide whether Disable / Cancel *exist*; per-row state (already-disabled, terminal run, mid-cancel) stays a `disabled` predicate per #259's rule. **Who can do what is unchanged** — only where the gate lives. Tests assert the absence in both renderers.
- **The thumbnail lives inside the leading column's `render`, not its own column.** A thumbnail-only column has no `value`, which would make it useless as the row's accessible name and empty in a CSV. An avatar + label in one `primary` column keeps the thumbnail in the card headline while keeping the scalar real.
- **Test framing for "polling preserves state":** the failed-item tables only mount once a run is terminal, at which point polling has stopped — so the test drives the exact artifact a tick produces (fresh `run` + fresh item objects with identical ids) via `rerender`, then asserts the table's own DOM node is `toBe` the same node and the expanded card is still open. Stronger than a timer-driven assertion.

## Testing

- [x] Unit tests pass (`npm test`) — full web suite **198 files / 4139 tests passed**; the 5 migrated surfaces re-verified against the freshly-merged `main` post-rebase (14 files / 205 tests)
- [x] Type checks pass (`npm run typecheck`) — zero errors
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

## Epic closeout — `TableContainer` audit

```
apps/web/src/components/review/MemberComparison.tsx:9,117,158   ← the only real usage
```

Everything else that matches is docblock prose or a comment. `MemberComparison.tsx` is a **transposed** matrix — columns are group members (so column count grows with the data), rows are attributes. It is not a row-per-record table, it already ships its own responsive story (matrix at `md`+, card-per-member below) from one derived model, and it is ruled out by epic #234's #239. I read the file rather than taking that on trust before writing the "no raw page-level table remains" claim into the spec.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

With this merged, all ten children of epic #238 are complete: the component is built, accessible, covered by a shared conformance suite, and all 16 table surfaces are migrated onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAMQC9PZrEBNrQe4Azi4iE)_