### PR TITLE
fix(tests): DB-gated specs report SKIPPED instead of vacuously passing

### DIFF
--- a/apps/api/test/circles/migration-backfill.integration.spec.ts
+++ b/apps/api/test/circles/migration-backfill.integration.spec.ts
@@ -1,6 +1,15 @@
-// DB_GATED: This test requires a real PostgreSQL database. It will not run in environments
-// without database connectivity (no POSTGRES_HOST or DATABASE_URL). In CI, ensure the
-// postgres service is available and migrations have been applied before running this suite.
+// DB_GATED: This test requires a real PostgreSQL database. When none is
+// reachable the whole suite is registered via a real `describe.skip`, so Jest
+// reports these tests as SKIPPED — never PASSED (issue #288).
+//
+// The gate is `describeMaybeDb` from test/helpers/db-probe.helper.ts, whose
+// probe is SYNCHRONOUS and evaluated at module load. This file previously
+// gated on env vars alone and probed asynchronously in `beforeAll`, which
+// meant: `.env.test` declares POSTGRES_HOST unconditionally so the `describe`
+// always ran, the async probe resolved long after Jest had already registered
+// the suite, and a per-test `skipIfNoDb` wrapper whose body was
+// `expect(true).toBe(true); return;` turned all 15 tests into vacuous PASSES
+// with no database anywhere. See that helper's header for the full rationale.
 //
 // Purpose: Validate that the post-migration schema invariants hold for the family-circles
 // feature. Specifically:
@@ -14,7 +23,7 @@
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { randomUUID } from 'crypto';
-import * as net from 'net';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
 
 // ---------------------------------------------------------------------------
 // Build a Postgres connection string from environment variables, mirroring
@@ -32,24 +41,6 @@ function buildConnectionString(): string {
   const dbName = process.env.POSTGRES_DB ?? 'appdb';
   const encoded = encodeURIComponent(password);
   return `postgresql://${user}:${encoded}@${host}:${port}/${dbName}`;
-}
-
-// ---------------------------------------------------------------------------
-// TCP connectivity probe — checks whether the Postgres server is actually
-// listening before we attempt to instantiate PrismaClient, so this suite
-// gracefully skips even when .env.test declares DB variables but no server
-// is running.
-// ---------------------------------------------------------------------------
-
-function probeDbConnectivity(host: string, port: number, timeoutMs = 1500): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = new net.Socket();
-    const fail = () => { socket.destroy(); resolve(false); };
-    socket.setTimeout(timeoutMs);
-    socket.once('error', fail);
-    socket.once('timeout', fail);
-    socket.connect(port, host, () => { socket.destroy(); resolve(true); });
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -76,28 +67,16 @@ const TAG_1_ID = padId('tag1');
 const TAG_2_ID = padId('tag2');
 
 // ---------------------------------------------------------------------------
-// Suite guard — only run the describe block when env vars are declared.
-// Within beforeAll we do a real TCP probe and skip if DB is unreachable.
+// Suite guard — `describeMaybeDb` is already resolved (see the header): inside
+// this block the database is known to be reachable, so `prisma` is
+// non-nullable and no test needs a runtime guard.
 // ---------------------------------------------------------------------------
 
-const DB_ENV_VARS_SET = !!(process.env.POSTGRES_HOST || process.env.DATABASE_URL);
-const describeMaybeDb = DB_ENV_VARS_SET ? describe : describe.skip;
-
 describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () => {
-  let prisma: PrismaClient | null = null;
-  let dbReachable = false;
+  let prisma: PrismaClient;
 
   beforeAll(async () => {
-    const host = process.env.POSTGRES_HOST ?? 'localhost';
-    const port = parseInt(process.env.POSTGRES_PORT ?? '5432', 10);
-    dbReachable = await probeDbConnectivity(host, port, 2000);
-
-    if (!dbReachable) {
-      // DB unreachable — tests below will be skipped individually
-      return;
-    }
-
-    // PrismaClient in this project requires the PrismaPg driver adapter
+    // PrismaClient in this project requires the PrismaPg driver adapter.
     const adapter = new PrismaPg(buildConnectionString());
     prisma = new PrismaClient({ adapter } as any);
     await prisma.$connect();
@@ -105,49 +84,36 @@ describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () 
   }, 30000);
 
   afterAll(async () => {
-    if (dbReachable && prisma) {
+    if (prisma) {
       await cleanupTestData(prisma);
       await prisma.$disconnect();
     }
   }, 30000);
-
-  // Helper: resolve immediately with a no-op expectation when DB is unavailable.
-  // This makes the test show as passing-with-note rather than erroring.
-  function skipIfNoDb(testFn: () => Promise<void>): () => Promise<void> {
-    return async () => {
-      if (!dbReachable || !prisma) {
-        // Database is not available in this environment — test is a no-op
-        expect(true).toBe(true); // satisfy Jest's "no assertions" check
-        return;
-      }
-      await testFn();
-    };
-  }
 
   // =========================================================================
   // 1. Every MediaItem created post-migration has a non-null circleId
   // =========================================================================
 
   describe('MediaItem circleId invariant', () => {
-    it('MediaItem has a non-null circleId after creation', skipIfNoDb(async () => {
-      const item = await prisma!.mediaItem.findUnique({ where: { id: MEDIA_1_ID } });
+    it('MediaItem has a non-null circleId after creation', async () => {
+      const item = await prisma.mediaItem.findUnique({ where: { id: MEDIA_1_ID } });
       expect(item).not.toBeNull();
       expect(item!.circleId).not.toBeNull();
       expect(item!.circleId).toBe(CIRCLE_1_ID);
-    }));
+    });
 
-    it('MediaItem created by user 2 belongs to user 2 circle', skipIfNoDb(async () => {
-      const item = await prisma!.mediaItem.findUnique({ where: { id: MEDIA_2_ID } });
+    it('MediaItem created by user 2 belongs to user 2 circle', async () => {
+      const item = await prisma.mediaItem.findUnique({ where: { id: MEDIA_2_ID } });
       expect(item).not.toBeNull();
       expect(item!.circleId).toBe(CIRCLE_2_ID);
-    }));
+    });
 
-    it('addedById is preserved and matches the creating user', skipIfNoDb(async () => {
-      const item1 = await prisma!.mediaItem.findUnique({ where: { id: MEDIA_1_ID } });
-      const item2 = await prisma!.mediaItem.findUnique({ where: { id: MEDIA_2_ID } });
+    it('addedById is preserved and matches the creating user', async () => {
+      const item1 = await prisma.mediaItem.findUnique({ where: { id: MEDIA_1_ID } });
+      const item2 = await prisma.mediaItem.findUnique({ where: { id: MEDIA_2_ID } });
       expect(item1!.addedById).toBe(USER_1_ID);
       expect(item2!.addedById).toBe(USER_2_ID);
-    }));
+    });
   });
 
   // =========================================================================
@@ -155,25 +121,25 @@ describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () 
   // =========================================================================
 
   describe('Album circleId invariant', () => {
-    it('Album has a non-null circleId after creation', skipIfNoDb(async () => {
-      const album = await prisma!.album.findUnique({ where: { id: ALBUM_1_ID } });
+    it('Album has a non-null circleId after creation', async () => {
+      const album = await prisma.album.findUnique({ where: { id: ALBUM_1_ID } });
       expect(album).not.toBeNull();
       expect(album!.circleId).not.toBeNull();
       expect(album!.circleId).toBe(CIRCLE_1_ID);
-    }));
+    });
 
-    it('Album created by user 2 belongs to user 2 circle', skipIfNoDb(async () => {
-      const album = await prisma!.album.findUnique({ where: { id: ALBUM_2_ID } });
+    it('Album created by user 2 belongs to user 2 circle', async () => {
+      const album = await prisma.album.findUnique({ where: { id: ALBUM_2_ID } });
       expect(album).not.toBeNull();
       expect(album!.circleId).toBe(CIRCLE_2_ID);
-    }));
+    });
 
-    it('addedById on Album is preserved', skipIfNoDb(async () => {
-      const album1 = await prisma!.album.findUnique({ where: { id: ALBUM_1_ID } });
-      const album2 = await prisma!.album.findUnique({ where: { id: ALBUM_2_ID } });
+    it('addedById on Album is preserved', async () => {
+      const album1 = await prisma.album.findUnique({ where: { id: ALBUM_1_ID } });
+      const album2 = await prisma.album.findUnique({ where: { id: ALBUM_2_ID } });
       expect(album1!.addedById).toBe(USER_1_ID);
       expect(album2!.addedById).toBe(USER_2_ID);
-    }));
+    });
   });
 
   // =========================================================================
@@ -181,18 +147,18 @@ describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () 
   // =========================================================================
 
   describe('Tag circleId invariant', () => {
-    it('Tag has a non-null circleId after creation', skipIfNoDb(async () => {
-      const tag = await prisma!.tag.findUnique({ where: { id: TAG_1_ID } });
+    it('Tag has a non-null circleId after creation', async () => {
+      const tag = await prisma.tag.findUnique({ where: { id: TAG_1_ID } });
       expect(tag).not.toBeNull();
       expect(tag!.circleId).not.toBeNull();
       expect(tag!.circleId).toBe(CIRCLE_1_ID);
-    }));
+    });
 
-    it('Tag created in user 2 circle has the correct circleId', skipIfNoDb(async () => {
-      const tag = await prisma!.tag.findUnique({ where: { id: TAG_2_ID } });
+    it('Tag created in user 2 circle has the correct circleId', async () => {
+      const tag = await prisma.tag.findUnique({ where: { id: TAG_2_ID } });
       expect(tag).not.toBeNull();
       expect(tag!.circleId).toBe(CIRCLE_2_ID);
-    }));
+    });
   });
 
   // =========================================================================
@@ -200,21 +166,21 @@ describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () 
   // =========================================================================
 
   describe('Personal circle membership invariant', () => {
-    it('circle owner is a circle_admin member of their personal circle', skipIfNoDb(async () => {
-      const membership1 = await prisma!.circleMember.findUnique({
+    it('circle owner is a circle_admin member of their personal circle', async () => {
+      const membership1 = await prisma.circleMember.findUnique({
         where: { circleId_userId: { circleId: CIRCLE_1_ID, userId: USER_1_ID } },
       });
       expect(membership1).not.toBeNull();
       expect(membership1!.role).toBe('circle_admin');
-    }));
+    });
 
-    it('user 2 is a circle_admin of their own personal circle', skipIfNoDb(async () => {
-      const membership2 = await prisma!.circleMember.findUnique({
+    it('user 2 is a circle_admin of their own personal circle', async () => {
+      const membership2 = await prisma.circleMember.findUnique({
         where: { circleId_userId: { circleId: CIRCLE_2_ID, userId: USER_2_ID } },
       });
       expect(membership2).not.toBeNull();
       expect(membership2!.role).toBe('circle_admin');
-    }));
+    });
   });
 
   // =========================================================================
@@ -222,19 +188,19 @@ describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () 
   // =========================================================================
 
   describe('Every user has at least one circle', () => {
-    it('user 1 has at least one circle', skipIfNoDb(async () => {
-      const circles = await prisma!.circle.findMany({
+    it('user 1 has at least one circle', async () => {
+      const circles = await prisma.circle.findMany({
         where: { ownerId: USER_1_ID },
       });
       expect(circles.length).toBeGreaterThanOrEqual(1);
-    }));
+    });
 
-    it('user 2 has at least one circle', skipIfNoDb(async () => {
-      const circles = await prisma!.circle.findMany({
+    it('user 2 has at least one circle', async () => {
+      const circles = await prisma.circle.findMany({
         where: { ownerId: USER_2_ID },
       });
       expect(circles.length).toBeGreaterThanOrEqual(1);
-    }));
+    });
   });
 
   // =========================================================================
@@ -242,35 +208,35 @@ describeMaybeDb('Migration Backfill Invariants (DB_GATED: real PostgreSQL)', () 
   // =========================================================================
 
   describe('Bulk null-check for seeded records', () => {
-    it('no seeded MediaItem has a null circleId', skipIfNoDb(async () => {
-      const items = await prisma!.mediaItem.findMany({
+    it('no seeded MediaItem has a null circleId', async () => {
+      const items = await prisma.mediaItem.findMany({
         where: { id: { in: [MEDIA_1_ID, MEDIA_2_ID] } },
       });
       expect(items).toHaveLength(2);
       items.forEach((item) => {
         expect(item.circleId).not.toBeNull();
       });
-    }));
+    });
 
-    it('no seeded Album has a null circleId', skipIfNoDb(async () => {
-      const albums = await prisma!.album.findMany({
+    it('no seeded Album has a null circleId', async () => {
+      const albums = await prisma.album.findMany({
         where: { id: { in: [ALBUM_1_ID, ALBUM_2_ID] } },
       });
       expect(albums).toHaveLength(2);
       albums.forEach((album) => {
         expect(album.circleId).not.toBeNull();
       });
-    }));
+    });
 
-    it('no seeded Tag has a null circleId', skipIfNoDb(async () => {
-      const tags = await prisma!.tag.findMany({
+    it('no seeded Tag has a null circleId', async () => {
+      const tags = await prisma.tag.findMany({
         where: { id: { in: [TAG_1_ID, TAG_2_ID] } },
       });
       expect(tags).toHaveLength(2);
       tags.forEach((tag) => {
         expect(tag.circleId).not.toBeNull();
       });
-    }));
+    });
   });
 });
 

--- a/apps/api/test/helpers/db-probe.helper.spec.ts
+++ b/apps/api/test/helpers/db-probe.helper.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Guard tests for the DB-gated-suite probe (issue #288).
+ *
+ * Two things are worth protecting here, and neither is "does TCP work":
+ *
+ *  1. `resolveDbProbeTarget` must return null when NOTHING is configured, so
+ *     the probe short-circuits instead of spawning a subprocess on every plain
+ *     unit-test run.
+ *  2. `isDatabaseReachable` must return false — never throw — for anything
+ *     unreachable. A probe that throws fails the whole spec file instead of
+ *     skipping it, which is the same class of dishonest result (a red that
+ *     isn't a real failure) as the vacuous green this helper exists to
+ *     prevent.
+ *
+ * There is also a static check that no spec has reintroduced the
+ * `skipIfNoDb`-style per-test guard, since that pattern is what manufactured
+ * the false passes in the first place and it reads as reasonable enough to be
+ * copied again.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { isDatabaseReachable, resolveDbProbeTarget } from './db-probe.helper';
+
+describe('db-probe.helper', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('resolveDbProbeTarget', () => {
+    it('returns null when neither DATABASE_URL nor POSTGRES_HOST is set', () => {
+      delete process.env['DATABASE_URL'];
+      delete process.env['POSTGRES_HOST'];
+      expect(resolveDbProbeTarget()).toBeNull();
+    });
+
+    it('prefers DATABASE_URL and parses host/port out of it', () => {
+      process.env['DATABASE_URL'] = 'postgresql://u:p@db.example.test:5433/appdb';
+      process.env['POSTGRES_HOST'] = 'ignored.example.test';
+      expect(resolveDbProbeTarget()).toEqual({ host: 'db.example.test', port: 5433 });
+    });
+
+    it('defaults the port to 5432 when DATABASE_URL omits it', () => {
+      process.env['DATABASE_URL'] = 'postgresql://u:p@db.example.test/appdb';
+      expect(resolveDbProbeTarget()).toEqual({ host: 'db.example.test', port: 5432 });
+    });
+
+    it('returns null for an unparseable DATABASE_URL rather than throwing', () => {
+      process.env['DATABASE_URL'] = 'not a url';
+      expect(resolveDbProbeTarget()).toBeNull();
+    });
+
+    it('falls back to the discrete POSTGRES_* variables', () => {
+      delete process.env['DATABASE_URL'];
+      process.env['POSTGRES_HOST'] = 'pg.example.test';
+      process.env['POSTGRES_PORT'] = '6543';
+      expect(resolveDbProbeTarget()).toEqual({ host: 'pg.example.test', port: 6543 });
+    });
+  });
+
+  describe('isDatabaseReachable', () => {
+    it('returns false (does not throw) when no database is configured', () => {
+      delete process.env['DATABASE_URL'];
+      delete process.env['POSTGRES_HOST'];
+      expect(isDatabaseReachable()).toBe(false);
+    });
+
+    it('returns false (does not throw) for a port with nothing listening', () => {
+      delete process.env['DATABASE_URL'];
+      process.env['POSTGRES_HOST'] = '127.0.0.1';
+      // Port 1 is privileged and never serves Postgres — connect is refused.
+      process.env['POSTGRES_PORT'] = '1';
+      expect(isDatabaseReachable(500)).toBe(false);
+    });
+
+    it('returns false (does not throw) for an unroutable address, via the timeout path', () => {
+      delete process.env['DATABASE_URL'];
+      // TEST-NET-1 (RFC 5737) is reserved for documentation and never routes,
+      // so this exercises the timeout branch rather than the refused branch.
+      process.env['POSTGRES_HOST'] = '192.0.2.1';
+      process.env['POSTGRES_PORT'] = '5432';
+      expect(isDatabaseReachable(500)).toBe(false);
+    });
+  });
+
+  describe('no spec reintroduces a per-test DB guard', () => {
+    it('has no `skipIfNoDb`-style wrapper anywhere under test/', () => {
+      // The wrapper's body was `expect(true).toBe(true); return;`, which Jest
+      // reports as a genuine PASS — so a suite using it reports green while
+      // asserting nothing. With a module-load `describe.skip` gate there is
+      // nothing left for such a wrapper to do; its only remaining effect
+      // would be to manufacture false passes again.
+      //
+      // Matches a CALL or DEFINITION (`skipIfNoDb(`), not the bare name, so
+      // prose that explains the history — this file's header, the helper's
+      // docs, migration-backfill's header — doesn't trip the guard.
+      const usagePattern = /skipIfNoDb\s*\(/;
+      const testRoot = join(__dirname, '..');
+      const offenders: string[] = [];
+
+      const walk = (dir: string): void => {
+        for (const entry of readdirSync(dir)) {
+          if (entry === 'node_modules') continue;
+          const full = join(dir, entry);
+          if (statSync(full).isDirectory()) {
+            walk(full);
+            continue;
+          }
+          if (!full.endsWith('.ts')) continue;
+          if (full === __filename) continue; // this file names it on purpose
+          if (usagePattern.test(readFileSync(full, 'utf8'))) {
+            offenders.push(full.slice(testRoot.length + 1));
+          }
+        }
+      };
+      walk(testRoot);
+
+      expect(offenders).toEqual([]);
+    });
+  });
+});

--- a/apps/api/test/helpers/db-probe.helper.ts
+++ b/apps/api/test/helpers/db-probe.helper.ts
@@ -1,0 +1,137 @@
+/**
+ * Synchronous database-reachability probe for DB-gated integration specs.
+ *
+ * ## Why this exists (issue #288)
+ *
+ * A DB-gated suite must report **skipped** when no database is reachable —
+ * never **passed**. Getting that right is subtler than it looks, and two
+ * plausible-looking gates both produce false greens:
+ *
+ *  1. **Env-var-only gate.** `.env.test` declares `POSTGRES_HOST`
+ *     unconditionally, so `!!process.env.POSTGRES_HOST` is true even with no
+ *     server listening. The `describe` block runs.
+ *
+ *  2. **Async probe in `beforeAll`.** Jest fixes which `describe`/`it` blocks
+ *     are registered — and therefore whether a suite reports "skipped" vs.
+ *     "passed" — at MODULE-EVALUATION time, which completes synchronously
+ *     before any `beforeAll` body runs. By the time an async probe resolves,
+ *     the suite has already been registered as a normal `describe`. The usual
+ *     fallback is then a per-test guard whose body is
+ *     `expect(true).toBe(true); return;` — and that is a genuine PASS. A suite
+ *     asserting nothing while reporting green is exactly the defect this
+ *     module exists to prevent.
+ *
+ * The fix is a probe that is **synchronous and evaluated at module load**, so
+ * a real `describe.skip` can be chosen before Jest registers anything. There
+ * is then nothing left for a per-test guard to do — `skipIfNoDb`-style
+ * wrappers should not exist alongside this.
+ *
+ * ## Usage
+ *
+ *   const describeMaybeDb = isDatabaseReachable() ? describe : describe.skip;
+ *
+ *   describeMaybeDb('… (DB_GATED: real PostgreSQL)', () => {
+ *     let prisma: PrismaClient;
+ *     beforeAll(async () => { prisma = …; await prisma.$connect(); });
+ *     …
+ *   });
+ *
+ * Inside the block the database is known to be reachable, so `prisma` can be
+ * non-nullable and every test can assume it — no null checks, no guards.
+ *
+ * ## How the probe works
+ *
+ * Node has no synchronous socket API, so we spawn a throwaway Node subprocess
+ * that attempts a `net.connect` and exits 0 on success / 1 on
+ * error-or-timeout, and read its exit code synchronously via `execFileSync`.
+ * ANY failure (non-zero exit, spawn error, the outer `execFileSync` timeout)
+ * is treated as "database unavailable" rather than propagating — a probe that
+ * throws would fail the whole file instead of skipping it.
+ *
+ * This checks that something is LISTENING on the port, not that it is
+ * Postgres, that credentials work, or that migrations have been applied. That
+ * is deliberate: it is the cheap check that distinguishes "no database here"
+ * from "database here", and a suite that then fails to connect or finds a
+ * missing table SHOULD fail loudly rather than silently skip.
+ */
+
+import { execFileSync } from 'child_process';
+
+/** Connection details a probe needs, resolved from the usual env vars. */
+export interface DbProbeTarget {
+  host: string;
+  port: number;
+}
+
+/**
+ * Resolve the probe target the same way `PrismaService` resolves its
+ * connection: `DATABASE_URL` wins when set, otherwise the discrete
+ * `POSTGRES_*` variables, with the same defaults.
+ */
+export function resolveDbProbeTarget(): DbProbeTarget | null {
+  const url = process.env['DATABASE_URL'];
+  if (url) {
+    try {
+      const parsed = new URL(url);
+      return { host: parsed.hostname, port: Number(parsed.port || 5432) };
+    } catch {
+      // An unparseable DATABASE_URL is a misconfiguration, not a reachable DB.
+      return null;
+    }
+  }
+
+  const host = process.env['POSTGRES_HOST'];
+  if (!host) {
+    // Neither variable set: no DB configured at all (e.g. a plain unit-test
+    // run). Short-circuit before paying for a subprocess spawn.
+    return null;
+  }
+  return { host, port: parseInt(process.env['POSTGRES_PORT'] ?? '5432', 10) };
+}
+
+/**
+ * Is a server listening on the resolved Postgres host/port?
+ *
+ * MUST be called at module scope, before `describe` is registered — see this
+ * module's header for why a `beforeAll` is structurally too late.
+ */
+export function isDatabaseReachable(timeoutMs = 1500): boolean {
+  const target = resolveDbProbeTarget();
+  if (!target) {
+    return false;
+  }
+
+  const script = `
+    const net = require('net');
+    const socket = new net.Socket();
+    const fail = () => { socket.destroy(); process.exit(1); };
+    socket.setTimeout(${timeoutMs});
+    socket.once('error', fail);
+    socket.once('timeout', fail);
+    socket.connect(${target.port}, ${JSON.stringify(target.host)}, () => {
+      socket.destroy();
+      process.exit(0);
+    });
+  `;
+
+  try {
+    execFileSync(process.execPath, ['-e', script], {
+      stdio: 'ignore',
+      timeout: timeoutMs + 1000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `describe` when a database is reachable, `describe.skip` otherwise.
+ *
+ * Evaluated eagerly at import time, which is precisely the point: importing
+ * this constant at module scope gives the caller a gate that is already
+ * decided by the time Jest registers its suite.
+ */
+export const describeMaybeDb: jest.Describe = isDatabaseReachable()
+  ? describe
+  : describe.skip;

--- a/apps/api/test/notifications/notification-dedup.integration.spec.ts
+++ b/apps/api/test/notifications/notification-dedup.integration.spec.ts
@@ -4,8 +4,11 @@
 // (`.env.test` DECLARES `POSTGRES_HOST` even when no Postgres server is
 // actually running, which would make an env-only gate a false positive), the
 // skip decision here is backed by a SYNCHRONOUS TCP connectivity probe
-// (`probeDbSync` below) evaluated at module load, before `describe` is
-// registered — see that function's comment for why it must be synchronous.
+// evaluated at module load, before `describe` is registered. That probe used
+// to be inlined here; issue #288 moved it to
+// test/helpers/db-probe.helper.ts (`describeMaybeDb`) so every DB-gated spec
+// shares one implementation — see that helper's header for why it must be
+// synchronous, and for the vacuous-pass defect it exists to prevent.
 // When the probe fails, the whole suite is registered via a real
 // `describe.skip`, so Jest reports these tests as SKIPPED, never PASSED. In
 // CI (which has no live database — see docs/ci-known-failing-tests.md) this
@@ -65,7 +68,7 @@
 import { PrismaClient, Prisma } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { randomUUID } from 'crypto';
-import { execFileSync } from 'child_process';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
 
 // ---------------------------------------------------------------------------
 // Build a Postgres connection string from environment variables, mirroring
@@ -84,50 +87,6 @@ function buildConnectionString(): string {
   const dbName = process.env.POSTGRES_DB ?? 'appdb';
   const encoded = encodeURIComponent(password);
   return `postgresql://${user}:${encoded}@${host}:${port}/${dbName}`;
-}
-
-// ---------------------------------------------------------------------------
-// Synchronous TCP connectivity probe — checks whether the Postgres server is
-// actually listening, evaluated at MODULE LOAD time (before `describe` is
-// registered) rather than inside `beforeAll`.
-//
-// This must be synchronous, not async. Jest fixes which `describe`/`it`
-// blocks are registered — and therefore whether a suite is reported as
-// "skipped" vs. "passed" — at module-evaluation time, which happens
-// synchronously before any `beforeAll`/`it` body ever runs. An async probe
-// awaited inside `beforeAll` is already too late to influence `describe` vs.
-// `describe.skip`: the suite has already been registered as a normal
-// `describe` by the time the probe resolves. Falling back to a per-test guard
-// (as this file used to do) doesn't fix that either — it just makes every
-// test body execute a trivial `expect(true).toBe(true)` and return, which
-// Jest reports as a genuine PASS. That is the exact vacuous-green defect this
-// probe exists to avoid: tests reporting green while exercising nothing.
-//
-// We spawn a throwaway Node subprocess that attempts a `net.connect` and
-// exits 0 on success / 1 on error-or-timeout, then inspect its exit code
-// synchronously via `execFileSync`. `stdio: 'ignore'` suppresses the child's
-// output; the try/catch treats ANY failure (non-zero exit, spawn error, the
-// outer timeout) as "database unavailable" rather than propagating.
-// ---------------------------------------------------------------------------
-
-function probeDbSync(host: string, port: number): boolean {
-  const script = `
-    const net = require('net');
-    const socket = new net.Socket();
-    const fail = () => { socket.destroy(); process.exit(1); };
-    socket.setTimeout(1500);
-    socket.once('error', fail);
-    socket.once('timeout', fail);
-    socket.connect(${port}, ${JSON.stringify(host)}, () => { socket.destroy(); process.exit(0); });
-  `;
-  try {
-    execFileSync(process.execPath, ['-e', script], { stdio: 'ignore', timeout: 2500 });
-    return true;
-  } catch {
-    // Non-zero exit code (connect failed), spawn error, or the outer
-    // execFileSync timeout all land here — treat all of them as "no DB".
-    return false;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -153,22 +112,6 @@ type ReviewQueueType =
   | 'review_queue_duplicates'
   | 'review_queue_location_suggestions'
   | 'review_queue_enhancements';
-
-// ---------------------------------------------------------------------------
-// Suite guard — evaluated synchronously at module load, BEFORE `describe` is
-// registered, so a missing database produces a real `describe.skip` (Jest
-// reports "skipped"), not a `describe` whose tests vacuously pass. Env vars
-// alone are not sufficient: `.env.test` declares `POSTGRES_HOST` even when no
-// Postgres server is listening, so `DB_ENV_VARS_SET` is also required to
-// short-circuit before paying for a subprocess spawn when the vars aren't
-// even set (e.g. a plain unit-test run with no DB-related env at all).
-// ---------------------------------------------------------------------------
-
-const DB_ENV_VARS_SET = !!(process.env.POSTGRES_HOST || process.env.DATABASE_URL);
-const DB_AVAILABLE =
-  DB_ENV_VARS_SET &&
-  probeDbSync(process.env.POSTGRES_HOST ?? 'localhost', parseInt(process.env.POSTGRES_PORT ?? '5432', 10));
-const describeMaybeDb = DB_AVAILABLE ? describe : describe.skip;
 
 describeMaybeDb('Notification review-queue dedup (DB_GATED: real PostgreSQL)', () => {
   let prisma: PrismaClient;

--- a/apps/api/test/review-runs/review-runs.integration.spec.ts
+++ b/apps/api/test/review-runs/review-runs.integration.spec.ts
@@ -55,8 +55,8 @@
 
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { execFileSync } from 'child_process';
 import { randomUUID } from 'crypto';
+import { isDatabaseReachable } from '../helpers/db-probe.helper';
 
 // ---------------------------------------------------------------------------
 // Connection string. `.env.test` sets DATABASE_URL to
@@ -79,43 +79,11 @@ function resolveDatabaseUrl(): string {
 
 const DATABASE_URL = resolveDatabaseUrl();
 
-/**
- * Synchronous TCP reachability probe, run at module load so the result is
- * known before Jest registers the tests below — `describe.skip` cannot be
- * decided from an async `beforeAll`, which runs too late.
- */
-function isDatabaseReachable(url: string): boolean {
-  let host: string;
-  let port: number;
-  try {
-    const parsed = new URL(url);
-    host = parsed.hostname;
-    port = Number(parsed.port || 5432);
-  } catch {
-    return false;
-  }
-  try {
-    execFileSync(
-      process.execPath,
-      [
-        '-e',
-        `const net=require('net');` +
-          `const s=net.connect({host:process.argv[1],port:Number(process.argv[2])});` +
-          `s.on('connect',()=>{s.destroy();process.exit(0)});` +
-          `s.on('error',()=>process.exit(1));` +
-          `setTimeout(()=>process.exit(1),2000);`,
-        host,
-        String(port),
-      ],
-      { stdio: 'ignore', timeout: 5000 },
-    );
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-const DB_REACHABLE = isDatabaseReachable(DATABASE_URL);
+// Synchronous reachability probe, evaluated at module load so the result is
+// known before Jest registers the tests below — `describe.skip` cannot be
+// decided from an async `beforeAll`, which runs too late. Shared with every
+// other DB-gated spec since issue #288; see test/helpers/db-probe.helper.ts.
+const DB_REACHABLE = isDatabaseReachable();
 
 if (!DB_REACHABLE) {
   // eslint-disable-next-line no-console
@@ -128,8 +96,9 @@ if (!DB_REACHABLE) {
 const describeDb = DB_REACHABLE ? describe : describe.skip;
 
 describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
-  let prisma: PrismaClient | null = null;
-  let dbReachable = false;
+  // `describeDb` is already resolved, so inside this block the database is
+  // known to be reachable: `prisma` is non-nullable and no test needs a guard.
+  let prisma: PrismaClient;
 
   // Shared fixture ids, created once in beforeAll and torn down in afterAll.
   const userId = randomUUID();
@@ -142,7 +111,6 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
     const client = new PrismaClient({ adapter });
     await client.$connect();
     prisma = client;
-    dbReachable = true;
 
     await prisma.user.create({
       data: { id: userId, email: `review-runs-${userId}@example.test` },
@@ -175,7 +143,7 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   }, 30000);
 
   afterAll(async () => {
-    if (!dbReachable || !prisma) return;
+    if (!prisma) return;
     // Reverse-order teardown. Deleting every ReviewRun scoped to this test's
     // circleId cascades away its ReviewRunItem rows automatically (ON DELETE
     // CASCADE on review_run_items.run_id) — no separate reviewRunItem cleanup
@@ -192,20 +160,10 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
     await prisma.$disconnect();
   }, 30000);
 
-  function skipIfNoDb(testFn: () => Promise<void>): () => Promise<void> {
-    return async () => {
-      if (!dbReachable || !prisma) {
-        expect(true).toBe(true);
-        return;
-      }
-      await testFn();
-    };
-  }
-
   async function makeRun(subjectType: 'burst_group' | 'duplicate_group' | 'location_suggestion') {
     const action =
       subjectType === 'location_suggestion' ? ('accept' as const) : ('resolve_archive' as const);
-    return prisma!.reviewRun.create({
+    return prisma.reviewRun.create({
       data: {
         circleId,
         subjectType,
@@ -223,24 +181,24 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   describe('exactly-one-subject CHECK constraint', () => {
     it(
       'rejects a row with zero subject columns populated',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
         await expect(
-          prisma!.reviewRunItem.create({
+          prisma.reviewRunItem.create({
             data: { runId: run.id, subjectType: 'burst_group' },
           }),
         ).rejects.toThrow(/review_run_items_exactly_one_subject_check/);
-      }),
+      },
     );
 
     it(
       'rejects a row with two subject columns populated',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
-        const dup = await prisma!.duplicateGroup.create({ data: { circleId } });
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
+        const dup = await prisma.duplicateGroup.create({ data: { circleId } });
         await expect(
-          prisma!.reviewRunItem.create({
+          prisma.reviewRunItem.create({
             data: {
               runId: run.id,
               subjectType: 'burst_group',
@@ -249,7 +207,7 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
             },
           }),
         ).rejects.toThrow(/review_run_items_exactly_one_subject_check/);
-      }),
+      },
     );
   });
 
@@ -260,22 +218,22 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   describe('subject_type agreement CHECK constraints', () => {
     it(
       'rejects subject_type="burst_group" with only duplicate_group_id populated',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
-        const dup = await prisma!.duplicateGroup.create({ data: { circleId } });
+        const dup = await prisma.duplicateGroup.create({ data: { circleId } });
         await expect(
-          prisma!.reviewRunItem.create({
+          prisma.reviewRunItem.create({
             data: { runId: run.id, subjectType: 'burst_group', duplicateGroupId: dup.id },
           }),
         ).rejects.toThrow(/review_run_items_subject_type_burst_group_check/);
-      }),
+      },
     );
 
     it(
       'rejects subject_type="duplicate_group" with only burst_group_id populated',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('duplicate_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
         // This row simultaneously violates BOTH
         // review_run_items_subject_type_burst_group_check ((subject_type =
         // 'burst_group') = (burst_group_id IS NOT NULL) -> false = true) AND
@@ -287,13 +245,13 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
         // assert on either name instead of hard-coding one and risking a
         // spurious failure if evaluation order ever differs.
         await expect(
-          prisma!.reviewRunItem.create({
+          prisma.reviewRunItem.create({
             data: { runId: run.id, subjectType: 'duplicate_group', burstGroupId: burst.id },
           }),
         ).rejects.toThrow(
           /review_run_items_subject_type_(burst_group|duplicate_group)_check/,
         );
-      }),
+      },
     );
   });
 
@@ -304,31 +262,31 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   describe('composite (run_id, subject_type) FK', () => {
     it(
       'rejects an item whose subject_type differs from its parent run, even though the item is internally well-formed',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group'); // run's subject_type is 'burst_group'
-        const dup = await prisma!.duplicateGroup.create({ data: { circleId } });
+        const dup = await prisma.duplicateGroup.create({ data: { circleId } });
         // This row is individually well-formed: subject_type='duplicate_group'
         // agrees with duplicateGroupId being the only populated column. It
         // must still be rejected because the run it points at is a
         // 'burst_group' run, not a 'duplicate_group' run.
         await expect(
-          prisma!.reviewRunItem.create({
+          prisma.reviewRunItem.create({
             data: { runId: run.id, subjectType: 'duplicate_group', duplicateGroupId: dup.id },
           }),
         ).rejects.toThrow(/review_run_items_run_id_subject_type_fkey/);
-      }),
+      },
     );
 
     it(
       'accepts an item whose subject_type matches its parent run',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
-        const item = await prisma!.reviewRunItem.create({
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
+        const item = await prisma.reviewRunItem.create({
           data: { runId: run.id, subjectType: 'burst_group', burstGroupId: burst.id },
         });
         expect(item.id).toBeTruthy();
-      }),
+      },
     );
   });
 
@@ -339,48 +297,48 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   describe('cascade delete: deleting the subject removes its ReviewRunItem, run survives', () => {
     it(
       'deleting a BurstGroup cascades its ReviewRunItem away',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
-        const item = await prisma!.reviewRunItem.create({
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
+        const item = await prisma.reviewRunItem.create({
           data: { runId: run.id, subjectType: 'burst_group', burstGroupId: burst.id },
         });
 
-        await prisma!.burstGroup.delete({ where: { id: burst.id } });
+        await prisma.burstGroup.delete({ where: { id: burst.id } });
 
-        const found = await prisma!.reviewRunItem.findUnique({ where: { id: item.id } });
+        const found = await prisma.reviewRunItem.findUnique({ where: { id: item.id } });
         expect(found).toBeNull();
-        const runStillThere = await prisma!.reviewRun.findUnique({ where: { id: run.id } });
+        const runStillThere = await prisma.reviewRun.findUnique({ where: { id: run.id } });
         expect(runStillThere).not.toBeNull();
-      }),
+      },
     );
 
     it(
       'deleting a DuplicateGroup cascades its ReviewRunItem away',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('duplicate_group');
-        const dup = await prisma!.duplicateGroup.create({ data: { circleId } });
-        const item = await prisma!.reviewRunItem.create({
+        const dup = await prisma.duplicateGroup.create({ data: { circleId } });
+        const item = await prisma.reviewRunItem.create({
           data: { runId: run.id, subjectType: 'duplicate_group', duplicateGroupId: dup.id },
         });
 
-        await prisma!.duplicateGroup.delete({ where: { id: dup.id } });
+        await prisma.duplicateGroup.delete({ where: { id: dup.id } });
 
-        const found = await prisma!.reviewRunItem.findUnique({ where: { id: item.id } });
+        const found = await prisma.reviewRunItem.findUnique({ where: { id: item.id } });
         expect(found).toBeNull();
-        const runStillThere = await prisma!.reviewRun.findUnique({ where: { id: run.id } });
+        const runStillThere = await prisma.reviewRun.findUnique({ where: { id: run.id } });
         expect(runStillThere).not.toBeNull();
-      }),
+      },
     );
 
     it(
       'deleting a LocationSuggestion cascades its ReviewRunItem away',
-      skipIfNoDb(async () => {
+      async () => {
         // LocationSuggestion.mediaItemId is @unique, so it needs its own
         // dedicated MediaItem (the shared fixture item is reused elsewhere).
         const localStorageId = randomUUID();
         const localMediaId = randomUUID();
-        await prisma!.storageObject.create({
+        await prisma.storageObject.create({
           data: {
             id: localStorageId,
             name: 'loc-test.jpg',
@@ -391,7 +349,7 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
             uploadedById: userId,
           },
         });
-        await prisma!.mediaItem.create({
+        await prisma.mediaItem.create({
           data: {
             id: localMediaId,
             storageObjectId: localStorageId,
@@ -402,7 +360,7 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
             originalFilename: 'loc-test.jpg',
           },
         });
-        const suggestion = await prisma!.locationSuggestion.create({
+        const suggestion = await prisma.locationSuggestion.create({
           data: {
             mediaItemId: localMediaId,
             circleId,
@@ -413,7 +371,7 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
           },
         });
         const run = await makeRun('location_suggestion');
-        const item = await prisma!.reviewRunItem.create({
+        const item = await prisma.reviewRunItem.create({
           data: {
             runId: run.id,
             subjectType: 'location_suggestion',
@@ -421,17 +379,17 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
           },
         });
 
-        await prisma!.locationSuggestion.delete({ where: { id: suggestion.id } });
+        await prisma.locationSuggestion.delete({ where: { id: suggestion.id } });
 
-        const found = await prisma!.reviewRunItem.findUnique({ where: { id: item.id } });
+        const found = await prisma.reviewRunItem.findUnique({ where: { id: item.id } });
         expect(found).toBeNull();
-        const runStillThere = await prisma!.reviewRun.findUnique({ where: { id: run.id } });
+        const runStillThere = await prisma.reviewRun.findUnique({ where: { id: run.id } });
         expect(runStillThere).not.toBeNull();
 
         // cleanup local-only fixtures (not covered by afterAll)
-        await prisma!.mediaItem.deleteMany({ where: { id: localMediaId } });
-        await prisma!.storageObject.deleteMany({ where: { id: localStorageId } });
-      }),
+        await prisma.mediaItem.deleteMany({ where: { id: localMediaId } });
+        await prisma.storageObject.deleteMany({ where: { id: localStorageId } });
+      },
     );
   });
 
@@ -442,24 +400,24 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   describe('cascade delete: deleting the ReviewRun removes its ReviewRunItem rows', () => {
     it(
       'deleting a ReviewRun cascades all of its ReviewRunItem rows',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
-        const burstA = await prisma!.burstGroup.create({ data: { circleId } });
-        const burstB = await prisma!.burstGroup.create({ data: { circleId } });
-        const itemA = await prisma!.reviewRunItem.create({
+        const burstA = await prisma.burstGroup.create({ data: { circleId } });
+        const burstB = await prisma.burstGroup.create({ data: { circleId } });
+        const itemA = await prisma.reviewRunItem.create({
           data: { runId: run.id, subjectType: 'burst_group', burstGroupId: burstA.id },
         });
-        const itemB = await prisma!.reviewRunItem.create({
+        const itemB = await prisma.reviewRunItem.create({
           data: { runId: run.id, subjectType: 'burst_group', burstGroupId: burstB.id },
         });
 
-        await prisma!.reviewRun.delete({ where: { id: run.id } });
+        await prisma.reviewRun.delete({ where: { id: run.id } });
 
-        const found = await prisma!.reviewRunItem.findMany({
+        const found = await prisma.reviewRunItem.findMany({
           where: { id: { in: [itemA.id, itemB.id] } },
         });
         expect(found).toHaveLength(0);
-      }),
+      },
     );
   });
 
@@ -470,24 +428,24 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
   describe('partial unique index on (run_id, subject_column)', () => {
     it(
       'rejects a duplicate (run_id, burst_group_id) pair',
-      skipIfNoDb(async () => {
+      async () => {
         const run = await makeRun('burst_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
-        await prisma!.reviewRunItem.create({
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
+        await prisma.reviewRunItem.create({
           data: { runId: run.id, subjectType: 'burst_group', burstGroupId: burst.id },
         });
 
         await expect(
-          prisma!.reviewRunItem.create({
+          prisma.reviewRunItem.create({
             data: { runId: run.id, subjectType: 'burst_group', burstGroupId: burst.id },
           }),
         ).rejects.toThrow(/run_id.*burst_group_id|burst_group_id.*run_id/);
-      }),
+      },
     );
 
     it(
       'permits two rows in the same run when they are different subject types (different partial indexes, no collision)',
-      skipIfNoDb(async () => {
+      async () => {
         // A single run is normally all one subjectType per the composite FK
         // above, but the partial-unique-index scoping itself is what's under
         // test here: two DIFFERENT runs whose items happen to reference the
@@ -495,22 +453,22 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
         // keyed on (run_id, column) — the run_id differs.
         const runA = await makeRun('burst_group');
         const runB = await makeRun('burst_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
 
-        const itemA = await prisma!.reviewRunItem.create({
+        const itemA = await prisma.reviewRunItem.create({
           data: { runId: runA.id, subjectType: 'burst_group', burstGroupId: burst.id },
         });
-        const itemB = await prisma!.reviewRunItem.create({
+        const itemB = await prisma.reviewRunItem.create({
           data: { runId: runB.id, subjectType: 'burst_group', burstGroupId: burst.id },
         });
 
         expect(itemA.id).not.toBe(itemB.id);
-      }),
+      },
     );
 
     it(
       'permits a burst_group_id row and a duplicate_group_id row to coexist in the same run without colliding on the partial index',
-      skipIfNoDb(async () => {
+      async () => {
         // Exercises that the partial index WHERE burst_group_id IS NOT NULL
         // does not apply to rows where burst_group_id is NULL (the
         // duplicate_group_id row here) — Postgres partial indexes only cover
@@ -520,19 +478,19 @@ describeDb('Review Runs — DB constraints (DB_GATED: real PostgreSQL)', () => {
         // of its own subjectType per the composite FK tested above.
         const runBurst = await makeRun('burst_group');
         const runDup = await makeRun('duplicate_group');
-        const burst = await prisma!.burstGroup.create({ data: { circleId } });
-        const dup = await prisma!.duplicateGroup.create({ data: { circleId } });
+        const burst = await prisma.burstGroup.create({ data: { circleId } });
+        const dup = await prisma.duplicateGroup.create({ data: { circleId } });
 
-        const burstItem = await prisma!.reviewRunItem.create({
+        const burstItem = await prisma.reviewRunItem.create({
           data: { runId: runBurst.id, subjectType: 'burst_group', burstGroupId: burst.id },
         });
-        const dupItem = await prisma!.reviewRunItem.create({
+        const dupItem = await prisma.reviewRunItem.create({
           data: { runId: runDup.id, subjectType: 'duplicate_group', duplicateGroupId: dup.id },
         });
 
         expect(burstItem.id).toBeTruthy();
         expect(dupItem.id).toBeTruthy();
-      }),
+      },
     );
   });
 });

--- a/docs/ci-known-failing-tests.md
+++ b/docs/ci-known-failing-tests.md
@@ -78,8 +78,23 @@ Added when `apps/cli` first gained CI coverage (`cli-test` job in `ci.yml`, issu
 
 ---
 
+## API — DB-gated suites must SKIP, never vacuously pass (RESOLVED, issue #288)
+
+Not an exclusion — a reporting-honesty rule, recorded here because it is the same failure mode this file exists to catch: a suite that looks green while covering nothing.
+
+Three suites (`circles/migration-backfill`, `notifications/notification-dedup`, `review-runs/review-runs`) need a real PostgreSQL server and cannot run in CI. `migration-backfill` reported its 15 tests as **passed** with no database anywhere, asserting nothing. Two mistakes combined:
+
+1. **The gate read env vars only.** `.env.test` declares `POSTGRES_HOST` unconditionally, so the check was true even with nothing listening and the `describe` block ran.
+2. **The real probe was async, inside `beforeAll`.** Jest fixes `describe`/`it` registration — and therefore skipped-vs-passed — at module-evaluation time, which completes before any `beforeAll` body runs. By the time the probe resolved, the suite was already registered as a normal `describe`. The fallback was a per-test `skipIfNoDb` wrapper whose body was `expect(true).toBe(true); return;` — **a genuine PASS.**
+
+**Rule:** a DB-gated suite gates on `describeMaybeDb` / `isDatabaseReachable` from `apps/api/test/helpers/db-probe.helper.ts`, whose probe is synchronous and evaluated at module load, so a real `describe.skip` is chosen before Jest registers anything. Inside the block the database is known reachable — `prisma` is non-nullable and no test needs a runtime guard. **Never add a per-test guard that returns early with a trivial assertion**; `test/helpers/db-probe.helper.spec.ts` fails the build if one reappears.
+
+With no database, the three suites now report **36 skipped** (previously 15 passed + 21 skipped).
+
+---
+
 ## Priority
 
 1. **CLI rotted fixture suites** — update stale fixture expectations (version numbers, column lists) to match current schema.
 2. **CLI TUI concurrency-flaky pattern** — convert the remaining ~13 files to the poll-based `wait-for.ts` helpers, then remove the retry safety net.
-3. **API integration suites** — requires CI infrastructure work (DB service container).
+3. **API DB-gated suites** — they skip honestly today. Running them for real needs a PostgreSQL service container in the CI job plus applied migrations; until then their coverage is local-only, which the skip count now states plainly.


### PR DESCRIPTION
## Summary

`circles/migration-backfill.integration.spec.ts` reported its **15 tests as passed** in CI with no database anywhere and none of its assertions running — zero coverage, presented as green. That is worse than a red: a real regression in those invariants would have shipped silently.

All three DB-gated suites now gate on one shared, synchronous, module-load probe, so a missing database produces a real `describe.skip`. With no database they report **36 skipped** (previously 15 passed + 21 skipped).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Documentation update

## Related Issues

Fixes #288. Found while building epic #240.

## Changes Made

**The defect, precisely.** Two mistakes had to combine:

1. **The gate read env vars only.** `.env.test` declares `POSTGRES_HOST` unconditionally, so `DB_ENV_VARS_SET` was true with nothing listening and the `describe` ran.
2. **The real probe was async, inside `beforeAll`.** Jest fixes `describe`/`it` registration — and therefore skipped-vs-passed — at module-evaluation time, which completes before any `beforeAll` body runs. The probe correctly found no database, but far too late. The fallback was a per-test `skipIfNoDb` wrapper whose body was `expect(true).toBe(true); return;` — **a genuine PASS**, which is what turned an honest "not run" into a false green.

**The fix:**

- **New `apps/api/test/helpers/db-probe.helper.ts`** — `isDatabaseReachable()` / `describeMaybeDb`. Synchronous (spawns a short `net.connect` script via `execFileSync`) and callable at module load, so a real `describe.skip` is chosen before Jest registers anything. It never throws: a probe that throws fails the whole file instead of skipping it, which is the same dishonesty pointing the other way. Resolves its target the way `PrismaService` does (`DATABASE_URL` first, then `POSTGRES_*`), and short-circuits before spawning when nothing is configured.
- **`migration-backfill`** — gated on the shared probe; `skipIfNoDb`, the `dbReachable` flag and the nullable `prisma` are **deleted**, not bypassed. Inside the block the database is known reachable, so every test drops its guard and its `prisma!` assertions.
- **`notification-dedup` and `review-runs`** — both already gated correctly (neither was producing false passes), but each carried its own copy of the probe, and `review-runs` still had a `skipIfNoDb` plus a `dbReachable` flag that could never be false inside a block the gate had already decided. Pointed at the shared helper and cleaned up. **No behavior change** for these two.
- **`db-probe.helper.spec.ts`** — unit tests for the resolver and the never-throws contract, plus a static check that **fails the build if a `skipIfNoDb`-style per-test guard reappears anywhere under `test/`**. Three separate probe implementations existed because each new spec copied a neighbour; the issue itself was found because a new #240 spec copied the broken one faithfully. The guard matches a call/definition (`skipIfNoDb(`), not the bare name, so prose explaining the history doesn't trip it.
- **`docs/ci-known-failing-tests.md`** — records the skip-not-pass rule and why an async `beforeAll` probe cannot work, alongside the file's existing lessons about coverage that looks green but isn't.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

`npm run test:ci --workspace=api`: **269 suites / 6456 tests passed, 4 suites / 107 tests skipped**. The delta versus before is exactly the intended one — 15 tests moved from *passed* to *skipped*, and 9 new helper tests were added. No production code touched.

### Test Instructions

```bash
cd apps/api
# With no PostgreSQL running:
npx jest --config ./test/jest.config.js \
  --testPathPatterns="migration-backfill|notification-dedup|review-runs.integration"
# => Test Suites: 3 skipped   Tests: 36 skipped
# (before this change: migration-backfill reported 15 PASSED)
```

## Additional Notes

Running these suites for real still needs a PostgreSQL service container in the CI job plus applied migrations — out of scope here. The point of this change is that their coverage is now *stated* as local-only rather than silently counted as CI coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYhmaWLgQNRHRE5aoAE42m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYhmaWLgQNRHRE5aoAE42m)_