### PR TITLE
fix(rbac): reconcile permissions on boot so new ones reach existing installs (#293)

### DIFF
--- a/apps/api/prisma/migrations/20260807000000_add_email_settings_permissions/migration.sql
+++ b/apps/api/prisma/migrations/20260807000000_add_email_settings_permissions/migration.sql
@@ -1,0 +1,41 @@
+-- Issue #293: `email_settings:read` / `email_settings:write` never reached any
+-- database that was installed before commit 18811b28 (2026-07-14) added them to
+-- prisma/seed.ts.
+--
+-- Permissions have only ever been created by the seed, and update.sh runs
+-- `prisma migrate deploy` WITHOUT the seed, so an already-installed deployment
+-- never picked them up. The result in production: an admin opening
+-- /admin/settings/email got "Missing permissions: email_settings:read", because
+-- email-settings.controller.ts guards its routes on permissions that did not
+-- exist as rows.
+--
+-- This migration backfills the two rows and their admin grants so the fix
+-- travels through the normal deploy path. It is idempotent: a freshly seeded
+-- database already has both rows and every statement below no-ops.
+--
+-- Going forward RbacReconcileService (src/common/services/rbac-reconcile.service.ts)
+-- reconciles the whole catalog on every API boot, so a future permission does
+-- not need a hand-written migration like this one.
+
+INSERT INTO "permissions" ("id", "name", "description")
+VALUES
+  (
+    gen_random_uuid(),
+    'email_settings:read',
+    'View email provider configuration and test connectivity'
+  ),
+  (
+    gen_random_uuid(),
+    'email_settings:write',
+    'Configure email provider credentials, set active provider, and send test emails'
+  )
+ON CONFLICT ("name") DO NOTHING;
+
+-- Grant both to the admin role (the only role they belong to, per the catalog).
+INSERT INTO "role_permissions" ("role_id", "permission_id")
+SELECT r."id", p."id"
+FROM "roles" r
+CROSS JOIN "permissions" p
+WHERE r."name" = 'admin'
+  AND p."name" IN ('email_settings:read', 'email_settings:write')
+ON CONFLICT ("role_id", "permission_id") DO NOTHING;

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AdminBootstrapService } from './services/admin-bootstrap.service';
+import { RbacReconcileService } from './services/rbac-reconcile.service';
 
 @Module({
-  providers: [AdminBootstrapService],
-  exports: [AdminBootstrapService],
+  providers: [AdminBootstrapService, RbacReconcileService],
+  exports: [AdminBootstrapService, RbacReconcileService],
 })
 export class CommonModule {}

--- a/apps/api/src/common/constants/rbac.catalog.spec.ts
+++ b/apps/api/src/common/constants/rbac.catalog.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Guards the RBAC catalog against the three ways it can silently drift (#293).
+ *
+ * 1. catalog vs. `roles.constants.ts` — a permission the API guards on but that
+ *    the catalog never creates is exactly the #293 failure mode: the route
+ *    compiles, the row never exists, and the page 403s at runtime.
+ * 2. catalog vs. `prisma/seed.ts` — the seed keeps a duplicate copy of this data
+ *    because it CANNOT import from `src/` (the production image ships `dist/`,
+ *    `prisma/` and `scripts/`, not `src/`, so a cross-import would break
+ *    install-time seeding). The duplication is only safe while something proves
+ *    the two stay identical. That is this file.
+ * 3. internal consistency — a role granted a permission that is not in the
+ *    catalog can never be reconciled into the database.
+ *
+ * The seed-parsing tests assert a plausible parse count BEFORE comparing. A
+ * regex that silently matches nothing would otherwise turn every comparison
+ * below into a vacuous pass — the test would go green precisely when it stopped
+ * testing anything.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { PERMISSIONS } from './roles.constants';
+import { PERMISSION_CATALOG, ROLE_PERMISSION_MATRIX } from './rbac.catalog';
+
+const SEED_PATH = join(__dirname, '..', '..', '..', 'prisma', 'seed.ts');
+
+function readSeedSource(): string {
+  return readFileSync(SEED_PATH, 'utf8');
+}
+
+/** Extracts `const <name> = [ ... ]` / `= { ... }` block bodies from the seed. */
+function extractBlock(source: string, declaration: string, close: string): string {
+  const start = source.indexOf(declaration);
+  if (start === -1) {
+    throw new Error(
+      `Could not find "${declaration}" in prisma/seed.ts. If the seed was ` +
+        `restructured, update this parser — do not delete the assertion.`,
+    );
+  }
+  const end = source.indexOf(close, start);
+  if (end === -1) {
+    throw new Error(`Could not find the end ("${close}") of "${declaration}" in prisma/seed.ts.`);
+  }
+  return source.slice(start, end);
+}
+
+function seedPermissionNames(): string[] {
+  const block = extractBlock(readSeedSource(), 'const PERMISSIONS = [', '] as const;');
+  return [...block.matchAll(/name:\s*'([^']+)'/g)].map((m) => m[1]);
+}
+
+function seedRolePermissions(): Record<string, string[]> {
+  const block = extractBlock(readSeedSource(), 'const ROLE_PERMISSIONS', '\n};');
+  const result: Record<string, string[]> = {};
+
+  for (const roleMatch of block.matchAll(/^\s{2}(\w+):\s*\[([\s\S]*?)^\s{2}\],?$/gm)) {
+    const roleName = roleMatch[1];
+    // Permission names only — comments in the block have no quoted strings.
+    result[roleName] = [...roleMatch[2].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+  }
+
+  return result;
+}
+
+describe('RBAC catalog', () => {
+  const catalogNames = PERMISSION_CATALOG.map((p) => p.name as string);
+
+  describe('internal consistency', () => {
+    it('has no duplicate permission entries', () => {
+      expect(catalogNames).toHaveLength(new Set(catalogNames).size);
+    });
+
+    it('gives every permission a non-empty description', () => {
+      for (const permission of PERMISSION_CATALOG) {
+        expect(permission.description.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it('only grants roles permissions that exist in the catalog', () => {
+      for (const [roleName, granted] of Object.entries(ROLE_PERMISSION_MATRIX)) {
+        const unknown = granted.filter((p) => !catalogNames.includes(p as string));
+        expect({ roleName, unknown }).toEqual({ roleName, unknown: [] });
+      }
+    });
+
+    it('grants no role a duplicate permission', () => {
+      for (const [roleName, granted] of Object.entries(ROLE_PERMISSION_MATRIX)) {
+        expect({ roleName, count: granted.length }).toEqual({
+          roleName,
+          count: new Set(granted).size,
+        });
+      }
+    });
+  });
+
+  describe('parity with roles.constants.ts (the permissions @Auth guards on)', () => {
+    const declaredNames = Object.values(PERMISSIONS) as string[];
+
+    it('catalogs every permission declared in PERMISSIONS', () => {
+      const missing = declaredNames.filter((name) => !catalogNames.includes(name));
+      expect(missing).toEqual([]);
+    });
+
+    it('declares every catalogued permission in PERMISSIONS', () => {
+      const extra = catalogNames.filter((name) => !declaredNames.includes(name));
+      expect(extra).toEqual([]);
+    });
+  });
+
+  describe('parity with prisma/seed.ts (deliberate duplicate — must not diverge)', () => {
+    it('parses a plausible number of permissions from the seed', () => {
+      // Fails loudly if the seed is reformatted and the regex stops matching,
+      // rather than letting the comparisons below pass vacuously.
+      expect(seedPermissionNames().length).toBeGreaterThan(30);
+    });
+
+    it('seeds exactly the catalogued permission set', () => {
+      expect([...seedPermissionNames()].sort()).toEqual([...catalogNames].sort());
+    });
+
+    it('parses all three roles from the seed', () => {
+      expect(Object.keys(seedRolePermissions()).sort()).toEqual([
+        'admin',
+        'contributor',
+        'viewer',
+      ]);
+    });
+
+    it('maps roles to exactly the catalogued permissions', () => {
+      const fromSeed = seedRolePermissions();
+
+      for (const [roleName, granted] of Object.entries(ROLE_PERMISSION_MATRIX)) {
+        expect({ roleName, permissions: [...(fromSeed[roleName] ?? [])].sort() }).toEqual({
+          roleName,
+          permissions: [...granted].sort(),
+        });
+      }
+    });
+  });
+});

--- a/apps/api/src/common/constants/rbac.catalog.ts
+++ b/apps/api/src/common/constants/rbac.catalog.ts
@@ -1,0 +1,231 @@
+// =============================================================================
+// RBAC Catalog — the canonical permission set and role→permission matrix
+// =============================================================================
+//
+// WHY THIS FILE EXISTS (issue #293)
+//
+// `roles.constants.ts` declares the permission *names* the API guards on
+// (`@Auth({ permissions: [...] })`), but a name means nothing until a matching
+// row exists in the `permissions` table and is granted to a role. Before this
+// file, the only place that mapping lived was `prisma/seed.ts` — and the seed
+// runs at INSTALL time only (`install-memoriahub.sh`), never on update
+// (`update.sh` runs `prisma migrate deploy` without the seed).
+//
+// So every permission added after a deployment was installed silently never
+// reached that database, and the first symptom was a runtime
+// "Missing permissions: <name>" error on the page that needed it. That is
+// exactly how `email_settings:read` broke /admin/settings/email in production.
+//
+// This catalog is the single source of truth that `RbacReconcileService`
+// applies to the database on every API boot, so a new permission deploys
+// itself. Adding a permission is now: add it to `roles.constants.ts`, add it
+// here with a description and its roles — no migration, no seed re-run.
+//
+// KEEPING THE SEED IN STEP
+//
+// `prisma/seed.ts` deliberately keeps its own copy of this data rather than
+// importing this file. It cannot import it: the production image
+// (`apps/api/Dockerfile`) ships `dist/`, `prisma/` and `scripts/` but NOT
+// `src/`, so a seed that reached into `src/` would break install-time seeding.
+// `rbac.catalog.spec.ts` parses `seed.ts` and fails if the two ever diverge,
+// which is what makes the duplication safe.
+
+import { PERMISSIONS, ROLES, type PermissionName, type RoleName } from './roles.constants';
+
+export interface PermissionDefinition {
+  name: PermissionName;
+  description: string;
+}
+
+/**
+ * Every permission the system knows about, with the description stored on the
+ * row. Order is cosmetic; grouping mirrors `roles.constants.ts`.
+ */
+export const PERMISSION_CATALOG: readonly PermissionDefinition[] = [
+  // System settings
+  { name: PERMISSIONS.SYSTEM_SETTINGS_READ, description: 'Read system settings' },
+  { name: PERMISSIONS.SYSTEM_SETTINGS_WRITE, description: 'Modify system settings' },
+
+  // User settings
+  { name: PERMISSIONS.USER_SETTINGS_READ, description: 'Read own user settings' },
+  { name: PERMISSIONS.USER_SETTINGS_WRITE, description: 'Modify own user settings' },
+
+  // Users management
+  { name: PERMISSIONS.USERS_READ, description: 'View user list and details' },
+  { name: PERMISSIONS.USERS_WRITE, description: 'Modify user accounts' },
+
+  // RBAC management
+  { name: PERMISSIONS.RBAC_MANAGE, description: 'Manage roles and permissions' },
+
+  // Allowlist management
+  { name: PERMISSIONS.ALLOWLIST_READ, description: 'View allowlisted emails' },
+  { name: PERMISSIONS.ALLOWLIST_WRITE, description: 'Manage allowlisted emails' },
+
+  // Storage management
+  { name: PERMISSIONS.STORAGE_READ, description: 'Read object metadata, get download URLs' },
+  { name: PERMISSIONS.STORAGE_WRITE, description: 'Upload, update metadata' },
+  { name: PERMISSIONS.STORAGE_DELETE_ANY, description: 'Admin: delete any object' },
+
+  // Media management
+  { name: PERMISSIONS.MEDIA_READ, description: 'Read own media items' },
+  { name: PERMISSIONS.MEDIA_WRITE, description: 'Create and update own media items' },
+  { name: PERMISSIONS.MEDIA_DELETE, description: 'Soft-delete own media items' },
+  { name: PERMISSIONS.MEDIA_READ_ANY, description: 'Admin: read any user media items' },
+  { name: PERMISSIONS.MEDIA_WRITE_ANY, description: 'Admin: update any user media items' },
+  { name: PERMISSIONS.MEDIA_DELETE_ANY, description: 'Admin: delete any user media items' },
+
+  // Circles (per-circle role still gates which circle; these grant API access)
+  { name: PERMISSIONS.CIRCLES_READ, description: 'Read circles and memberships' },
+  { name: PERMISSIONS.CIRCLES_WRITE, description: 'Create and manage own circles' },
+  { name: PERMISSIONS.CIRCLES_MANAGE_ANY, description: 'Admin: manage any circle' },
+
+  // Backup (admin-only: local-drive backup/replication)
+  { name: PERMISSIONS.BACKUP_RUN, description: 'Admin: trigger local-drive backup job' },
+  { name: PERMISSIONS.BACKUP_READ, description: 'Admin: read backup status and manifests' },
+
+  // AI Settings
+  { name: PERMISSIONS.AI_SETTINGS_READ, description: 'Read AI provider settings and status' },
+  {
+    name: PERMISSIONS.AI_SETTINGS_WRITE,
+    description: 'Configure AI provider credentials and settings',
+  },
+
+  // Face Recognition Settings (Admin only)
+  {
+    name: PERMISSIONS.FACE_SETTINGS_READ,
+    description: 'Read face recognition provider settings and status',
+  },
+  {
+    name: PERMISSIONS.FACE_SETTINGS_WRITE,
+    description: 'Configure face recognition provider credentials and settings',
+  },
+
+  // Storage Provider Settings (Admin only)
+  {
+    name: PERMISSIONS.STORAGE_SETTINGS_READ,
+    description: 'View storage provider configuration and test connectivity',
+  },
+  {
+    name: PERMISSIONS.STORAGE_SETTINGS_WRITE,
+    description: 'Configure storage provider credentials, set active provider, run migrations',
+  },
+
+  // Search feature usage
+  { name: PERMISSIONS.SEARCH_USE, description: 'Use the AI-powered search feature' },
+
+  // Job queue dashboard (Admin only)
+  { name: PERMISSIONS.JOBS_READ, description: 'Admin: read enrichment job queue stats and list' },
+  { name: PERMISSIONS.JOBS_WRITE, description: 'Admin: retry, reset, or delete enrichment jobs' },
+
+  // Geo Provider Settings (Admin only)
+  { name: PERMISSIONS.GEO_SETTINGS_READ, description: 'Read geo provider settings and status' },
+  {
+    name: PERMISSIONS.GEO_SETTINGS_WRITE,
+    description: 'Configure geo provider credentials and active reverse-geocoding provider',
+  },
+
+  // Sharing (Admin + Contributor; manage_any = Admin only)
+  { name: PERMISSIONS.SHARES_MANAGE, description: 'Create, list, update, and revoke own shares' },
+  { name: PERMISSIONS.SHARES_MANAGE_ANY, description: "Admin: manage any user's shares" },
+
+  // Email Provider Settings (Admin only)
+  {
+    name: PERMISSIONS.EMAIL_SETTINGS_READ,
+    description: 'View email provider configuration and test connectivity',
+  },
+  {
+    name: PERMISSIONS.EMAIL_SETTINGS_WRITE,
+    description:
+      'Configure email provider credentials, set active provider, and send test emails',
+  },
+];
+
+/**
+ * Which permissions each role is granted by default.
+ *
+ * Nothing in the API mutates `role_permissions` at runtime (`rbac:manage` only
+ * guards user→role assignment in `users.controller.ts`), so this matrix is the
+ * complete intended state — there are no operator customisations to preserve.
+ * The reconciler is still additive-only; see the service for why.
+ */
+export const ROLE_PERMISSION_MATRIX: Record<RoleName, readonly PermissionName[]> = {
+  [ROLES.ADMIN]: [
+    PERMISSIONS.SYSTEM_SETTINGS_READ,
+    PERMISSIONS.SYSTEM_SETTINGS_WRITE,
+    PERMISSIONS.USER_SETTINGS_READ,
+    PERMISSIONS.USER_SETTINGS_WRITE,
+    PERMISSIONS.USERS_READ,
+    PERMISSIONS.USERS_WRITE,
+    PERMISSIONS.RBAC_MANAGE,
+    PERMISSIONS.ALLOWLIST_READ,
+    PERMISSIONS.ALLOWLIST_WRITE,
+    PERMISSIONS.STORAGE_READ,
+    PERMISSIONS.STORAGE_WRITE,
+    PERMISSIONS.STORAGE_DELETE_ANY,
+    PERMISSIONS.MEDIA_READ,
+    PERMISSIONS.MEDIA_WRITE,
+    PERMISSIONS.MEDIA_DELETE,
+    PERMISSIONS.MEDIA_READ_ANY,
+    PERMISSIONS.MEDIA_WRITE_ANY,
+    PERMISSIONS.MEDIA_DELETE_ANY,
+    // Circles: full access including super-admin operations
+    PERMISSIONS.CIRCLES_READ,
+    PERMISSIONS.CIRCLES_WRITE,
+    PERMISSIONS.CIRCLES_MANAGE_ANY,
+    // Backup: admin-only
+    PERMISSIONS.BACKUP_RUN,
+    PERMISSIONS.BACKUP_READ,
+    // AI: admin-only credential management
+    PERMISSIONS.AI_SETTINGS_READ,
+    PERMISSIONS.AI_SETTINGS_WRITE,
+    // Face Recognition: admin-only credential management
+    PERMISSIONS.FACE_SETTINGS_READ,
+    PERMISSIONS.FACE_SETTINGS_WRITE,
+    // Storage Provider Settings: admin-only configuration
+    PERMISSIONS.STORAGE_SETTINGS_READ,
+    PERMISSIONS.STORAGE_SETTINGS_WRITE,
+    // Search: all authenticated users
+    PERMISSIONS.SEARCH_USE,
+    // Job queue dashboard: admin-only
+    PERMISSIONS.JOBS_READ,
+    PERMISSIONS.JOBS_WRITE,
+    // Geo Provider Settings: admin-only
+    PERMISSIONS.GEO_SETTINGS_READ,
+    PERMISSIONS.GEO_SETTINGS_WRITE,
+    // Sharing: admin can manage any share
+    PERMISSIONS.SHARES_MANAGE,
+    PERMISSIONS.SHARES_MANAGE_ANY,
+    // Email Provider Settings: admin-only
+    PERMISSIONS.EMAIL_SETTINGS_READ,
+    PERMISSIONS.EMAIL_SETTINGS_WRITE,
+  ],
+  [ROLES.CONTRIBUTOR]: [
+    PERMISSIONS.USER_SETTINGS_READ,
+    PERMISSIONS.USER_SETTINGS_WRITE,
+    PERMISSIONS.STORAGE_READ,
+    PERMISSIONS.STORAGE_WRITE,
+    PERMISSIONS.MEDIA_READ,
+    PERMISSIONS.MEDIA_WRITE,
+    PERMISSIONS.MEDIA_DELETE,
+    // Circles: any user can use circles; per-circle role gates which circle
+    PERMISSIONS.CIRCLES_READ,
+    PERMISSIONS.CIRCLES_WRITE,
+    // Search: contributors can use AI search
+    PERMISSIONS.SEARCH_USE,
+    // Sharing: contributors can manage their own shares
+    PERMISSIONS.SHARES_MANAGE,
+  ],
+  [ROLES.VIEWER]: [
+    PERMISSIONS.USER_SETTINGS_READ,
+    PERMISSIONS.USER_SETTINGS_WRITE,
+    PERMISSIONS.STORAGE_READ,
+    PERMISSIONS.MEDIA_READ,
+    PERMISSIONS.MEDIA_WRITE,
+    PERMISSIONS.MEDIA_DELETE,
+    // Circles: any user can use circles; per-circle role gates which circle
+    PERMISSIONS.CIRCLES_READ,
+    PERMISSIONS.CIRCLES_WRITE,
+    // Search: viewers can use AI search
+    PERMISSIONS.SEARCH_USE,
+  ],
+};

--- a/apps/api/src/common/regression/issue-293-email-settings-permissions.spec.ts
+++ b/apps/api/src/common/regression/issue-293-email-settings-permissions.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for GitHub issue #293.
+ *
+ * THE BUG: an admin opening /admin/settings/email in production got
+ * "Missing permissions: email_settings:read". The email feature itself was
+ * fine — the `email_settings:read` and `email_settings:write` rows simply did
+ * not exist in that database.
+ *
+ * WHY: permission rows have only ever been created by `prisma/seed.ts`. The
+ * seed runs at install time (`install-memoriahub.sh`) and nowhere else —
+ * `update.sh` runs `prisma migrate deploy` WITHOUT it, and no migration had
+ * ever inserted into `permissions`. Commit 18811b28 (2026-07-14) added
+ * `email_settings:*` to the seed, long after the production instance was
+ * installed, so those two rows never landed. Verified against production: the
+ * seed defined 38 permissions, the database held 36 — missing exactly these two.
+ *
+ * WHY THIS FILE EXISTS — the important part: no unit test could have caught
+ * this, because nothing was wrong with the code. `email-settings.controller.ts`
+ * correctly guards on `PERMISSIONS.EMAIL_SETTINGS_READ`, and the seed correctly
+ * listed it. The defect lived in the gap between the code and the deployed
+ * database, so the assertions below pin the two mechanisms that close that gap
+ * rather than re-testing the controller:
+ *
+ *   1. the backfill migration exists and is idempotent, so the fix reaches
+ *      already-installed databases through the normal deploy path; and
+ *   2. the permissions are in the catalog that `RbacReconcileService` applies
+ *      on every boot, so this class of drift cannot recur for a future
+ *      permission.
+ *
+ * See `rbac.catalog.spec.ts` for the catalog/seed parity guards and
+ * `rbac-reconcile.service.spec.ts` for the reconciler's behaviour.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { PERMISSIONS } from '../constants/roles.constants';
+import { PERMISSION_CATALOG, ROLE_PERMISSION_MATRIX } from '../constants/rbac.catalog';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'prisma',
+  'migrations',
+  '20260807000000_add_email_settings_permissions',
+  'migration.sql',
+);
+
+describe('issue #293 — email_settings permissions reach existing deployments', () => {
+  describe('the catalog (what RbacReconcileService applies on every boot)', () => {
+    const catalogNames = PERMISSION_CATALOG.map((p) => p.name as string);
+
+    it('contains both email_settings permissions', () => {
+      expect(catalogNames).toEqual(
+        expect.arrayContaining(['email_settings:read', 'email_settings:write']),
+      );
+    });
+
+    it('matches the constants the controller guards on', () => {
+      expect(PERMISSIONS.EMAIL_SETTINGS_READ).toBe('email_settings:read');
+      expect(PERMISSIONS.EMAIL_SETTINGS_WRITE).toBe('email_settings:write');
+      expect(catalogNames).toEqual(
+        expect.arrayContaining([
+          PERMISSIONS.EMAIL_SETTINGS_READ,
+          PERMISSIONS.EMAIL_SETTINGS_WRITE,
+        ]),
+      );
+    });
+
+    it('grants both to admin — the role that was locked out of the page', () => {
+      expect(ROLE_PERMISSION_MATRIX.admin).toEqual(
+        expect.arrayContaining([
+          PERMISSIONS.EMAIL_SETTINGS_READ,
+          PERMISSIONS.EMAIL_SETTINGS_WRITE,
+        ]),
+      );
+    });
+
+    it('keeps them admin-only', () => {
+      for (const role of ['contributor', 'viewer'] as const) {
+        expect(ROLE_PERMISSION_MATRIX[role]).not.toContain(PERMISSIONS.EMAIL_SETTINGS_READ);
+        expect(ROLE_PERMISSION_MATRIX[role]).not.toContain(PERMISSIONS.EMAIL_SETTINGS_WRITE);
+      }
+    });
+  });
+
+  describe('the backfill migration (what repairs already-installed databases)', () => {
+    let sql: string;
+
+    beforeAll(() => {
+      // Throws if the migration was renamed or removed — deliberate. Without it
+      // an existing deployment stays broken until the API next boots.
+      sql = readFileSync(MIGRATION_PATH, 'utf8');
+    });
+
+    it('inserts both permissions', () => {
+      expect(sql).toContain('email_settings:read');
+      expect(sql).toContain('email_settings:write');
+      expect(sql).toMatch(/INSERT INTO "permissions"/i);
+    });
+
+    it('grants them to the admin role', () => {
+      expect(sql).toMatch(/INSERT INTO "role_permissions"/i);
+      expect(sql).toMatch(/'admin'/);
+    });
+
+    it('is idempotent — safe on a freshly seeded database that already has them', () => {
+      const conflictClauses = sql.match(/ON CONFLICT[\s\S]*?DO NOTHING/gi) ?? [];
+      // One for the permissions insert, one for the role_permissions insert.
+      expect(conflictClauses).toHaveLength(2);
+    });
+
+    it('uses the descriptions the catalog will reconcile to, so the two agree', () => {
+      for (const name of ['email_settings:read', 'email_settings:write'] as const) {
+        const catalogued = PERMISSION_CATALOG.find((p) => p.name === name);
+        expect(catalogued).toBeDefined();
+        expect(sql).toContain(catalogued!.description);
+      }
+    });
+  });
+});

--- a/apps/api/src/common/services/rbac-reconcile.service.spec.ts
+++ b/apps/api/src/common/services/rbac-reconcile.service.spec.ts
@@ -1,0 +1,236 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { RbacReconcileService } from './rbac-reconcile.service';
+import { PERMISSION_CATALOG, ROLE_PERMISSION_MATRIX } from '../constants/rbac.catalog';
+
+type MockPrisma = {
+  permission: {
+    findMany: jest.Mock;
+    createMany: jest.Mock;
+    update: jest.Mock;
+  };
+  role: { findMany: jest.Mock };
+  rolePermission: {
+    findMany: jest.Mock;
+    createMany: jest.Mock;
+  };
+};
+
+const ROLE_IDS: Record<string, string> = {
+  admin: 'role-admin',
+  contributor: 'role-contributor',
+  viewer: 'role-viewer',
+};
+
+/** A database already holding the full catalog and every catalogued grant. */
+function fullyInSyncState() {
+  const permissions = PERMISSION_CATALOG.map((p) => ({
+    id: `perm-${p.name}`,
+    name: p.name as string,
+    description: p.description,
+  }));
+
+  const grants = Object.entries(ROLE_PERMISSION_MATRIX).flatMap(([roleName, names]) =>
+    names.map((name) => ({ roleId: ROLE_IDS[roleName], permissionId: `perm-${name}` })),
+  );
+
+  return { permissions, grants };
+}
+
+describe('RbacReconcileService', () => {
+  let service: RbacReconcileService;
+  let prisma: MockPrisma;
+
+  /** Wires the mock to report `permissions`/`grants` as the current DB state. */
+  function seedMockState(
+    permissions: Array<{ id: string; name: string; description: string }>,
+    grants: Array<{ roleId: string; permissionId: string }>,
+  ) {
+    prisma.permission.findMany.mockResolvedValue(permissions);
+    prisma.rolePermission.findMany.mockResolvedValue(grants);
+    prisma.role.findMany.mockResolvedValue(
+      Object.entries(ROLE_IDS).map(([name, id]) => ({ id, name })),
+    );
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      permission: {
+        findMany: jest.fn().mockResolvedValue([]),
+        createMany: jest.fn().mockImplementation(({ data }) => ({ count: data.length })),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      role: { findMany: jest.fn().mockResolvedValue([]) },
+      rolePermission: {
+        findMany: jest.fn().mockResolvedValue([]),
+        createMany: jest.fn().mockImplementation(({ data }) => ({ count: data.length })),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RbacReconcileService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+
+    service = module.get<RbacReconcileService>(RbacReconcileService);
+  });
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('on an empty database', () => {
+    it('creates every catalogued permission', async () => {
+      await service.reconcile();
+
+      expect(prisma.permission.createMany).toHaveBeenCalledTimes(1);
+      const created = prisma.permission.createMany.mock.calls[0][0].data;
+      expect(created.map((p: { name: string }) => p.name).sort()).toEqual(
+        PERMISSION_CATALOG.map((p) => p.name as string).sort(),
+      );
+    });
+
+    it('uses skipDuplicates so a concurrent boot cannot collide', async () => {
+      await service.reconcile();
+
+      expect(prisma.permission.createMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skipDuplicates: true }),
+      );
+    });
+  });
+
+  describe('when the catalog is already fully applied', () => {
+    beforeEach(() => {
+      const { permissions, grants } = fullyInSyncState();
+      seedMockState(permissions, grants);
+    });
+
+    it('writes nothing', async () => {
+      const result = await service.reconcile();
+
+      expect(result).toEqual({
+        permissionsCreated: 0,
+        descriptionsUpdated: 0,
+        grantsCreated: 0,
+      });
+      expect(prisma.permission.createMany).not.toHaveBeenCalled();
+      expect(prisma.permission.update).not.toHaveBeenCalled();
+      expect(prisma.rolePermission.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the #293 scenario: a permission is missing from an existing install', () => {
+    beforeEach(() => {
+      const { permissions, grants } = fullyInSyncState();
+
+      // Reproduce production: every permission present EXCEPT email_settings:*,
+      // and no grants for them either.
+      const withoutEmail = permissions.filter((p) => !p.name.startsWith('email_settings:'));
+      const grantsWithoutEmail = grants.filter(
+        (g) => !g.permissionId.startsWith('perm-email_settings:'),
+      );
+
+      seedMockState(withoutEmail, grantsWithoutEmail);
+
+      // After the insert, the rows exist — reflect that for the grant pass.
+      prisma.permission.findMany
+        .mockResolvedValueOnce(withoutEmail) // reconcilePermissions
+        .mockResolvedValueOnce(withoutEmail) // reconcileDescriptions
+        .mockResolvedValue(permissions); // reconcileRoleGrants
+    });
+
+    it('creates exactly the two missing email_settings permissions', async () => {
+      await service.reconcile();
+
+      const created = prisma.permission.createMany.mock.calls[0][0].data;
+      expect(created.map((p: { name: string }) => p.name).sort()).toEqual([
+        'email_settings:read',
+        'email_settings:write',
+      ]);
+    });
+
+    it('grants both to the admin role', async () => {
+      await service.reconcile();
+
+      const grants = prisma.rolePermission.createMany.mock.calls[0][0].data;
+      expect(grants).toEqual(
+        expect.arrayContaining([
+          { roleId: ROLE_IDS.admin, permissionId: 'perm-email_settings:read' },
+          { roleId: ROLE_IDS.admin, permissionId: 'perm-email_settings:write' },
+        ]),
+      );
+    });
+
+    it('grants them to admin only, not to contributor or viewer', async () => {
+      await service.reconcile();
+
+      const grants = prisma.rolePermission.createMany.mock.calls[0][0].data;
+      const nonAdmin = grants.filter(
+        (g: { roleId: string }) => g.roleId !== ROLE_IDS.admin,
+      );
+      expect(nonAdmin).toEqual([]);
+    });
+  });
+
+  describe('additive-only guarantee', () => {
+    it('never revokes a grant that is absent from the catalog', async () => {
+      const { permissions, grants } = fullyInSyncState();
+
+      // A grant nobody catalogues — e.g. left over from a removed feature.
+      const strayGrant = { roleId: ROLE_IDS.viewer, permissionId: 'perm-jobs:write' };
+      seedMockState(permissions, [...grants, strayGrant]);
+
+      const result = await service.reconcile();
+
+      // The stray grant is left exactly as-is: nothing written, nothing removed.
+      expect(prisma.rolePermission.createMany).not.toHaveBeenCalled();
+      expect(result.grantsCreated).toBe(0);
+    });
+
+    it('updates a stale description rather than recreating the row', async () => {
+      const { permissions, grants } = fullyInSyncState();
+      const stale = permissions.map((p, i) =>
+        i === 0 ? { ...p, description: 'outdated text' } : p,
+      );
+
+      seedMockState(stale, grants);
+
+      const result = await service.reconcile();
+
+      expect(result.descriptionsUpdated).toBe(1);
+      expect(prisma.permission.update).toHaveBeenCalledWith({
+        where: { name: permissions[0].name },
+        data: { description: permissions[0].description },
+      });
+      expect(prisma.permission.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failure handling at boot', () => {
+    it('does not throw out of onModuleInit when the database is unreachable', async () => {
+      prisma.permission.findMany.mockRejectedValue(new Error('connection refused'));
+
+      // A throw here would abort Nest bootstrap and crash-loop the API.
+      await expect(service.onModuleInit()).resolves.toBeUndefined();
+    });
+
+    it('still propagates the error to direct reconcile() callers', async () => {
+      prisma.permission.findMany.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.reconcile()).rejects.toThrow('connection refused');
+    });
+
+    it('skips a role that does not exist instead of failing', async () => {
+      const { permissions } = fullyInSyncState();
+      prisma.permission.findMany.mockResolvedValue(permissions);
+      prisma.rolePermission.findMany.mockResolvedValue([]);
+      // Only the admin role exists.
+      prisma.role.findMany.mockResolvedValue([{ id: ROLE_IDS.admin, name: 'admin' }]);
+
+      const result = await service.reconcile();
+
+      const grants = prisma.rolePermission.createMany.mock.calls[0][0].data;
+      expect(grants.every((g: { roleId: string }) => g.roleId === ROLE_IDS.admin)).toBe(true);
+      expect(result.grantsCreated).toBe(ROLE_PERMISSION_MATRIX.admin.length);
+    });
+  });
+});

--- a/apps/api/src/common/services/rbac-reconcile.service.ts
+++ b/apps/api/src/common/services/rbac-reconcile.service.ts
@@ -1,0 +1,231 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  PERMISSION_CATALOG,
+  ROLE_PERMISSION_MATRIX,
+} from '../constants/rbac.catalog';
+
+/**
+ * Reconciles the RBAC catalog into the database on every API boot (issue #293).
+ *
+ * THE BUG THIS EXISTS TO PREVENT
+ *
+ * Permission rows were only ever created by `prisma/seed.ts`, which runs at
+ * install time and nowhere else — `update.sh` runs `prisma migrate deploy`
+ * without the seed. Any permission added after a deployment was installed
+ * therefore never reached that database, and the only symptom was a runtime
+ * "Missing permissions: <name>" error for whoever opened the page that needed
+ * it. `email_settings:read` broke /admin/settings/email in production this way.
+ *
+ * Reconciling at boot closes that gap for every future permission: deploying
+ * the code deploys the permission.
+ *
+ * ADDITIVE ONLY — WHY
+ *
+ * This service inserts what is missing and never deletes. It does not revoke a
+ * grant that exists in the database but not in the catalog, and it never drops
+ * a permission row. Dropping rows would cascade into `role_permissions` (see
+ * the schema's `onDelete: Cascade`), so a catalog typo or a half-finished
+ * rename could silently strip access from a live system. An unexpected grant is
+ * logged as a warning instead, which is the safe direction to fail: extra
+ * access is visible and correctable, revoked admin access during a deploy is an
+ * outage. Removals stay deliberate — a hand-written migration.
+ *
+ * NEVER FATAL
+ *
+ * Every failure path is caught and logged rather than rethrown. An exception
+ * escaping `onModuleInit` aborts Nest's bootstrap and puts the API into a
+ * crash loop, which would turn a cosmetic RBAC drift into a total outage. A
+ * reconcile that fails leaves the previous grants untouched, so the API is
+ * never worse off than before it ran — it just logs loudly at ERROR.
+ */
+@Injectable()
+export class RbacReconcileService implements OnModuleInit {
+  private readonly logger = new Logger(RbacReconcileService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.reconcile();
+    } catch (error) {
+      // Deliberately swallowed — see "NEVER FATAL" above.
+      this.logger.error(
+        `RBAC reconcile failed; leaving existing permissions untouched. ` +
+          `Admin pages may report "Missing permissions" until this is resolved. ` +
+          `Cause: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    }
+  }
+
+  /**
+   * Brings `permissions` and `role_permissions` in line with the catalog.
+   * Public so it can be invoked directly from tests and, if ever needed, from
+   * an admin/maintenance path.
+   */
+  async reconcile(): Promise<{
+    permissionsCreated: number;
+    descriptionsUpdated: number;
+    grantsCreated: number;
+  }> {
+    const permissionsCreated = await this.reconcilePermissions();
+    const descriptionsUpdated = await this.reconcileDescriptions();
+    const grantsCreated = await this.reconcileRoleGrants();
+
+    if (permissionsCreated === 0 && descriptionsUpdated === 0 && grantsCreated === 0) {
+      this.logger.log(`RBAC catalog already in sync (${PERMISSION_CATALOG.length} permissions)`);
+    } else {
+      this.logger.log(
+        `RBAC catalog reconciled: ${permissionsCreated} permission(s) created, ` +
+          `${descriptionsUpdated} description(s) updated, ${grantsCreated} role grant(s) created`,
+      );
+    }
+
+    return { permissionsCreated, descriptionsUpdated, grantsCreated };
+  }
+
+  /** Inserts catalog permissions that have no row yet. */
+  private async reconcilePermissions(): Promise<number> {
+    const existing = await this.prisma.permission.findMany({ select: { name: true } });
+    const existingNames = new Set(existing.map((p) => p.name));
+
+    const missing = PERMISSION_CATALOG.filter((p) => !existingNames.has(p.name));
+    if (missing.length === 0) {
+      return 0;
+    }
+
+    this.logger.log(
+      `Creating ${missing.length} missing permission(s): ${missing.map((p) => p.name).join(', ')}`,
+    );
+
+    // `skipDuplicates` keeps this safe if another instance boots concurrently.
+    const result = await this.prisma.permission.createMany({
+      data: missing.map((p) => ({ name: p.name, description: p.description })),
+      skipDuplicates: true,
+    });
+
+    return result.count;
+  }
+
+  /** Keeps stored descriptions in step with the catalog. Cosmetic but cheap. */
+  private async reconcileDescriptions(): Promise<number> {
+    const catalogByName = new Map(PERMISSION_CATALOG.map((p) => [p.name as string, p.description]));
+
+    const rows = await this.prisma.permission.findMany({
+      select: { name: true, description: true },
+    });
+
+    const stale = rows.filter((row) => {
+      const expected = catalogByName.get(row.name);
+      return expected !== undefined && expected !== row.description;
+    });
+
+    for (const row of stale) {
+      await this.prisma.permission.update({
+        where: { name: row.name },
+        data: { description: catalogByName.get(row.name) },
+      });
+    }
+
+    return stale.length;
+  }
+
+  /** Grants each role the catalog permissions it is missing. Never revokes. */
+  private async reconcileRoleGrants(): Promise<number> {
+    const [roles, permissions] = await Promise.all([
+      this.prisma.role.findMany({ select: { id: true, name: true } }),
+      this.prisma.permission.findMany({ select: { id: true, name: true } }),
+    ]);
+
+    const roleIdByName = new Map(roles.map((r) => [r.name, r.id]));
+    const permissionIdByName = new Map(permissions.map((p) => [p.name, p.id]));
+
+    const existingGrants = await this.prisma.rolePermission.findMany({
+      select: { roleId: true, permissionId: true },
+    });
+    const existingGrantKeys = new Set(
+      existingGrants.map((g) => `${g.roleId}:${g.permissionId}`),
+    );
+
+    const toCreate: Array<{ roleId: string; permissionId: string }> = [];
+
+    for (const [roleName, permissionNames] of Object.entries(ROLE_PERMISSION_MATRIX)) {
+      const roleId = roleIdByName.get(roleName);
+      if (!roleId) {
+        // Roles are created by the seed at install time; a missing one means a
+        // broken/partial install, which this service should surface, not paper over.
+        this.logger.warn(
+          `Role "${roleName}" is missing from the database — skipping its grants. ` +
+            `Run the seed (install-memoriahub.sh) to create the base roles.`,
+        );
+        continue;
+      }
+
+      for (const permissionName of permissionNames) {
+        const permissionId = permissionIdByName.get(permissionName);
+        if (!permissionId) {
+          // reconcilePermissions() ran first, so this should be unreachable.
+          this.logger.warn(
+            `Permission "${permissionName}" missing after reconcile — skipping grant to "${roleName}"`,
+          );
+          continue;
+        }
+
+        if (!existingGrantKeys.has(`${roleId}:${permissionId}`)) {
+          toCreate.push({ roleId, permissionId });
+          this.logger.log(`Granting "${permissionName}" to role "${roleName}"`);
+        }
+      }
+    }
+
+    this.warnOnUncatalogedGrants(roles, permissions, existingGrants);
+
+    if (toCreate.length === 0) {
+      return 0;
+    }
+
+    const result = await this.prisma.rolePermission.createMany({
+      data: toCreate,
+      skipDuplicates: true,
+    });
+
+    return result.count;
+  }
+
+  /**
+   * Reports grants present in the database but absent from the catalog. Not
+   * revoked — see "ADDITIVE ONLY" above — but surfaced so drift in the other
+   * direction is not invisible.
+   */
+  private warnOnUncatalogedGrants(
+    roles: Array<{ id: string; name: string }>,
+    permissions: Array<{ id: string; name: string }>,
+    existingGrants: Array<{ roleId: string; permissionId: string }>,
+  ): void {
+    const roleNameById = new Map(roles.map((r) => [r.id, r.name]));
+    const permissionNameById = new Map(permissions.map((p) => [p.id, p.name]));
+
+    const extras: string[] = [];
+
+    for (const grant of existingGrants) {
+      const roleName = roleNameById.get(grant.roleId);
+      const permissionName = permissionNameById.get(grant.permissionId);
+      if (!roleName || !permissionName) {
+        continue;
+      }
+
+      const cataloged = ROLE_PERMISSION_MATRIX[roleName as keyof typeof ROLE_PERMISSION_MATRIX];
+      if (cataloged && !cataloged.includes(permissionName as never)) {
+        extras.push(`${roleName} → ${permissionName}`);
+      }
+    }
+
+    if (extras.length > 0) {
+      this.logger.warn(
+        `${extras.length} role grant(s) exist in the database but not in the catalog ` +
+          `(left in place, remove with a migration if unintended): ${extras.join(', ')}`,
+      );
+    }
+  }
+}

--- a/apps/api/test/helpers/test-app.helper.ts
+++ b/apps/api/test/helpers/test-app.helper.ts
@@ -33,6 +33,33 @@ const inertGeoProvider = {
   reverseGeocode: async (): Promise<null> => null,
 };
 
+/**
+ * Gives the boot-time RBAC reconcile something sane to read (issue #293).
+ *
+ * Booting AppModule runs RbacReconcileService.onModuleInit, which reads
+ * `permission`/`role`/`rolePermission`. Under `mockDeep<PrismaClient>()` those
+ * delegates exist but resolve to `undefined`, so the reconcile threw on
+ * `undefined.map(...)`. It caught and logged its own failure — by design, so a
+ * reconcile problem can never crash-loop the API — but that meant every
+ * integration suite printed an ERROR + stack at boot that looked like a real
+ * failure while the suite passed.
+ *
+ * Returning empty sets makes the reconcile a well-defined no-op: nothing exists,
+ * no roles exist, so it has nothing to create. Specs that actually care about
+ * permission rows set their own mock returns afterwards (and `resetPrismaMock()`
+ * in a `beforeEach` runs after boot, so it cannot disturb this).
+ *
+ * Same rationale as `inertGeoProvider` above: neutralise a boot-time side
+ * effect that no integration spec is asserting on.
+ */
+function stubRbacReconcileQueries(): void {
+  prismaMock.permission.findMany.mockResolvedValue([]);
+  prismaMock.permission.createMany.mockResolvedValue({ count: 0 });
+  prismaMock.role.findMany.mockResolvedValue([]);
+  prismaMock.rolePermission.findMany.mockResolvedValue([]);
+  prismaMock.rolePermission.createMany.mockResolvedValue({ count: 0 });
+}
+
 export interface TestContext {
   app: NestFastifyApplication;
   prisma: PrismaService;
@@ -70,6 +97,8 @@ export async function createTestApp(
     .useValue(inertGeoProvider);
 
   if (shouldUseMock) {
+    stubRbacReconcileQueries();
+
     // Mocked PrismaService — no real database connection is opened.
     moduleFixture = await builder
       .overrideProvider(PrismaService)


### PR DESCRIPTION
Fixes #293.

## The bug

An admin opening `/admin/settings/email` in production got **`Missing permissions: email_settings:read`**. The email feature is fine — the `email_settings:read` / `email_settings:write` rows did not exist in that database at all.

Permission rows have only ever been created by `prisma/seed.ts`, which runs at install time (`install-memoriahub.sh`) and nowhere else: `update.sh` runs `prisma migrate deploy` **without** the seed, and no migration had ever inserted into `permissions`. Commit `18811b28` added `email_settings:*` to the seed on 2026-07-14, long after the production instance was installed, so those two rows never landed.

Verified against production before writing any code — the seed defined 38 permissions, the database held 36:

```
=== IN SEED, MISSING FROM DB ===
email_settings:read
email_settings:write
=== IN DB, NOT IN SEED ===
(none)
```

The `admin` role already held all 36 permissions that existed, so this was purely the two missing rows, not a role-mapping problem.

**This is a deployment gap, not an email bug.** Every permission added after a deployment is installed breaks the same way, and the only symptom is a runtime `Missing permissions` error on whichever page needs it.

## The fix

**`RbacReconcileService`** reconciles the catalog into the database on every API boot, so deploying the code now deploys the permission. Two deliberate safety properties:

- **Additive only.** It never revokes a grant or drops a permission row. Deletes would cascade through `role_permissions` (`onDelete: Cascade` in the schema), so a catalog typo or half-finished rename could strip access from a live system. Uncatalogued grants are logged as a warning instead — extra access is visible and correctable, revoked admin access during a deploy is an outage. Removals stay deliberate: a hand-written migration.
- **Never fatal.** Every failure path is caught and logged rather than rethrown. An exception escaping `onModuleInit` aborts Nest's bootstrap and puts the API in a crash loop, which would turn cosmetic RBAC drift into a total outage. A failed reconcile leaves existing grants untouched, so the API is never worse off than before it ran.

**Backfill migration** (`20260807000000_add_email_settings_permissions`) inserts the two rows and their admin grants, so already-installed databases are repaired through the normal deploy path rather than waiting on the next boot. Both inserts are `ON CONFLICT DO NOTHING`, so a freshly seeded database no-ops.

## On the duplicated permission list

`rbac.catalog.ts` is the single source of truth the reconciler applies. `prisma/seed.ts` **deliberately keeps its own copy rather than importing it** — the production image (`apps/api/Dockerfile`) ships `dist/`, `prisma/` and `scripts/` but *not* `src/`, so a cross-import would break install-time seeding. `rbac.catalog.spec.ts` parses the seed and fails if the two ever diverge, which is what makes the duplication safe. Its seed-parsing tests assert a plausible parse count *before* comparing, so a reformat that breaks the regex fails loudly instead of turning every comparison into a vacuous pass.

## Test-helper change

`test-app.helper.ts` now gives the boot-time reconcile empty result sets. Under `mockDeep<PrismaClient>()` those delegates resolve to `undefined`, so the reconcile caught and logged its own failure at boot — harmless, and exactly the designed behaviour, but it printed an ERROR + stack in every integration suite that looked like a real failure. Same rationale as the existing `inertGeoProvider` stub: neutralise a boot-time side effect no integration spec asserts on.

## Verification

- 30 new tests across three specs, all passing.
- **Mutation-tested the guards** — removing `email_settings:write` from the catalog fails 6 assertions, including `catalogs every permission declared in PERMISSIONS` and `seeds exactly the catalogued permission set`. These are the assertions that would have caught #293.
- `tsc --noEmit` clean.
- Existing `email-settings`, `rbac` and `guard-integration` integration suites: 43 passed, and the boot-time ERROR noise is gone.

Note that no unit test *could* have caught the original bug: nothing was wrong with the code. The controller correctly guarded on `PERMISSIONS.EMAIL_SETTINGS_READ` and the seed correctly listed it — the defect lived in the gap between the code and the deployed database. The new specs therefore pin the two mechanisms that close that gap rather than re-testing the controller.

## Deploy note

After merge, `./update.sh` applies the backfill migration and the reconciler runs on API boot. No seed re-run and no manual SQL needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVXrSm9m6sxcg75Yd41ZpZ
