### PR TITLE
feat(api): backup change-feed foundations — (updatedAt,id) index, MediaTouchService, feed/manifest/sidecar queries

### DIFF
--- a/apps/api/prisma/migrations/20260808010000_add_backup_feed_foundations/migration.sql
+++ b/apps/api/prisma/migrations/20260808010000_add_backup_feed_foundations/migration.sql
@@ -1,0 +1,92 @@
+-- Local Media Backup via Worker Nodes (issue #310, child 1 of epic #308).
+--
+-- Prisma-schema foundation only — no service/API/CLI logic lands in this
+-- migration. Adds:
+--   1. media_items(updated_at, id) — serves the backup feed's cursor-based
+--      incremental scan (a node backup run pages through media_items
+--      ordered by (updated_at, id) since its config's checkpoint).
+--   2. NodeBackupRunKind / NodeBackupRunStatus enums.
+--   3. node_backup_configs — per-node backup schedule/scope/checkpoint,
+--      one row per WorkerNode (1:1, unique node_id).
+--   4. node_backup_runs — one row per backup run attempt for a node,
+--      mirroring the existing WorkerNode job-run pattern (e.g.
+--      StorageMigrationRun, TrashEmptyRun).
+
+-- -----------------------------------------------------------------------------
+-- Index: media_items (updated_at, id)
+-- -----------------------------------------------------------------------------
+
+CREATE INDEX "media_items_updated_at_id_idx" ON "media_items" ("updated_at", "id");
+
+-- -----------------------------------------------------------------------------
+-- Enums
+-- -----------------------------------------------------------------------------
+
+CREATE TYPE "NodeBackupRunKind" AS ENUM ('incremental', 'reconcile');
+
+CREATE TYPE "NodeBackupRunStatus" AS ENUM ('running', 'completed', 'failed', 'aborted', 'stale');
+
+-- -----------------------------------------------------------------------------
+-- Table: node_backup_configs
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "node_backup_configs" (
+    "id"                     UUID         NOT NULL DEFAULT gen_random_uuid(),
+    "node_id"                UUID         NOT NULL,
+    "enabled"                BOOLEAN      NOT NULL DEFAULT true,
+    "schedule_cron"          TEXT,
+    "timezone"               TEXT,
+    "next_run_at"            TIMESTAMPTZ(6),
+    "circle_ids"             UUID[]       NOT NULL,
+    "checkpoint_updated_at"  TIMESTAMPTZ(6),
+    "checkpoint_id"          UUID,
+    "items_acked"            BIGINT       NOT NULL DEFAULT 0,
+    "bytes_acked"            BIGINT       NOT NULL DEFAULT 0,
+    "last_run_at"            TIMESTAMPTZ(6),
+    "last_completed_run_at"  TIMESTAMPTZ(6),
+    "last_reconcile_at"      TIMESTAMPTZ(6),
+    "created_at"             TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    "updated_at"             TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT "node_backup_configs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "node_backup_configs_node_id_fkey"
+        FOREIGN KEY ("node_id") REFERENCES "worker_nodes"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "node_backup_configs_node_id_key" ON "node_backup_configs" ("node_id");
+
+CREATE INDEX "node_backup_configs_next_run_at_idx" ON "node_backup_configs" ("next_run_at");
+
+-- -----------------------------------------------------------------------------
+-- Table: node_backup_runs
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "node_backup_runs" (
+    "id"                       UUID                    NOT NULL DEFAULT gen_random_uuid(),
+    "node_id"                  UUID                    NOT NULL,
+    "kind"                     "NodeBackupRunKind"     NOT NULL,
+    "status"                   "NodeBackupRunStatus"   NOT NULL DEFAULT 'running',
+    "trigger"                  TEXT                    NOT NULL,
+    "started_at"               TIMESTAMPTZ(6)          NOT NULL DEFAULT now(),
+    "finished_at"              TIMESTAMPTZ(6),
+    "last_ack_at"              TIMESTAMPTZ(6),
+    "items_downloaded"         INTEGER                 NOT NULL DEFAULT 0,
+    "items_skipped"            INTEGER                 NOT NULL DEFAULT 0,
+    "sidecars_written"         INTEGER                 NOT NULL DEFAULT 0,
+    "bytes_downloaded"         BIGINT                  NOT NULL DEFAULT 0,
+    "error_count"              INTEGER                 NOT NULL DEFAULT 0,
+    "last_error"               TEXT,
+    "cli_version"              TEXT,
+    "cursor_start_updated_at"  TIMESTAMPTZ(6),
+    "cursor_start_id"          UUID,
+    "cursor_end_updated_at"    TIMESTAMPTZ(6),
+    "cursor_end_id"            UUID,
+
+    CONSTRAINT "node_backup_runs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "node_backup_runs_node_id_fkey"
+        FOREIGN KEY ("node_id") REFERENCES "worker_nodes"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "node_backup_runs_node_id_started_at_idx" ON "node_backup_runs" ("node_id", "started_at" DESC);
+
+CREATE INDEX "node_backup_runs_status_idx" ON "node_backup_runs" ("status");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -414,7 +414,7 @@ model Circle {
   // supersedes the former LocationSuggestionRun-only relation, issue #190)
   reviewRuns            ReviewRun[]
   // Notification Center relations (epic #240, issue #244; schema-only)
-  notifications         Notification[]       @relation("CircleNotifications")
+  notifications         Notification[]        @relation("CircleNotifications")
 
   @@index([ownerId])
   @@map("circles")
@@ -601,6 +601,10 @@ model MediaItem {
   @@index([burstGroupId])
   @@index([duplicateGroupId])
   @@index([circleId, perceptualHash])
+  // Serves the Local Media Backup feed's cursor-based incremental scan
+  // (node backup runs page media_items by updatedAt with an id tiebreak).
+  // See NodeBackupConfig/NodeBackupRun below (issue #310, epic #308).
+  @@index([updatedAt, id])
   // NOTE: a hand-authored partial composite index "media_items_map_locations_idx"
   // ON (circle_id, captured_at DESC, taken_lat, taken_lng) WHERE deleted_at IS NULL
   // AND archived_at IS NULL AND taken_lat IS NOT NULL AND taken_lng IS NOT NULL
@@ -1413,8 +1417,11 @@ model WorkerNode {
   createdById     String     @map("created_by_id") @db.Uuid
 
   // Relations
-  createdBy   User            @relation(fields: [createdById], references: [id], onDelete: Cascade)
-  claimedJobs EnrichmentJob[]
+  createdBy    User              @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  claimedJobs  EnrichmentJob[]
+  // Local Media Backup relations (issue #310, epic #308)
+  backupConfig NodeBackupConfig?
+  backupRuns   NodeBackupRun[]
 
   // Idempotent register-or-reattach: a containerized replica re-registering
   // under the same (owner, name) re-attaches to its existing row instead of
@@ -1446,6 +1453,109 @@ model NodeCredential {
 
   @@index([userId])
   @@map("node_credentials")
+}
+
+// =============================================================================
+// Local Media Backup via Worker Nodes (issue #310, epic #308)
+// =============================================================================
+//
+// Prisma-schema foundation only — no service/API/CLI logic lands in this
+// change. A worker node can run a local backup feed that pulls a circle
+// owner's media down to local disk. NodeBackupConfig is the per-node
+// schedule/scope/checkpoint; NodeBackupRun is one execution attempt's
+// progress/outcome, mirroring the WorkerNode job-run pattern already used
+// elsewhere (e.g. StorageMigrationRun, TrashEmptyRun).
+
+enum NodeBackupRunKind {
+  incremental
+  reconcile
+}
+
+enum NodeBackupRunStatus {
+  running
+  completed
+  failed
+  aborted
+  stale
+}
+
+// Per-node backup configuration; at most one row per WorkerNode (1:1).
+// circleIds empty = ALL circles the node owner belongs to. The checkpoint
+// columns track the cursor position of the last successfully-acknowledged
+// item in the incremental media_items (updated_at, id) scan (see the
+// media_items updatedAt+id index above), so the next run resumes rather
+// than rescanning the whole library.
+model NodeBackupConfig {
+  id      String  @id @default(uuid()) @db.Uuid
+  nodeId  String  @unique @map("node_id") @db.Uuid
+  enabled Boolean @default(true)
+
+  // Schedule
+  scheduleCron String?   @map("schedule_cron") // cron expression; null = manual-trigger only
+  timezone     String? // IANA timezone name the cron is evaluated in
+  nextRunAt    DateTime? @map("next_run_at") @db.Timestamptz(6)
+
+  // Scope
+  circleIds String[] @map("circle_ids") @db.Uuid // empty = ALL circles the owner belongs to
+
+  // Checkpoint (incremental scan cursor)
+  checkpointUpdatedAt DateTime? @map("checkpoint_updated_at") @db.Timestamptz(6)
+  checkpointId        String?   @map("checkpoint_id") @db.Uuid
+  itemsAcked          BigInt    @default(0) @map("items_acked")
+  bytesAcked          BigInt    @default(0) @map("bytes_acked")
+
+  // Run history summary
+  lastRunAt          DateTime? @map("last_run_at") @db.Timestamptz(6)
+  lastCompletedRunAt DateTime? @map("last_completed_run_at") @db.Timestamptz(6)
+  lastReconcileAt    DateTime? @map("last_reconcile_at") @db.Timestamptz(6)
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  // Relations
+  node WorkerNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
+
+  @@index([nextRunAt])
+  @@map("node_backup_configs")
+}
+
+// One row per backup run attempt for a node. kind='incremental' scans only
+// media_items updated since the config's checkpoint; kind='reconcile' is a
+// full re-scan/verification pass. The cursor snapshot columns record the
+// (updatedAt, id) window this specific run covered, independent of the
+// config's live checkpoint (which only advances on ack).
+model NodeBackupRun {
+  id      String              @id @default(uuid()) @db.Uuid
+  nodeId  String              @map("node_id") @db.Uuid
+  kind    NodeBackupRunKind
+  status  NodeBackupRunStatus @default(running)
+  trigger String // 'manual' | 'scheduled'
+
+  startedAt  DateTime  @default(now()) @map("started_at") @db.Timestamptz(6)
+  finishedAt DateTime? @map("finished_at") @db.Timestamptz(6)
+  lastAckAt  DateTime? @map("last_ack_at") @db.Timestamptz(6) // staleness detection
+
+  itemsDownloaded Int    @default(0) @map("items_downloaded")
+  itemsSkipped    Int    @default(0) @map("items_skipped")
+  sidecarsWritten Int    @default(0) @map("sidecars_written")
+  bytesDownloaded BigInt @default(0) @map("bytes_downloaded")
+
+  errorCount Int     @default(0) @map("error_count")
+  lastError  String? @map("last_error")
+  cliVersion String? @map("cli_version")
+
+  // Cursor snapshot for this run's (updatedAt, id) scan window.
+  cursorStartUpdatedAt DateTime? @map("cursor_start_updated_at") @db.Timestamptz(6)
+  cursorStartId        String?   @map("cursor_start_id") @db.Uuid
+  cursorEndUpdatedAt   DateTime? @map("cursor_end_updated_at") @db.Timestamptz(6)
+  cursorEndId          String?   @map("cursor_end_id") @db.Uuid
+
+  // Relations
+  node WorkerNode @relation(fields: [nodeId], references: [id], onDelete: Cascade)
+
+  @@index([nodeId, startedAt(sort: Desc)])
+  @@index([status])
+  @@map("node_backup_runs")
 }
 
 // =============================================================================
@@ -1484,20 +1594,20 @@ model MediaEnhancement {
   prompt      String?                   @db.Text
 
   // --- Staged result (pre-decision) ---
-  stagingStorageKey String? @map("staging_storage_key")
+  stagingStorageKey   String? @map("staging_storage_key")
   // Thumbnail derivative of the staged bytes (issue #203), so the /enhancements
   // hub can paint a ~148px card without downloading the full-resolution
   // gpt-image-1 output. Lives on the SAME stagingProvider/stagingBucket (written
   // in the same handler run) and has no StorageObject row of its own; nullable
   // because generation is best-effort and pre-#203 rows never had one.
   stagingThumbnailKey String? @map("staging_thumbnail_key")
-  stagingProvider   String? @map("staging_provider")
-  stagingBucket     String? @map("staging_bucket")
-  originalWidth     Int?    @map("original_width")
-  originalHeight    Int?    @map("original_height")
-  enhancedWidth     Int?    @map("enhanced_width")
-  enhancedHeight    Int?    @map("enhanced_height")
-  enhancedSize      BigInt? @map("enhanced_size")
+  stagingProvider     String? @map("staging_provider")
+  stagingBucket       String? @map("staging_bucket")
+  originalWidth       Int?    @map("original_width")
+  originalHeight      Int?    @map("original_height")
+  enhancedWidth       Int?    @map("enhanced_width")
+  enhancedHeight      Int?    @map("enhanced_height")
+  enhancedSize        BigInt? @map("enhanced_size")
 
   resultMediaItemId String? @map("result_media_item_id") @db.Uuid
   lastError         String? @map("last_error")
@@ -1939,18 +2049,18 @@ enum NotificationType {
 //   media_items_map_locations_idx, people_circle_id_hidden_at_idx, and the
 //   review_run_items partial uniques above.
 model Notification {
-  id          String            @id @default(uuid()) @db.Uuid
-  userId      String            @map("user_id") @db.Uuid
-  circleId    String?           @map("circle_id") @db.Uuid
+  id          String           @id @default(uuid()) @db.Uuid
+  userId      String           @map("user_id") @db.Uuid
+  circleId    String?          @map("circle_id") @db.Uuid
   type        NotificationType
   title       String
   body        String?
   link        String?
-  data        Json?             @db.JsonB
-  readAt      DateTime?         @map("read_at") @db.Timestamptz
-  dismissedAt DateTime?         @map("dismissed_at") @db.Timestamptz
-  createdAt   DateTime          @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime          @updatedAt @map("updated_at") @db.Timestamptz
+  data        Json?            @db.JsonB
+  readAt      DateTime?        @map("read_at") @db.Timestamptz
+  dismissedAt DateTime?        @map("dismissed_at") @db.Timestamptz
+  createdAt   DateTime         @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime         @updatedAt @map("updated_at") @db.Timestamptz
 
   // Relations
   user   User    @relation("UserNotifications", fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -370,6 +370,17 @@ export const systemSettingsSchema = z.object({
     maxInputMegapixels: 50,
     retentionHours: 168,
   }),
+  // Node backup change feed (issue #310, epic #308). Read by
+  // NodeBackupQueryService via the cached getSettings() call.
+  backup: z.object({
+    maxPageSize: z.number().int().min(50).max(500).default(200),
+    feedSafetyHorizonSeconds: z.number().int().min(0).max(60).default(5),
+    runStaleMinutes: z.number().int().min(5).max(120).default(15),
+  }).optional().default({
+    maxPageSize: 200,
+    feedSafetyHorizonSeconds: 5,
+    runStaleMinutes: 15,
+  }),
   // Media Workflow Automation (issue #139 / epic #138). The full namespace ships
   // here in Phase 1; later phases read these values via getSettings() without a
   // further schema change. Phase 1 actively reads maxItemsPerRun,
@@ -523,6 +534,11 @@ export const systemSettingsPatchSchema = z.object({
     blockReplaceOnDownscale: z.boolean().optional(),
     maxInputMegapixels: z.number().min(1).max(100).optional(),
     retentionHours: z.number().int().min(1).max(720).optional(),
+  }).optional(),
+  backup: z.object({
+    maxPageSize: z.number().int().min(50).max(500).optional(),
+    feedSafetyHorizonSeconds: z.number().int().min(0).max(60).optional(),
+    runStaleMinutes: z.number().int().min(5).max(120).optional(),
   }).optional(),
   workflows: z.object({
     maxItemsPerRun: z.number().int().min(100).max(500000).optional(),

--- a/apps/api/src/common/types/backup-settings.spec.ts
+++ b/apps/api/src/common/types/backup-settings.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the `backup.*` system-settings namespace (issue #310, epic
+ * #308 — Local Media Backup via Worker Nodes). Read by NodeBackupQueryService
+ * via the cached SystemSettingsService.getSettings() call. Mirrors the
+ * pattern established by workflows-settings.spec.ts.
+ */
+import { DEFAULT_SYSTEM_SETTINGS } from './settings.types';
+import {
+  systemSettingsSchema,
+  systemSettingsPatchSchema,
+} from '../schemas/settings.schema';
+
+describe('backup system settings', () => {
+  describe('DEFAULT_SYSTEM_SETTINGS.backup', () => {
+    it('matches the documented defaults', () => {
+      expect(DEFAULT_SYSTEM_SETTINGS.backup).toEqual({
+        maxPageSize: 200,
+        feedSafetyHorizonSeconds: 5,
+        runStaleMinutes: 15,
+      });
+    });
+
+    it('parses cleanly against the Zod systemSettingsSchema (schema/defaults agree)', () => {
+      const parsed = systemSettingsSchema.parse(DEFAULT_SYSTEM_SETTINGS);
+      expect(parsed.backup).toEqual(DEFAULT_SYSTEM_SETTINGS.backup);
+    });
+
+    it('applies the schema default when the backup block is omitted entirely', () => {
+      const { backup, ...rest } = DEFAULT_SYSTEM_SETTINGS as any;
+      const parsed = systemSettingsSchema.parse(rest);
+      expect(parsed.backup).toEqual(DEFAULT_SYSTEM_SETTINGS.backup);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // systemSettingsSchema (PUT — full replace)
+  // ---------------------------------------------------------------------------
+
+  describe('systemSettingsSchema bounds (Zod, PUT)', () => {
+    it('accepts values at the documented min/max bounds', () => {
+      const parsed = systemSettingsSchema.parse({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        backup: {
+          maxPageSize: 50, // min
+          feedSafetyHorizonSeconds: 0, // min
+          runStaleMinutes: 5, // min
+        },
+      });
+      expect(parsed.backup).toEqual({
+        maxPageSize: 50,
+        feedSafetyHorizonSeconds: 0,
+        runStaleMinutes: 5,
+      });
+
+      const parsedMax = systemSettingsSchema.parse({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        backup: {
+          maxPageSize: 500, // max
+          feedSafetyHorizonSeconds: 60, // max
+          runStaleMinutes: 120, // max
+        },
+      });
+      expect(parsedMax.backup).toEqual({
+        maxPageSize: 500,
+        feedSafetyHorizonSeconds: 60,
+        runStaleMinutes: 120,
+      });
+    });
+
+    it('rejects maxPageSize below the min (49 < 50)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, maxPageSize: 49 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects maxPageSize above the max (501 > 500)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, maxPageSize: 501 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects feedSafetyHorizonSeconds below the min (-1 < 0)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, feedSafetyHorizonSeconds: -1 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects feedSafetyHorizonSeconds above the max (61 > 60)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, feedSafetyHorizonSeconds: 61 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects runStaleMinutes below the min (4 < 5)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, runStaleMinutes: 4 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects runStaleMinutes above the max (121 > 120)', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, runStaleMinutes: 121 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, maxPageSize: 200.5 },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects string values', () => {
+      expect(() =>
+        systemSettingsSchema.parse({
+          ...DEFAULT_SYSTEM_SETTINGS,
+          backup: { ...DEFAULT_SYSTEM_SETTINGS.backup, maxPageSize: '200' },
+        }),
+      ).toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // systemSettingsPatchSchema (PATCH — partial update)
+  // ---------------------------------------------------------------------------
+
+  describe('systemSettingsPatchSchema (PATCH)', () => {
+    it('accepts an empty object (all fields optional)', () => {
+      const result = systemSettingsPatchSchema.parse({});
+      expect(result.backup).toBeUndefined();
+    });
+
+    it('accepts a patch with only maxPageSize', () => {
+      const result = systemSettingsPatchSchema.parse({
+        backup: { maxPageSize: 300 },
+      });
+      expect(result.backup).toEqual({ maxPageSize: 300 });
+    });
+
+    it('accepts a patch with all three fields at their bounds', () => {
+      const result = systemSettingsPatchSchema.parse({
+        backup: { maxPageSize: 50, feedSafetyHorizonSeconds: 0, runStaleMinutes: 5 },
+      });
+      expect(result.backup).toEqual({
+        maxPageSize: 50,
+        feedSafetyHorizonSeconds: 0,
+        runStaleMinutes: 5,
+      });
+    });
+
+    it('allows any single field to be omitted (independently optional)', () => {
+      const result = systemSettingsPatchSchema.parse({
+        backup: { runStaleMinutes: 30 },
+      });
+      expect(result.backup).toEqual({ runStaleMinutes: 30 });
+    });
+
+    it('rejects maxPageSize 49 in a patch', () => {
+      expect(() =>
+        systemSettingsPatchSchema.parse({ backup: { maxPageSize: 49 } }),
+      ).toThrow();
+    });
+
+    it('rejects maxPageSize 501 in a patch', () => {
+      expect(() =>
+        systemSettingsPatchSchema.parse({ backup: { maxPageSize: 501 } }),
+      ).toThrow();
+    });
+
+    it('rejects feedSafetyHorizonSeconds -1 in a patch', () => {
+      expect(() =>
+        systemSettingsPatchSchema.parse({ backup: { feedSafetyHorizonSeconds: -1 } }),
+      ).toThrow();
+    });
+
+    it('rejects feedSafetyHorizonSeconds 61 in a patch', () => {
+      expect(() =>
+        systemSettingsPatchSchema.parse({ backup: { feedSafetyHorizonSeconds: 61 } }),
+      ).toThrow();
+    });
+
+    it('rejects runStaleMinutes 4 in a patch', () => {
+      expect(() =>
+        systemSettingsPatchSchema.parse({ backup: { runStaleMinutes: 4 } }),
+      ).toThrow();
+    });
+
+    it('rejects runStaleMinutes 121 in a patch', () => {
+      expect(() =>
+        systemSettingsPatchSchema.parse({ backup: { runStaleMinutes: 121 } }),
+      ).toThrow();
+    });
+
+    it('leaves other namespaces untouched when patching only backup', () => {
+      const result = systemSettingsPatchSchema.parse({
+        backup: { maxPageSize: 250 },
+      });
+      expect(result.storage).toBeUndefined();
+      expect(result.workflows).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -252,6 +252,22 @@ export interface SystemSettingsValue {
     retentionHours: number;
   };
   /**
+   * Node backup change feed (issue #310, epic #308). Read by
+   * NodeBackupQueryService via the cached SystemSettingsService.getSettings().
+   */
+  backup?: {
+    /** Max rows a node may request per change-feed / manifest page. */
+    maxPageSize: number;
+    /**
+     * Rows with `updatedAt` within the last N seconds are withheld from the
+     * feed so in-flight same-timestamp writes cannot be skipped by the keyset
+     * cursor. 0 disables the horizon.
+     */
+    feedSafetyHorizonSeconds: number;
+    /** Minutes without an ack before a `running` backup run is marked stale. */
+    runStaleMinutes: number;
+  };
+  /**
    * Media Workflow Automation (epic #138). Full namespace ships in Phase 1 so all
    * later phases read through getSettings() with no further schema change. Phase 1
    * actively reads maxItemsPerRun / maxWorkflowsPerCircle / requirePreview /
@@ -490,6 +506,11 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
     blockReplaceOnDownscale: false,
     maxInputMegapixels: 50,
     retentionHours: 168,
+  },
+  backup: {
+    maxPageSize: 200,
+    feedSafetyHorizonSeconds: 5,
+    runStaleMinutes: 15,
   },
   workflows: {
     maxItemsPerRun: 10000,

--- a/apps/api/src/face/face-auto-archive-sweep.handler.spec.ts
+++ b/apps/api/src/face/face-auto-archive-sweep.handler.spec.ts
@@ -85,6 +85,7 @@ describe('FaceAutoArchiveSweepHandler', () => {
       mockPrisma as unknown as PrismaService,
       mockMatchingService as unknown as FaceMatchingService,
       mockSystemSettings as unknown as SystemSettingsService,
+      { touchMediaItems: jest.fn().mockResolvedValue(undefined) } as any,
     );
   });
 

--- a/apps/api/src/face/face-auto-archive-sweep.handler.spec.ts
+++ b/apps/api/src/face/face-auto-archive-sweep.handler.spec.ts
@@ -199,7 +199,11 @@ describe('FaceAutoArchiveSweepHandler', () => {
     (mockPrisma.face.findMany as jest.Mock)
       .mockResolvedValueOnce([{ id: 'archived-1', embedding: [1, 0] }]) // archived pool
       .mockResolvedValueOnce(firstPage)
-      .mockResolvedValueOnce(secondPage);
+      // Backup change-feed parent lookup for the first page's hidden faces (issue #310)
+      .mockResolvedValueOnce([{ mediaItemId: 'media-0' }])
+      .mockResolvedValueOnce(secondPage)
+      // Parent lookup for the second page's hidden faces
+      .mockResolvedValueOnce([{ mediaItemId: 'media-500' }]);
 
     // First page match: live-0; second page match: live-500.
     mockMatchingService.findLiveMatchesAgainstArchived
@@ -213,11 +217,11 @@ describe('FaceAutoArchiveSweepHandler', () => {
     const job = makeJob();
     await handler.process(job);
 
-    // archived pool + 2 live pages = 3 findMany calls total.
-    expect((mockPrisma.face.findMany as jest.Mock).mock.calls.length).toBe(3);
+    // archived pool + 2 live pages + 2 backup-touch parent lookups = 5 calls.
+    expect((mockPrisma.face.findMany as jest.Mock).mock.calls.length).toBe(5);
 
     // Second live-page query must use the last id of the first page as cursor.
-    const secondPageCall = (mockPrisma.face.findMany as jest.Mock).mock.calls[2][0];
+    const secondPageCall = (mockPrisma.face.findMany as jest.Mock).mock.calls[3][0];
     expect(secondPageCall.cursor).toEqual({ id: 'live-499' });
     expect(secondPageCall.skip).toBe(1);
 

--- a/apps/api/src/face/face-auto-archive-sweep.handler.ts
+++ b/apps/api/src/face/face-auto-archive-sweep.handler.ts
@@ -5,6 +5,7 @@ import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.regi
 import { PrismaService } from '../prisma/prisma.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { FaceMatchingService } from './face-matching.service';
+import { MediaTouchService } from '../media/media-touch.service';
 
 /**
  * FaceAutoArchiveSweepHandler
@@ -34,6 +35,7 @@ export class FaceAutoArchiveSweepHandler implements EnrichmentHandler, OnModuleI
     private readonly prisma: PrismaService,
     private readonly matchingService: FaceMatchingService,
     private readonly systemSettings: SystemSettingsService,
+    private readonly mediaTouch: MediaTouchService,
   ) {}
 
   onModuleInit(): void {
@@ -120,6 +122,14 @@ export class FaceAutoArchiveSweepHandler implements EnrichmentHandler, OnModuleI
           data: { hiddenAt: new Date(), hiddenReason: 'auto_archive_match' },
         });
         hidden += count;
+
+        // Backup change feed: Face.hiddenAt is a Face-row-only write (issue #310)
+        const parents = await this.prisma.face.findMany({
+          where: { id: { in: matchedIds }, circleId },
+          select: { mediaItemId: true },
+          distinct: ['mediaItemId'],
+        });
+        await this.mediaTouch.touchMediaItems(parents.map((f) => f.mediaItemId));
       }
 
       if (batch.length < FaceAutoArchiveSweepHandler.LIVE_BATCH_SIZE) break;

--- a/apps/api/src/face/face-detection.service.spec.ts
+++ b/apps/api/src/face/face-detection.service.spec.ts
@@ -27,6 +27,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Readable } from 'stream';
 import { FaceDetectionService } from './face-detection.service';
 import { FaceDetectionCore } from './face-detection-core.service';
+import { MediaTouchService } from '../media/media-touch.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { FaceSettingsService } from './face-settings.service';
 import { FaceProviderRegistry } from './providers/face-provider.registry';
@@ -179,6 +180,10 @@ describe('FaceDetectionService', () => {
         { provide: FaceMatchingService, useValue: mockMatchingService },
         { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
         { provide: SystemSettingsService, useValue: mockSystemSettings },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/face/face-detection.service.spec.ts
+++ b/apps/api/src/face/face-detection.service.spec.ts
@@ -110,6 +110,7 @@ describe('FaceDetectionService', () => {
   };
   let mockEnrichmentJobService: { recordModel: jest.Mock };
   let mockSystemSettings: { getSettings: jest.Mock };
+  let mockMediaTouch: { touchMediaItems: jest.Mock };
 
   beforeEach(async () => {
     // Reset sharp mock call counts between tests (implementations set in the factory are retained)
@@ -168,6 +169,12 @@ describe('FaceDetectionService', () => {
     // Default face.update succeeds
     (mockPrisma.face.update as jest.Mock).mockResolvedValue({});
 
+    // Backup change feed (issue #310) — captured in a variable so tests can
+    // assert exactly which MediaItem ids persistFaces touches.
+    mockMediaTouch = {
+      touchMediaItems: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FaceDetectionService,
@@ -180,10 +187,7 @@ describe('FaceDetectionService', () => {
         { provide: FaceMatchingService, useValue: mockMatchingService },
         { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
         { provide: SystemSettingsService, useValue: mockSystemSettings },
-        {
-          provide: MediaTouchService,
-          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
-        },
+        { provide: MediaTouchService, useValue: mockMediaTouch },
       ],
     }).compile();
 
@@ -755,6 +759,20 @@ describe('FaceDetectionService', () => {
       expect(mockPrisma.face.deleteMany).toHaveBeenCalledWith({
         where: { mediaItemId: 'media-1', manuallyAssigned: false },
       });
+    });
+
+    it('touches the MediaItem for the backup change feed after persisting (issue #310)', async () => {
+      await service.persistFaces(makeJob(), makeCannedResult());
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(['media-1']);
+    });
+
+    it('still touches the MediaItem when the DTO has zero faces (Face rows cleared, not created)', async () => {
+      const empty = { ...makeCannedResult(), faces: [] };
+
+      await service.persistFaces(makeJob(), empty);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(['media-1']);
     });
 
     it('normalizes the PIXEL bounding box by the DTO imageWidth/imageHeight (not raw MediaItem dims)', async () => {

--- a/apps/api/src/face/face-detection.service.ts
+++ b/apps/api/src/face/face-detection.service.ts
@@ -7,6 +7,7 @@ import { StorageProviderResolver } from '../storage/providers/storage-provider.r
 import { prepareImageForProcessing } from '../storage/processing/image-orientation.util';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { FaceDetectionCore, ResolvedProvider } from './face-detection-core.service';
+import { MediaTouchService } from '../media/media-touch.service';
 import type { DetectedFace } from './providers/face-provider.interface';
 
 @Injectable()
@@ -18,6 +19,7 @@ export class FaceDetectionService {
     private readonly resolver: StorageProviderResolver,
     private readonly enrichmentJobService: EnrichmentJobService,
     private readonly core: FaceDetectionCore,
+    private readonly mediaTouch: MediaTouchService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -230,6 +232,10 @@ export class FaceDetectionService {
       result.providerKey,
       result.modelVersion,
     );
+
+    // Backup change feed (issue #310): Face rows were deleted/recreated (and
+    // possibly person-matched) without any MediaItem column write.
+    await this.mediaTouch.touchMediaItems([job.mediaItemId]);
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/api/src/face/face.module.ts
+++ b/apps/api/src/face/face.module.ts
@@ -21,9 +21,10 @@ import { VideoFaceDetectionService } from './video-face-detection.service';
 import { VideoFaceDetectionHandler } from './video-face-detection.handler';
 import { FaceAutoArchiveSweepHandler } from './face-auto-archive-sweep.handler';
 import { MediaModule } from '../media/media.module';
+import { MediaTouchModule } from '../media/media-touch.module';
 
 @Module({
-  imports: [SettingsModule, StorageProvidersModule, CirclesModule, EnrichmentModule, MediaModule],
+  imports: [SettingsModule, StorageProvidersModule, CirclesModule, EnrichmentModule, MediaModule, MediaTouchModule],
   controllers: [FaceSettingsController, FaceDetectionController, PeopleController, AdminFaceBackfillController],
   providers: [
     FaceSettingsService,

--- a/apps/api/src/face/people.service.spec.ts
+++ b/apps/api/src/face/people.service.spec.ts
@@ -14,6 +14,7 @@ import { FaceMatchingService } from './face-matching.service';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { MediaThumbnailService } from '../media/media-thumbnail.service';
+import { MediaTouchService } from '../media/media-touch.service';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,10 @@ describe('PeopleService', () => {
         { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
         { provide: SystemSettingsService, useValue: mockSystemSettings },
         { provide: MediaThumbnailService, useValue: mockMediaThumbnailService },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/face/people.service.spec.ts
+++ b/apps/api/src/face/people.service.spec.ts
@@ -75,6 +75,7 @@ describe('PeopleService', () => {
   let mockEnrichmentJobService: { enqueue: jest.Mock };
   let mockSystemSettings: { isFeatureEnabled: jest.Mock; getSettings: jest.Mock };
   let mockMediaThumbnailService: { signThumb: jest.Mock; signThumbsBatched: jest.Mock };
+  let mockMediaTouch: { touchMediaItems: jest.Mock };
 
   beforeEach(async () => {
     mockPrisma = createMockPrismaService();
@@ -109,6 +110,11 @@ describe('PeopleService', () => {
       // faithful default; override per-test if a specific URL is needed.
       signThumbsBatched: jest.fn().mockResolvedValue(new Map()),
     };
+    // Backup change feed (issue #310) — captured in a variable so tests can
+    // assert exactly which MediaItem ids each mutation touches.
+    mockMediaTouch = {
+      touchMediaItems: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -120,10 +126,7 @@ describe('PeopleService', () => {
         { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
         { provide: SystemSettingsService, useValue: mockSystemSettings },
         { provide: MediaThumbnailService, useValue: mockMediaThumbnailService },
-        {
-          provide: MediaTouchService,
-          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
-        },
+        { provide: MediaTouchService, useValue: mockMediaTouch },
       ],
     }).compile();
 
@@ -376,6 +379,32 @@ describe('PeopleService', () => {
       });
     });
 
+    it('with faceIds: touches the affected MediaItem for the backup change feed (issue #310)', async () => {
+      (mockPrisma.person.create as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findMany as jest.Mock)
+        .mockResolvedValueOnce([makeFace()])
+        .mockResolvedValueOnce([
+          { mediaItemId: MEDIA_ID, mediaItem: { circleId: CIRCLE_ID } },
+        ]);
+      (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await service.createPerson(
+        { circleId: CIRCLE_ID, name: 'Carol', faceIds: [FACE_ID] } as any,
+        USER_ID,
+        PERMS,
+      );
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([MEDIA_ID]);
+    });
+
+    it('with no faceIds: does NOT touch anything', async () => {
+      (mockPrisma.person.create as jest.Mock).mockResolvedValue(makePerson());
+
+      await service.createPerson({ circleId: CIRCLE_ID, name: 'Bob' } as any, USER_ID, PERMS);
+
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+    });
+
     it('throws NotFoundException when faceId is not in the circle', async () => {
       (mockPrisma.person.create as jest.Mock).mockResolvedValue(makePerson());
       // assertFacesInCircle finds zero faces → length mismatch
@@ -456,6 +485,45 @@ describe('PeopleService', () => {
       );
       expect(result.name).toBe('Updated Name');
     });
+
+    it('renaming touches every MediaItem the person appears in via the backup change feed (issue #310)', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.person.update as jest.Mock).mockResolvedValue(makePerson({ name: 'Updated Name' }));
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([
+        { mediaItemId: 'media-a' },
+        { mediaItemId: 'media-b' },
+      ]);
+
+      await service.updatePerson(PERSON_ID, { name: 'Updated Name' } as any, USER_ID, PERMS);
+
+      expect(mockPrisma.face.findMany).toHaveBeenCalledWith({
+        where: { personId: { in: [PERSON_ID] }, circleId: CIRCLE_ID },
+        select: { mediaItemId: true },
+        distinct: ['mediaItemId'],
+      });
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(['media-a', 'media-b']);
+    });
+
+    it('a coverFaceId-only update does NOT touch anything (no name/favorite change)', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findUnique as jest.Mock).mockResolvedValue(makeFace({ personId: PERSON_ID }));
+      (mockPrisma.person.update as jest.Mock).mockResolvedValue(makePerson({ coverFaceId: FACE_ID }));
+
+      await service.updatePerson(PERSON_ID, { coverFaceId: FACE_ID } as any, USER_ID, PERMS);
+
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+      expect(mockPrisma.face.findMany).not.toHaveBeenCalled();
+    });
+
+    it('a best-effort touch failure never rejects updatePerson itself', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.person.update as jest.Mock).mockResolvedValue(makePerson({ name: 'Updated Name' }));
+      (mockPrisma.face.findMany as jest.Mock).mockRejectedValueOnce(new Error('db blip'));
+
+      await expect(
+        service.updatePerson(PERSON_ID, { name: 'Updated Name' } as any, USER_ID, PERMS),
+      ).resolves.toMatchObject({ name: 'Updated Name' });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -493,6 +561,20 @@ describe('PeopleService', () => {
         where: { id: { in: [FACE_ID] }, circleId: CIRCLE_ID },
         data: { personId: PERSON_ID, manuallyAssigned: true },
       });
+    });
+
+    it('touches the affected MediaItem for the backup change feed (issue #310)', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findMany as jest.Mock)
+        .mockResolvedValueOnce([makeFace()])
+        .mockResolvedValueOnce([
+          { mediaItemId: MEDIA_ID, mediaItem: { circleId: CIRCLE_ID } },
+        ]);
+      (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await service.assignFaces(PERSON_ID, { faceIds: [FACE_ID] } as any, USER_ID, PERMS);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([MEDIA_ID]);
     });
 
     it('throws NotFoundException when face is not in circle', async () => {
@@ -782,6 +864,39 @@ describe('PeopleService', () => {
           data: expect.objectContaining({ action: 'person:merge', targetId: TARGET_ID }),
         }),
       );
+    });
+
+    it('touches the union of source and target affected MediaItems for the backup change feed (issue #310)', async () => {
+      (mockPrisma.person.findUnique as jest.Mock)
+        .mockResolvedValueOnce(makeSource())
+        .mockResolvedValueOnce(makeTarget());
+      // fetchAffectedMediaItemsByPersonId(sourceId) then (targetId), keyed by where.personId.
+      (mockPrisma.face.findMany as jest.Mock).mockImplementation(async ({ where }: any) => {
+        if (where.personId === SOURCE_ID) {
+          return [{ mediaItemId: 'media-source', mediaItem: { circleId: CIRCLE_ID } }];
+        }
+        if (where.personId === TARGET_ID) {
+          return [
+            { mediaItemId: 'media-target', mediaItem: { circleId: CIRCLE_ID } },
+            // Overlapping id — must be deduplicated in the merged touch set.
+            { mediaItemId: 'media-source', mediaItem: { circleId: CIRCLE_ID } },
+          ];
+        }
+        return [];
+      });
+      mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+        (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+        (mockPrisma.person.update as jest.Mock)
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce({ id: TARGET_ID, name: 'Alice', circleId: CIRCLE_ID, coverFaceId: null, _count: { faces: 1 }, createdAt: new Date(), updatedAt: new Date() });
+        (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
+        return cb(mockPrisma);
+      });
+
+      await service.mergePeople({ sourceId: SOURCE_ID, targetId: TARGET_ID }, USER_ID, PERMS);
+
+      const [touchedIds] = (mockMediaTouch.touchMediaItems as jest.Mock).mock.calls[0];
+      expect(touchedIds.sort()).toEqual(['media-source', 'media-target'].sort());
     });
 
     it('carries source coverFaceId to target when target has none', async () => {
@@ -3152,6 +3267,175 @@ describe('PeopleService', () => {
       await expect(
         service.purgeArchivedFaces(dto, USER_ID, PERMS),
       ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addPersonToMedia (manual people association, issue #310 touch propagation)
+  // -------------------------------------------------------------------------
+
+  describe('addPersonToMedia', () => {
+    function makeMediaItemRow(overrides: Partial<any> = {}) {
+      return {
+        id: MEDIA_ID,
+        circleId: CIRCLE_ID,
+        deletedAt: null,
+        ...overrides,
+      };
+    }
+
+    it('throws NotFoundException when the media item does not exist', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, { personId: PERSON_ID }),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the media item is soft-deleted', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItemRow({ deletedAt: new Date() }),
+      );
+
+      await expect(
+        service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, { personId: PERSON_ID }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('calls assertCircleAccess with collaborator role', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItemRow());
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.face.create as jest.Mock).mockResolvedValue({ id: FACE_ID });
+
+      await service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, { personId: PERSON_ID });
+
+      expect(mockCircleMembershipService.assertCircleAccess).toHaveBeenCalledWith(
+        USER_ID,
+        CIRCLE_ID,
+        PERMS,
+        'collaborator',
+      );
+    });
+
+    it('creates a manual Face row (providerKey=manual, manuallyAssigned=true) and touches the MediaItem (issue #310)', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItemRow());
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.face.create as jest.Mock).mockResolvedValue({ id: FACE_ID });
+
+      const result = await service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, {
+        personId: PERSON_ID,
+      });
+
+      expect(mockPrisma.face.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          mediaItemId: MEDIA_ID,
+          circleId: CIRCLE_ID,
+          personId: PERSON_ID,
+          providerKey: 'manual',
+          manuallyAssigned: true,
+        }),
+      });
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([MEDIA_ID]);
+      expect(result).toEqual({
+        personId: PERSON_ID,
+        personName: 'Alice',
+        faceId: FACE_ID,
+        mediaItemId: MEDIA_ID,
+      });
+    });
+
+    it('find-or-creates a person by name, then creates the manual face and touches the MediaItem', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItemRow());
+      // No existing person by name -> create path.
+      (mockPrisma.person.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.person.create as jest.Mock).mockResolvedValue({
+        id: 'new-person-id',
+        name: 'Dave',
+      });
+      (mockPrisma.face.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.face.create as jest.Mock).mockResolvedValue({ id: FACE_ID });
+
+      const result = await service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, { name: 'Dave' });
+
+      expect(mockPrisma.person.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ name: 'Dave' }) }),
+      );
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([MEDIA_ID]);
+      expect(result.personId).toBe('new-person-id');
+    });
+
+    it('is idempotent: an existing manual face for this person+item short-circuits WITHOUT touching (no new write)', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItemRow());
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findFirst as jest.Mock).mockResolvedValue({
+        id: 'existing-face-id',
+      });
+
+      const result = await service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, {
+        personId: PERSON_ID,
+      });
+
+      expect(mockPrisma.face.create).not.toHaveBeenCalled();
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+      expect(result.faceId).toBe('existing-face-id');
+    });
+
+    it('throws NotFoundException when the given personId does not exist in this circle', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItemRow());
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.addPersonToMedia(MEDIA_ID, USER_ID, PERMS, { personId: 'missing-person' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removePersonFromMedia (manual people association removal)
+  // -------------------------------------------------------------------------
+
+  describe('removePersonFromMedia', () => {
+    it('throws NotFoundException when the media item does not exist', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.removePersonFromMedia(MEDIA_ID, PERSON_ID, USER_ID, PERMS),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException (no manual association) when nothing was deleted', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({
+        id: MEDIA_ID,
+        circleId: CIRCLE_ID,
+        deletedAt: null,
+      });
+      (mockPrisma.face.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.removePersonFromMedia(MEDIA_ID, PERSON_ID, USER_ID, PERMS),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+    });
+
+    it('deletes the manual Face row and touches the MediaItem for the backup change feed (issue #310)', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({
+        id: MEDIA_ID,
+        circleId: CIRCLE_ID,
+        deletedAt: null,
+      });
+      (mockPrisma.face.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await service.removePersonFromMedia(MEDIA_ID, PERSON_ID, USER_ID, PERMS);
+
+      expect(mockPrisma.face.deleteMany).toHaveBeenCalledWith({
+        where: { mediaItemId: MEDIA_ID, personId: PERSON_ID, providerKey: 'manual' },
+      });
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([MEDIA_ID]);
+      expect(result).toEqual({ deleted: 1 });
     });
   });
 });

--- a/apps/api/src/face/people.service.ts
+++ b/apps/api/src/face/people.service.ts
@@ -28,6 +28,7 @@ import {
 } from './dto/people.dto';
 import { MergePeopleDto } from './dto/merge-people.dto';
 import { MediaThumbnailService } from '../media/media-thumbnail.service';
+import { MediaTouchService } from '../media/media-touch.service';
 
 @Injectable()
 export class PeopleService {
@@ -41,6 +42,7 @@ export class PeopleService {
     private readonly enrichmentJobService: EnrichmentJobService,
     private readonly systemSettings: SystemSettingsService,
     private readonly mediaThumbnailService: MediaThumbnailService,
+    private readonly mediaTouch: MediaTouchService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -374,6 +376,8 @@ export class PeopleService {
       // Re-enqueue auto-tagging for media items that now have a person assigned
       const createAffected = await this.fetchAffectedMediaItems(dto.faceIds);
       await this.enqueueAutoTaggingForMediaItems(createAffected);
+      // Backup change feed: face→person assignment doesn't bump MediaItem.updatedAt (issue #310)
+      await this.mediaTouch.touchMediaItems(createAffected.map((m) => m.mediaItemId));
     }
 
     this.logger.log(
@@ -467,6 +471,14 @@ export class PeopleService {
       data: updateData as any,
     });
 
+    // Backup change feed: sidecars embed person names/favorite, so a rename or
+    // favorite flip must surface every item this person appears in (issue #310).
+    // Renames are rare; touching thousands of items is acceptable.
+    if (dto.name !== undefined || dto.favorite !== undefined) {
+      const renameAffected = await this.fetchAffectedMediaItemsByPersonId(personId);
+      await this.mediaTouch.touchMediaItems(renameAffected.map((m) => m.mediaItemId));
+    }
+
     this.logger.log(`Person updated: ${personId} by user ${userId}`);
 
     return {
@@ -525,6 +537,9 @@ export class PeopleService {
     const affectedItems = await this.fetchAffectedMediaItems(dto.faceIds);
     await this.enqueueAutoTaggingForMediaItems(affectedItems);
 
+    // Backup change feed: face→person assignment doesn't bump MediaItem.updatedAt (issue #310)
+    await this.mediaTouch.touchMediaItems(affectedItems.map((m) => m.mediaItemId));
+
     this.logger.log(
       `Assigned ${dto.faceIds.length} face(s) to person ${personId} by user ${userId}`,
     );
@@ -574,6 +589,9 @@ export class PeopleService {
     await this.enqueueAutoTaggingForMediaItems([
       { mediaItemId: face.mediaItemId, circleId: person.circleId },
     ]);
+
+    // Backup change feed: face unassignment doesn't bump MediaItem.updatedAt (issue #310)
+    await this.mediaTouch.touchMediaItems([face.mediaItemId]);
 
     this.logger.log(
       `Unassigned face ${faceId} from person ${personId} by user ${userId}`,
@@ -732,6 +750,9 @@ export class PeopleService {
     // Re-enqueue auto-tagging for all media items affected by the merge
     await this.enqueueAutoTaggingForMediaItems(allMergeAffected);
 
+    // Backup change feed: the merge rewired Face.personId rows only (issue #310)
+    await this.mediaTouch.touchMediaItems(allMergeAffected.map((m) => m.mediaItemId));
+
     this.logger.log(
       `Person merge: ${sourceId} → ${targetId} in circle ${circleId} by user ${userId}`,
     );
@@ -805,6 +826,9 @@ export class PeopleService {
     // Re-enqueue auto-tagging for all media items that lost a person assignment
     await this.enqueueAutoTaggingForMediaItems(deleteAffected);
 
+    // Backup change feed: faces released to the unknown pool (issue #310)
+    await this.mediaTouch.touchMediaItems(deleteAffected.map((m) => m.mediaItemId));
+
     this.logger.log(
       `Person ${personId} soft-deleted by user ${userId}; faces returned to unknown pool`,
     );
@@ -837,6 +861,9 @@ export class PeopleService {
       },
       data: { hiddenAt: new Date() },
     });
+
+    // Backup change feed: person hide is a Person-row-only write (issue #310)
+    await this.touchMediaForPersons(ids, circleId);
 
     await this.prisma.auditEvent.create({
       data: {
@@ -882,6 +909,9 @@ export class PeopleService {
       },
       data: { hiddenAt: null },
     });
+
+    // Backup change feed: person unhide is a Person-row-only write (issue #310)
+    await this.touchMediaForPersons(ids, circleId);
 
     await this.prisma.auditEvent.create({
       data: {
@@ -966,6 +996,9 @@ export class PeopleService {
     // Re-enqueue auto-tagging for all affected media items (people removed from context)
     await this.enqueueAutoTaggingForMediaItems(dedupedMedia);
 
+    // Backup change feed: Face + Person rows hard-deleted (issue #310)
+    await this.mediaTouch.touchMediaItems(dedupedMedia.map((m) => m.mediaItemId));
+
     this.logger.log(
       `purgePeople: ${deleted} person(s) permanently deleted in circle ${circleId} by user ${userId}`,
     );
@@ -1002,6 +1035,10 @@ export class PeopleService {
       },
       data: { hiddenAt: new Date() },
     });
+
+    // Face ids whose parent MediaItems must be touched for the backup change
+    // feed (issue #310): the manual hides plus any auto-archive sweep hides.
+    const touchFaceIds: string[] = [...ids];
 
     // Best-effort auto-archive sweep: retroactively hide the currently-visible
     // unassigned faces that match the just-archived person(s), so the queue is
@@ -1047,6 +1084,7 @@ export class PeopleService {
               data: { hiddenAt: new Date(), hiddenReason: 'auto_archive_match' },
             });
             autoHidden = swept;
+            touchFaceIds.push(...sweepIds);
           }
         }
       }
@@ -1057,6 +1095,9 @@ export class PeopleService {
         }`,
       );
     }
+
+    // Backup change feed: Face.hiddenAt is a Face-row-only write (issue #310)
+    await this.touchMediaForFaceIds(touchFaceIds, circleId);
 
     await this.prisma.auditEvent.create({
       data: {
@@ -1102,6 +1143,9 @@ export class PeopleService {
       },
       data: { hiddenAt: null },
     });
+
+    // Backup change feed: Face.hiddenAt is a Face-row-only write (issue #310)
+    await this.touchMediaForFaceIds(ids, circleId);
 
     await this.prisma.auditEvent.create({
       data: {
@@ -1182,6 +1226,9 @@ export class PeopleService {
     // Re-enqueue auto-tagging for all affected media items (faces removed from context)
     await this.enqueueAutoTaggingForMediaItems(dedupedMedia);
 
+    // Backup change feed: Face rows hard-deleted (issue #310)
+    await this.mediaTouch.touchMediaItems(dedupedMedia.map((m) => m.mediaItemId));
+
     this.logger.log(
       `purgeFaces: ${deleted} face(s) permanently deleted in circle ${circleId} by user ${userId}`,
     );
@@ -1251,6 +1298,9 @@ export class PeopleService {
 
     // Re-enqueue auto-tagging for all affected media items (faces removed from context)
     await this.enqueueAutoTaggingForMediaItems(dedupedMedia);
+
+    // Backup change feed: Face rows hard-deleted (issue #310)
+    await this.mediaTouch.touchMediaItems(dedupedMedia.map((m) => m.mediaItemId));
 
     this.logger.log(
       `purgeArchivedFaces: ${deleted} archived face(s) permanently deleted in circle ${circleId} by user ${userId}`,
@@ -1348,6 +1398,9 @@ export class PeopleService {
     // 6. Enqueue auto-tagging rerun so description/embedding reflect the new person
     await this.enqueueAutoTaggingForMediaItems([{ mediaItemId, circleId: mediaItem.circleId }]);
 
+    // 7. Backup change feed: the manual Face row doesn't bump MediaItem.updatedAt (issue #310)
+    await this.mediaTouch.touchMediaItems([mediaItemId]);
+
     this.logger.log(
       `Manual person association created: person ${person.id} → media ${mediaItemId} by user ${userId}`,
     );
@@ -1396,6 +1449,9 @@ export class PeopleService {
 
     // 5. Enqueue auto-tagging rerun so description/embedding reflect the removed person
     await this.enqueueAutoTaggingForMediaItems([{ mediaItemId, circleId: mediaItem.circleId }]);
+
+    // 6. Backup change feed: the manual Face delete doesn't bump MediaItem.updatedAt (issue #310)
+    await this.mediaTouch.touchMediaItems([mediaItemId]);
 
     this.logger.log(
       `Manual person association removed: person ${personId} → media ${mediaItemId} by user ${userId}`,
@@ -1491,6 +1547,53 @@ export class PeopleService {
           `Failed to enqueue auto-tagging rerun for MediaItem ${mediaItemId}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+    }
+  }
+
+  /**
+   * Backup change feed helper (issue #310): touch all media items containing a
+   * face assigned to any of the given persons. Best-effort — failures inside
+   * MediaTouchService are swallowed, and the lookup itself is guarded here so a
+   * feed-bookkeeping failure never fails the user action.
+   */
+  private async touchMediaForPersons(
+    personIds: string[],
+    circleId: string,
+  ): Promise<void> {
+    try {
+      const faces = await this.prisma.face.findMany({
+        where: { personId: { in: personIds }, circleId },
+        select: { mediaItemId: true },
+        distinct: ['mediaItemId'],
+      });
+      await this.mediaTouch.touchMediaItems(faces.map((f) => f.mediaItemId));
+    } catch (err) {
+      this.logger.warn(
+        `touchMediaForPersons failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Backup change feed helper (issue #310): touch the parent media items of the
+   * given face ids. Best-effort, mirrors touchMediaForPersons.
+   */
+  private async touchMediaForFaceIds(
+    faceIds: string[],
+    circleId: string,
+  ): Promise<void> {
+    if (faceIds.length === 0) return;
+    try {
+      const faces = await this.prisma.face.findMany({
+        where: { id: { in: faceIds }, circleId },
+        select: { mediaItemId: true },
+        distinct: ['mediaItemId'],
+      });
+      await this.mediaTouch.touchMediaItems(faces.map((f) => f.mediaItemId));
+    } catch (err) {
+      this.logger.warn(
+        `touchMediaForFaceIds failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/apps/api/src/face/people.service.ts
+++ b/apps/api/src/face/people.service.ts
@@ -475,8 +475,7 @@ export class PeopleService {
     // favorite flip must surface every item this person appears in (issue #310).
     // Renames are rare; touching thousands of items is acceptable.
     if (dto.name !== undefined || dto.favorite !== undefined) {
-      const renameAffected = await this.fetchAffectedMediaItemsByPersonId(personId);
-      await this.mediaTouch.touchMediaItems(renameAffected.map((m) => m.mediaItemId));
+      await this.touchMediaForPersons([personId], person.circleId);
     }
 
     this.logger.log(`Person updated: ${personId} by user ${userId}`);

--- a/apps/api/src/face/video-face-detection.handler.spec.ts
+++ b/apps/api/src/face/video-face-detection.handler.spec.ts
@@ -365,6 +365,7 @@ describe('VideoFaceDetectionHandler', () => {
       mockMatchingService as any,
       mockResolver as any,
       mockEnrichmentJobService as any,
+      { touchMediaItems: jest.fn().mockResolvedValue(undefined) } as any,
     );
 
     handler = new VideoFaceDetectionHandler(

--- a/apps/api/src/face/video-face-detection.service.ts
+++ b/apps/api/src/face/video-face-detection.service.ts
@@ -62,6 +62,7 @@ import {
 import { VideoFrameExtractionService } from './video-frame-extraction.service';
 import { FaceMatchingService } from './face-matching.service';
 import type { DetectedFace } from './providers/face-provider.interface';
+import { MediaTouchService } from '../media/media-touch.service';
 
 // Max long-edge for face detection on video frames (same env var as photo path).
 const FACE_MAX_IMAGE_DIM = (): number =>
@@ -128,6 +129,7 @@ export class VideoFaceDetectionService {
     private readonly matchingService: FaceMatchingService,
     private readonly resolver: StorageProviderResolver,
     private readonly enrichmentJobService: EnrichmentJobService,
+    private readonly mediaTouch: MediaTouchService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -595,5 +597,9 @@ export class VideoFaceDetectionService {
       result.providerKey,
       result.modelVersion,
     );
+
+    // Backup change feed (issue #310): Face rows were deleted/recreated (and
+    // possibly person-matched) without any MediaItem column write.
+    await this.mediaTouch.touchMediaItems([job.mediaItemId]);
   }
 }

--- a/apps/api/src/media/archive-trash.service.spec.ts
+++ b/apps/api/src/media/archive-trash.service.spec.ts
@@ -36,6 +36,7 @@ import { ForwardGeocodeService } from './geo/forward-geocode.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../notifications/producers/upload-notification.service';
+import { MediaTouchService } from './media-touch.service';
 import { MediaThumbnailService } from './media-thumbnail.service';
 import { randomUUID } from 'crypto';
 
@@ -188,6 +189,10 @@ describe('MediaService — archive & trash methods', () => {
           // #247 upload_completed producer — fire-and-forget, not asserted here.
           provide: UploadNotificationService,
           useValue: { recordUploadAsync: jest.fn(), recordUpload: jest.fn() },
+        },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
         },
         {
           provide: MediaEnrichmentService,

--- a/apps/api/src/media/media-touch.module.ts
+++ b/apps/api/src/media/media-touch.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { MediaTouchService } from './media-touch.service';
+
+/**
+ * MediaTouchModule (issue #310)
+ *
+ * Deliberately tiny and dependency-free (PrismaModule only) so ANY module that
+ * mutates sidecar-visible related rows (tagging, face, media itself) can import
+ * it without ever closing a module cycle — the same "imports nothing" rationale
+ * as NotificationsModule. MediaModule re-exports this module so existing
+ * MediaModule consumers can also resolve MediaTouchService.
+ */
+@Module({
+  imports: [PrismaModule],
+  providers: [MediaTouchService],
+  exports: [MediaTouchService],
+})
+export class MediaTouchModule {}

--- a/apps/api/src/media/media-touch.service.spec.ts
+++ b/apps/api/src/media/media-touch.service.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for MediaTouchService (issue #310, epic #308 — Local Media Backup
+ * via Worker Nodes).
+ *
+ * Covers the contract documented at the top of media-touch.service.ts:
+ *   - chunks at 500 ids per updateMany call
+ *   - deduplicates ids before chunking
+ *   - no-ops (no DB call) on an empty array
+ *   - explicitly sets `updatedAt = new Date()` (updateMany does not apply @updatedAt)
+ *   - swallows a failed updateMany and logs a warning instead of throwing
+ *   - uses the passed Prisma.TransactionClient instead of the injected PrismaService
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { MediaTouchService } from './media-touch.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
+
+describe('MediaTouchService', () => {
+  let service: MediaTouchService;
+  let mockPrisma: MockPrismaService;
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    (mockPrisma.mediaItem.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaTouchService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<MediaTouchService>(MediaTouchService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // empty array — no-op
+  // -------------------------------------------------------------------------
+
+  it('no-ops on an empty array (no updateMany call)', async () => {
+    await service.touchMediaItems([]);
+
+    expect(mockPrisma.mediaItem.updateMany).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // dedupe
+  // -------------------------------------------------------------------------
+
+  it('deduplicates ids before writing', async () => {
+    await service.touchMediaItems(['a', 'a', 'b', 'a', 'b']);
+
+    expect(mockPrisma.mediaItem.updateMany).toHaveBeenCalledTimes(1);
+    const call = (mockPrisma.mediaItem.updateMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.id.in).toEqual(['a', 'b']);
+  });
+
+  // -------------------------------------------------------------------------
+  // explicit updatedAt
+  // -------------------------------------------------------------------------
+
+  it('explicitly sets updatedAt to a fresh Date (updateMany does not apply @updatedAt)', async () => {
+    const before = Date.now();
+
+    await service.touchMediaItems(['a']);
+
+    const call = (mockPrisma.mediaItem.updateMany as jest.Mock).mock.calls[0][0];
+    expect(call.data.updatedAt).toBeInstanceOf(Date);
+    const stamped = (call.data.updatedAt as Date).getTime();
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Date.now());
+  });
+
+  // -------------------------------------------------------------------------
+  // chunking at 500
+  // -------------------------------------------------------------------------
+
+  describe('chunking', () => {
+    it('issues a single updateMany call for exactly 500 ids', async () => {
+      const ids = Array.from({ length: 500 }, (_, i) => `id-${i}`);
+
+      await service.touchMediaItems(ids);
+
+      expect(mockPrisma.mediaItem.updateMany).toHaveBeenCalledTimes(1);
+      const call = (mockPrisma.mediaItem.updateMany as jest.Mock).mock.calls[0][0];
+      expect(call.where.id.in).toHaveLength(500);
+    });
+
+    it('splits 501 unique ids into two chunks (500 + 1)', async () => {
+      const ids = Array.from({ length: 501 }, (_, i) => `id-${i}`);
+
+      await service.touchMediaItems(ids);
+
+      expect(mockPrisma.mediaItem.updateMany).toHaveBeenCalledTimes(2);
+      const calls = (mockPrisma.mediaItem.updateMany as jest.Mock).mock.calls;
+      expect(calls[0][0].where.id.in).toHaveLength(500);
+      expect(calls[1][0].where.id.in).toHaveLength(1);
+      expect(calls[1][0].where.id.in).toEqual(['id-500']);
+    });
+
+    it('splits 1200 unique ids into three chunks (500 + 500 + 200)', async () => {
+      const ids = Array.from({ length: 1200 }, (_, i) => `id-${i}`);
+
+      await service.touchMediaItems(ids);
+
+      expect(mockPrisma.mediaItem.updateMany).toHaveBeenCalledTimes(3);
+      const calls = (mockPrisma.mediaItem.updateMany as jest.Mock).mock.calls;
+      expect(calls[0][0].where.id.in).toHaveLength(500);
+      expect(calls[1][0].where.id.in).toHaveLength(500);
+      expect(calls[2][0].where.id.in).toHaveLength(200);
+    });
+
+    it('deduplicates BEFORE chunking, so duplicates never inflate the chunk count', async () => {
+      // 500 unique ids, each duplicated once => 1000 raw entries but still
+      // only 500 unique ids => exactly one chunk, not two.
+      const unique = Array.from({ length: 500 }, (_, i) => `id-${i}`);
+      const withDupes = [...unique, ...unique];
+
+      await service.touchMediaItems(withDupes);
+
+      expect(mockPrisma.mediaItem.updateMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // error swallowed with warning
+  // -------------------------------------------------------------------------
+
+  describe('best-effort error handling', () => {
+    it('swallows an updateMany rejection and never throws', async () => {
+      (mockPrisma.mediaItem.updateMany as jest.Mock).mockRejectedValueOnce(
+        new Error('db unavailable'),
+      );
+
+      await expect(service.touchMediaItems(['a'])).resolves.toBeUndefined();
+    });
+
+    it('logs a warning including the failure count and error message on rejection', async () => {
+      const warnSpy = jest.spyOn((service as any).logger, 'warn');
+      (mockPrisma.mediaItem.updateMany as jest.Mock).mockRejectedValueOnce(
+        new Error('db unavailable'),
+      );
+
+      await service.touchMediaItems(['a', 'b']);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('failed to bump updatedAt on 2 item(s): db unavailable'),
+      );
+    });
+
+    it('handles a non-Error rejection by stringifying it in the warning', async () => {
+      const warnSpy = jest.spyOn((service as any).logger, 'warn');
+      (mockPrisma.mediaItem.updateMany as jest.Mock).mockRejectedValueOnce('boom');
+
+      await service.touchMediaItems(['a']);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    });
+
+    it('stops issuing further chunk calls once a chunk throws (loop aborts on first failure)', async () => {
+      const ids = Array.from({ length: 1000 }, (_, i) => `id-${i}`);
+      (mockPrisma.mediaItem.updateMany as jest.Mock)
+        .mockRejectedValueOnce(new Error('first chunk failed'))
+        .mockResolvedValueOnce({ count: 500 });
+
+      await service.touchMediaItems(ids);
+
+      // Only the first chunk's call was attempted before the try/catch
+      // swallowed the error and returned.
+      expect(mockPrisma.mediaItem.updateMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // tx client used when passed
+  // -------------------------------------------------------------------------
+
+  describe('transaction client', () => {
+    it('writes through the passed Prisma.TransactionClient instead of the injected PrismaService', async () => {
+      const txUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+      const fakeTx = { mediaItem: { updateMany: txUpdateMany } } as any;
+
+      await service.touchMediaItems(['a'], fakeTx);
+
+      expect(txUpdateMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.mediaItem.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('still chunks at 500 when writing through a tx client', async () => {
+      const txUpdateMany = jest.fn().mockResolvedValue({ count: 500 });
+      const fakeTx = { mediaItem: { updateMany: txUpdateMany } } as any;
+      const ids = Array.from({ length: 501 }, (_, i) => `id-${i}`);
+
+      await service.touchMediaItems(ids, fakeTx);
+
+      expect(txUpdateMany).toHaveBeenCalledTimes(2);
+    });
+
+    it('swallows a tx-client failure the same as the default-client path', async () => {
+      const txUpdateMany = jest.fn().mockRejectedValue(new Error('tx aborted'));
+      const fakeTx = { mediaItem: { updateMany: txUpdateMany } } as any;
+
+      await expect(service.touchMediaItems(['a'], fakeTx)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/media/media-touch.service.ts
+++ b/apps/api/src/media/media-touch.service.ts
@@ -1,0 +1,69 @@
+// =============================================================================
+// MediaTouchService (issue #310, epic #308 — Local Media Backup via Worker Nodes)
+// =============================================================================
+//
+// The node backup change feed is keyset-paginated over
+// `media_items (updated_at, id)`. Direct MediaItem column writes (description,
+// favorite, capturedAt, archive/trash/restore, geo, orientation) bump
+// `updatedAt` for free via Prisma's @updatedAt — but sidecar-visible metadata
+// that lives in RELATED tables (media_tags, album_items, faces, people) does
+// not touch the MediaItem row at all, so those mutations would be invisible to
+// an incremental backup scan. This service is the single, explicit
+// "propagate a related-row change onto the parent MediaItem" primitive.
+//
+// Contract:
+//   - Best-effort: a failed touch logs a warning and NEVER throws into the
+//     caller — a backup-feed bookkeeping failure must not fail a user action.
+//   - Deduplicates ids and no-ops on an empty array.
+//   - Explicitly sets `updatedAt = new Date()` because `updateMany` does not
+//     reliably apply @updatedAt.
+//   - Accepts an optional Prisma.TransactionClient so a caller already inside
+//     a transaction can keep the touch atomic with its own writes. NOTE: when
+//     a tx client is passed, a failed touch statement aborts that transaction
+//     at the Postgres level even though this method swallows the error —
+//     prefer touching AFTER the transaction commits unless atomicity matters.
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+/** Ids per UPDATE statement — bounds parameter-list size on huge batches. */
+const TOUCH_CHUNK_SIZE = 500;
+
+@Injectable()
+export class MediaTouchService {
+  private readonly logger = new Logger(MediaTouchService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Bump `updatedAt` on the given MediaItem ids so the backup change feed
+   * picks them up. Best-effort; never throws.
+   */
+  async touchMediaItems(
+    ids: string[],
+    tx?: Prisma.TransactionClient,
+  ): Promise<void> {
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) return;
+
+    const client = tx ?? this.prisma;
+
+    try {
+      for (let i = 0; i < unique.length; i += TOUCH_CHUNK_SIZE) {
+        const chunk = unique.slice(i, i + TOUCH_CHUNK_SIZE);
+        await client.mediaItem.updateMany({
+          where: { id: { in: chunk } },
+          // Explicit set — updateMany does not reliably apply @updatedAt.
+          data: { updatedAt: new Date() },
+        });
+      }
+    } catch (err) {
+      this.logger.warn(
+        `touchMediaItems: failed to bump updatedAt on ${unique.length} item(s): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}

--- a/apps/api/src/media/media.module.ts
+++ b/apps/api/src/media/media.module.ts
@@ -7,6 +7,7 @@ import { GeoLocationModule } from './geo/geo-location.module';
 import { SettingsModule } from '../settings/settings.module';
 import { EnrichmentModule } from '../enrichment/enrichment.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { MediaTouchModule } from './media-touch.module';
 import { MediaController } from './media.controller';
 import { MediaService } from './media.service';
 import { MediaMetadataSyncService } from './sync/media-metadata-sync.service';
@@ -86,6 +87,7 @@ import { TrashEmptyExecuteBatchHandler } from './trash-empty/trash-empty-execute
     SettingsModule,
     EnrichmentModule,
     NotificationsModule,
+    MediaTouchModule,
   ],
   controllers: [
     MediaController,
@@ -115,6 +117,6 @@ import { TrashEmptyExecuteBatchHandler } from './trash-empty/trash-empty-execute
     TrashEmptyEvaluateHandler,
     TrashEmptyExecuteBatchHandler,
   ],
-  exports: [MediaService, MediaReprocessService, MediaMetadataSyncService, MediaEnrichmentService, MediaThumbnailService, TrashEmptyRunService],
+  exports: [MediaService, MediaReprocessService, MediaMetadataSyncService, MediaEnrichmentService, MediaThumbnailService, TrashEmptyRunService, MediaTouchModule],
 })
 export class MediaModule {}

--- a/apps/api/src/media/media.service.facets.spec.ts
+++ b/apps/api/src/media/media.service.facets.spec.ts
@@ -15,6 +15,7 @@ import { ForwardGeocodeService } from './geo/forward-geocode.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../notifications/producers/upload-notification.service';
+import { MediaTouchService } from './media-touch.service';
 import { MediaThumbnailService } from './media-thumbnail.service';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 
@@ -66,6 +67,10 @@ describe('MediaService.facetsLocations', () => {
           // #247 upload_completed producer — fire-and-forget, not asserted here.
           provide: UploadNotificationService,
           useValue: { recordUploadAsync: jest.fn(), recordUpload: jest.fn() },
+        },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
         },
         { provide: MediaEnrichmentService, useValue: {} },
       ],

--- a/apps/api/src/media/media.service.fallback-location.spec.ts
+++ b/apps/api/src/media/media.service.fallback-location.spec.ts
@@ -30,6 +30,7 @@ import { ForwardGeocodeService } from './geo/forward-geocode.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../notifications/producers/upload-notification.service';
+import { MediaTouchService } from './media-touch.service';
 import { MediaThumbnailService } from './media-thumbnail.service';
 
 const CIRCLE_ID = 'circle-uuid-0001-0002-0003';
@@ -179,6 +180,10 @@ describe('MediaService.createMedia — fallback location', () => {
           // #247 upload_completed producer — fire-and-forget, not asserted here.
           provide: UploadNotificationService,
           useValue: { recordUploadAsync: jest.fn(), recordUpload: jest.fn() },
+        },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
         },
         { provide: MediaEnrichmentService, useValue: mockMediaEnrichmentService },
       ],

--- a/apps/api/src/media/media.service.locations.spec.ts
+++ b/apps/api/src/media/media.service.locations.spec.ts
@@ -21,6 +21,7 @@ import { ForwardGeocodeService } from './geo/forward-geocode.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../notifications/producers/upload-notification.service';
+import { MediaTouchService } from './media-touch.service';
 import { MediaThumbnailService } from './media-thumbnail.service';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 
@@ -86,6 +87,10 @@ describe('MediaService.exploreLocations / exploreLocationLevel', () => {
           // #247 upload_completed producer — fire-and-forget, not asserted here.
           provide: UploadNotificationService,
           useValue: { recordUploadAsync: jest.fn(), recordUpload: jest.fn() },
+        },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
         },
         { provide: MediaEnrichmentService, useValue: {} },
       ],

--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -21,6 +21,7 @@ import { ForwardGeocodeService } from './geo/forward-geocode.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../notifications/producers/upload-notification.service';
+import { MediaTouchService } from './media-touch.service';
 import { mediaThumbnailsQuerySchema } from './dto/media-thumbnails-query.dto';
 import { MediaThumbnailService } from './media-thumbnail.service';
 
@@ -294,6 +295,10 @@ describe('MediaService', () => {
           useValue: mockUploadNotificationService,
         },
         { provide: MediaEnrichmentService, useValue: mockMediaEnrichmentService },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -214,6 +214,7 @@ describe('MediaService', () => {
     enqueueThumbnailRerun: jest.Mock;
   };
   let mockUploadNotificationService: { recordUploadAsync: jest.Mock; recordUpload: jest.Mock };
+  let mockMediaTouch: { touchMediaItems: jest.Mock };
 
   beforeEach(async () => {
     mockPrisma = createMockPrismaService();
@@ -266,6 +267,11 @@ describe('MediaService', () => {
       recordUploadAsync: jest.fn(),
       recordUpload: jest.fn(),
     };
+    // Backup change feed (issue #310) — captured in a variable so tests can
+    // assert exactly which MediaItem ids each mutation touches.
+    mockMediaTouch = {
+      touchMediaItems: jest.fn().mockResolvedValue(undefined),
+    };
     // Batched thumbnail signing (MediaThumbnailService.signThumbsBatched) always
     // issues one storageObject.findMany call. The deep prisma mock returns
     // undefined for unconfigured methods, which would throw inside a `for...of`
@@ -295,10 +301,7 @@ describe('MediaService', () => {
           useValue: mockUploadNotificationService,
         },
         { provide: MediaEnrichmentService, useValue: mockMediaEnrichmentService },
-        {
-          provide: MediaTouchService,
-          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
-        },
+        { provide: MediaTouchService, useValue: mockMediaTouch },
       ],
     }).compile();
 
@@ -1191,6 +1194,19 @@ describe('MediaService', () => {
       expect(result).toHaveLength(2);
     });
 
+    it('touches the MediaItem for the backup change feed (issue #310)', async () => {
+      const item = makeMediaItem({ addedById: 'user-1' });
+      const tag = makeTag({ name: 'nature' });
+
+      mockPrisma.mediaItem.findUnique.mockResolvedValue(item as any);
+      mockPrisma.tag.upsert.mockResolvedValue(tag as any);
+      mockPrisma.mediaTag.upsert.mockResolvedValue({} as any);
+
+      await service.attachTags(item.id, { names: ['nature'] }, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([item.id]);
+    });
+
     it('creates MediaTag with source=manual and promotes only ai rows to manual (never downgrades system/manual)', async () => {
       const item = makeMediaItem({ addedById: 'user-1' });
       const tag = makeTag({ name: 'nature' });
@@ -1267,6 +1283,20 @@ describe('MediaService', () => {
       expect(mockPrisma.mediaTag.delete).toHaveBeenCalledWith({
         where: { tagId_mediaItemId: { tagId: tag.id, mediaItemId: item.id } },
       });
+    });
+
+    it('touches the MediaItem for the backup change feed (issue #310)', async () => {
+      const item = makeMediaItem({ addedById: 'user-1' });
+      const tag = makeTag();
+      const mediaTag = { id: randomUUID(), tagId: tag.id, mediaItemId: item.id, addedAt: new Date() };
+
+      mockPrisma.mediaItem.findUnique.mockResolvedValue(item as any);
+      mockPrisma.mediaTag.findUnique.mockResolvedValue(mediaTag as any);
+      mockPrisma.mediaTag.delete.mockResolvedValue(mediaTag as any);
+
+      await service.removeTag(item.id, tag.id, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([item.id]);
     });
 
     it('should throw NotFoundException when the tag is not attached', async () => {
@@ -1590,6 +1620,61 @@ describe('MediaService', () => {
     });
 
     // -----------------------------------------------------------------------
+    // backup change feed (issue #310) — renames touch every member item
+    // -----------------------------------------------------------------------
+
+    it('touches every album member when the name actually changes (issue #310)', async () => {
+      const album = makeAlbum({ addedById: 'user-1', name: 'Old Name' });
+      const updated = { ...album, name: 'New Name' };
+      const memberIds = [randomUUID(), randomUUID()];
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.album.update.mockResolvedValue(updated as any);
+      mockPrisma.albumItem.findMany.mockResolvedValue(
+        memberIds.map((mediaItemId) => ({ mediaItemId })) as any,
+      );
+
+      await service.updateAlbum(album.id, { name: 'New Name' }, 'user-1', ownPerms);
+
+      expect(mockPrisma.albumItem.findMany).toHaveBeenCalledWith({
+        where: { albumId: album.id },
+        select: { mediaItemId: true },
+      });
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(memberIds);
+    });
+
+    it('does NOT touch members when name is set to the same value it already had', async () => {
+      const album = makeAlbum({ addedById: 'user-1', name: 'Same Name' });
+      const updated = { ...album };
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.album.update.mockResolvedValue(updated as any);
+
+      await service.updateAlbum(album.id, { name: 'Same Name' }, 'user-1', ownPerms);
+
+      expect(mockPrisma.albumItem.findMany).not.toHaveBeenCalled();
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+    });
+
+    it('does NOT touch members for a non-rename update (e.g. description-only)', async () => {
+      const album = makeAlbum({ addedById: 'user-1', name: 'Unchanged' });
+      const updated = { ...album, description: 'New description' };
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.album.update.mockResolvedValue(updated as any);
+
+      await service.updateAlbum(
+        album.id,
+        { description: 'New description' },
+        'user-1',
+        ownPerms,
+      );
+
+      expect(mockPrisma.albumItem.findMany).not.toHaveBeenCalled();
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
+    });
+
+    // -----------------------------------------------------------------------
     // coverMediaItemId (album cover pointer)
     // -----------------------------------------------------------------------
 
@@ -1719,6 +1804,36 @@ describe('MediaService', () => {
         service.deleteAlbum(album.id, 'user-1', ownPerms),
       ).rejects.toThrow(ForbiddenException);
     });
+
+    it('touches every member captured BEFORE the cascade removes AlbumItem rows (issue #310)', async () => {
+      const album = makeAlbum({ addedById: 'user-1' });
+      const memberIds = [randomUUID(), randomUUID(), randomUUID()];
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.albumItem.findMany.mockResolvedValue(
+        memberIds.map((mediaItemId) => ({ mediaItemId })) as any,
+      );
+      mockPrisma.album.delete.mockResolvedValue(album as any);
+
+      await service.deleteAlbum(album.id, 'user-1', ownPerms);
+
+      expect(mockPrisma.albumItem.findMany).toHaveBeenCalledWith({
+        where: { albumId: album.id },
+        select: { mediaItemId: true },
+      });
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(memberIds);
+    });
+
+    it('still deletes the album and touches an empty set when the member lookup throws (best-effort)', async () => {
+      const album = makeAlbum({ addedById: 'user-1' });
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.albumItem.findMany.mockRejectedValueOnce(new Error('db blip'));
+      mockPrisma.album.delete.mockResolvedValue(album as any);
+
+      await expect(service.deleteAlbum(album.id, 'user-1', ownPerms)).resolves.toBeUndefined();
+
+      expect(mockPrisma.album.delete).toHaveBeenCalledWith({ where: { id: album.id } });
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([]);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -1749,6 +1864,30 @@ describe('MediaService', () => {
 
       expect(mockPrisma.albumItem.upsert).toHaveBeenCalledTimes(2);
       expect(result).toHaveLength(2);
+    });
+
+    it('touches every added MediaItem for the backup change feed (issue #310)', async () => {
+      const album = makeAlbum({ addedById: 'user-1' });
+      const item1 = makeMediaItem({ addedById: 'user-1' });
+      const item2 = makeMediaItem({ addedById: 'user-1' });
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.mediaItem.findMany.mockResolvedValue([item1, item2] as any);
+      (mockPrisma.albumItem.upsert as jest.Mock).mockImplementation(async ({ create }: any) => ({
+        id: randomUUID(),
+        albumId: create.albumId,
+        mediaItemId: create.mediaItemId,
+        addedAt: new Date(),
+      }));
+
+      await service.addAlbumItems(
+        album.id,
+        { mediaItemIds: [item1.id, item2.id] },
+        'user-1',
+        ownPerms,
+      );
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([item1.id, item2.id]);
     });
 
     it('should throw NotFoundException when a mediaItemId is not found', async () => {
@@ -1805,6 +1944,33 @@ describe('MediaService', () => {
       );
 
       expect(result).toEqual({ added: 3 });
+    });
+
+    it('touches every matched item for the backup change feed when items land (issue #310)', async () => {
+      const album = makeAlbum({ addedById: 'user-1', circleId: CIRCLE_ID });
+      const matches = [{ id: 'item-a' }, { id: 'item-b' }, { id: 'item-c' }];
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.mediaItem.findMany.mockResolvedValue(matches as any);
+      (mockPrisma.albumItem.createMany as jest.Mock).mockResolvedValue({ count: 3 });
+
+      await service.addAlbumItemsByFilter(album.id, dto, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(['item-a', 'item-b', 'item-c']);
+    });
+
+    it('does NOT touch anything when nothing was added (createMany count 0)', async () => {
+      const album = makeAlbum({ addedById: 'user-1', circleId: CIRCLE_ID });
+      const matches = [{ id: 'item-a' }];
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.mediaItem.findMany.mockResolvedValue(matches as any);
+      // Everything already existed — skipDuplicates left count at 0.
+      (mockPrisma.albumItem.createMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      await service.addAlbumItemsByFilter(album.id, dto, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
     });
 
     it('cross-circle safety: where clause uses album.circleId even if dto carries a different circleId', async () => {
@@ -1917,6 +2083,25 @@ describe('MediaService', () => {
       expect(mockPrisma.albumItem.delete).toHaveBeenCalledWith({
         where: { albumId_mediaItemId: { albumId: album.id, mediaItemId: item.id } },
       });
+    });
+
+    it('touches the MediaItem for the backup change feed (issue #310)', async () => {
+      const album = makeAlbum({ addedById: 'user-1' });
+      const item = makeMediaItem({ addedById: 'user-1' });
+      const albumItem = {
+        id: randomUUID(),
+        albumId: album.id,
+        mediaItemId: item.id,
+        addedAt: new Date(),
+      };
+
+      mockPrisma.album.findUnique.mockResolvedValue(album as any);
+      mockPrisma.albumItem.findUnique.mockResolvedValue(albumItem as any);
+      mockPrisma.albumItem.delete.mockResolvedValue(albumItem as any);
+
+      await service.removeAlbumItem(album.id, item.id, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith([item.id]);
     });
 
     it('should NOT delete the underlying MediaItem', async () => {
@@ -3183,6 +3368,45 @@ describe('MediaService', () => {
           ]),
         }),
       );
+    });
+
+    it('touches every id for the backup change feed when tags were added (issue #310)', async () => {
+      const ids = [randomUUID(), randomUUID()];
+      const dto = makeBulkTagsDto({ ids, add: ['nature'] });
+
+      mockPrisma.mediaItem.findMany.mockResolvedValue(ids.map((id) => ({ id })) as any);
+      mockPrisma.tag.upsert.mockResolvedValue(makeTag({ name: 'nature' }) as any);
+      mockPrisma.mediaTag.createMany.mockResolvedValue({ count: 2 });
+
+      await service.bulkTags(dto, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(ids);
+    });
+
+    it('touches every id for the backup change feed when tags were removed (issue #310)', async () => {
+      const ids = [randomUUID(), randomUUID()];
+      const tagId = randomUUID();
+      const dto = makeBulkTagsDto({ ids, add: undefined, remove: ['nature'] });
+
+      mockPrisma.mediaItem.findMany.mockResolvedValue(ids.map((id) => ({ id })) as any);
+      mockPrisma.tag.findMany.mockResolvedValue([{ id: tagId }] as any);
+      mockPrisma.mediaTag.deleteMany.mockResolvedValue({ count: 2 });
+
+      await service.bulkTags(dto, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).toHaveBeenCalledWith(ids);
+    });
+
+    it('does NOT touch anything when nothing was added or removed', async () => {
+      const ids = [randomUUID()];
+      const dto = makeBulkTagsDto({ ids, add: undefined, remove: ['nonexistent'] });
+
+      mockPrisma.mediaItem.findMany.mockResolvedValue(ids.map((id) => ({ id })) as any);
+      mockPrisma.tag.findMany.mockResolvedValue([] as any);
+
+      await service.bulkTags(dto, 'user-1', ownPerms);
+
+      expect(mockMediaTouch.touchMediaItems).not.toHaveBeenCalled();
     });
 
     it('promotes existing ai-sourced MediaTags to manual via updateMany after createMany', async () => {

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -1269,11 +1269,7 @@ export class MediaService {
     // every member item in the incremental scan (issue #310). Renames are rare;
     // an updateMany over thousands of members is acceptable.
     if (dto.name !== undefined && dto.name !== album.name) {
-      const members = await this.prisma.albumItem.findMany({
-        where: { albumId: album.id },
-        select: { mediaItemId: true },
-      });
-      await this.mediaTouch.touchMediaItems(members.map((m) => m.mediaItemId));
+      await this.touchAlbumMembers(album.id);
     }
 
     this.logger.log(`Album updated: ${id} by user ${userId}`);
@@ -1294,15 +1290,22 @@ export class MediaService {
 
     // Backup change feed: capture member ids BEFORE the cascade removes the
     // join rows — the members' sidecars lose this album (issue #310).
-    const members = await this.prisma.albumItem.findMany({
-      where: { albumId: id },
-      select: { mediaItemId: true },
-    });
+    // Best-effort: a lookup failure must never block the delete.
+    let memberIds: string[] = [];
+    try {
+      const rows = await this.prisma.albumItem.findMany({
+        where: { albumId: id },
+        select: { mediaItemId: true },
+      });
+      memberIds = (rows ?? []).map((m) => m.mediaItemId);
+    } catch {
+      // swallowed — feed bookkeeping only
+    }
 
     // Cascade in the schema deletes AlbumItems when Album is deleted
     await this.prisma.album.delete({ where: { id } });
 
-    await this.mediaTouch.touchMediaItems(members.map((m) => m.mediaItemId));
+    await this.mediaTouch.touchMediaItems(memberIds);
 
     this.logger.log(`Album deleted: ${id} by user ${userId}`);
   }
@@ -1458,6 +1461,27 @@ export class MediaService {
 
     this.logger.log(`Added ${totalAdded} item(s) to album ${albumId} by filter`);
     return { added: totalAdded };
+  }
+
+  /**
+   * Backup change feed helper (issue #310): touch every member item of an
+   * album. Best-effort — a lookup failure is logged and swallowed so backup
+   * bookkeeping can never fail the triggering album mutation.
+   */
+  private async touchAlbumMembers(albumId: string): Promise<void> {
+    try {
+      const members = await this.prisma.albumItem.findMany({
+        where: { albumId },
+        select: { mediaItemId: true },
+      });
+      await this.mediaTouch.touchMediaItems(
+        (members ?? []).map((m) => m.mediaItemId),
+      );
+    } catch (err) {
+      this.logger.warn(
+        `touchAlbumMembers failed for album ${albumId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -52,6 +52,7 @@ import { ReviewCountsQueryDto } from './dto/review-counts-query.dto';
 import { MediaEnrichmentService } from './enrichment/media-enrichment.service';
 import { MediaThumbnailService } from './media-thumbnail.service';
 import { UploadNotificationService } from '../notifications/producers/upload-notification.service';
+import { MediaTouchService } from './media-touch.service';
 
 /** Shape of each element returned by listLocations. */
 export interface MediaLocation {
@@ -85,6 +86,7 @@ export class MediaService {
     private readonly mediaEnrichmentService: MediaEnrichmentService,
     private readonly mediaThumbnailService: MediaThumbnailService,
     private readonly uploadNotificationService: UploadNotificationService,
+    private readonly mediaTouch: MediaTouchService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -1042,6 +1044,9 @@ export class MediaService {
       result.push({ tagId: tag.id, name: tag.name });
     }
 
+    // Backup change feed: tag joins don't touch the MediaItem row (issue #310).
+    await this.mediaTouch.touchMediaItems([item.id]);
+
     this.logger.log(
       `Attached ${dto.names.length} tag(s) to MediaItem ${mediaItemId}`,
     );
@@ -1078,6 +1083,9 @@ export class MediaService {
     await this.prisma.mediaTag.delete({
       where: { tagId_mediaItemId: { tagId, mediaItemId } },
     });
+
+    // Backup change feed: tag joins don't touch the MediaItem row (issue #310).
+    await this.mediaTouch.touchMediaItems([mediaItemId]);
 
     this.logger.log(`Removed tag ${tagId} from MediaItem ${mediaItemId}`);
   }
@@ -1257,6 +1265,17 @@ export class MediaService {
       },
     });
 
+    // Backup change feed: sidecars embed album names, so a rename must surface
+    // every member item in the incremental scan (issue #310). Renames are rare;
+    // an updateMany over thousands of members is acceptable.
+    if (dto.name !== undefined && dto.name !== album.name) {
+      const members = await this.prisma.albumItem.findMany({
+        where: { albumId: album.id },
+        select: { mediaItemId: true },
+      });
+      await this.mediaTouch.touchMediaItems(members.map((m) => m.mediaItemId));
+    }
+
     this.logger.log(`Album updated: ${id} by user ${userId}`);
 
     return updated;
@@ -1273,8 +1292,17 @@ export class MediaService {
       'collaborator' as CircleRole,
     );
 
+    // Backup change feed: capture member ids BEFORE the cascade removes the
+    // join rows — the members' sidecars lose this album (issue #310).
+    const members = await this.prisma.albumItem.findMany({
+      where: { albumId: id },
+      select: { mediaItemId: true },
+    });
+
     // Cascade in the schema deletes AlbumItems when Album is deleted
     await this.prisma.album.delete({ where: { id } });
+
+    await this.mediaTouch.touchMediaItems(members.map((m) => m.mediaItemId));
 
     this.logger.log(`Album deleted: ${id} by user ${userId}`);
   }
@@ -1322,6 +1350,9 @@ export class MediaService {
       });
       created.push(item);
     }
+
+    // Backup change feed: AlbumItem joins don't bump MediaItem.updatedAt (issue #310).
+    await this.mediaTouch.touchMediaItems(dto.mediaItemIds);
 
     this.logger.log(
       `Added ${dto.mediaItemIds.length} item(s) to album ${albumId}`,
@@ -1418,6 +1449,13 @@ export class MediaService {
       totalAdded += result.count;
     }
 
+    // Backup change feed (issue #310). skipDuplicates hides which rows were
+    // actually inserted, so touch the whole matched set when anything landed —
+    // an over-touch only re-syncs an unchanged sidecar, never loses a change.
+    if (totalAdded > 0) {
+      await this.mediaTouch.touchMediaItems(matches.map((m) => m.id));
+    }
+
     this.logger.log(`Added ${totalAdded} item(s) to album ${albumId} by filter`);
     return { added: totalAdded };
   }
@@ -1451,6 +1489,9 @@ export class MediaService {
     await this.prisma.albumItem.delete({
       where: { albumId_mediaItemId: { albumId, mediaItemId: itemId } },
     });
+
+    // Backup change feed: AlbumItem joins don't bump MediaItem.updatedAt (issue #310).
+    await this.mediaTouch.touchMediaItems([itemId]);
 
     this.logger.log(
       `Removed MediaItem ${itemId} from album ${albumId} by user ${userId}`,
@@ -2001,6 +2042,11 @@ export class MediaService {
         }
       }
     });
+
+    // Backup change feed: MediaTag joins don't bump MediaItem.updatedAt (issue #310).
+    if (added > 0 || removed > 0) {
+      await this.mediaTouch.touchMediaItems(dto.ids);
+    }
 
     this.logger.log(
       `bulkTags: added=${added} removed=${removed} for ${dto.ids.length} items by user ${userId}`,

--- a/apps/api/src/nodes/node-backup-query.service.spec.ts
+++ b/apps/api/src/nodes/node-backup-query.service.spec.ts
@@ -1,0 +1,638 @@
+/**
+ * Unit tests for NodeBackupQueryService (issue #310, epic #308 — Local Media
+ * Backup via Worker Nodes).
+ *
+ * Covers: resolveScope intersection semantics, getChanges keyset where-clause
+ * shape (cursor null vs. set), maxPageSize clamping, the safety horizon,
+ * trashed/archived inclusion, scope filtering, ordering, and the deep-scan
+ * guarantee that the select never touches `embedding`/`embeddingVec`;
+ * getManifest id-keyset paging and the 1000-row hard cap; composeSidecar's
+ * exact schemaVersion-1 shape and BigInt-safe JSON round-trip.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  NodeBackupQueryService,
+  BackupFeedItem,
+} from './node-backup-query.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Forbidden select keys — these must never appear anywhere in a change-feed select. */
+const FORBIDDEN_SELECT_KEYS = ['embedding', 'embeddingVec'];
+
+/** Recursively scan an object (e.g. a Prisma `select`) for forbidden keys. */
+function findForbiddenKeys(
+  obj: unknown,
+  forbidden: string[],
+  path = '$',
+  hits: string[] = [],
+): string[] {
+  if (obj === null || typeof obj !== 'object') return hits;
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (forbidden.includes(key)) {
+      hits.push(`${path}.${key}`);
+    }
+    findForbiddenKeys(value, forbidden, `${path}.${key}`, hits);
+  }
+  return hits;
+}
+
+function defaultSettings(overrides: Partial<{ maxPageSize: number; feedSafetyHorizonSeconds: number }> = {}) {
+  return {
+    backup: {
+      maxPageSize: 200,
+      feedSafetyHorizonSeconds: 5,
+      runStaleMinutes: 15,
+      ...overrides,
+    },
+  };
+}
+
+function makeFeedItem(overrides: Partial<any> = {}): BackupFeedItem {
+  return {
+    id: 'item-1',
+    circleId: 'circle-1',
+    type: 'photo',
+    originalFilename: 'photo.jpg',
+    capturedAt: new Date('2026-01-01T10:00:00.000Z'),
+    capturedAtOffset: -300,
+    createdAt: new Date('2026-01-01T10:05:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    importedAt: new Date('2026-01-01T10:05:01.000Z'),
+    contentHash: 'a'.repeat(64),
+    width: 1600,
+    height: 1200,
+    durationMs: null,
+    orientation: 1,
+    cameraMake: 'Apple',
+    cameraModel: 'iPhone 15',
+    description: 'A photo of a sunset',
+    favorite: true,
+    archivedAt: null,
+    deletedAt: null,
+    takenLat: 37.7749,
+    takenLng: -122.4194,
+    takenAltitude: 12.3,
+    coordSource: 'exif',
+    geoCountry: 'United States',
+    geoCountryCode: 'US',
+    geoAdmin1: 'California',
+    geoAdmin2: 'San Francisco County',
+    geoLocality: 'San Francisco',
+    geoPlaceName: 'Golden Gate Park',
+    geoSource: 'offline',
+    sourcePath: '/DCIM/100APPLE/IMG_0001.jpg',
+    sourceDeviceId: 'device-abc',
+    sourceDeviceName: "Oscar's iPhone",
+    metadata: { foo: 'bar' },
+    circle: { name: 'Family' },
+    storageObject: {
+      id: 'obj-1',
+      size: BigInt('123456789012'),
+      mimeType: 'image/jpeg',
+      storageKey: 'uploads/img-0001.jpg',
+      status: 'ready',
+    },
+    mediaTags: [
+      { source: 'manual', tag: { name: 'vacation' } },
+      { source: 'ai', tag: { name: 'sunset' } },
+    ],
+    albumItems: [
+      { album: { id: 'album-1', name: 'Summer 2026' } },
+    ],
+    faces: [
+      {
+        id: 'face-1',
+        personId: 'person-1',
+        boundingBox: { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+        confidence: 0.98,
+        videoTimestampMs: null,
+        manuallyAssigned: false,
+        person: { id: 'person-1', name: 'Alice', favorite: false },
+      },
+      // Same person again on a second face — must dedupe to ONE people entry.
+      {
+        id: 'face-2',
+        personId: 'person-1',
+        boundingBox: { x: 0.5, y: 0.5, w: 0.15, h: 0.15 },
+        confidence: 0.91,
+        videoTimestampMs: null,
+        manuallyAssigned: false,
+        person: { id: 'person-1', name: 'Alice', favorite: false },
+      },
+      // Unassigned face — personId null, no person row.
+      {
+        id: 'face-3',
+        personId: null,
+        boundingBox: { x: 0.8, y: 0.05, w: 0.1, h: 0.1 },
+        confidence: 0.72,
+        videoTimestampMs: null,
+        manuallyAssigned: false,
+        person: null,
+      },
+    ],
+    ...overrides,
+  } as unknown as BackupFeedItem;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NodeBackupQueryService', () => {
+  let service: NodeBackupQueryService;
+  let mockPrisma: MockPrismaService;
+  let mockSystemSettings: { getSettings: jest.Mock };
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    mockSystemSettings = {
+      getSettings: jest.fn().mockResolvedValue(defaultSettings()),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NodeBackupQueryService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: SystemSettingsService, useValue: mockSystemSettings },
+      ],
+    }).compile();
+
+    service = module.get<NodeBackupQueryService>(NodeBackupQueryService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // resolveScope
+  // -------------------------------------------------------------------------
+
+  describe('resolveScope', () => {
+    it('returns ALL member circle ids when configured circleIds is empty (empty = all circles)', async () => {
+      (mockPrisma.circleMember.findMany as jest.Mock).mockResolvedValue([
+        { circleId: 'circle-a' },
+        { circleId: 'circle-b' },
+        { circleId: 'circle-c' },
+      ]);
+
+      const scope = await service.resolveScope('owner-1', []);
+
+      expect(mockPrisma.circleMember.findMany).toHaveBeenCalledWith({
+        where: { userId: 'owner-1' },
+        select: { circleId: true },
+      });
+      expect(scope.sort()).toEqual(['circle-a', 'circle-b', 'circle-c'].sort());
+    });
+
+    it('intersects membership with a non-empty configured circleIds list', async () => {
+      (mockPrisma.circleMember.findMany as jest.Mock).mockResolvedValue([
+        { circleId: 'circle-a' },
+        { circleId: 'circle-b' },
+        { circleId: 'circle-c' },
+      ]);
+
+      const scope = await service.resolveScope('owner-1', ['circle-b', 'circle-d']);
+
+      // circle-d is requested but the owner isn't a member -> excluded.
+      // circle-a/c are memberships but not requested -> excluded.
+      expect(scope).toEqual(['circle-b']);
+    });
+
+    it('returns an empty array when the intersection is empty', async () => {
+      (mockPrisma.circleMember.findMany as jest.Mock).mockResolvedValue([
+        { circleId: 'circle-a' },
+      ]);
+
+      const scope = await service.resolveScope('owner-1', ['circle-z']);
+
+      expect(scope).toEqual([]);
+    });
+
+    it('returns an empty array when the owner has no memberships at all', async () => {
+      (mockPrisma.circleMember.findMany as jest.Mock).mockResolvedValue([]);
+
+      const scope = await service.resolveScope('owner-1', []);
+
+      expect(scope).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getChanges
+  // -------------------------------------------------------------------------
+
+  describe('getChanges', () => {
+    beforeEach(() => {
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('returns [] and never queries Prisma when scope is empty', async () => {
+      const result = await service.getChanges([], null, 100);
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.mediaItem.findMany).not.toHaveBeenCalled();
+    });
+
+    it('builds a plain (no OR) where clause when cursor is null', async () => {
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where.OR).toBeUndefined();
+      expect(call.where.circleId).toEqual({ in: ['circle-1'] });
+      expect(call.where.updatedAt).toHaveProperty('lte');
+    });
+
+    it('builds the two-branch OR/updatedAt-id tiebreak clause when a cursor is set', async () => {
+      const cursor = { updatedAt: new Date('2026-01-01T00:00:00.000Z'), id: 'cursor-item' };
+
+      await service.getChanges(['circle-1'], cursor, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where.OR).toEqual([
+        { updatedAt: { gt: cursor.updatedAt } },
+        { updatedAt: cursor.updatedAt, id: { gt: cursor.id } },
+      ]);
+      // The AND-composed circleId/horizon predicates remain present alongside OR.
+      expect(call.where.circleId).toEqual({ in: ['circle-1'] });
+    });
+
+    it('clamps the requested limit to backup.maxPageSize', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(defaultSettings({ maxPageSize: 50 }));
+
+      await service.getChanges(['circle-1'], null, 5000);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.take).toBe(50);
+    });
+
+    it('uses the requested limit as-is when it is below maxPageSize', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(defaultSettings({ maxPageSize: 200 }));
+
+      await service.getChanges(['circle-1'], null, 25);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.take).toBe(25);
+    });
+
+    it('floors take at 1 even for a non-positive requested limit', async () => {
+      await service.getChanges(['circle-1'], null, 0);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.take).toBe(1);
+    });
+
+    it('applies the safety horizon: updatedAt.lte is ~feedSafetyHorizonSeconds in the past', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(defaultSettings({ feedSafetyHorizonSeconds: 5 }));
+      const before = Date.now();
+
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      const lte = call.where.updatedAt.lte as Date;
+      const diffMs = before - lte.getTime();
+
+      // Should be very close to 5000ms in the past — generous tolerance for
+      // test-runner scheduling jitter, but far from 0 or from a wildly
+      // different horizon.
+      expect(diffMs).toBeGreaterThanOrEqual(5000 - 50);
+      expect(diffMs).toBeLessThan(5000 + 2000);
+    });
+
+    it('honors a custom horizon value from settings', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(defaultSettings({ feedSafetyHorizonSeconds: 30 }));
+      const before = Date.now();
+
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      const lte = call.where.updatedAt.lte as Date;
+      const diffMs = before - lte.getTime();
+
+      expect(diffMs).toBeGreaterThanOrEqual(30000 - 50);
+      expect(diffMs).toBeLessThan(30000 + 2000);
+    });
+
+    it('includes trashed items — no deletedAt filter in the where clause', async () => {
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('deletedAt');
+    });
+
+    it('includes archived items — no archivedAt filter in the where clause', async () => {
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('archivedAt');
+    });
+
+    it('filters by the given scope (circleId in [...])', async () => {
+      await service.getChanges(['circle-a', 'circle-b'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where.circleId).toEqual({ in: ['circle-a', 'circle-b'] });
+    });
+
+    it('orders by (updatedAt asc, id asc)', async () => {
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.orderBy).toEqual([{ updatedAt: 'asc' }, { id: 'asc' }]);
+    });
+
+    it('never selects embedding or embeddingVec anywhere in the select tree', async () => {
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      const hits = findForbiddenKeys(call.select, FORBIDDEN_SELECT_KEYS);
+      expect(hits).toEqual([]);
+    });
+
+    it('the select faces sub-select carries no embedding-shaped field', async () => {
+      await service.getChanges(['circle-1'], null, 50);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      const faceSelect = call.select.faces.select;
+      expect(Object.keys(faceSelect)).not.toEqual(
+        expect.arrayContaining(['embedding', 'embeddingVec']),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // composeSidecar
+  // -------------------------------------------------------------------------
+
+  describe('composeSidecar', () => {
+    it('builds the exact schemaVersion-1 shape from a fully-populated item', () => {
+      const item = makeFeedItem();
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(sidecar.schemaVersion).toBe(1);
+      expect(sidecar.mediaItemId).toBe('item-1');
+      expect(sidecar.circleId).toBe('circle-1');
+      expect(sidecar.circleName).toBe('Family');
+      expect(sidecar.type).toBe('photo');
+      expect(sidecar.originalFilename).toBe('photo.jpg');
+      expect(sidecar.capturedAt).toBe('2026-01-01T10:00:00.000Z');
+      expect(sidecar.capturedAtOffset).toBe(-300);
+      expect(sidecar.createdAt).toBe('2026-01-01T10:05:00.000Z');
+      expect(sidecar.updatedAt).toBe('2026-01-02T00:00:00.000Z');
+      expect(sidecar.importedAt).toBe('2026-01-01T10:05:01.000Z');
+      expect(sidecar.contentHash).toBe('a'.repeat(64));
+
+      // BigInt size becomes a STRING (BigInt-safe boundary).
+      expect(sidecar.size).toBe('123456789012');
+      expect(typeof sidecar.size).toBe('string');
+
+      expect(sidecar.mimeType).toBe('image/jpeg');
+      expect(sidecar.width).toBe(1600);
+      expect(sidecar.height).toBe(1200);
+      expect(sidecar.durationMs).toBeNull();
+      expect(sidecar.orientation).toBe(1);
+      expect(sidecar.cameraMake).toBe('Apple');
+      expect(sidecar.cameraModel).toBe('iPhone 15');
+      expect(sidecar.description).toBe('A photo of a sunset');
+      expect(sidecar.favorite).toBe(true);
+      expect(sidecar.archivedAt).toBeNull();
+      expect(sidecar.deletedAt).toBeNull();
+
+      expect(sidecar.geo).toEqual({
+        takenLat: 37.7749,
+        takenLng: -122.4194,
+        takenAltitude: 12.3,
+        coordSource: 'exif',
+        country: 'United States',
+        countryCode: 'US',
+        admin1: 'California',
+        admin2: 'San Francisco County',
+        locality: 'San Francisco',
+        placeName: 'Golden Gate Park',
+        geoSource: 'offline',
+      });
+
+      expect(sidecar.tags).toEqual([
+        { name: 'vacation', source: 'manual' },
+        { name: 'sunset', source: 'ai' },
+      ]);
+
+      expect(sidecar.albums).toEqual([{ id: 'album-1', name: 'Summer 2026' }]);
+
+      expect(sidecar.faces).toEqual([
+        {
+          id: 'face-1',
+          personId: 'person-1',
+          boundingBox: { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+          confidence: 0.98,
+          videoTimestampMs: null,
+          manuallyAssigned: false,
+        },
+        {
+          id: 'face-2',
+          personId: 'person-1',
+          boundingBox: { x: 0.5, y: 0.5, w: 0.15, h: 0.15 },
+          confidence: 0.91,
+          videoTimestampMs: null,
+          manuallyAssigned: false,
+        },
+        {
+          id: 'face-3',
+          personId: null,
+          boundingBox: { x: 0.8, y: 0.05, w: 0.1, h: 0.1 },
+          confidence: 0.72,
+          videoTimestampMs: null,
+          manuallyAssigned: false,
+        },
+      ]);
+
+      expect(sidecar.sourcePath).toBe('/DCIM/100APPLE/IMG_0001.jpg');
+      expect(sidecar.sourceDeviceId).toBe('device-abc');
+      expect(sidecar.sourceDeviceName).toBe("Oscar's iPhone");
+      expect(sidecar.metadata).toEqual({ foo: 'bar' });
+
+      // exportedAt is generated at call time — assert it's a valid ISO string.
+      expect(typeof sidecar.exportedAt).toBe('string');
+      expect(() => new Date(sidecar.exportedAt).toISOString()).not.toThrow();
+    });
+
+    it('derives `people` as the DISTINCT set of persons across faces (dedupes repeated personId)', () => {
+      const item = makeFeedItem();
+
+      const sidecar = service.composeSidecar(item);
+
+      // Two faces share person-1, one face is unassigned (personId null) -> one person.
+      expect(sidecar.people).toEqual([
+        { personId: 'person-1', name: 'Alice', favorite: false },
+      ]);
+    });
+
+    it('produces an empty people array when no face has an assigned person', () => {
+      const item = makeFeedItem({
+        faces: [
+          {
+            id: 'face-x',
+            personId: null,
+            boundingBox: { x: 0, y: 0, w: 0, h: 0 },
+            confidence: null,
+            videoTimestampMs: null,
+            manuallyAssigned: false,
+            person: null,
+          },
+        ],
+      });
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(sidecar.people).toEqual([]);
+    });
+
+    it('handles a null storageObject by nulling size and mimeType', () => {
+      const item = makeFeedItem({ storageObject: null });
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(sidecar.size).toBeNull();
+      expect(sidecar.mimeType).toBeNull();
+    });
+
+    it('handles null timestamps (capturedAt, archivedAt, deletedAt) as null, not throwing', () => {
+      const item = makeFeedItem({ capturedAt: null, archivedAt: null, deletedAt: null });
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(sidecar.capturedAt).toBeNull();
+      expect(sidecar.archivedAt).toBeNull();
+      expect(sidecar.deletedAt).toBeNull();
+    });
+
+    it('defaults metadata to {} when the item metadata is null', () => {
+      const item = makeFeedItem({ metadata: null });
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(sidecar.metadata).toEqual({});
+    });
+
+    it('round-trips through JSON.stringify without throwing (BigInt-safety proof)', () => {
+      const item = makeFeedItem();
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(() => JSON.stringify(sidecar)).not.toThrow();
+      const roundTripped = JSON.parse(JSON.stringify(sidecar));
+      expect(roundTripped.size).toBe('123456789012');
+      expect(roundTripped.mediaItemId).toBe('item-1');
+    });
+
+    it('round-trips a huge (>2^53) size value as a lossless string, unlike a raw BigInt', () => {
+      const hugeSize = BigInt('9223372036854775000'); // near int64 max, unsigned-safe territory
+      const item = makeFeedItem({ storageObject: { id: 'obj-1', size: hugeSize, mimeType: 'video/mp4', storageKey: 'k', status: 'ready' } });
+
+      const sidecar = service.composeSidecar(item);
+
+      expect(sidecar.size).toBe('9223372036854775000');
+      expect(() => JSON.stringify(sidecar)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getManifest
+  // -------------------------------------------------------------------------
+
+  describe('getManifest', () => {
+    beforeEach(() => {
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('returns [] and never queries Prisma when scope is empty', async () => {
+      const result = await service.getManifest([], null, 100);
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.mediaItem.findMany).not.toHaveBeenCalled();
+    });
+
+    it('omits the id filter when afterId is null (first page)', async () => {
+      await service.getManifest(['circle-1'], null, 100);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('id');
+      expect(call.where.circleId).toEqual({ in: ['circle-1'] });
+    });
+
+    it('applies an id-gt keyset filter when afterId is set', async () => {
+      await service.getManifest(['circle-1'], 'cursor-item-id', 100);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where.id).toEqual({ gt: 'cursor-item-id' });
+    });
+
+    it('orders by id asc', async () => {
+      await service.getManifest(['circle-1'], null, 100);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.orderBy).toEqual({ id: 'asc' });
+    });
+
+    it('caps the requested limit at 1000 regardless of a larger request', async () => {
+      await service.getManifest(['circle-1'], null, 5000);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.take).toBe(1000);
+    });
+
+    it('uses the requested limit as-is when below the 1000 cap', async () => {
+      await service.getManifest(['circle-1'], null, 250);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.take).toBe(250);
+    });
+
+    it('floors take at 1 even for a non-positive requested limit', async () => {
+      await service.getManifest(['circle-1'], null, -5);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.take).toBe(1);
+    });
+
+    it('is not gated by backup.maxPageSize — cap is independent of the feed page size setting', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(defaultSettings({ maxPageSize: 50 }));
+
+      await service.getManifest(['circle-1'], null, 900);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      // maxPageSize (50) is NOT applied here — only the 1000 manifest cap is.
+      expect(call.take).toBe(900);
+      // getManifest never even reads settings.
+      expect(mockSystemSettings.getSettings).not.toHaveBeenCalled();
+    });
+
+    it('selects exactly id, contentHash, updatedAt, deletedAt, archivedAt', async () => {
+      await service.getManifest(['circle-1'], null, 100);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.select).toEqual({
+        id: true,
+        contentHash: true,
+        updatedAt: true,
+        deletedAt: true,
+        archivedAt: true,
+      });
+    });
+
+    it('includes trashed and archived items — no deletedAt/archivedAt filter in where', async () => {
+      await service.getManifest(['circle-1'], null, 100);
+
+      const call = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('deletedAt');
+      expect(call.where).not.toHaveProperty('archivedAt');
+    });
+  });
+});

--- a/apps/api/src/nodes/node-backup-query.service.ts
+++ b/apps/api/src/nodes/node-backup-query.service.ts
@@ -1,0 +1,509 @@
+// =============================================================================
+// NodeBackupQueryService (issue #310, epic #308 — Local Media Backup via Worker Nodes)
+// =============================================================================
+//
+// Pure query layer for the node backup data plane — no HTTP concerns, no
+// authorization beyond the owner-scope resolution the caller feeds it. The
+// controller layer (a later child of epic #308) calls these methods from the
+// PAT/nod_-authenticated /api/nodes/* routes.
+//
+//   - resolveScope: owner's circle memberships ∩ the config's circleIds
+//   - getChanges: (updatedAt, id) keyset page over EVERYTHING sidecar-visible,
+//     including trashed (tombstones — the feed reports deletedAt) and archived
+//     items, held back by backup.feedSafetyHorizonSeconds so a burst of
+//     same-timestamp in-flight writes can never be skipped by the cursor
+//   - composeSidecar: the schemaVersion-1 sidecar object — SINGLE source of
+//     truth for what a node writes next to each backed-up file
+//   - getManifest: id-keyset page of {id, contentHash, updatedAt, deletedAt,
+//     archivedAt} for the reconcile pass
+//   - getPendingLag: how many items/bytes remain past a cursor
+//   - getDimensions: album/person/tag catalogs for sidecar-independent restore
+//
+// Serialization rule: every BigInt (sizes, byte sums) leaves this service as a
+// STRING — never let a raw BigInt escape to JSON (see CLAUDE.md gotchas).
+
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+
+/** Hard cap on manifest page size, independent of backup.maxPageSize. */
+const MANIFEST_MAX_LIMIT = 1000;
+
+/** Keyset cursor over (updatedAt, id). */
+export interface BackupFeedCursor {
+  updatedAt: Date;
+  id: string;
+}
+
+/**
+ * Explicit select for a change-feed row. NEVER add `embedding` or
+ * `embeddingVec` to the faces select — `embeddingVec` is a Prisma
+ * `Unsupported` column and must not appear in any select; `embedding` is a
+ * 128-float vector with no sidecar value.
+ */
+const changeFeedSelect = {
+  id: true,
+  circleId: true,
+  type: true,
+  originalFilename: true,
+  capturedAt: true,
+  capturedAtOffset: true,
+  createdAt: true,
+  updatedAt: true,
+  importedAt: true,
+  contentHash: true,
+  width: true,
+  height: true,
+  durationMs: true,
+  orientation: true,
+  cameraMake: true,
+  cameraModel: true,
+  description: true,
+  favorite: true,
+  archivedAt: true,
+  deletedAt: true,
+  takenLat: true,
+  takenLng: true,
+  takenAltitude: true,
+  coordSource: true,
+  geoCountry: true,
+  geoCountryCode: true,
+  geoAdmin1: true,
+  geoAdmin2: true,
+  geoLocality: true,
+  geoPlaceName: true,
+  geoSource: true,
+  sourcePath: true,
+  sourceDeviceId: true,
+  sourceDeviceName: true,
+  metadata: true,
+  circle: { select: { name: true } },
+  storageObject: {
+    select: {
+      id: true,
+      size: true,
+      mimeType: true,
+      storageKey: true,
+      status: true,
+    },
+  },
+  mediaTags: {
+    select: {
+      source: true,
+      tag: { select: { name: true } },
+    },
+  },
+  albumItems: {
+    select: {
+      album: { select: { id: true, name: true } },
+    },
+  },
+  faces: {
+    select: {
+      id: true,
+      personId: true,
+      boundingBox: true,
+      confidence: true,
+      videoTimestampMs: true,
+      manuallyAssigned: true,
+      person: { select: { id: true, name: true, favorite: true } },
+    },
+  },
+} satisfies Prisma.MediaItemSelect;
+
+/** A fully-loaded change-feed row, as returned by getChanges. */
+export type BackupFeedItem = Prisma.MediaItemGetPayload<{
+  select: typeof changeFeedSelect;
+}>;
+
+/** The schemaVersion-1 sidecar document. */
+export interface BackupSidecar {
+  schemaVersion: 1;
+  mediaItemId: string;
+  circleId: string;
+  circleName: string;
+  type: string;
+  originalFilename: string;
+  capturedAt: string | null;
+  capturedAtOffset: number | null;
+  createdAt: string;
+  updatedAt: string;
+  importedAt: string;
+  contentHash: string | null;
+  /** Bytes as a STRING (BigInt-safe). */
+  size: string | null;
+  mimeType: string | null;
+  width: number | null;
+  height: number | null;
+  durationMs: number | null;
+  orientation: number | null;
+  cameraMake: string | null;
+  cameraModel: string | null;
+  description: string | null;
+  favorite: boolean;
+  archivedAt: string | null;
+  deletedAt: string | null;
+  geo: {
+    takenLat: number | null;
+    takenLng: number | null;
+    takenAltitude: number | null;
+    coordSource: string | null;
+    country: string | null;
+    countryCode: string | null;
+    admin1: string | null;
+    admin2: string | null;
+    locality: string | null;
+    placeName: string | null;
+    geoSource: string | null;
+  };
+  tags: Array<{ name: string; source: string }>;
+  albums: Array<{ id: string; name: string }>;
+  people: Array<{ personId: string; name: string | null; favorite: boolean }>;
+  faces: Array<{
+    id: string;
+    personId: string | null;
+    boundingBox: unknown;
+    confidence: number | null;
+    videoTimestampMs: number | null;
+    manuallyAssigned: boolean;
+  }>;
+  sourcePath: string | null;
+  sourceDeviceId: string | null;
+  sourceDeviceName: string | null;
+  metadata: unknown;
+  exportedAt: string;
+}
+
+const iso = (d: Date | null | undefined): string | null =>
+  d ? d.toISOString() : null;
+
+@Injectable()
+export class NodeBackupQueryService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly systemSettings: SystemSettingsService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // resolveScope
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The owner's circle memberships, intersected with the config's circleIds
+   * when that array is non-empty (empty = ALL circles the owner belongs to).
+   */
+  async resolveScope(ownerId: string, circleIds: string[]): Promise<string[]> {
+    const memberships = await this.prisma.circleMember.findMany({
+      where: { userId: ownerId },
+      select: { circleId: true },
+    });
+    const memberCircleIds = memberships.map((m) => m.circleId);
+
+    if (circleIds.length === 0) return memberCircleIds;
+
+    const requested = new Set(circleIds);
+    return memberCircleIds.filter((id) => requested.has(id));
+  }
+
+  // ---------------------------------------------------------------------------
+  // getChanges
+  // ---------------------------------------------------------------------------
+
+  /**
+   * One keyset page of the change feed, ordered (updatedAt asc, id asc).
+   * Includes trashed (tombstones) and archived items. Rows whose updatedAt is
+   * within backup.feedSafetyHorizonSeconds of now are withheld so an in-flight
+   * same-timestamp write can never be skipped by the cursor.
+   */
+  async getChanges(
+    scope: string[],
+    cursor: BackupFeedCursor | null,
+    limit: number,
+  ): Promise<BackupFeedItem[]> {
+    if (scope.length === 0) return [];
+
+    const settings = await this.systemSettings.getSettings();
+    const maxPageSize = settings.backup?.maxPageSize ?? 200;
+    const horizonSeconds = settings.backup?.feedSafetyHorizonSeconds ?? 5;
+    const take = Math.max(1, Math.min(limit, maxPageSize));
+
+    const horizon = new Date(Date.now() - horizonSeconds * 1000);
+
+    return this.prisma.mediaItem.findMany({
+      where: {
+        circleId: { in: scope },
+        updatedAt: { lte: horizon },
+        ...(cursor
+          ? {
+              OR: [
+                { updatedAt: { gt: cursor.updatedAt } },
+                { updatedAt: cursor.updatedAt, id: { gt: cursor.id } },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
+      take,
+      select: changeFeedSelect,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // composeSidecar
+  // ---------------------------------------------------------------------------
+
+  /** Build the schemaVersion-1 sidecar document — single source of truth. */
+  composeSidecar(item: BackupFeedItem): BackupSidecar {
+    // People derived from the distinct persons across the item's faces.
+    const peopleById = new Map<
+      string,
+      { personId: string; name: string | null; favorite: boolean }
+    >();
+    for (const face of item.faces) {
+      if (face.person && !peopleById.has(face.person.id)) {
+        peopleById.set(face.person.id, {
+          personId: face.person.id,
+          name: face.person.name,
+          favorite: face.person.favorite,
+        });
+      }
+    }
+
+    return {
+      schemaVersion: 1,
+      mediaItemId: item.id,
+      circleId: item.circleId,
+      circleName: item.circle.name,
+      type: item.type,
+      originalFilename: item.originalFilename,
+      capturedAt: iso(item.capturedAt),
+      capturedAtOffset: item.capturedAtOffset,
+      createdAt: item.createdAt.toISOString(),
+      updatedAt: item.updatedAt.toISOString(),
+      importedAt: item.importedAt.toISOString(),
+      contentHash: item.contentHash,
+      // BigInt → STRING at the DTO boundary (never serialize a raw BigInt).
+      size: item.storageObject ? item.storageObject.size.toString() : null,
+      mimeType: item.storageObject?.mimeType ?? null,
+      width: item.width,
+      height: item.height,
+      durationMs: item.durationMs,
+      orientation: item.orientation,
+      cameraMake: item.cameraMake,
+      cameraModel: item.cameraModel,
+      description: item.description,
+      favorite: item.favorite,
+      archivedAt: iso(item.archivedAt),
+      deletedAt: iso(item.deletedAt),
+      geo: {
+        takenLat: item.takenLat,
+        takenLng: item.takenLng,
+        takenAltitude: item.takenAltitude,
+        coordSource: item.coordSource,
+        country: item.geoCountry,
+        countryCode: item.geoCountryCode,
+        admin1: item.geoAdmin1,
+        admin2: item.geoAdmin2,
+        locality: item.geoLocality,
+        placeName: item.geoPlaceName,
+        geoSource: item.geoSource,
+      },
+      tags: item.mediaTags.map((mt) => ({
+        name: mt.tag.name,
+        source: mt.source,
+      })),
+      albums: item.albumItems.map((ai) => ({
+        id: ai.album.id,
+        name: ai.album.name,
+      })),
+      people: [...peopleById.values()],
+      faces: item.faces.map((f) => ({
+        id: f.id,
+        personId: f.personId,
+        boundingBox: f.boundingBox,
+        confidence: f.confidence,
+        videoTimestampMs: f.videoTimestampMs,
+        manuallyAssigned: f.manuallyAssigned,
+      })),
+      sourcePath: item.sourcePath,
+      sourceDeviceId: item.sourceDeviceId,
+      sourceDeviceName: item.sourceDeviceName,
+      metadata: item.metadata ?? {},
+      exportedAt: new Date().toISOString(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // getManifest
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Id-keyset page over ALL non-hard-deleted items in scope (trashed included),
+   * ordered id asc — the reconcile pass compares this against the node's local
+   * store to find drift the incremental feed missed.
+   */
+  async getManifest(
+    scope: string[],
+    afterId: string | null,
+    limit: number,
+  ): Promise<
+    Array<{
+      id: string;
+      contentHash: string | null;
+      updatedAt: Date;
+      deletedAt: Date | null;
+      archivedAt: Date | null;
+    }>
+  > {
+    if (scope.length === 0) return [];
+
+    const take = Math.max(1, Math.min(limit, MANIFEST_MAX_LIMIT));
+
+    return this.prisma.mediaItem.findMany({
+      where: {
+        circleId: { in: scope },
+        ...(afterId ? { id: { gt: afterId } } : {}),
+      },
+      orderBy: { id: 'asc' },
+      take,
+      select: {
+        id: true,
+        contentHash: true,
+        updatedAt: true,
+        deletedAt: true,
+        archivedAt: true,
+      },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // getPendingLag
+  // ---------------------------------------------------------------------------
+
+  /**
+   * How much work remains past the cursor: item count and total original
+   * bytes. Respects the same safety horizon as getChanges so the number
+   * matches what the feed will actually serve. Every MediaItem has exactly
+   * one StorageObject (storageObjectId is unique), so aggregating over
+   * StorageObject filtered by its mediaItem yields both numbers in one query.
+   */
+  async getPendingLag(
+    scope: string[],
+    cursor: BackupFeedCursor | null,
+  ): Promise<{ items: number; bytes: bigint }> {
+    if (scope.length === 0) return { items: 0, bytes: 0n };
+
+    const settings = await this.systemSettings.getSettings();
+    const horizonSeconds = settings.backup?.feedSafetyHorizonSeconds ?? 5;
+    const horizon = new Date(Date.now() - horizonSeconds * 1000);
+
+    const mediaWhere: Prisma.MediaItemWhereInput = {
+      circleId: { in: scope },
+      updatedAt: { lte: horizon },
+      ...(cursor
+        ? {
+            OR: [
+              { updatedAt: { gt: cursor.updatedAt } },
+              { updatedAt: cursor.updatedAt, id: { gt: cursor.id } },
+            ],
+          }
+        : {}),
+    };
+
+    const agg = await this.prisma.storageObject.aggregate({
+      where: { mediaItem: { is: mediaWhere } },
+      _count: { _all: true },
+      _sum: { size: true },
+    });
+
+    return {
+      items: agg._count._all,
+      bytes: agg._sum.size ?? 0n,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // getDimensions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Album / person / tag catalogs across the scope circles, so a node can
+   * materialize collection-level structure (e.g. album folders) without
+   * re-deriving it from every sidecar.
+   */
+  async getDimensions(scope: string[]): Promise<{
+    albums: Array<{
+      id: string;
+      name: string;
+      description: string | null;
+      itemCount: number;
+      itemIds: string[];
+    }>;
+    people: Array<{
+      id: string;
+      name: string | null;
+      favorite: boolean;
+      faceCount: number;
+    }>;
+    tags: Array<{ name: string; itemCount: number }>;
+  }> {
+    if (scope.length === 0) return { albums: [], people: [], tags: [] };
+
+    const [albums, people, tags] = await Promise.all([
+      this.prisma.album.findMany({
+        where: { circleId: { in: scope } },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          items: { select: { mediaItemId: true } },
+        },
+        orderBy: { name: 'asc' },
+      }),
+      this.prisma.person.findMany({
+        where: { circleId: { in: scope }, deletedAt: null },
+        select: {
+          id: true,
+          name: true,
+          favorite: true,
+          _count: { select: { faces: true } },
+        },
+        orderBy: { name: 'asc' },
+      }),
+      this.prisma.tag.findMany({
+        where: { circleId: { in: scope } },
+        select: {
+          name: true,
+          _count: { select: { mediaTags: true } },
+        },
+      }),
+    ]);
+
+    // Tags are circle-scoped rows; aggregate by name across circles (and
+    // across sources — the count is total MediaTag instances per name).
+    const tagCounts = new Map<string, number>();
+    for (const tag of tags) {
+      tagCounts.set(tag.name, (tagCounts.get(tag.name) ?? 0) + tag._count.mediaTags);
+    }
+
+    return {
+      albums: albums.map((a) => ({
+        id: a.id,
+        name: a.name,
+        description: a.description,
+        itemCount: a.items.length,
+        itemIds: a.items.map((i) => i.mediaItemId),
+      })),
+      people: people.map((p) => ({
+        id: p.id,
+        name: p.name,
+        favorite: p.favorite,
+        faceCount: p._count.faces,
+      })),
+      tags: [...tagCounts.entries()]
+        .map(([name, itemCount]) => ({ name, itemCount }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    };
+  }
+}

--- a/apps/api/src/nodes/nodes.module.ts
+++ b/apps/api/src/nodes/nodes.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { NodesService } from './nodes.service';
+import { NodeBackupQueryService } from './node-backup-query.service';
 import { NodesController } from './nodes.controller';
 import { NodesAdminController } from './nodes-admin.controller';
 import { NodeCredentialsController } from './node-credentials.controller';
@@ -43,6 +44,7 @@ import { TaggingModule } from '../tagging/tagging.module';
     NodeCredentialModule,
   ],
   controllers: [NodesController, NodesAdminController, NodeCredentialsController],
-  providers: [NodesService, NodeOfflinePruneTask],
+  providers: [NodesService, NodeOfflinePruneTask, NodeBackupQueryService],
+  exports: [NodeBackupQueryService],
 })
 export class NodesModule {}

--- a/apps/api/src/settings/system-settings/system-settings.service.spec.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.spec.ts
@@ -138,6 +138,7 @@ describe('SystemSettingsService', () => {
         email: DEFAULT_SYSTEM_SETTINGS.email,
         pictureEnhancement: DEFAULT_SYSTEM_SETTINGS.pictureEnhancement,
         workflows: DEFAULT_SYSTEM_SETTINGS.workflows,
+        backup: DEFAULT_SYSTEM_SETTINGS.backup,
         reviewRuns: DEFAULT_SYSTEM_SETTINGS.reviewRuns,
         notifications: DEFAULT_SYSTEM_SETTINGS.notifications,
       };
@@ -241,6 +242,7 @@ describe('SystemSettingsService', () => {
         email: DEFAULT_SYSTEM_SETTINGS.email,
         pictureEnhancement: DEFAULT_SYSTEM_SETTINGS.pictureEnhancement,
         workflows: DEFAULT_SYSTEM_SETTINGS.workflows,
+        backup: DEFAULT_SYSTEM_SETTINGS.backup,
         reviewRuns: DEFAULT_SYSTEM_SETTINGS.reviewRuns,
         notifications: DEFAULT_SYSTEM_SETTINGS.notifications,
       };

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -38,6 +38,7 @@ export interface ResolvedSettings {
   reviewRuns: SystemSettingsValue['reviewRuns'];
   notifications: SystemSettingsValue['notifications'];
   pictureEnhancement: SystemSettingsValue['pictureEnhancement'];
+  backup: SystemSettingsValue['backup'];
   workflows: SystemSettingsValue['workflows'];
   updatedAt: Date;
   updatedBy: { id: string; email: string } | null;
@@ -139,6 +140,7 @@ export class SystemSettingsService {
       reviewRuns: value.reviewRuns,
       notifications: value.notifications,
       pictureEnhancement: value.pictureEnhancement,
+      backup: value.backup,
       workflows: value.workflows,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
@@ -235,6 +237,7 @@ export class SystemSettingsService {
       reviewRuns: value.reviewRuns,
       notifications: value.notifications,
       pictureEnhancement: value.pictureEnhancement,
+      backup: value.backup,
       workflows: value.workflows,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
@@ -634,6 +637,7 @@ export class SystemSettingsService {
       reviewRuns: value.reviewRuns,
       notifications: value.notifications,
       pictureEnhancement: value.pictureEnhancement,
+      backup: value.backup,
       workflows: value.workflows,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,

--- a/apps/api/src/tagging/auto-tagging.service.spec.ts
+++ b/apps/api/src/tagging/auto-tagging.service.spec.ts
@@ -46,6 +46,7 @@ import {
 } from '@prisma/client';
 import { detectImageMime } from './image-mime.util';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { MediaTouchService } from '../media/media-touch.service';
 import { RateLimitError } from '../enrichment/rate-limit.error';
 
 // ---------------------------------------------------------------------------
@@ -213,6 +214,10 @@ describe('AutoTaggingService', () => {
         { provide: STORAGE_PROVIDER, useValue: mockStorageProvider },
         { provide: StorageProviderResolver, useValue: mockResolver },
         { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/tagging/auto-tagging.service.ts
+++ b/apps/api/src/tagging/auto-tagging.service.ts
@@ -15,6 +15,7 @@ import { prepareImageForProcessing } from '../storage/processing/image-orientati
 import { detectImageMime } from './image-mime.util';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { RateLimitError, parseRetryAfterMs, classifyRateLimit } from '../enrichment/rate-limit.error';
+import { MediaTouchService } from '../media/media-touch.service';
 
 /**
  * System prompt sent alongside every tagging vision call. Extracted to a
@@ -56,6 +57,7 @@ export class AutoTaggingService {
     @Inject(STORAGE_PROVIDER) private readonly storageProvider: StorageProvider,
     private readonly resolver: StorageProviderResolver,
     private readonly enrichmentJobService: EnrichmentJobService,
+    private readonly mediaTouch: MediaTouchService,
   ) {}
 
   async processMediaItem(job: EnrichmentJob): Promise<void> {
@@ -449,6 +451,13 @@ export class AutoTaggingService {
         });
       }
     });
+
+    // Backup change feed (issue #310): the parseOk branch above already bumps
+    // updatedAt via mediaItem.update; when the parse failed, only MediaTag rows
+    // changed (stale-AI-tag deletion) and the item must be touched explicitly.
+    if (!parseOk) {
+      await this.mediaTouch.touchMediaItems([mediaItem.id]);
+    }
 
     // Best-effort embedding — must not fail the tagging job. Reloads people
     // names independently since a node-result call has no preloaded context.

--- a/apps/api/src/tagging/tag-labels.service.spec.ts
+++ b/apps/api/src/tagging/tag-labels.service.spec.ts
@@ -14,6 +14,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { TagLabelsService } from './tag-labels.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { MediaTouchService } from '../media/media-touch.service';
 import {
   createMockPrismaService,
   MockPrismaService,
@@ -61,6 +62,10 @@ describe('TagLabelsService', () => {
       providers: [
         TagLabelsService,
         { provide: PrismaService, useValue: mockPrisma },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/tagging/tag-labels.service.ts
+++ b/apps/api/src/tagging/tag-labels.service.ts
@@ -8,6 +8,7 @@ import { createZodDto } from 'nestjs-zod';
 import { z } from 'zod';
 import { stringify as csvStringify } from 'csv-stringify/sync';
 import { PrismaService } from '../prisma/prisma.service';
+import { MediaTouchService } from '../media/media-touch.service';
 
 // ---------------------------------------------------------------------------
 // DTOs
@@ -53,7 +54,10 @@ export interface ImportSummary {
 
 @Injectable()
 export class TagLabelsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mediaTouch: MediaTouchService,
+  ) {}
 
   getAll() {
     return this.prisma.tagLabel.findMany({ orderBy: { name: 'asc' } });
@@ -95,17 +99,37 @@ export class TagLabelsService {
       throw new NotFoundException(`Tag label ${id} not found`);
     }
 
-    await this.prisma.$transaction(async (tx) => {
-      await this.cascadeDeleteLabel(tx, id, label.name);
+    const affected = await this.prisma.$transaction(async (tx) => {
+      return this.cascadeDeleteLabel(tx, id, label.name);
     });
+
+    // Backup change feed (issue #310): the cascade deleted MediaTag rows across
+    // all circles — touch the affected items AFTER the transaction commits.
+    await this.mediaTouch.touchMediaItems(affected);
   }
 
+  /**
+   * Delete a label and cascade away its AI-applied MediaTag instances.
+   * Returns the distinct affected mediaItemIds so the caller can propagate the
+   * change onto the parent MediaItems (backup change feed, issue #310) once the
+   * surrounding transaction has committed.
+   */
   private async cascadeDeleteLabel(
     tx: Prisma.TransactionClient,
     labelId: string,
     labelName: string,
-  ): Promise<void> {
+  ): Promise<string[]> {
     await tx.tagLabel.delete({ where: { id: labelId } });
+
+    // Capture the affected media items BEFORE deleting the joins.
+    const affectedRows = await tx.mediaTag.findMany({
+      where: {
+        source: 'ai',
+        tag: { name: { equals: labelName, mode: 'insensitive' } },
+      },
+      select: { mediaItemId: true },
+      distinct: ['mediaItemId'],
+    });
 
     // Delete all AI-sourced MediaTag instances for this label name (case-insensitive)
     await tx.mediaTag.deleteMany({
@@ -128,6 +152,8 @@ export class TagLabelsService {
         where: { id: { in: emptyTags.map((t) => t.id) } },
       });
     }
+
+    return affectedRows.map((r) => r.mediaItemId);
   }
 
   // ---------------------------------------------------------------------------
@@ -178,6 +204,10 @@ export class TagLabelsService {
       return ['true', '1', 'yes'].includes(val.trim().toLowerCase());
     };
 
+    // Distinct media ids whose AI tag instances were cascade-deleted; touched
+    // after the transaction commits (backup change feed, issue #310).
+    const touchedMediaIds = new Set<string>();
+
     // Process inside a transaction so successful rows commit together.
     await this.prisma.$transaction(async (tx) => {
       for (let i = 0; i < rows.length; i++) {
@@ -217,7 +247,8 @@ export class TagLabelsService {
             continue;
           }
           try {
-            await this.cascadeDeleteLabel(tx, id, labelToDelete.name);
+            const affected = await this.cascadeDeleteLabel(tx, id, labelToDelete.name);
+            for (const mediaId of affected) touchedMediaIds.add(mediaId);
             summary.deleted++;
           } catch (e: any) {
             summary.errors.push({
@@ -264,6 +295,8 @@ export class TagLabelsService {
         }
       }
     });
+
+    await this.mediaTouch.touchMediaItems([...touchedMediaIds]);
 
     return summary;
   }

--- a/apps/api/src/tagging/tag-labels.service.ts
+++ b/apps/api/src/tagging/tag-labels.service.ts
@@ -153,7 +153,7 @@ export class TagLabelsService {
       });
     }
 
-    return affectedRows.map((r) => r.mediaItemId);
+    return (affectedRows ?? []).map((r) => r.mediaItemId);
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/api/src/tagging/tagging.module.ts
+++ b/apps/api/src/tagging/tagging.module.ts
@@ -5,6 +5,7 @@ import { StorageProvidersModule } from '../storage/providers/storage-providers.m
 import { PrismaModule } from '../prisma/prisma.module';
 import { CirclesModule } from '../circles/circles.module';
 import { SettingsModule } from '../settings/settings.module';
+import { MediaTouchModule } from '../media/media-touch.module';
 import { AutoTaggingHandler } from './auto-tagging.handler';
 import { AutoTaggingService } from './auto-tagging.service';
 import { TaggingController } from './tagging.controller';
@@ -14,7 +15,7 @@ import { TaggingBackfillService } from './tagging-backfill.service';
 import { AdminTaggingController } from './admin-tagging.controller';
 
 @Module({
-  imports: [EnrichmentModule, AiModule, StorageProvidersModule, PrismaModule, CirclesModule, SettingsModule],
+  imports: [EnrichmentModule, AiModule, StorageProvidersModule, PrismaModule, CirclesModule, SettingsModule, MediaTouchModule],
   controllers: [TaggingController, TagLabelsController, AdminTaggingController],
   providers: [AutoTaggingHandler, AutoTaggingService, TagLabelsService, TaggingBackfillService],
   exports: [AutoTaggingService],

--- a/apps/api/test/circles/circle-authorization-matrix.spec.ts
+++ b/apps/api/test/circles/circle-authorization-matrix.spec.ts
@@ -13,6 +13,7 @@ import { ForwardGeocodeService } from '../../src/media/geo/forward-geocode.servi
 import { StorageProviderResolver } from '../../src/storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from '../../src/media/enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../../src/notifications/producers/upload-notification.service';
+import { MediaTouchService } from '../../src/media/media-touch.service';
 import { MediaThumbnailService } from '../../src/media/media-thumbnail.service';
 import { randomUUID } from 'crypto';
 
@@ -176,6 +177,10 @@ describe('Circle Authorization Matrix (MediaService unit)', () => {
           // #247 upload_completed producer — fire-and-forget, not asserted here.
           provide: UploadNotificationService,
           useValue: { recordUploadAsync: jest.fn(), recordUpload: jest.fn() },
+        },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
         },
         { provide: MediaEnrichmentService, useValue: { enqueueUploadEnrichment: jest.fn().mockResolvedValue(undefined) } },
       ],

--- a/apps/api/test/media/media-export.service.spec.ts
+++ b/apps/api/test/media/media-export.service.spec.ts
@@ -35,6 +35,7 @@ import { ForwardGeocodeService } from '../../src/media/geo/forward-geocode.servi
 import { StorageProviderResolver } from '../../src/storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from '../../src/media/enrichment/media-enrichment.service';
 import { UploadNotificationService } from '../../src/notifications/producers/upload-notification.service';
+import { MediaTouchService } from '../../src/media/media-touch.service';
 import { MediaThumbnailService } from '../../src/media/media-thumbnail.service';
 import { randomUUID } from 'crypto';
 
@@ -200,6 +201,10 @@ describe('MediaService.streamExport', () => {
           // #247 upload_completed producer — fire-and-forget, not asserted here.
           provide: UploadNotificationService,
           useValue: { recordUploadAsync: jest.fn(), recordUpload: jest.fn() },
+        },
+        {
+          provide: MediaTouchService,
+          useValue: { touchMediaItems: jest.fn().mockResolvedValue(undefined) },
         },
         { provide: MediaEnrichmentService, useValue: { enqueueUploadEnrichment: jest.fn().mockResolvedValue(undefined) } },
       ],


### PR DESCRIPTION
## Summary

Child 1 of Epic #308 (Local Media Backup via Worker Nodes). Lays the server-side foundations for the per-node backup change feed: a keyset-paginated `(updatedAt, id)` index on `media_items`, the `NodeBackupConfig`/`NodeBackupRun` data model, explicit touch propagation so join-table mutations (tags, albums, people, faces) become visible to the feed, the `backup` system-settings namespace, and the pure query layer (`NodeBackupQueryService`) the control plane (#312) will consume.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #310
Relates to #308

## Changes Made

- **Prisma schema** (migration `20260808010000_add_backup_feed_foundations`): `MediaItem @@index([updatedAt, id])`; new enums `NodeBackupRunKind` / `NodeBackupRunStatus`; new models `NodeBackupConfig` (`node_backup_configs`, unique per node, cascade FK, checkpoint + acked counters + schedule fields) and `NodeBackupRun` (`node_backup_runs`, run lifecycle, counters, cursor snapshots); `WorkerNode` back-relations.
- **`MediaTouchService`** (`apps/api/src/media/media-touch.service.ts`, cycle-free `MediaTouchModule`): chunked (500/statement) explicit `updatedAt` bump, best-effort (never throws). Wired into every sidecar-visible mutation that doesn't already bump `MediaItem.updatedAt`: tag attach/remove/bulk, album item add (single/by-filter)/remove, album rename/delete, person create-with-faces/rename/merge/delete/hide/unhide/purge, face assign/unassign/persist (photo + video), face bulk hide/unhide/purge + auto-archive sweep, manual people association, AI auto-tagging persist (non-description branch), tag-label delete cascade. Direct MediaItem column writers deliberately not double-wired.
- **`backup` settings namespace**: `{ maxPageSize 50–500 (200), feedSafetyHorizonSeconds 0–60 (5), runStaleMinutes 5–120 (15) }` in defaults + zod full/patch schemas.
- **`NodeBackupQueryService`** (`apps/api/src/nodes/`): `resolveScope` (owner memberships ∩ configured circleIds), `getChanges` (keyset feed with 5s safety horizon, tombstones + archived included, no `embedding`/`embeddingVec` in any select), `composeSidecar` (schemaVersion-1 payload, BigInt-as-string), `getManifest` (id-keyset, cap 1000), `getPendingLag`, `getDimensions`.

## Testing

- [x] Unit tests pass (`npm test`) — 272 suites / 6562 tests passed, 0 failures (4 DB-gated suites skipped, no live DB in CI env)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

New specs: `media-touch.service.spec.ts` (14), `node-backup-query.service.spec.ts` (36, incl. deep-scan proof no embedding columns are selected and a `JSON.stringify` BigInt round-trip), `backup-settings.spec.ts` (23), plus touch-call-site assertions added to `media.service.spec.ts`, `people.service.spec.ts`, `face-detection.service.spec.ts`.

## Additional Notes

Migration is hand-authored in Prisma's generated-SQL style (no live DB in the dev environment); `prisma validate`/`generate` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ)_