### PR TITLE
fix(api): accept a genuinely bodyless POST on all-optional Zod body DTOs

### DIFF
--- a/apps/api/src/ai/dto/ai-credentials.dto.ts
+++ b/apps/api/src/ai/dto/ai-credentials.dto.ts
@@ -38,8 +38,10 @@ export const setEnhanceFeatureSchema = z.object({
 });
 export class SetEnhanceFeatureDto extends createZodDto(setEnhanceFeatureSchema) {}
 
+// Both fields optional — an empty body tests the configured ai.features.embedding.
+// .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
 export const testEmbeddingSchema = z.object({
   provider: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
-});
+}).default({});
 export class TestEmbeddingDto extends createZodDto(testEmbeddingSchema) {}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -111,6 +111,33 @@ import configuration from './config/configuration';
   ],
   providers: [
     // Global validation pipe (Zod)
+    //
+    // NOTE (issue #289) — the bodyless-POST rule for body DTOs:
+    // Fastify leaves `request.body` as `undefined` when a request carries no
+    // body at all (e.g. `fetch(url, { method: 'POST' })`, no Content-Type, no
+    // payload). Nest's `@Body()` hands that `undefined` straight to this pipe,
+    // and `z.object({...}).parse(undefined)` throws `invalid_type` no matter
+    // how optional every one of its fields is — so an endpoint documenting an
+    // empty body as "use the defaults" would still 400.
+    //
+    // The fix is per-DTO: any body schema whose fields are ALL optional carries
+    // a top-level `.default({})`, which maps that `undefined` to `{}` before
+    // the object schema ever sees it. It must come LAST in the chain (after any
+    // `.strict()` / `.refine()`), and it also surfaces as `default: {}` in the
+    // generated OpenAPI schema.
+    //
+    // Caveat 1: `.default({})` does not re-parse the default — it short-circuits
+    // and returns that `{}` as-is. When a field carries its own inner default
+    // (e.g. `force: z.boolean().optional().default(false)`), that inner default
+    // would therefore NOT be applied to a bodyless request, and `{}` would not
+    // even satisfy the schema's own output type. Those schemas use `.prefault({})`
+    // instead, which feeds `{}` through the parse so a bodyless request is exactly
+    // equivalent to `{}`; see metadata/admin-metadata.controller.ts.
+    //
+    // Caveat 2: `.default({})` BYPASSES a top-level `.refine()` for the default
+    // value — the refine never runs for a bodyless request. So it must not be
+    // added to a schema whose refine is what makes an empty body invalid; see
+    // jobs/backup/dto/trigger-backup.dto.ts for the one deliberate exclusion.
     {
       provide: APP_PIPE,
       useClass: ZodValidationPipe,

--- a/apps/api/src/burst/admin-burst.controller.ts
+++ b/apps/api/src/burst/admin-burst.controller.ts
@@ -20,7 +20,9 @@ const adminBurstBackfillSchema = z.object({
   from: z.string().datetime({ offset: true }).optional(),
   to: z.string().datetime({ offset: true }).optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
+  // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
+}).prefault({});
 class AdminBurstBackfillDto extends createZodDto(adminBurstBackfillSchema) {}
 
 @ApiTags('Admin — Bursts')

--- a/apps/api/src/circles/dto/update-circle.dto.ts
+++ b/apps/api/src/circles/dto/update-circle.dto.ts
@@ -4,5 +4,6 @@ import { z } from 'zod';
 export const updateCircleSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(500).nullish(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 export class UpdateCircleDto extends createZodDto(updateCircleSchema) {}

--- a/apps/api/src/common/regression/issue-289-bodyless-post.spec.ts
+++ b/apps/api/src/common/regression/issue-289-bodyless-post.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * End-to-end (pipe-level) regression test for GitHub issue #289.
+ *
+ * WHICH FORM THIS IS, AND WHY: the task asked for the "highest-value form" —
+ * driving the request through Fastify + supertest so `request.body` is
+ * genuinely `undefined`, exactly as a real `fetch(url, { method: 'POST' })`
+ * produces it — rather than only calling the pipe directly with a hand-built
+ * `undefined` + metatype. This file does the real-HTTP-round-trip form: it
+ * mounts the REAL production controllers (`EnrichmentAdminController`,
+ * `AdminMetadataController`) on a REAL `NestFastifyApplication`, with the
+ * REAL global `ZodValidationPipe` wired in via `APP_PIPE` (nestjs-zod) and
+ * the REAL `RolesGuard`/`PermissionsGuard` — only `JwtAuthGuard` is stubbed,
+ * stamping a fake authenticated Admin user, mirroring
+ * `notifications.controller.spec.ts` / `media-enhancement.controller.spec.ts`.
+ * The underlying services (`EnrichmentAdminService`, `MetadataBackfillService`)
+ * are mocked — no database required. This was practical here because both
+ * controllers' dependency graphs are cheap to construct fully-mocked (see the
+ * companion schema-level spec's header comment for why other candidate
+ * controllers were avoided as being import-heavy in this environment).
+ *
+ * Calling `POST /some/route` via supertest with NO `.send(...)` call at all —
+ * not even `.send({})` — never sets a request body or a Content-Type header,
+ * which is exactly the shape Fastify leaves `request.body` as `undefined` for.
+ * That is the precise mechanism issue #289 describes.
+ *
+ * This file additionally proves the `.prefault({})` half of the fix
+ * end-to-end: `AdminMetadataController`'s body DTO (`AdminMetadataBackfillDto`
+ * / `adminMetadataBackfillSchema`) is declared WITHOUT `export` in
+ * `apps/api/src/metadata/admin-metadata.controller.ts`, so it cannot be
+ * imported by name from a test file — but routing an actual bodyless HTTP
+ * request through the actual mounted route exercises that exact schema via
+ * Nest's own DTO-metatype resolution, without ever needing to name it. This
+ * is what lets this file assert the inner `force: z.boolean().default(false)`
+ * default actually reaches the service call, which is the one part of the
+ * fix `.default({})` alone cannot provide (see `app.module.ts` Caveat 1 and
+ * the "Contrast" describe block below).
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { APP_PIPE } from '@nestjs/core';
+import { Body, Controller, ExecutionContext, Post } from '@nestjs/common';
+import { ZodValidationPipe, createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import request from 'supertest';
+
+import { EnrichmentAdminController } from '../../enrichment/enrichment-admin.controller';
+import { EnrichmentAdminService } from '../../enrichment/enrichment-admin.service';
+import { AdminMetadataController } from '../../metadata/admin-metadata.controller';
+import { MetadataBackfillService } from '../../metadata/metadata-backfill.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+import { PERMISSIONS, ROLES } from '../constants/roles.constants';
+
+/** Builds a minimal AuthenticatedUser-shaped fixture with the given roles/permissions. */
+function fakeAuthenticatedUser(
+  roleNames: string[],
+  permissionNames: string[],
+): Partial<AuthenticatedUser> {
+  return {
+    id: 'admin-1',
+    email: 'admin-1@example.com',
+    isActive: true,
+    userRoles: roleNames.map((name) => ({
+      role: {
+        id: `role-${name}`,
+        name,
+        description: `${name} role`,
+        rolePermissions: permissionNames.map((p) => ({
+          permission: { id: `perm-${p}`, name: p, description: p },
+        })),
+      } as any,
+    })),
+  };
+}
+
+/** JwtAuthGuard stub: always "authenticates", stamping the given user onto the request. */
+function stubJwtAuthGuard(user: Partial<AuthenticatedUser>) {
+  return {
+    canActivate: (ctx: ExecutionContext) => {
+      const req = ctx.switchToHttp().getRequest();
+      req.user = user;
+      return true;
+    },
+  };
+}
+
+const ADMIN = fakeAuthenticatedUser(
+  [ROLES.ADMIN],
+  [PERMISSIONS.JOBS_READ, PERMISSIONS.JOBS_WRITE, PERMISSIONS.SYSTEM_SETTINGS_WRITE],
+);
+
+// ---------------------------------------------------------------------------
+// Contrast fixture: an UNFIXED body schema (no top-level .default({})),
+// mounted through the SAME real pipe, to prove this harness genuinely
+// reproduces the pre-#289 bug rather than the pipe being lenient by
+// construction. See the "Contrast" describe block below.
+// ---------------------------------------------------------------------------
+const unfixedAllOptionalSchema = z.object({
+  note: z.string().optional(),
+});
+class UnfixedAllOptionalDto extends createZodDto(unfixedAllOptionalSchema) {}
+
+@Controller('__test-only/unfixed')
+class UnfixedController {
+  @Post()
+  async handle(@Body() dto: UnfixedAllOptionalDto) {
+    return { received: dto };
+  }
+}
+
+function makeMockEnrichmentAdminService() {
+  return {
+    getStats: jest.fn(),
+    listJobs: jest.fn(),
+    retryJob: jest.fn(),
+    retryAllFailed: jest.fn().mockResolvedValue({ retried: 5 }),
+    resetStuck: jest.fn().mockResolvedValue({ reset: 2, failed: 0 }),
+    deleteJob: jest.fn(),
+  };
+}
+
+function makeMockMetadataBackfillService() {
+  return {
+    backfillAllCircles: jest.fn().mockResolvedValue({ enqueued: 42 }),
+  };
+}
+
+describe('issue #289 — bodyless POST reaches the handler via the REAL ZodValidationPipe + Fastify', () => {
+  let app: NestFastifyApplication;
+  let mockEnrichmentAdminService: ReturnType<typeof makeMockEnrichmentAdminService>;
+  let mockMetadataBackfillService: ReturnType<typeof makeMockMetadataBackfillService>;
+
+  async function buildApp(): Promise<NestFastifyApplication> {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [EnrichmentAdminController, AdminMetadataController, UnfixedController],
+      providers: [
+        { provide: EnrichmentAdminService, useValue: mockEnrichmentAdminService },
+        { provide: MetadataBackfillService, useValue: mockMetadataBackfillService },
+        { provide: APP_PIPE, useClass: ZodValidationPipe },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(stubJwtAuthGuard(ADMIN))
+      .compile();
+    // NOTE: RolesGuard/PermissionsGuard are NOT overridden — they run for
+    // real, resolving the real @Auth() metadata via the real Reflector. The
+    // fake ADMIN user above carries every permission these three controllers'
+    // routes require, so 403 is never the reason a request fails here.
+
+    const nestApp = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    await nestApp.init();
+    await nestApp.getHttpAdapter().getInstance().ready();
+    return nestApp;
+  }
+
+  beforeEach(async () => {
+    mockEnrichmentAdminService = makeMockEnrichmentAdminService();
+    mockMetadataBackfillService = makeMockMetadataBackfillService();
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    if (app) await app.close();
+    jest.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // POST /admin/jobs/reset-stuck — ResetStuckDto, the DTO named in the issue.
+  // ===========================================================================
+  describe('POST /admin/jobs/reset-stuck (ResetStuckDto)', () => {
+    it('201s for a genuinely bodyless request (no .send() at all) and calls the service with undefined', async () => {
+      // No .send(...) call whatsoever: supertest issues the request with no
+      // body and no Content-Type header, so Fastify leaves request.body
+      // undefined — the exact shape of `fetch(url, { method: 'POST' })`.
+      const res = await request(app.getHttpServer()).post('/admin/jobs/reset-stuck').expect(201);
+
+      expect(mockEnrichmentAdminService.resetStuck).toHaveBeenCalledWith(undefined);
+      expect(res.body).toEqual({ reset: 2, failed: 0 });
+    });
+
+    it('still 400s for a malformed body — the fix did not loosen validation', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/jobs/reset-stuck')
+        .send({ olderThanMinutes: -1 })
+        .expect(400);
+
+      expect(mockEnrichmentAdminService.resetStuck).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // POST /admin/jobs/retry-failed — RetryAllFailedDto.
+  // ===========================================================================
+  describe('POST /admin/jobs/retry-failed (RetryAllFailedDto)', () => {
+    it('201s for a genuinely bodyless request and calls the service with undefined', async () => {
+      const res = await request(app.getHttpServer()).post('/admin/jobs/retry-failed').expect(201);
+
+      expect(mockEnrichmentAdminService.retryAllFailed).toHaveBeenCalledWith(undefined);
+      expect(res.body).toEqual({ retried: 5 });
+    });
+  });
+
+  // ===========================================================================
+  // POST /admin/metadata/backfill — AdminMetadataBackfillDto, the .prefault({})
+  // case. Its schema/class are both unexported production code, so this is
+  // the ONLY way to assert its contract without modifying production code:
+  // route a real bodyless request through the real mounted route.
+  // ===========================================================================
+  describe('POST /admin/metadata/backfill (AdminMetadataBackfillDto — unexported, .prefault({}) case)', () => {
+    it('201s for a genuinely bodyless request and the inner `force` default reaches the service', async () => {
+      const res = await request(app.getHttpServer()).post('/admin/metadata/backfill').expect(201);
+
+      // This is the assertion .default({}) alone could not satisfy: a bare
+      // .default({}) would short-circuit and return a literal {} WITHOUT
+      // running force's own `.optional().default(false)` — force would come
+      // out `undefined`, not `false`. .prefault({}) feeds {} THROUGH the
+      // schema, so force really is `false` here, exactly like an explicit {}
+      // body would produce.
+      expect(mockMetadataBackfillService.backfillAllCircles).toHaveBeenCalledWith({
+        from: undefined,
+        to: undefined,
+        force: false,
+      });
+      expect(res.body).toEqual({ data: { enqueued: 42 } });
+    });
+
+    it('an explicit {} body produces the identical service call (proves bodyless === {})', async () => {
+      await request(app.getHttpServer()).post('/admin/metadata/backfill').send({}).expect(201);
+
+      expect(mockMetadataBackfillService.backfillAllCircles).toHaveBeenCalledWith({
+        from: undefined,
+        to: undefined,
+        force: false,
+      });
+    });
+
+    it('an explicit force:true still overrides the default correctly', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/metadata/backfill')
+        .send({ force: true })
+        .expect(201);
+
+      expect(mockMetadataBackfillService.backfillAllCircles).toHaveBeenCalledWith({
+        from: undefined,
+        to: undefined,
+        force: true,
+      });
+    });
+
+    it('still 400s for a malformed body — the fix did not loosen validation', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/metadata/backfill')
+        .send({ from: 'not-a-date' })
+        .expect(400);
+
+      expect(mockMetadataBackfillService.backfillAllCircles).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // Contrast: an all-optional body schema WITHOUT the #289 fix still 400s on
+  // a genuinely bodyless request through this exact same harness. This proves
+  // the 201s above are because of the fix, not because this test setup's pipe
+  // is somehow more lenient than production's.
+  // ===========================================================================
+  describe('Contrast — an unfixed all-optional schema (no .default({})) still reproduces the #289 bug', () => {
+    it('400s for a genuinely bodyless request against a schema with NO top-level default', async () => {
+      const res = await request(app.getHttpServer()).post('/__test-only/unfixed').expect(400);
+
+      expect(res.body).toMatchObject({ statusCode: 400 });
+    });
+
+    it('the same schema accepts an explicit {} body just fine (confirms the bug is specifically about undefined)', async () => {
+      await request(app.getHttpServer()).post('/__test-only/unfixed').send({}).expect(201);
+    });
+  });
+});

--- a/apps/api/src/common/regression/issue-289-empty-body-defaults.spec.ts
+++ b/apps/api/src/common/regression/issue-289-empty-body-defaults.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * Schema-level regression tests for GitHub issue #289.
+ *
+ * THE BUG: Fastify leaves `request.body` as `undefined` for a request that
+ * carries no body at all (e.g. `fetch(url, { method: 'POST' })` — no
+ * Content-Type, no payload). Nest's `@Body()` hands that `undefined` straight
+ * to the global `ZodValidationPipe`, and `z.object({...}).parse(undefined)`
+ * throws a Zod `invalid_type` error regardless of how optional every one of
+ * the object's fields is. Any endpoint whose DTO documented an empty body as
+ * "use the defaults" therefore 400'd on a genuinely bodyless request.
+ *
+ * THE FIX (commit 3f5d88f): a top-level `.default({})` (or, where an inner
+ * field carries its OWN default, `.prefault({})` — see the ReprocessFailedBodyDto
+ * block below) on all 34 affected body schemas, placed LAST in the chain
+ * after any `.strict()`/`.refine()`. See `app.module.ts` for the full
+ * convention writeup and its two caveats.
+ *
+ * WHY THIS FILE EXISTS — the critical point from the issue: the pre-existing
+ * `ResetStuckDto` spec (`enrichment-admin.controller.spec.ts`) never caught
+ * this bug because it calls `controller.resetStuck({} as ResetStuckDto)`
+ * DIRECTLY — a hand-constructed DTO that never goes near the
+ * `ZodValidationPipe`, and `{}` was always valid input anyway (the crash only
+ * happens on `undefined`, not `{}`). A test that constructs a DTO by hand or
+ * invokes a controller method directly is WORTHLESS for this bug class. Every
+ * assertion below therefore calls `schema.parse(...)` (or the `ZodDto`'s
+ * static `.schema.parse(...)` — `createZodDto` attaches the real schema as a
+ * static property even on DTO classes whose local schema `const` isn't
+ * exported) — i.e. the exact same code path the real `ZodValidationPipe`
+ * invokes. `parse(undefined)` is the assertion that would have thrown before
+ * commit 3f5d88f; everything else pins that the fix did not loosen
+ * validation. For a genuine end-to-end proof through the real pipe + a real
+ * Fastify HTTP round trip (no `request.body` at all, not a simulated
+ * `parse(undefined)` call), see `issue-289-bodyless-post.spec.ts` in this
+ * same directory.
+ *
+ * This does not attempt all 34 fixed schemas — it picks a representative
+ * spread: a plain `.default({})` case, a `.strict()` case, a `.refine()`
+ * case, a nested/complex settings-patch case, and (via the pipe-level
+ * companion file) the one case that additionally needed `.prefault({})`
+ * because it has its own inner field default. It also pins the ONE
+ * deliberate exclusion (`TriggerBackupSchema`) as a guard against a future
+ * sweep "helpfully" adding `.default({})` there.
+ */
+
+import { randomUUID } from 'crypto';
+import { ResetStuckDto, RetryAllFailedDto } from '../../enrichment/enrichment-admin.controller';
+import { updateWorkflowSchema, UpdateWorkflowDto } from '../../workflows/dto/update-workflow.dto';
+import { updatePersonSchema, UpdatePersonDto } from '../../face/dto/people.dto';
+import { ReprocessFailedBodyDto } from '../../media/media-reprocess.controller';
+import { patchUserSettingsSchema, PatchUserSettingsDto } from '../../settings/dto/update-user-settings.dto';
+import { AcceptLocationSuggestionDto } from '../../location-inference/dto/accept-location-suggestion.dto';
+import { TriggerBackupSchema } from '../../jobs/backup/dto/trigger-backup.dto';
+
+describe('issue #289 — top-level .default({}) contract on all-optional Zod body schemas', () => {
+  // ===========================================================================
+  // ResetStuckDto — the DTO named explicitly in the issue.
+  // POST /api/admin/jobs/reset-stuck body { olderThanMinutes? }
+  // `resetStuckSchema` itself is not exported from enrichment-admin.controller.ts,
+  // so we reach it via the ZodDto's static `.schema` — createZodDto attaches the
+  // real schema instance there regardless of whether the local const is exported.
+  // ===========================================================================
+  describe('ResetStuckDto (apps/api/src/enrichment/enrichment-admin.controller.ts)', () => {
+    const schema = ResetStuckDto.schema;
+
+    it('parse(undefined) -> {} — THE #289 REGRESSION ASSERTION: this threw ZodError before commit 3f5d88f', () => {
+      expect(schema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged pre-existing behavior)', () => {
+      expect(schema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body round-trips', () => {
+      expect(schema.parse({ olderThanMinutes: 15 })).toEqual({ olderThanMinutes: 15 });
+    });
+
+    it('an invalid field value still throws — the fix must not have loosened validation', () => {
+      expect(() => schema.parse({ olderThanMinutes: 0 })).toThrow();
+      expect(() => schema.parse({ olderThanMinutes: -5 })).toThrow();
+      expect(() => schema.parse({ olderThanMinutes: 15.5 })).toThrow();
+      expect(() => schema.parse({ olderThanMinutes: 'soon' })).toThrow();
+    });
+  });
+
+  // ===========================================================================
+  // RetryAllFailedDto — ResetStuckDto's sibling in the same controller/commit hunk.
+  // POST /api/admin/jobs/retry-failed body { type? }
+  // ===========================================================================
+  describe('RetryAllFailedDto (apps/api/src/enrichment/enrichment-admin.controller.ts)', () => {
+    const schema = RetryAllFailedDto.schema;
+
+    it('parse(undefined) -> {} — would have thrown before commit 3f5d88f', () => {
+      expect(schema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged)', () => {
+      expect(schema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body round-trips', () => {
+      expect(schema.parse({ type: 'auto_tagging' })).toEqual({ type: 'auto_tagging' });
+    });
+
+    it('an invalid field value still throws', () => {
+      expect(() => schema.parse({ type: '' })).toThrow(); // min(1)
+      expect(() => schema.parse({ type: 123 })).toThrow(); // wrong type
+    });
+  });
+
+  // ===========================================================================
+  // UpdateWorkflowDto — the .strict() case. `.default({})` is placed LAST,
+  // after `.strict()`, so a bodyless request still parses as {} while an
+  // unknown key on a REAL body still throws.
+  // ===========================================================================
+  describe('UpdateWorkflowDto (apps/api/src/workflows/dto/update-workflow.dto.ts) — .strict() case', () => {
+    it('parse(undefined) -> {} — would have thrown before commit 3f5d88f', () => {
+      expect(updateWorkflowSchema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged)', () => {
+      expect(updateWorkflowSchema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body round-trips', () => {
+      const result = updateWorkflowSchema.parse({ name: 'Archive old screenshots', enabled: true });
+      expect(result).toEqual({ name: 'Archive old screenshots', enabled: true });
+    });
+
+    it('an invalid field value still throws', () => {
+      expect(() => updateWorkflowSchema.parse({ enabled: 'yes' })).toThrow();
+      expect(() => updateWorkflowSchema.parse({ trigger: 'on_full_moon' })).toThrow();
+    });
+
+    it('an unknown key still throws — .strict() survives the added .default({})', () => {
+      expect(() => updateWorkflowSchema.parse({ notARealField: 'x' })).toThrow();
+    });
+
+    it('UpdateWorkflowDto.schema is the same schema instance exercised above', () => {
+      expect(UpdateWorkflowDto.schema).toBe(updateWorkflowSchema);
+    });
+  });
+
+  // ===========================================================================
+  // UpdatePersonDto — the .refine() case. `.default({})` is placed LAST, after
+  // `.refine()`, so the refine is skipped ONLY for the literal {} default value
+  // (harmless here — both fields absent trivially satisfies the refine) but
+  // still runs, and still rejects, any REAL populated body that violates it.
+  // ===========================================================================
+  describe('UpdatePersonDto (apps/api/src/face/dto/people.dto.ts) — .refine() case', () => {
+    it('parse(undefined) -> {} — would have thrown before commit 3f5d88f', () => {
+      expect(updatePersonSchema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged) — refine trivially satisfied (both fields absent)', () => {
+      expect(updatePersonSchema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body round-trips', () => {
+      expect(updatePersonSchema.parse({ name: 'Grandma Rose' })).toEqual({ name: 'Grandma Rose' });
+    });
+
+    it('an invalid field value still throws', () => {
+      expect(() => updatePersonSchema.parse({ name: '' })).toThrow(); // min(1)
+      expect(() => updatePersonSchema.parse({ coverFaceId: 'not-a-uuid' })).toThrow();
+    });
+
+    it('the .refine() is still enforced on a real populated body (fix did not bypass it)', () => {
+      // profileMediaItemId without profileCrop must still be rejected.
+      expect(() =>
+        updatePersonSchema.parse({ profileMediaItemId: randomUUID() }),
+      ).toThrow(/must both be provided or both be null/);
+      // profileCrop without profileMediaItemId must still be rejected.
+      expect(() =>
+        updatePersonSchema.parse({ profileCrop: { x: 0, y: 0, w: 1, h: 1 } }),
+      ).toThrow(/must both be provided or both be null/);
+      // both together is valid.
+      expect(
+        updatePersonSchema.parse({
+          profileMediaItemId: randomUUID(),
+          profileCrop: { x: 0, y: 0, w: 1, h: 1 },
+        }),
+      ).toMatchObject({ profileCrop: { x: 0, y: 0, w: 1, h: 1 } });
+    });
+
+    it('UpdatePersonDto.schema is the same schema instance exercised above', () => {
+      expect(UpdatePersonDto.schema).toBe(updatePersonSchema);
+    });
+  });
+
+  // ===========================================================================
+  // ReprocessFailedBodyDto — stand-in "admin-backfill clone" representative.
+  //
+  // The task named `AdminMetadataBackfillDto` (apps/api/src/metadata/admin-metadata.controller.ts)
+  // as the canonical admin-backfill example, but BOTH its local schema const
+  // (`adminMetadataBackfillSchema`) AND the DTO class itself are declared
+  // without `export` — there is no way to import either without changing
+  // production code, which the task explicitly says not to do here.
+  // `ReprocessFailedBodyDto` (apps/api/src/media/media-reprocess.controller.ts,
+  // `POST /api/admin/media/reprocess-failed` body `{ limit? }`) is fixed by the
+  // exact same commit, follows the exact same top-level `.default({})`
+  // pattern, lives in the same "admin bulk-operation" family, and — unlike
+  // the *-backfill controllers — IS exported, so it stands in as the
+  // representative here without touching production code.
+  //
+  // The genuinely `.prefault({})`-flavored case (an inner field default that
+  // must survive the top-level default — e.g. AdminMetadataBackfillDto's
+  // `force: z.boolean().optional().default(false)`) is instead exercised
+  // end-to-end through the real HTTP route in issue-289-bodyless-post.spec.ts,
+  // which never needs to import the unexported class/schema by name.
+  // ===========================================================================
+  describe('ReprocessFailedBodyDto (apps/api/src/media/media-reprocess.controller.ts) — admin-backfill-clone stand-in', () => {
+    const schema = ReprocessFailedBodyDto.schema;
+
+    it('parse(undefined) -> {} — would have thrown before commit 3f5d88f', () => {
+      expect(schema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged)', () => {
+      expect(schema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body round-trips', () => {
+      expect(schema.parse({ limit: 50 })).toEqual({ limit: 50 });
+    });
+
+    it('an invalid field value still throws', () => {
+      expect(() => schema.parse({ limit: -1 })).toThrow(); // positive()
+      expect(() => schema.parse({ limit: 1.5 })).toThrow(); // int()
+    });
+  });
+
+  // ===========================================================================
+  // PatchUserSettingsDto — nested/complex settings-patch case (JSON Merge
+  // Patch style, multiple optional nested objects).
+  // ===========================================================================
+  describe('PatchUserSettingsDto (apps/api/src/settings/dto/update-user-settings.dto.ts)', () => {
+    it('parse(undefined) -> {} — would have thrown before commit 3f5d88f', () => {
+      expect(patchUserSettingsSchema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged)', () => {
+      expect(patchUserSettingsSchema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body round-trips', () => {
+      const result = patchUserSettingsSchema.parse({
+        theme: 'dark',
+        profile: { displayName: 'Oscar' },
+      });
+      expect(result).toEqual({ theme: 'dark', profile: { displayName: 'Oscar' } });
+    });
+
+    it('an invalid field value still throws', () => {
+      expect(() => patchUserSettingsSchema.parse({ theme: 'purple' })).toThrow();
+      expect(() =>
+        patchUserSettingsSchema.parse({ profile: { customImageUrl: 'not-a-url' } }),
+      ).toThrow();
+    });
+
+    it('PatchUserSettingsDto.schema is the same schema instance exercised above', () => {
+      expect(PatchUserSettingsDto.schema).toBe(patchUserSettingsSchema);
+    });
+  });
+
+  // ===========================================================================
+  // AcceptLocationSuggestionDto — a second plain `.default({})` case (numeric
+  // optional fields) rounding out the spread.
+  // ===========================================================================
+  describe('AcceptLocationSuggestionDto (apps/api/src/location-inference/dto/accept-location-suggestion.dto.ts)', () => {
+    const schema = AcceptLocationSuggestionDto.schema;
+
+    it('parse(undefined) -> {} — accept-unmodified is the documented bodyless use case', () => {
+      expect(schema.parse(undefined)).toEqual({});
+    });
+
+    it('parse({}) -> {} (unchanged)', () => {
+      expect(schema.parse({})).toEqual({});
+    });
+
+    it('a valid populated body (adjusted accept) round-trips', () => {
+      expect(schema.parse({ lat: 9.93, lng: -84.08 })).toEqual({ lat: 9.93, lng: -84.08 });
+    });
+
+    it('an invalid field value still throws', () => {
+      expect(() => schema.parse({ lat: 999 })).toThrow(); // max(90)
+      expect(() => schema.parse({ lng: -999 })).toThrow(); // min(-180)
+    });
+  });
+
+  // ===========================================================================
+  // TriggerBackupSchema — the DELIBERATE EXCLUSION guard.
+  //
+  // Every key on this schema is optional, so it pattern-matches every other
+  // schema fixed in this sweep — but its top-level `.refine()` is what makes a
+  // bodyless request semantically INVALID (a backup must name a circle or
+  // opt into "all"), and `.default({})` BYPASSES a top-level `.refine()` for
+  // the default value it substitutes in. Adding `.default({})` here would
+  // therefore silently ACCEPT an empty body that this endpoint must reject.
+  //
+  // This test is the guardrail: it fails loudly if a future "helpful" sweep
+  // adds `.default({})` to TriggerBackupSchema, because a bodyless request
+  // must keep throwing.
+  // ===========================================================================
+  describe('TriggerBackupSchema (apps/api/src/jobs/backup/dto/trigger-backup.dto.ts) — deliberately excluded', () => {
+    it('parse(undefined) still throws — do NOT add .default({}) here (see file-level comment)', () => {
+      expect(() => TriggerBackupSchema.parse(undefined)).toThrow();
+    });
+
+    it('parse({}) still throws — the refine (circleId or all:true required) is not bypassable', () => {
+      expect(() => TriggerBackupSchema.parse({})).toThrow(/Provide either circleId or all/);
+    });
+
+    it('a body satisfying the refine still parses correctly', () => {
+      expect(TriggerBackupSchema.parse({ all: true })).toEqual({ all: true });
+      const circleId = randomUUID();
+      expect(TriggerBackupSchema.parse({ circleId })).toEqual({ circleId });
+    });
+  });
+});

--- a/apps/api/src/dedup/admin-duplicate.controller.ts
+++ b/apps/api/src/dedup/admin-duplicate.controller.ts
@@ -20,16 +20,20 @@ import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { DuplicateBackfillService } from './duplicate-backfill.service';
 import { VisualEmbeddingService, VISUAL_EMBEDDING_MODEL_TAG } from './visual-embedding.service';
 
+// Both schemas below accept a bodyless POST — see issue #289 (app.module.ts).
+// This one uses .prefault({}) rather than .default({}) so the empty body is fed
+// THROUGH the schema and still yields force: false; see the fuller note in
+// admin-metadata.controller.ts.
 const adminDuplicateBackfillSchema = z.object({
   from: z.string().datetime({ offset: true }).optional(),
   to: z.string().datetime({ offset: true }).optional(),
   force: z.boolean().optional().default(false),
-});
+}).prefault({});
 class AdminDuplicateBackfillDto extends createZodDto(adminDuplicateBackfillSchema) {}
 
 const adminDuplicateConfidenceBackfillSchema = z.object({
   limit: z.coerce.number().int().min(1).optional(),
-});
+}).default({});
 class AdminDuplicateConfidenceBackfillDto extends createZodDto(
   adminDuplicateConfidenceBackfillSchema,
 ) {}

--- a/apps/api/src/device-auth/dto/device-code-request.dto.ts
+++ b/apps/api/src/device-auth/dto/device-code-request.dto.ts
@@ -49,7 +49,8 @@ export const ClientInfoSchema = z.object({
  */
 export const DeviceCodeRequestSchema = z.object({
   clientInfo: ClientInfoSchema.optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class DeviceCodeRequestDto extends createZodDto(DeviceCodeRequestSchema) {
   @ApiProperty({

--- a/apps/api/src/enhancement/dto/enhance-params.dto.ts
+++ b/apps/api/src/enhancement/dto/enhance-params.dto.ts
@@ -34,7 +34,8 @@ export const enhanceParamsSchema = z.object({
   instructions: z.string().max(500).optional(),
   /** Optional per-call override of ai.features.enhance.model. */
   model: z.string().max(200).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export type EnhanceParams = z.infer<typeof enhanceParamsSchema>;
 

--- a/apps/api/src/enrichment/enrichment-admin.controller.ts
+++ b/apps/api/src/enrichment/enrichment-admin.controller.ts
@@ -58,7 +58,8 @@ export class JobInsightsQueryDto extends createZodDto(jobInsightsQuerySchema) {}
 
 const retryAllFailedSchema = z.object({
   type: z.string().min(1).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class RetryAllFailedDto extends createZodDto(retryAllFailedSchema) {}
 
@@ -66,7 +67,8 @@ export class RetryAllFailedDto extends createZodDto(retryAllFailedSchema) {}
 // resolve the jobs.stuckThresholdMinutes system setting (default 3 minutes).
 const resetStuckSchema = z.object({
   olderThanMinutes: z.number().int().min(1).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class ResetStuckDto extends createZodDto(resetStuckSchema) {}
 

--- a/apps/api/src/face/admin-face-backfill.controller.ts
+++ b/apps/api/src/face/admin-face-backfill.controller.ts
@@ -26,7 +26,9 @@ const adminFaceBackfillSchema = z.object({
   from: flexibleDate.optional(),
   to: flexibleDate.optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
+  // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
+}).prefault({});
 class AdminFaceBackfillDto extends createZodDto(adminFaceBackfillSchema) {}
 
 @ApiTags('Admin — Face Recognition')

--- a/apps/api/src/face/dto/face-credentials.dto.ts
+++ b/apps/api/src/face/dto/face-credentials.dto.ts
@@ -8,7 +8,8 @@ export const upsertFaceCredentialsSchema = z.object({
   apiKey: z.string().optional(),
   baseUrl: z.string().url().optional(),
   enabled: z.boolean().optional(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 export class UpsertFaceCredentialsDto extends createZodDto(upsertFaceCredentialsSchema) {}
 
 // No model field — face providers have a fixed modelVersion per deployment

--- a/apps/api/src/face/dto/people.dto.ts
+++ b/apps/api/src/face/dto/people.dto.ts
@@ -69,7 +69,12 @@ export const updatePersonSchema = z
         'profileMediaItemId and profileCrop must both be provided or both be null',
       path: ['profileMediaItemId'],
     },
-  );
+  )
+  // .default({}) LAST, after .refine(), so a bodyless request parses as {} —
+  // see issue #289 (app.module.ts). Note the refine is SKIPPED for that default
+  // value; harmless here because {} would satisfy it anyway (both absent, so
+  // hasId === hasCrop === false).
+  .default({});
 
 export class UpdatePersonDto extends createZodDto(updatePersonSchema) {}
 

--- a/apps/api/src/geo/geocode-admin.controller.ts
+++ b/apps/api/src/geo/geocode-admin.controller.ts
@@ -14,7 +14,9 @@ const backfillGeoSchema = z.object({
   from: flexibleDate.optional(),
   to: flexibleDate.optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
+  // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
+}).prefault({});
 class BackfillGeoDto extends createZodDto(backfillGeoSchema) {}
 
 @ApiTags('Admin - Geocode')

--- a/apps/api/src/jobs/backup/dto/trigger-backup.dto.ts
+++ b/apps/api/src/jobs/backup/dto/trigger-backup.dto.ts
@@ -2,6 +2,14 @@ import { z } from 'zod';
 import { createZodDto } from 'nestjs-zod';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
+// DELIBERATELY has NO top-level `.default({})`, unlike the other all-optional
+// body schemas fixed in issue #289 — do not add one in a future sweep.
+//
+// Every key here is optional, so this schema pattern-matches the #289 fix, but
+// the `.refine()` below is what makes a bodyless request semantically INVALID:
+// a backup must name a circle or opt into all of them. `.default({})` BYPASSES
+// a top-level refine for the default value, so adding it would silently ACCEPT
+// an empty body that this endpoint must reject. See app.module.ts for the rule.
 export const TriggerBackupSchema = z
   .object({
     circleId: z.string().uuid().optional(),

--- a/apps/api/src/location-inference/admin-location-inference.controller.ts
+++ b/apps/api/src/location-inference/admin-location-inference.controller.ts
@@ -12,7 +12,9 @@ const adminLocationInferenceBackfillSchema = z.object({
   from: z.string().datetime({ offset: true }).optional(),
   to: z.string().datetime({ offset: true }).optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
+  // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
+}).prefault({});
 class AdminLocationInferenceBackfillDto extends createZodDto(adminLocationInferenceBackfillSchema) {}
 
 @ApiTags('Admin — Location Inference')

--- a/apps/api/src/location-inference/dto/accept-location-suggestion.dto.ts
+++ b/apps/api/src/location-inference/dto/accept-location-suggestion.dto.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 const schema = z.object({
   lat: z.number().min(-90).max(90).optional(),
   lng: z.number().min(-180).max(180).optional(),
-});
+  // .default({}) so a bodyless POST (accept unmodified) parses as {} — see
+  // issue #289 (app.module.ts).
+}).default({});
 
 export class AcceptLocationSuggestionDto extends createZodDto(schema) {}

--- a/apps/api/src/media/dto/update-album.dto.ts
+++ b/apps/api/src/media/dto/update-album.dto.ts
@@ -7,6 +7,7 @@ export const updateAlbumSchema = z.object({
   // Album cover pointer: a valid member's UUID sets the cover, null clears it,
   // omitted leaves the existing cover untouched.
   coverMediaItemId: z.string().uuid().nullable().optional(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class UpdateAlbumDto extends createZodDto(updateAlbumSchema) {}

--- a/apps/api/src/media/dto/update-media.dto.ts
+++ b/apps/api/src/media/dto/update-media.dto.ts
@@ -8,6 +8,7 @@ export const updateMediaSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
   description: z.string().max(8192).nullable().optional(),
   favorite: z.boolean().optional(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class UpdateMediaDto extends createZodDto(updateMediaSchema) {}

--- a/apps/api/src/media/media-reprocess.controller.ts
+++ b/apps/api/src/media/media-reprocess.controller.ts
@@ -13,22 +13,24 @@ import { PrismaService } from '../prisma/prisma.service';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { PERMISSIONS, ROLES } from '../common/constants/roles.constants';
 
+// .default({}) on all three so a bodyless POST parses as {} — see issue #289
+// (app.module.ts).
 const reprocessBodySchema = z.object({
   circleId: z.string().uuid().optional(),
   all: z.boolean().optional(),
-});
+}).default({});
 
 export class ReprocessBodyDto extends createZodDto(reprocessBodySchema) {}
 
 const reprocessStuckBodySchema = z.object({
   olderThanMinutes: z.number().int().positive().optional(),
-});
+}).default({});
 
 export class ReprocessStuckBodyDto extends createZodDto(reprocessStuckBodySchema) {}
 
 const reprocessFailedBodySchema = z.object({
   limit: z.number().int().positive().optional(),
-});
+}).default({});
 
 export class ReprocessFailedBodyDto extends createZodDto(reprocessFailedBodySchema) {}
 

--- a/apps/api/src/metadata/admin-metadata.controller.ts
+++ b/apps/api/src/metadata/admin-metadata.controller.ts
@@ -18,7 +18,11 @@ const adminMetadataBackfillSchema = z.object({
   from: flexibleDate.optional(),
   to: flexibleDate.optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) — not .default({}) — because the inner force default makes
+  // `force` required in the output type, and .default() would return a bare {}
+  // without running this parse (leaving force undefined). .prefault() feeds {}
+  // THROUGH the schema, so a bodyless POST is identical to {}. See issue #289.
+}).prefault({});
 class AdminMetadataBackfillDto extends createZodDto(adminMetadataBackfillSchema) {}
 
 @ApiTags('Admin — Metadata')

--- a/apps/api/src/nodes/nodes.controller.ts
+++ b/apps/api/src/nodes/nodes.controller.ts
@@ -54,20 +54,23 @@ const heartbeatSchema = z.object({
   concurrency: z.number().int().min(1).optional(),
   // Accepted for forward-compat (current in-flight job count); service ignores it.
   inFlight: z.number().int().min(0).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class HeartbeatDto extends createZodDto(heartbeatSchema) {}
 
 const claimSchema = z.object({
   max: z.number().int().min(1).optional(),
   types: z.array(z.string().min(1)).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class ClaimDto extends createZodDto(claimSchema) {}
 
 const renewLeaseSchema = z.object({
   leaseMs: z.number().int().min(1000).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class RenewLeaseDto extends createZodDto(renewLeaseSchema) {}
 

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -35,6 +35,7 @@ export class UpdateSystemSettingsDto extends createZodDto(
 ) {}
 
 // Partial update (PATCH)
+// .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
 export const patchSystemSettingsSchema = z.object({
   ui: z
     .object({
@@ -192,7 +193,7 @@ export const patchSystemSettingsSchema = z.object({
       retentionHours: z.number().int().min(1).max(720).optional(),
     })
     .optional(),
-});
+}).default({});
 
 export class PatchSystemSettingsDto extends createZodDto(
   patchSystemSettingsSchema,

--- a/apps/api/src/settings/dto/update-user-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-user-settings.dto.ts
@@ -33,6 +33,7 @@ export class UpdateUserSettingsDto extends createZodDto(
 ) {}
 
 // Partial update (PATCH) - JSON Merge Patch style
+// .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
 export const patchUserSettingsSchema = z.object({
   theme: z.enum(['light', 'dark', 'system']).optional(),
   profile: z
@@ -55,7 +56,7 @@ export const patchUserSettingsSchema = z.object({
   // another's stored value; a `null` type entry resets that type to its
   // default, and `notifications: null` clears the whole namespace.
   notifications: notificationPreferencesPatchSchema.nullable().optional(),
-});
+}).default({});
 
 export class PatchUserSettingsDto extends createZodDto(
   patchUserSettingsSchema,

--- a/apps/api/src/social-media/admin-social-media.controller.ts
+++ b/apps/api/src/social-media/admin-social-media.controller.ts
@@ -30,7 +30,9 @@ const adminSocialMediaBackfillSchema = z.object({
   from: flexibleDate.optional(),
   to: flexibleDate.optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
+  // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
+}).prefault({});
 class AdminSocialMediaBackfillDto extends createZodDto(
   adminSocialMediaBackfillSchema,
 ) {}

--- a/apps/api/src/storage-settings/dto/storage-credentials.dto.ts
+++ b/apps/api/src/storage-settings/dto/storage-credentials.dto.ts
@@ -9,5 +9,6 @@ export const upsertStorageCredentialsSchema = z.object({
   region: z.string().optional(),
   endpoint: z.string().url().optional(),
   enabled: z.boolean().optional(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 export class UpsertStorageCredentialsDto extends createZodDto(upsertStorageCredentialsSchema) {}

--- a/apps/api/src/tagging/admin-tagging.controller.ts
+++ b/apps/api/src/tagging/admin-tagging.controller.ts
@@ -21,7 +21,9 @@ const adminBackfillSchema = z.object({
   from: flexibleDate.optional(),
   to: flexibleDate.optional(),
   force: z.boolean().optional().default(false),
-});
+  // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
+  // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
+}).prefault({});
 class AdminBackfillDto extends createZodDto(adminBackfillSchema) {}
 
 @ApiTags('Admin — Tagging')

--- a/apps/api/src/tagging/tag-labels.service.ts
+++ b/apps/api/src/tagging/tag-labels.service.ts
@@ -22,7 +22,8 @@ export class CreateTagLabelDto extends createZodDto(createTagLabelSchema) {}
 export const updateTagLabelSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   enabled: z.boolean().optional(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class UpdateTagLabelDto extends createZodDto(updateTagLabelSchema) {}
 

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 export const updateUserSchema = z.object({
   displayName: z.string().max(100).optional(),
   isActive: z.boolean().optional(),
-});
+  // .default({}) so a bodyless request parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class UpdateUserDto extends createZodDto(updateUserSchema) {}

--- a/apps/api/src/workflows/dto/update-workflow.dto.ts
+++ b/apps/api/src/workflows/dto/update-workflow.dto.ts
@@ -6,6 +6,9 @@ import { workflowDefinitionSchema } from '../definition/workflow-definition.sche
  * PATCH /api/workflows/:id body. All fields optional; `circleId` and
  * `subjectType` are immutable (subjectType follows `definition.subject` when a
  * new definition is supplied). Cron validity is enforced in the service.
+ *
+ * `.default({})` comes LAST, after `.strict()`, so a bodyless request parses as
+ * {} while unknown keys still throw — see issue #289 (app.module.ts).
  */
 export const updateWorkflowSchema = z
   .object({
@@ -16,6 +19,7 @@ export const updateWorkflowSchema = z
     cronExpression: z.string().max(200).nullable().optional(),
     definition: workflowDefinitionSchema.optional(),
   })
-  .strict();
+  .strict()
+  .default({});
 
 export class UpdateWorkflowDto extends createZodDto(updateWorkflowSchema) {}

--- a/apps/api/src/workflows/runs/dto/approve-run.dto.ts
+++ b/apps/api/src/workflows/runs/dto/approve-run.dto.ts
@@ -7,6 +7,7 @@ export const approveRunSchema = z.object({
   excludedItemIds: z.array(z.string().uuid()).max(500).optional(),
   /** Required "DELETE <count>" confirmation when the run contains hard_delete. */
   confirmation: z.string().max(200).optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class ApproveRunDto extends createZodDto(approveRunSchema) {}

--- a/apps/api/src/workflows/runs/dto/create-run.dto.ts
+++ b/apps/api/src/workflows/runs/dto/create-run.dto.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 export const createRunSchema = z.object({
   /** Optional per-run cap; the effective cap is min(this, options.maxItems, system ceiling). */
   maxItems: z.coerce.number().int().positive().optional(),
-});
+  // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
+}).default({});
 
 export class CreateRunDto extends createZodDto(createRunSchema) {}


### PR DESCRIPTION
## Summary

`POST /api/admin/jobs/reset-stuck` returned **400** for a request with no body at all, despite `ResetStuckDto` documenting an empty body as "use defaults". An audit found the same gap on **34 schemas** across 25 files — every `@Body()` DTO whose fields are all optional.

Root cause is unchanged from the issue: Fastify leaves `request.body` as `undefined` for a bodyless request, Nest's `@Body()` forwards that `undefined` to the global `ZodValidationPipe`, and `z.object({...}).parse(undefined)` throws `invalid_type` no matter how optional every field is. Field-level `.optional()` does not make the *object* optional.

This takes **option 1** from the issue (per-DTO top-level default), following the precedent set for `notificationScopeSchema` in #245. Option 2 (normalizing `undefined` → `{}` globally in the pipe) is deliberately not taken here — the issue flags it as needing explicit sign-off, and it would change validation behavior app-wide. See *Notes* below for the tradeoff.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #289

## Changes Made

- **26 schemas get a top-level `.default({})`**, placed **last** in the chain — after any `.strict()` (`updateWorkflowSchema`) or `.refine()` (`updatePersonSchema`), so unknown-key and refine enforcement survive.
- **8 admin-backfill schemas get `.prefault({})` instead**, and this distinction matters. They carry an inner `force: z.boolean().optional().default(false)`. On those, `.default({})` short-circuits and returns a bare `{}` *without running the inner parse*, so a bodyless POST would yield `force: undefined` while `{}` yields `force: false` — the two shapes this fix is supposed to make equivalent would diverge, and the result would contradict the DTO's own `force: boolean` type. `.prefault({})` feeds `{}` *through* the schema. Verified against the installed zod 4.4.3:

  | | `parse(undefined)` | `parse({})` |
  |---|---|---|
  | `.default({})` | `{}` | `{"force":false}` |
  | `.prefault({})` | `{"force":false}` | `{"force":false}` |

  It also isn't merely stylistic: `.default({})` fails to compile there (`TS2769`), because zod 4 types the argument against the *output* type and the inner default makes `force` required in it.

- **`TriggerBackupSchema` is deliberately excluded**, with an in-file comment so a future regex sweep doesn't "fix" it. Every key is optional so it pattern-matches the rest, but its top-level `.refine()` (a backup must name a circle or opt into all) is what makes a bodyless request invalid. Critically, **`.default({})` bypasses a top-level refine for the default value** — verified — so adding it there would silently *accept* an invalid backup request rather than just changing the error message.

- The shared rationale, the `.default`-vs-`.prefault` rule, and the refine-bypass caveat are documented once at the pipe registration site in `app.module.ts` (comment only, no behavior change); each DTO carries a one-line pointer back to it.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

**Full API suite: 6353 passed, 0 failed** (3 consecutive clean runs). **Typecheck: 0 errors.**

Two new specs in `apps/api/src/common/regression/`. The issue notes the existing `ResetStuckDto` spec never caught this because it calls `controller.resetStuck({} as ResetStuckDto)` directly, bypassing the pipe — so both new specs exercise the **real** `ZodValidationPipe`:

- `issue-289-bodyless-post.spec.ts` — real `NestFastifyApplication` + supertest with **no `.send()` at all**, so `request.body` is truly `undefined` (the only shape that reproduces the bug). Asserts the handler is reached, that bodyless and explicit `{}` produce an *identical* service call, that the inner `force` default survives on the `.prefault({})` path, and that malformed bodies still 400. A contrast case pins an unfixed schema still reproducing the bug, so the harness is self-validating.
- `issue-289-empty-body-defaults.spec.ts` — schema-level contract across a representative spread including the `.strict()` and `.refine()` shapes.

Both guard the exclusion by asserting `TriggerBackupSchema` **still rejects** a bodyless request.

Verified the tests aren't vacuous two ways: reverting the production files to their pre-fix content fails **10 of 45** assertions, and a targeted mutation (removing `.default({})` from `resetStuckSchema` alone) fails exactly the corresponding bodyless assertion.

### Test Instructions

```bash
cd apps/api
npx jest --config ./test/jest.config.js src/common/regression/
```

Or against a running instance — this returned 400 before, 200 now:

```bash
curl -X POST "$APP_URL/api/admin/jobs/reset-stuck" -H "Authorization: Bearer $TOKEN"
```

## Notes

**Scope of the behavior change.** Only requests that previously **failed** with 400 now succeed. `{}`, populated bodies, and invalid-field rejection are all byte-identical, so no currently-working client changes behavior. `default: {}` now also surfaces in the generated OpenAPI schema.

**The tradeoff worth a reviewer's judgement:** per-DTO is safe and self-documenting, but it's 34 edits and nothing structurally prevents a *future* all-optional DTO from reintroducing the bug — the `app.module.ts` comment is the only guardrail. If you'd prefer the systemic fix, normalizing `undefined` → `{}` for body params in the pipe would cover all current and future DTOs; the one caveat is that DTOs with required fields would then return field-level errors instead of `expected object, received undefined` (still a 400, arguably a better message). Happy to switch — I stayed with per-DTO because the issue asked for sign-off before changing pipe behavior app-wide.

**Not addressed (upstream of this fix, as the issue notes):** a request sending `Content-Type: application/json` with a zero-length body is still rejected by Fastify itself (`FST_ERR_CTP_EMPTY_JSON_BODY`) before Nest or Zod run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187byno5Eh5osLWCNzsR92h

---
_Generated by [Claude Code](https://claude.ai/code/session_0187byno5Eh5osLWCNzsR92h)_