### PR TITLE
feat(api): node backup control plane — /api/nodes/:id/backup/* config, runs, change feed, ack, manifest, dimensions

### DIFF
--- a/apps/api/src/nodes/dto/node-backup.dto.ts
+++ b/apps/api/src/nodes/dto/node-backup.dto.ts
@@ -1,0 +1,125 @@
+// =============================================================================
+// Node Backup DTOs (issue #312, epic #308 — Local Media Backup via Worker Nodes)
+// =============================================================================
+//
+// Request-body and query-param schemas for the node backup control plane
+// (`/api/nodes/:id/backup/*`). Zod + createZodDto, matching the project
+// convention — the global ZodValidationPipe validates bodies AND query DTOs.
+//
+// Serialization rule (see CLAUDE.md gotchas): every byte-count field crosses
+// the wire as a STRING. `bytesDownloaded` is accepted as a decimal string
+// (parsed with BigInt() server-side); a plain non-negative integer is also
+// tolerated for robustness.
+// =============================================================================
+
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// PUT /nodes/:id/backup/config
+// ---------------------------------------------------------------------------
+
+export const updateBackupConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+  /** 5-field cron expression; null clears the schedule (manual-trigger only). */
+  scheduleCron: z.string().min(1).max(200).nullable().optional(),
+  /** IANA timezone the cron is evaluated in; null clears (falls back to UTC). */
+  timezone: z.string().min(1).max(100).nullable().optional(),
+  /** Circle scope; empty array = ALL circles the node owner belongs to. */
+  circleIds: z.array(z.string().uuid()).max(200).optional(),
+});
+
+export class UpdateBackupConfigDto extends createZodDto(updateBackupConfigSchema) {}
+
+// ---------------------------------------------------------------------------
+// POST /nodes/:id/backup/runs
+// ---------------------------------------------------------------------------
+
+export const startBackupRunSchema = z.object({
+  kind: z.enum(['incremental', 'reconcile']),
+  trigger: z.enum(['manual', 'scheduled']),
+  cliVersion: z.string().min(1).max(64).optional(),
+});
+
+export class StartBackupRunDto extends createZodDto(startBackupRunSchema) {}
+
+// ---------------------------------------------------------------------------
+// Shared run stats (ack + finish finalStats)
+// ---------------------------------------------------------------------------
+
+export const backupRunStatsSchema = z.object({
+  itemsDownloaded: z.number().int().min(0),
+  itemsSkipped: z.number().int().min(0),
+  sidecarsWritten: z.number().int().min(0),
+  /** Bytes as a decimal STRING (BigInt-safe); a plain integer is tolerated. */
+  bytesDownloaded: z.union([z.string().regex(/^\d+$/), z.number().int().min(0)]),
+  errors: z.number().int().min(0),
+});
+
+export type BackupRunStats = z.infer<typeof backupRunStatsSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /nodes/:id/backup/ack
+// ---------------------------------------------------------------------------
+
+export const backupAckSchema = z.object({
+  runId: z.string().uuid(),
+  cursor: z.object({
+    updatedAt: z.iso.datetime({ offset: true }),
+    id: z.string().uuid(),
+  }),
+  stats: backupRunStatsSchema,
+});
+
+export class BackupAckDto extends createZodDto(backupAckSchema) {}
+
+// ---------------------------------------------------------------------------
+// POST /nodes/:id/backup/runs/:runId/finish
+// ---------------------------------------------------------------------------
+
+export const finishBackupRunSchema = z.object({
+  status: z.enum(['completed', 'failed', 'aborted']),
+  error: z.string().min(1).max(4000).optional(),
+  finalStats: backupRunStatsSchema.optional(),
+});
+
+export class FinishBackupRunDto extends createZodDto(finishBackupRunSchema) {}
+
+// ---------------------------------------------------------------------------
+// GET /nodes/:id/backup/changes
+// ---------------------------------------------------------------------------
+
+export const backupChangesQuerySchema = z.object({
+  runId: z.string().uuid(),
+  /** Keyset cursor half 1 — must be provided together with afterId. */
+  updatedAfter: z.iso.datetime({ offset: true }).optional(),
+  /** Keyset cursor half 2 — must be provided together with updatedAfter. */
+  afterId: z.string().uuid().optional(),
+  /** Page size; defaults to 100, clamped to backup.maxPageSize. */
+  limit: z.coerce.number().int().min(1).optional(),
+});
+
+export class BackupChangesQueryDto extends createZodDto(backupChangesQuerySchema) {}
+
+// ---------------------------------------------------------------------------
+// GET /nodes/:id/backup/runs
+// ---------------------------------------------------------------------------
+
+export const backupRunsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export class BackupRunsQueryDto extends createZodDto(backupRunsQuerySchema) {}
+
+// ---------------------------------------------------------------------------
+// GET /nodes/:id/backup/manifest
+// ---------------------------------------------------------------------------
+
+export const backupManifestQuerySchema = z.object({
+  runId: z.string().uuid(),
+  afterId: z.string().uuid().optional(),
+  /** Id-keyset page size; defaults to 1000, hard-capped at 1000. */
+  limit: z.coerce.number().int().min(1).optional(),
+});
+
+export class BackupManifestQueryDto extends createZodDto(backupManifestQuerySchema) {}

--- a/apps/api/src/nodes/node-backup-stale.task.spec.ts
+++ b/apps/api/src/nodes/node-backup-stale.task.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for NodeBackupStaleTask (issue #312) — the 10-minute sweep that
+ * releases running backup runs with no ack inside backup.runStaleMinutes.
+ * Delegates the actual updateMany to NodeBackupService.markStaleRuns (covered
+ * in node-backup.service.spec.ts); this spec pins the never-throws contract.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { NodeBackupStaleTask } from './node-backup-stale.task';
+import { NodeBackupService } from './node-backup.service';
+
+describe('NodeBackupStaleTask', () => {
+  let task: NodeBackupStaleTask;
+  let backupService: { markStaleRuns: jest.Mock };
+
+  beforeEach(async () => {
+    backupService = { markStaleRuns: jest.fn().mockResolvedValue(0) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NodeBackupStaleTask,
+        { provide: NodeBackupService, useValue: backupService },
+      ],
+    }).compile();
+
+    task = module.get(NodeBackupStaleTask);
+  });
+
+  it('invokes the stale-run sweep', async () => {
+    backupService.markStaleRuns.mockResolvedValue(3);
+    await task.handleStaleSweep();
+    expect(backupService.markStaleRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws when the sweep fails', async () => {
+    backupService.markStaleRuns.mockRejectedValue(new Error('db down'));
+    await expect(task.handleStaleSweep()).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/nodes/node-backup-stale.task.ts
+++ b/apps/api/src/nodes/node-backup-stale.task.ts
@@ -1,0 +1,32 @@
+// =============================================================================
+// Node Backup Staleness Sweep (issue #312, epic #308)
+// =============================================================================
+//
+// Every 10 minutes, marks `running` NodeBackupRun rows whose lastAckAt has
+// fallen outside the backup.runStaleMinutes window as `stale` (+ finishedAt),
+// releasing the single-active-run guard a crashed node would otherwise hold
+// forever. Mirrors the never-throws task pattern of trash-purge.task.ts.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { NodeBackupService } from './node-backup.service';
+
+@Injectable()
+export class NodeBackupStaleTask {
+  private readonly logger = new Logger(NodeBackupStaleTask.name);
+
+  constructor(private readonly backupService: NodeBackupService) {}
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async handleStaleSweep(): Promise<void> {
+    try {
+      const released = await this.backupService.markStaleRuns();
+      if (released > 0) {
+        this.logger.log(`Marked ${released} stale node backup run(s)`);
+      }
+    } catch (err) {
+      this.logger.error('node backup staleness sweep failed', err as Error);
+    }
+  }
+}

--- a/apps/api/src/nodes/node-backup.controller.spec.ts
+++ b/apps/api/src/nodes/node-backup.controller.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for NodeBackupController (issue #312) — thin delegation layer:
+ * every handler passes the caller's user id + the :id node param straight to
+ * NodeBackupService, which owns ownership/validation. Also asserts the
+ * class-level jobs:write auth metadata is present (mirrors nodes.controller).
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { NodeBackupController } from './node-backup.controller';
+import { NodeBackupService } from './node-backup.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { PermissionsGuard } from '../auth/guards/permissions.guard';
+import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+
+const USER = { id: 'user-1' } as RequestUser;
+const NODE_ID = 'node-1';
+const RUN_ID = 'run-1';
+
+describe('NodeBackupController', () => {
+  let controller: NodeBackupController;
+  let service: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    service = {
+      getConfig: jest.fn().mockResolvedValue({ config: null }),
+      updateConfig: jest.fn().mockResolvedValue({ config: {} }),
+      startRun: jest.fn().mockResolvedValue({ run: {} }),
+      getChanges: jest.fn().mockResolvedValue({ items: [] }),
+      ack: jest.fn().mockResolvedValue({ ok: true }),
+      finishRun: jest.fn().mockResolvedValue({ ok: true }),
+      listRuns: jest.fn().mockResolvedValue({ runs: [] }),
+      getManifest: jest.fn().mockResolvedValue({ items: [] }),
+      getDimensions: jest.fn().mockResolvedValue({ albums: [] }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NodeBackupController],
+      providers: [{ provide: NodeBackupService, useValue: service }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(PermissionsGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(NodeBackupController);
+  });
+
+  it('GET config delegates with (userId, nodeId)', async () => {
+    await expect(controller.getConfig(USER, NODE_ID)).resolves.toEqual({
+      config: null,
+    });
+    expect(service.getConfig).toHaveBeenCalledWith('user-1', NODE_ID);
+  });
+
+  it('PUT config delegates with the dto', async () => {
+    const dto = { enabled: false } as any;
+    await controller.updateConfig(USER, NODE_ID, dto);
+    expect(service.updateConfig).toHaveBeenCalledWith('user-1', NODE_ID, dto);
+  });
+
+  it('POST runs delegates with the dto', async () => {
+    const dto = { kind: 'incremental', trigger: 'manual', cliVersion: '1.2.0' } as any;
+    await controller.startRun(USER, NODE_ID, dto);
+    expect(service.startRun).toHaveBeenCalledWith('user-1', NODE_ID, dto);
+  });
+
+  it('GET changes delegates with the query dto', async () => {
+    const query = { runId: RUN_ID, limit: 50 } as any;
+    await controller.getChanges(USER, NODE_ID, query);
+    expect(service.getChanges).toHaveBeenCalledWith('user-1', NODE_ID, query);
+  });
+
+  it('POST ack delegates with the dto', async () => {
+    const dto = { runId: RUN_ID } as any;
+    await controller.ack(USER, NODE_ID, dto);
+    expect(service.ack).toHaveBeenCalledWith('user-1', NODE_ID, dto);
+  });
+
+  it('POST runs/:runId/finish delegates with runId and dto', async () => {
+    const dto = { status: 'completed' } as any;
+    await controller.finishRun(USER, NODE_ID, RUN_ID, dto);
+    expect(service.finishRun).toHaveBeenCalledWith('user-1', NODE_ID, RUN_ID, dto);
+  });
+
+  it('GET runs delegates with the limit', async () => {
+    await controller.listRuns(USER, NODE_ID, { limit: 30 } as any);
+    expect(service.listRuns).toHaveBeenCalledWith('user-1', NODE_ID, 30);
+  });
+
+  it('GET manifest delegates with the query dto', async () => {
+    const query = { runId: RUN_ID } as any;
+    await controller.getManifest(USER, NODE_ID, query);
+    expect(service.getManifest).toHaveBeenCalledWith('user-1', NODE_ID, query);
+  });
+
+  it('GET dimensions delegates with (userId, nodeId)', async () => {
+    await controller.getDimensions(USER, NODE_ID);
+    expect(service.getDimensions).toHaveBeenCalledWith('user-1', NODE_ID);
+  });
+
+  it('carries the class-level jobs:write permission metadata', () => {
+    const permissions = Reflect.getMetadata('permissions', NodeBackupController);
+    expect(permissions).toEqual(['jobs:write']);
+  });
+});

--- a/apps/api/src/nodes/node-backup.controller.ts
+++ b/apps/api/src/nodes/node-backup.controller.ts
@@ -1,0 +1,273 @@
+// =============================================================================
+// NodeBackupController (issue #312, epic #308 — Local Media Backup via Worker Nodes)
+// =============================================================================
+//
+// HTTP surface for the node backup control plane, mounted at
+// /api/nodes/:id/backup. Auth mirrors nodes.controller.ts exactly: every
+// route requires jobs:write, `nod_` node credentials pass the guard on
+// /api/nodes* paths, and owner-scoping (404 unknown node / 403 foreign node)
+// is enforced in the service via NodesService.assertOwnership.
+// =============================================================================
+
+import { Body, Controller, Get, Param, Post, Put, Query } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { NodeBackupService } from './node-backup.service';
+import {
+  BackupAckDto,
+  BackupChangesQueryDto,
+  BackupManifestQueryDto,
+  BackupRunsQueryDto,
+  FinishBackupRunDto,
+  StartBackupRunDto,
+  UpdateBackupConfigDto,
+} from './dto/node-backup.dto';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+import { PERMISSIONS } from '../common/constants/roles.constants';
+
+@ApiTags('Nodes - Backup')
+@Controller('nodes/:id/backup')
+@Auth({ permissions: [PERMISSIONS.JOBS_WRITE] })
+export class NodeBackupController {
+  constructor(private readonly backupService: NodeBackupService) {}
+
+  // -------------------------------------------------------------------------
+  // GET /nodes/:id/backup/config
+  // -------------------------------------------------------------------------
+
+  @Get('config')
+  @ApiOperation({
+    summary: 'Get a node backup configuration with pending lag and active run',
+    description:
+      'Returns { config: null } when backup has never been configured for the node. ' +
+      'Otherwise returns the schedule/scope/checkpoint plus a live pending-lag ' +
+      'computation ({ items, bytes }) and the id of the currently-active run (null ' +
+      'when none). BigInt byte fields are serialized as strings.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 200, description: '{ config: null | {...} }' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async getConfig(@CurrentUser() user: RequestUser, @Param('id') id: string) {
+    return this.backupService.getConfig(user.id, id);
+  }
+
+  // -------------------------------------------------------------------------
+  // PUT /nodes/:id/backup/config
+  // -------------------------------------------------------------------------
+
+  @Put('config')
+  @ApiOperation({
+    summary: 'Create or update a node backup configuration (partial upsert)',
+    description:
+      'Partial body — only the provided keys change. scheduleCron must be a valid ' +
+      '5-field cron (null clears the schedule and nextRunAt); timezone must be an ' +
+      'IANA name from Intl.supportedValuesOf; every circleIds entry must be a circle ' +
+      'the node owner belongs to (empty array = all owner circles). Setting or ' +
+      'changing scheduleCron/timezone recomputes nextRunAt in the config timezone ' +
+      '(default UTC). Response matches GET.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 200, description: 'Updated config (GET shape)' })
+  @ApiResponse({ status: 400, description: 'Invalid cron, timezone, or circleIds' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async updateConfig(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateBackupConfigDto,
+  ) {
+    return this.backupService.updateConfig(user.id, id, dto);
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /nodes/:id/backup/runs
+  // -------------------------------------------------------------------------
+
+  @Post('runs')
+  @ApiOperation({
+    summary: 'Start a backup run (single-active-run rule)',
+    description:
+      'Creates a running NodeBackupRun whose cursorStart snapshots the current ' +
+      'checkpoint. 409 (with activeRunId) when a fresh running run exists; a STALE ' +
+      'running run (no ack within backup.runStaleMinutes) is released as `stale` and ' +
+      'the new run proceeds. trigger="scheduled" rolls the config nextRunAt forward ' +
+      'at start. 400 when backup is unconfigured or disabled.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 201, description: '{ run: { id, kind, startedAt, cursorStart } }' })
+  @ApiResponse({ status: 400, description: 'Backup not configured or disabled' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  @ApiResponse({ status: 409, description: 'A run is already active — { message, activeRunId }' })
+  async startRun(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Body() dto: StartBackupRunDto,
+  ) {
+    return this.backupService.startRun(user.id, id, dto);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /nodes/:id/backup/changes
+  // -------------------------------------------------------------------------
+
+  @Get('changes')
+  @ApiOperation({
+    summary: 'Fetch one keyset page of the backup change feed',
+    description:
+      'Requires runId of the node\'s ACTIVE running run (409 otherwise); the page ' +
+      'fetch refreshes the run\'s lastAckAt. Cursor params updatedAfter/afterId are ' +
+      'both-or-neither (400 if only one). limit defaults to 100, clamped to ' +
+      'backup.maxPageSize. Each item carries a per-page presigned downloadUrl (null ' +
+      'for tombstones, not-ready objects, or presign failures) and the full ' +
+      'schemaVersion-1 sidecar. nextCursor advances even on a partial page; ' +
+      'safetyHorizon is the feed\'s hold-back timestamp.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({
+    status: 200,
+    description: '{ items[], nextCursor|null, hasMore, safetyHorizon }',
+  })
+  @ApiResponse({ status: 400, description: 'Backup unconfigured or one-sided cursor' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  @ApiResponse({ status: 409, description: 'runId is not the active running run' })
+  async getChanges(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Query() query: BackupChangesQueryDto,
+  ) {
+    return this.backupService.getChanges(user.id, id, query);
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /nodes/:id/backup/ack
+  // -------------------------------------------------------------------------
+
+  @Post('ack')
+  @ApiOperation({
+    summary: 'Acknowledge downloaded pages and advance the checkpoint',
+    description:
+      'Validates the active run (409 otherwise) and the MONOTONIC checkpoint rule: a ' +
+      'cursor strictly behind the stored checkpoint is rejected with 409 (equal is an ' +
+      'allowed no-op advance). In one transaction: advances the config checkpoint, ' +
+      'increments itemsAcked (downloaded + skipped) and bytesAcked, and accumulates ' +
+      'the same stats onto the run\'s counters (errors → errorCount), refreshing ' +
+      'lastAckAt and cursorEnd. bytesDownloaded is a decimal string (BigInt-safe).',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 201, description: '{ ok: true, checkpoint: { updatedAt, id } }' })
+  @ApiResponse({ status: 400, description: 'Backup not configured for this node' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'runId is not the active running run, or the cursor regressed',
+  })
+  async ack(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Body() dto: BackupAckDto,
+  ) {
+    return this.backupService.ack(user.id, id, dto);
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /nodes/:id/backup/runs/:runId/finish
+  // -------------------------------------------------------------------------
+
+  @Post('runs/:runId/finish')
+  @ApiOperation({
+    summary: 'Finish a backup run (completed / failed / aborted)',
+    description:
+      'Sets the terminal status + finishedAt (+ lastError from error); accumulates ' +
+      'optional finalStats onto the run counters. On completed, stamps the config\'s ' +
+      'lastCompletedRunAt (and lastReconcileAt for a reconcile run). 404 for an ' +
+      'unknown run or a run of another node; 400 when the run is already terminal.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiParam({ name: 'runId', description: 'Backup run UUID' })
+  @ApiResponse({ status: 201, description: '{ ok: true }' })
+  @ApiResponse({ status: 400, description: 'Run already terminal' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node or run not found' })
+  async finishRun(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Param('runId') runId: string,
+    @Body() dto: FinishBackupRunDto,
+  ) {
+    return this.backupService.finishRun(user.id, id, runId, dto);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /nodes/:id/backup/runs
+  // -------------------------------------------------------------------------
+
+  @Get('runs')
+  @ApiOperation({
+    summary: 'List recent backup runs for a node (newest first)',
+    description:
+      'Ordered startedAt desc; limit defaults to 20, capped at 100. bytesDownloaded ' +
+      'is serialized as a string.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 200, description: '{ runs: [...] }' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async listRuns(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Query() query: BackupRunsQueryDto,
+  ) {
+    return this.backupService.listRuns(user.id, id, query.limit);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /nodes/:id/backup/manifest
+  // -------------------------------------------------------------------------
+
+  @Get('manifest')
+  @ApiOperation({
+    summary: 'Fetch one id-keyset page of the reconcile manifest',
+    description:
+      'Requires the active running run (409 otherwise; the fetch refreshes ' +
+      'lastAckAt). Pages by afterId; limit defaults to 1000 and is hard-capped at ' +
+      '1000. Returns { items: [{ id, contentHash, updatedAt, deletedAt, archivedAt }], ' +
+      'nextAfterId, hasMore }.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 200, description: '{ items[], nextAfterId|null, hasMore }' })
+  @ApiResponse({ status: 400, description: 'Backup not configured for this node' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  @ApiResponse({ status: 409, description: 'runId is not the active running run' })
+  async getManifest(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Query() query: BackupManifestQueryDto,
+  ) {
+    return this.backupService.getManifest(user.id, id, query);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /nodes/:id/backup/dimensions
+  // -------------------------------------------------------------------------
+
+  @Get('dimensions')
+  @ApiOperation({
+    summary: 'Get the album/person/tag dimension catalogs for the backup scope',
+    description:
+      'No run required. Scope is the config\'s circleIds (or ALL owner circles when ' +
+      'unconfigured). Returns { albums, people, tags, generatedAt }.',
+  })
+  @ApiParam({ name: 'id', description: 'Worker node UUID' })
+  @ApiResponse({ status: 200, description: '{ albums[], people[], tags[], generatedAt }' })
+  @ApiResponse({ status: 403, description: 'Caller does not own this node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async getDimensions(@CurrentUser() user: RequestUser, @Param('id') id: string) {
+    return this.backupService.getDimensions(user.id, id);
+  }
+}

--- a/apps/api/src/nodes/node-backup.service.spec.ts
+++ b/apps/api/src/nodes/node-backup.service.spec.ts
@@ -1,0 +1,1099 @@
+/**
+ * Unit tests for NodeBackupService (issue #312, epic #308 — node backup
+ * control plane).
+ *
+ * Covers:
+ *  1. getConfig — { config: null } when unconfigured; populated shape with
+ *     BigInt-as-string fields, pending wired to getPendingLag, checkpoint
+ *     null-vs-set, and activeRunId resolution
+ *  2. updateConfig — bad cron 400, bad timezone 400, foreign circleId 400,
+ *     nextRunAt recompute on schedule change and clear on scheduleCron null
+ *  3. startRun — cursorStart snapshots the checkpoint; 409 (with activeRunId)
+ *     on a fresh active run; stale running runs are released (marked stale)
+ *     and the new run proceeds; scheduled trigger rolls nextRunAt; 400 when
+ *     unconfigured or disabled
+ *  4. getChanges — 409 without the active run; lastAckAt refreshed by the
+ *     page fetch; both-or-neither cursor 400; limit clamped to
+ *     backup.maxPageSize; downloadUrl null on tombstone / not-ready /
+ *     presign-throw; nextCursor from the last item even on a partial page
+ *  5. ack — 409 on cursor regression; equal cursor accepted; single
+ *     $transaction accumulating config checkpoint/counters + run counters;
+ *     checkpoint echoed back
+ *  6. finishRun — completed stamps lastCompletedRunAt (+ lastReconcileAt for
+ *     reconcile runs); 400 on double-finish; 404 for a foreign node's run
+ *  7. getManifest — 409 without the active run; id-keyset paging + 1000 cap
+ *  8. markStaleRuns — only stale running runs are targeted
+ *  9. Serialization — JSON.stringify never throws on any response shape
+ *     (BigInt-as-string rule)
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NodeBackupService } from './node-backup.service';
+import { NodesService } from './nodes.service';
+import { NodeBackupQueryService } from './node-backup-query.service';
+import { ObjectsService } from '../storage/objects/objects.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const USER_ID = 'user-1';
+const OWNER_ID = 'user-1';
+const NODE_ID = '11111111-1111-4111-8111-111111111111';
+const RUN_ID = '22222222-2222-4222-8222-222222222222';
+const CIRCLE_A = '33333333-3333-4333-8333-333333333333';
+const CIRCLE_B = '44444444-4444-4444-8444-444444444444';
+const ITEM_ID_1 = '55555555-5555-4555-8555-555555555555';
+const ITEM_ID_2 = '66666666-6666-4666-8666-666666666666';
+const OBJECT_ID = '77777777-7777-4777-8777-777777777777';
+const CKPT_ID = '88888888-8888-4888-8888-888888888888';
+
+const NOW = Date.now();
+
+function makeNode(overrides: Partial<any> = {}) {
+  return {
+    id: NODE_ID,
+    name: 'backup-node',
+    hostname: 'host',
+    platform: 'linux',
+    cliVersion: '1.2.0',
+    eligibleTypes: [],
+    concurrency: 1,
+    status: 'online',
+    capabilities: null,
+    registeredAt: new Date(NOW - 86_400_000),
+    lastHeartbeatAt: new Date(NOW),
+    createdById: OWNER_ID,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<any> = {}) {
+  return {
+    id: 'cfg-1',
+    nodeId: NODE_ID,
+    enabled: true,
+    scheduleCron: '0 3 * * *',
+    timezone: 'America/Costa_Rica',
+    nextRunAt: new Date(NOW + 3_600_000),
+    circleIds: [],
+    checkpointUpdatedAt: new Date('2026-08-01T00:00:00.000Z'),
+    checkpointId: CKPT_ID,
+    itemsAcked: 41230n,
+    bytesAcked: 812345678901n,
+    lastRunAt: new Date('2026-08-07T03:00:00.000Z'),
+    lastCompletedRunAt: new Date('2026-08-07T03:30:00.000Z'),
+    lastReconcileAt: null,
+    createdAt: new Date(NOW - 86_400_000),
+    updatedAt: new Date(NOW),
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<any> = {}) {
+  return {
+    id: RUN_ID,
+    nodeId: NODE_ID,
+    kind: 'incremental',
+    status: 'running',
+    trigger: 'manual',
+    startedAt: new Date(NOW - 60_000),
+    finishedAt: null,
+    lastAckAt: new Date(NOW - 30_000),
+    itemsDownloaded: 10,
+    itemsSkipped: 2,
+    sidecarsWritten: 12,
+    bytesDownloaded: 1234n,
+    errorCount: 0,
+    lastError: null,
+    cliVersion: '1.2.0',
+    cursorStartUpdatedAt: null,
+    cursorStartId: null,
+    cursorEndUpdatedAt: null,
+    cursorEndId: null,
+    ...overrides,
+  };
+}
+
+function makeFeedItem(overrides: Partial<any> = {}) {
+  return {
+    id: ITEM_ID_1,
+    circleId: CIRCLE_A,
+    type: 'photo',
+    originalFilename: 'photo.jpg',
+    capturedAt: new Date('2026-01-01T10:00:00.000Z'),
+    capturedAtOffset: -300,
+    createdAt: new Date('2026-01-01T10:05:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    importedAt: new Date('2026-01-01T10:05:01.000Z'),
+    contentHash: 'a'.repeat(64),
+    deletedAt: null,
+    archivedAt: null,
+    storageObject: {
+      id: OBJECT_ID,
+      size: 5242880n,
+      mimeType: 'image/jpeg',
+      storageKey: 'originals/x.jpg',
+      status: 'ready',
+    },
+    ...overrides,
+  };
+}
+
+function defaultSettings(overrides: Partial<any> = {}) {
+  return {
+    backup: {
+      maxPageSize: 200,
+      feedSafetyHorizonSeconds: 5,
+      runStaleMinutes: 15,
+      ...overrides,
+    },
+  };
+}
+
+const defaultStats = {
+  itemsDownloaded: 5,
+  itemsSkipped: 3,
+  sidecarsWritten: 8,
+  bytesDownloaded: '1000',
+  errors: 1,
+};
+
+// ---------------------------------------------------------------------------
+// Test module
+// ---------------------------------------------------------------------------
+
+describe('NodeBackupService', () => {
+  let service: NodeBackupService;
+  let mockPrisma: MockPrismaService & any;
+  let nodesService: { assertOwnership: jest.Mock };
+  let queryService: {
+    resolveScope: jest.Mock;
+    getPendingLag: jest.Mock;
+    getChanges: jest.Mock;
+    composeSidecar: jest.Mock;
+    getManifest: jest.Mock;
+    getDimensions: jest.Mock;
+  };
+  let objectsService: { getInternalDownloadUrl: jest.Mock };
+  let systemSettings: { getSettings: jest.Mock };
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService() as any;
+    nodesService = { assertOwnership: jest.fn().mockResolvedValue(makeNode()) };
+    queryService = {
+      resolveScope: jest.fn().mockResolvedValue([CIRCLE_A]),
+      getPendingLag: jest.fn().mockResolvedValue({ items: 152, bytes: 9876543210n }),
+      getChanges: jest.fn().mockResolvedValue([]),
+      composeSidecar: jest.fn().mockReturnValue({ schemaVersion: 1 }),
+      getManifest: jest.fn().mockResolvedValue([]),
+      getDimensions: jest
+        .fn()
+        .mockResolvedValue({ albums: [], people: [], tags: [] }),
+    };
+    objectsService = {
+      getInternalDownloadUrl: jest.fn().mockResolvedValue('https://signed.example/get'),
+    };
+    systemSettings = { getSettings: jest.fn().mockResolvedValue(defaultSettings()) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NodeBackupService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: NodesService, useValue: nodesService },
+        { provide: NodeBackupQueryService, useValue: queryService },
+        { provide: ObjectsService, useValue: objectsService },
+        { provide: SystemSettingsService, useValue: systemSettings },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((_key: string, def?: unknown) => def) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(NodeBackupService);
+  });
+
+  // =========================================================================
+  // getConfig
+  // =========================================================================
+
+  describe('getConfig', () => {
+    it('returns { config: null } when backup has never been configured', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(null);
+
+      await expect(service.getConfig(USER_ID, NODE_ID)).resolves.toEqual({
+        config: null,
+      });
+      expect(nodesService.assertOwnership).toHaveBeenCalledWith(USER_ID, NODE_ID);
+    });
+
+    it('returns the populated shape with BigInt fields as STRINGS and pending from getPendingLag', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findFirst.mockResolvedValue({ id: RUN_ID });
+
+      const result = await service.getConfig(USER_ID, NODE_ID);
+
+      expect(result.config).toMatchObject({
+        nodeId: NODE_ID,
+        enabled: true,
+        scheduleCron: '0 3 * * *',
+        timezone: 'America/Costa_Rica',
+        circleIds: [],
+        checkpoint: { updatedAt: '2026-08-01T00:00:00.000Z', id: CKPT_ID },
+        itemsAcked: '41230',
+        bytesAcked: '812345678901',
+        pending: { items: 152, bytes: '9876543210' },
+        activeRunId: RUN_ID,
+      });
+      // Pending is computed past the CURRENT checkpoint cursor.
+      expect(queryService.getPendingLag).toHaveBeenCalledWith([CIRCLE_A], {
+        updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+        id: CKPT_ID,
+      });
+    });
+
+    it('reports a null checkpoint and null activeRunId before the first ack / with no active run', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(
+        makeConfig({ checkpointUpdatedAt: null, checkpointId: null }),
+      );
+      mockPrisma.nodeBackupRun.findFirst.mockResolvedValue(null);
+
+      const result = await service.getConfig(USER_ID, NODE_ID);
+
+      expect(result.config).toMatchObject({ checkpoint: null, activeRunId: null });
+      expect(queryService.getPendingLag).toHaveBeenCalledWith([CIRCLE_A], null);
+    });
+
+    it('only treats a FRESH running run as active (lastAckAt >= now - runStaleMinutes)', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findFirst.mockResolvedValue(null);
+
+      await service.getConfig(USER_ID, NODE_ID);
+
+      const arg = mockPrisma.nodeBackupRun.findFirst.mock.calls[0][0];
+      expect(arg.where.status).toBe('running');
+      const cutoff: Date = arg.where.lastAckAt.gte;
+      const expected = Date.now() - 15 * 60_000;
+      expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(5_000);
+    });
+  });
+
+  // =========================================================================
+  // updateConfig
+  // =========================================================================
+
+  describe('updateConfig', () => {
+    beforeEach(() => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(null);
+      mockPrisma.nodeBackupRun.findFirst.mockResolvedValue(null);
+      mockPrisma.nodeBackupConfig.upsert.mockImplementation(async (args: any) =>
+        makeConfig({
+          ...args.create,
+          itemsAcked: 0n,
+          bytesAcked: 0n,
+          checkpointUpdatedAt: null,
+          checkpointId: null,
+          lastRunAt: null,
+          lastCompletedRunAt: null,
+        }),
+      );
+    });
+
+    it('rejects an invalid cron expression with 400', async () => {
+      await expect(
+        service.updateConfig(USER_ID, NODE_ID, { scheduleCron: 'not a cron' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(mockPrisma.nodeBackupConfig.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown timezone with 400', async () => {
+      await expect(
+        service.updateConfig(USER_ID, NODE_ID, { timezone: 'Not/AZone' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(mockPrisma.nodeBackupConfig.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects circleIds the node owner is not a member of with 400', async () => {
+      mockPrisma.circleMember.findMany.mockResolvedValue([{ circleId: CIRCLE_A }]);
+
+      await expect(
+        service.updateConfig(USER_ID, NODE_ID, { circleIds: [CIRCLE_A, CIRCLE_B] }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(mockPrisma.circleMember.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: OWNER_ID }),
+        }),
+      );
+      expect(mockPrisma.nodeBackupConfig.upsert).not.toHaveBeenCalled();
+    });
+
+    it('accepts member circleIds and persists them', async () => {
+      mockPrisma.circleMember.findMany.mockResolvedValue([
+        { circleId: CIRCLE_A },
+        { circleId: CIRCLE_B },
+      ]);
+
+      await service.updateConfig(USER_ID, NODE_ID, {
+        circleIds: [CIRCLE_A, CIRCLE_B],
+      });
+
+      const upsert = mockPrisma.nodeBackupConfig.upsert.mock.calls[0][0];
+      expect(upsert.create.circleIds).toEqual([CIRCLE_A, CIRCLE_B]);
+    });
+
+    it('computes nextRunAt when scheduleCron is set (timezone-aware, default UTC)', async () => {
+      await service.updateConfig(USER_ID, NODE_ID, { scheduleCron: '0 3 * * *' });
+
+      const upsert = mockPrisma.nodeBackupConfig.upsert.mock.calls[0][0];
+      const next: Date = upsert.create.nextRunAt;
+      expect(next).toBeInstanceOf(Date);
+      expect(next.getTime()).toBeGreaterThan(Date.now());
+      // 03:00 UTC — cron evaluated in UTC when no timezone was supplied.
+      expect(next.getUTCHours()).toBe(3);
+      expect(next.getUTCMinutes()).toBe(0);
+    });
+
+    it('recomputes nextRunAt when the timezone changes on an existing schedule', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(
+        makeConfig({ timezone: null, nextRunAt: new Date('2020-01-01T03:00:00Z') }),
+      );
+
+      await service.updateConfig(USER_ID, NODE_ID, {
+        timezone: 'America/Costa_Rica',
+      });
+
+      const upsert = mockPrisma.nodeBackupConfig.upsert.mock.calls[0][0];
+      const next: Date = upsert.update.nextRunAt;
+      expect(next.getTime()).toBeGreaterThan(Date.now());
+      // 03:00 in UTC-06:00 (no DST) = 09:00 UTC.
+      expect(next.getUTCHours()).toBe(9);
+    });
+
+    it('clears nextRunAt when scheduleCron is set to null', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+
+      await service.updateConfig(USER_ID, NODE_ID, { scheduleCron: null });
+
+      const upsert = mockPrisma.nodeBackupConfig.upsert.mock.calls[0][0];
+      expect(upsert.update.scheduleCron).toBeNull();
+      expect(upsert.update.nextRunAt).toBeNull();
+    });
+
+    it('leaves nextRunAt untouched when only enabled changes', async () => {
+      const existing = makeConfig();
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(existing);
+
+      await service.updateConfig(USER_ID, NODE_ID, { enabled: false });
+
+      const upsert = mockPrisma.nodeBackupConfig.upsert.mock.calls[0][0];
+      expect(upsert.update.enabled).toBe(false);
+      expect(upsert.update.nextRunAt).toBe(existing.nextRunAt);
+    });
+
+    it('responds with the GET shape', async () => {
+      const result = await service.updateConfig(USER_ID, NODE_ID, {
+        scheduleCron: '0 3 * * *',
+      });
+
+      expect(result.config).toMatchObject({
+        nodeId: NODE_ID,
+        scheduleCron: '0 3 * * *',
+        pending: { items: 152, bytes: '9876543210' },
+      });
+    });
+  });
+
+  // =========================================================================
+  // startRun
+  // =========================================================================
+
+  describe('startRun', () => {
+    const startDto = {
+      kind: 'incremental' as const,
+      trigger: 'manual' as const,
+      cliVersion: '1.2.0',
+    };
+
+    beforeEach(() => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([]);
+      mockPrisma.nodeBackupRun.create.mockImplementation(async (args: any) =>
+        makeRun({ ...args.data, id: 'new-run-1' }),
+      );
+      mockPrisma.nodeBackupConfig.update.mockResolvedValue(makeConfig());
+    });
+
+    it('400s when backup is not configured', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(null);
+      await expect(service.startRun(USER_ID, NODE_ID, startDto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('400s when the config is disabled (manual runs too)', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(
+        makeConfig({ enabled: false }),
+      );
+      await expect(service.startRun(USER_ID, NODE_ID, startDto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('snapshots the config checkpoint into cursorStart and sets lastAckAt/lastRunAt', async () => {
+      const result = await service.startRun(USER_ID, NODE_ID, startDto);
+
+      const createArgs = mockPrisma.nodeBackupRun.create.mock.calls[0][0];
+      expect(createArgs.data).toMatchObject({
+        nodeId: NODE_ID,
+        kind: 'incremental',
+        status: 'running',
+        trigger: 'manual',
+        cliVersion: '1.2.0',
+        cursorStartUpdatedAt: new Date('2026-08-01T00:00:00.000Z'),
+        cursorStartId: CKPT_ID,
+      });
+      expect(createArgs.data.lastAckAt).toBeInstanceOf(Date);
+
+      const configUpdate = mockPrisma.nodeBackupConfig.update.mock.calls[0][0];
+      expect(configUpdate.data.lastRunAt).toBeInstanceOf(Date);
+      // Manual trigger must NOT roll nextRunAt.
+      expect(configUpdate.data.nextRunAt).toBeUndefined();
+
+      expect(result).toEqual({
+        run: {
+          id: 'new-run-1',
+          kind: 'incremental',
+          startedAt: expect.any(String),
+          cursorStart: {
+            updatedAt: '2026-08-01T00:00:00.000Z',
+            id: CKPT_ID,
+          },
+        },
+      });
+    });
+
+    it('409s with the activeRunId when a fresh running run exists', async () => {
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([
+        makeRun({ lastAckAt: new Date() }),
+      ]);
+
+      let err: any;
+      try {
+        await service.startRun(USER_ID, NODE_ID, startDto);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(ConflictException);
+      expect(err.getResponse()).toMatchObject({ activeRunId: RUN_ID });
+      expect(mockPrisma.nodeBackupRun.create).not.toHaveBeenCalled();
+    });
+
+    it('releases a STALE running run (marks it stale + finishedAt) and proceeds', async () => {
+      const staleRun = makeRun({
+        id: 'stale-run-1',
+        lastAckAt: new Date(NOW - 60 * 60_000), // 1h ago >> 15 min window
+      });
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([staleRun]);
+
+      const result = await service.startRun(USER_ID, NODE_ID, startDto);
+
+      expect(mockPrisma.nodeBackupRun.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['stale-run-1'] } },
+        data: { status: 'stale', finishedAt: expect.any(Date) },
+      });
+      expect(result.run.id).toBe('new-run-1');
+    });
+
+    it('rolls nextRunAt forward (config timezone) when trigger is scheduled', async () => {
+      await service.startRun(USER_ID, NODE_ID, { ...startDto, trigger: 'scheduled' });
+
+      const configUpdate = mockPrisma.nodeBackupConfig.update.mock.calls[0][0];
+      const next: Date = configUpdate.data.nextRunAt;
+      expect(next).toBeInstanceOf(Date);
+      expect(next.getTime()).toBeGreaterThan(Date.now());
+      // '0 3 * * *' in America/Costa_Rica (UTC-06:00, no DST) fires at 09:00 UTC.
+      expect(next.getUTCHours()).toBe(9);
+    });
+  });
+
+  // =========================================================================
+  // getChanges
+  // =========================================================================
+
+  describe('getChanges', () => {
+    beforeEach(() => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(makeRun());
+      mockPrisma.nodeBackupRun.update.mockResolvedValue(makeRun());
+    });
+
+    it('409s when runId is not a run of this node', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ nodeId: 'other-node' }),
+      );
+      await expect(
+        service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('409s when the run is no longer running or has gone stale', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ status: 'completed' }),
+      );
+      await expect(
+        service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID }),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ lastAckAt: new Date(NOW - 60 * 60_000) }),
+      );
+      await expect(
+        service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('refreshes the run lastAckAt — a page fetch counts as liveness', async () => {
+      await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID });
+
+      expect(mockPrisma.nodeBackupRun.update).toHaveBeenCalledWith({
+        where: { id: RUN_ID },
+        data: { lastAckAt: expect.any(Date) },
+      });
+    });
+
+    it('400s when only one cursor half is provided', async () => {
+      await expect(
+        service.getChanges(USER_ID, NODE_ID, {
+          runId: RUN_ID,
+          updatedAfter: '2026-08-01T00:00:00.000Z',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      await expect(
+        service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID, afterId: ITEM_ID_1 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('passes the parsed cursor through and defaults limit to 100', async () => {
+      await service.getChanges(USER_ID, NODE_ID, {
+        runId: RUN_ID,
+        updatedAfter: '2026-08-01T00:00:00.000Z',
+        afterId: ITEM_ID_1,
+      });
+
+      expect(queryService.getChanges).toHaveBeenCalledWith(
+        [CIRCLE_A],
+        { updatedAt: new Date('2026-08-01T00:00:00.000Z'), id: ITEM_ID_1 },
+        100,
+      );
+    });
+
+    it('clamps limit to backup.maxPageSize', async () => {
+      await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID, limit: 100000 });
+      expect(queryService.getChanges).toHaveBeenCalledWith([CIRCLE_A], null, 200);
+    });
+
+    it('returns presigned items with sidecars, nextCursor from the last item, and hasMore on a full page', async () => {
+      const item1 = makeFeedItem();
+      const item2 = makeFeedItem({
+        id: ITEM_ID_2,
+        updatedAt: new Date('2026-01-03T00:00:00.000Z'),
+      });
+      queryService.getChanges.mockResolvedValue([item1, item2]);
+
+      const result = await service.getChanges(USER_ID, NODE_ID, {
+        runId: RUN_ID,
+        limit: 2,
+      });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toMatchObject({
+        id: ITEM_ID_1,
+        circleId: CIRCLE_A,
+        storage: {
+          objectId: OBJECT_ID,
+          size: '5242880',
+          mimeType: 'image/jpeg',
+          status: 'ready',
+        },
+        downloadUrl: 'https://signed.example/get',
+        sidecar: { schemaVersion: 1 },
+      });
+      expect(result.items[0].downloadUrlExpiresAt).toEqual(expect.any(String));
+      expect(result.nextCursor).toEqual({
+        updatedAt: '2026-01-03T00:00:00.000Z',
+        id: ITEM_ID_2,
+      });
+      expect(result.hasMore).toBe(true);
+      expect(result.safetyHorizon).toEqual(expect.any(String));
+    });
+
+    it('still advances nextCursor on a PARTIAL page, with hasMore false', async () => {
+      queryService.getChanges.mockResolvedValue([makeFeedItem()]);
+
+      const result = await service.getChanges(USER_ID, NODE_ID, {
+        runId: RUN_ID,
+        limit: 50,
+      });
+
+      expect(result.nextCursor).toEqual({
+        updatedAt: '2026-01-02T00:00:00.000Z',
+        id: ITEM_ID_1,
+      });
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('returns nextCursor null on a zero-item page', async () => {
+      queryService.getChanges.mockResolvedValue([]);
+      const result = await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID });
+      expect(result.nextCursor).toBeNull();
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('nulls downloadUrl for a tombstone (deletedAt set) without presigning', async () => {
+      queryService.getChanges.mockResolvedValue([
+        makeFeedItem({ deletedAt: new Date('2026-08-01T00:00:00.000Z') }),
+      ]);
+
+      const result = await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID });
+
+      expect(result.items[0].downloadUrl).toBeNull();
+      expect(result.items[0].downloadUrlExpiresAt).toBeNull();
+      expect(objectsService.getInternalDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('nulls downloadUrl when the storage object is not ready', async () => {
+      queryService.getChanges.mockResolvedValue([
+        makeFeedItem({
+          storageObject: { ...makeFeedItem().storageObject, status: 'processing' },
+        }),
+      ]);
+
+      const result = await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID });
+
+      expect(result.items[0].downloadUrl).toBeNull();
+      expect(objectsService.getInternalDownloadUrl).not.toHaveBeenCalled();
+    });
+
+    it('nulls downloadUrl (item still returned) when presigning throws', async () => {
+      queryService.getChanges.mockResolvedValue([makeFeedItem()]);
+      objectsService.getInternalDownloadUrl.mockRejectedValue(new Error('boom'));
+
+      const result = await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].downloadUrl).toBeNull();
+      expect(result.items[0].downloadUrlExpiresAt).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // ack
+  // =========================================================================
+
+  describe('ack', () => {
+    const ackDto = {
+      runId: RUN_ID,
+      cursor: { updatedAt: '2026-08-02T00:00:00.000Z', id: CKPT_ID },
+      stats: defaultStats,
+    };
+
+    beforeEach(() => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(makeRun());
+    });
+
+    it('409s when the run is not the active running run', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ status: 'stale' }),
+      );
+      await expect(service.ack(USER_ID, NODE_ID, ackDto)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+    });
+
+    it('409s on a cursor strictly behind the stored checkpoint (time regression)', async () => {
+      await expect(
+        service.ack(USER_ID, NODE_ID, {
+          ...ackDto,
+          cursor: { updatedAt: '2026-07-01T00:00:00.000Z', id: CKPT_ID },
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('409s on an equal-time, lower-id cursor regression', async () => {
+      await expect(
+        service.ack(USER_ID, NODE_ID, {
+          ...ackDto,
+          cursor: {
+            updatedAt: '2026-08-01T00:00:00.000Z',
+            // Lexicographically below the stored checkpoint id (8888…).
+            id: '00000000-0000-4000-8000-000000000000',
+          },
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('accepts an EQUAL cursor as a no-op advance', async () => {
+      const result = await service.ack(USER_ID, NODE_ID, {
+        ...ackDto,
+        cursor: { updatedAt: '2026-08-01T00:00:00.000Z', id: CKPT_ID },
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(result.checkpoint).toEqual({
+        updatedAt: '2026-08-01T00:00:00.000Z',
+        id: CKPT_ID,
+      });
+    });
+
+    it('advances the checkpoint and accumulates stats in ONE transaction, echoing the checkpoint', async () => {
+      const result = await service.ack(USER_ID, NODE_ID, ackDto);
+
+      // Both writes went through a single $transaction call.
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+
+      const configUpdate = mockPrisma.nodeBackupConfig.update.mock.calls[0][0];
+      expect(configUpdate).toEqual({
+        where: { nodeId: NODE_ID },
+        data: {
+          checkpointUpdatedAt: new Date('2026-08-02T00:00:00.000Z'),
+          checkpointId: CKPT_ID,
+          // itemsAcked += downloaded + skipped; bytesAcked += BigInt(bytes).
+          itemsAcked: { increment: 8 },
+          bytesAcked: { increment: 1000n },
+        },
+      });
+
+      const runUpdate = mockPrisma.nodeBackupRun.update.mock.calls[0][0];
+      expect(runUpdate.where).toEqual({ id: RUN_ID });
+      expect(runUpdate.data).toMatchObject({
+        itemsDownloaded: { increment: 5 },
+        itemsSkipped: { increment: 3 },
+        sidecarsWritten: { increment: 8 },
+        bytesDownloaded: { increment: 1000n },
+        errorCount: { increment: 1 },
+        lastAckAt: expect.any(Date),
+        cursorEndUpdatedAt: new Date('2026-08-02T00:00:00.000Z'),
+        cursorEndId: CKPT_ID,
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        checkpoint: { updatedAt: '2026-08-02T00:00:00.000Z', id: CKPT_ID },
+      });
+    });
+
+    it('accepts any cursor when no checkpoint is stored yet (first ack)', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(
+        makeConfig({ checkpointUpdatedAt: null, checkpointId: null }),
+      );
+
+      await expect(service.ack(USER_ID, NODE_ID, ackDto)).resolves.toMatchObject({
+        ok: true,
+      });
+    });
+  });
+
+  // =========================================================================
+  // finishRun
+  // =========================================================================
+
+  describe('finishRun', () => {
+    beforeEach(() => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(makeRun());
+      mockPrisma.nodeBackupRun.update.mockResolvedValue(makeRun());
+      mockPrisma.nodeBackupConfig.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it('404s for an unknown run', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(null);
+      await expect(
+        service.finishRun(USER_ID, NODE_ID, RUN_ID, { status: 'completed' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("404s for another node's run (enumeration-resistant)", async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ nodeId: 'other-node' }),
+      );
+      await expect(
+        service.finishRun(USER_ID, NODE_ID, RUN_ID, { status: 'completed' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('400s when the run is already terminal', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ status: 'completed' }),
+      );
+      await expect(
+        service.finishRun(USER_ID, NODE_ID, RUN_ID, { status: 'failed' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('completed sets finishedAt and stamps config lastCompletedRunAt (incremental: no lastReconcileAt)', async () => {
+      await service.finishRun(USER_ID, NODE_ID, RUN_ID, { status: 'completed' });
+
+      expect(mockPrisma.nodeBackupRun.update).toHaveBeenCalledWith({
+        where: { id: RUN_ID },
+        data: expect.objectContaining({
+          status: 'completed',
+          finishedAt: expect.any(Date),
+        }),
+      });
+      const cfgUpdate = mockPrisma.nodeBackupConfig.updateMany.mock.calls[0][0];
+      expect(cfgUpdate.where).toEqual({ nodeId: NODE_ID });
+      expect(cfgUpdate.data.lastCompletedRunAt).toBeInstanceOf(Date);
+      expect(cfgUpdate.data.lastReconcileAt).toBeUndefined();
+    });
+
+    it('a completed reconcile run also stamps lastReconcileAt', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(
+        makeRun({ kind: 'reconcile' }),
+      );
+
+      await service.finishRun(USER_ID, NODE_ID, RUN_ID, { status: 'completed' });
+
+      const cfgUpdate = mockPrisma.nodeBackupConfig.updateMany.mock.calls[0][0];
+      expect(cfgUpdate.data.lastReconcileAt).toBeInstanceOf(Date);
+    });
+
+    it('failed records lastError and does NOT stamp lastCompletedRunAt', async () => {
+      await service.finishRun(USER_ID, NODE_ID, RUN_ID, {
+        status: 'failed',
+        error: 'disk full',
+      });
+
+      expect(mockPrisma.nodeBackupRun.update).toHaveBeenCalledWith({
+        where: { id: RUN_ID },
+        data: expect.objectContaining({ status: 'failed', lastError: 'disk full' }),
+      });
+      expect(mockPrisma.nodeBackupConfig.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('accumulates finalStats onto the run counters when provided', async () => {
+      await service.finishRun(USER_ID, NODE_ID, RUN_ID, {
+        status: 'completed',
+        finalStats: defaultStats,
+      });
+
+      const update = mockPrisma.nodeBackupRun.update.mock.calls[0][0];
+      expect(update.data).toMatchObject({
+        itemsDownloaded: { increment: 5 },
+        itemsSkipped: { increment: 3 },
+        sidecarsWritten: { increment: 8 },
+        bytesDownloaded: { increment: 1000n },
+        errorCount: { increment: 1 },
+      });
+    });
+  });
+
+  // =========================================================================
+  // listRuns
+  // =========================================================================
+
+  describe('listRuns', () => {
+    it('lists newest first with the default limit of 20 and BigInt bytes as strings', async () => {
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([makeRun()]);
+
+      const result = await service.listRuns(USER_ID, NODE_ID);
+
+      expect(mockPrisma.nodeBackupRun.findMany).toHaveBeenCalledWith({
+        where: { nodeId: NODE_ID },
+        orderBy: { startedAt: 'desc' },
+        take: 20,
+      });
+      expect(result.runs[0]).toMatchObject({
+        id: RUN_ID,
+        kind: 'incremental',
+        status: 'running',
+        trigger: 'manual',
+        bytesDownloaded: '1234',
+        cliVersion: '1.2.0',
+      });
+    });
+
+    it('caps limit at 100', async () => {
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([]);
+      await service.listRuns(USER_ID, NODE_ID, 5000);
+      expect(mockPrisma.nodeBackupRun.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // getManifest
+  // =========================================================================
+
+  describe('getManifest', () => {
+    beforeEach(() => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(makeRun());
+      mockPrisma.nodeBackupRun.update.mockResolvedValue(makeRun());
+    });
+
+    it('409s without a valid active run', async () => {
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(null);
+      await expect(
+        service.getManifest(USER_ID, NODE_ID, { runId: RUN_ID }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('refreshes lastAckAt, pages by afterId, and hard-caps the limit at 1000', async () => {
+      queryService.getManifest.mockResolvedValue([
+        {
+          id: ITEM_ID_1,
+          contentHash: 'abc',
+          updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+          deletedAt: null,
+          archivedAt: null,
+        },
+      ]);
+
+      const result = await service.getManifest(USER_ID, NODE_ID, {
+        runId: RUN_ID,
+        afterId: CKPT_ID,
+        limit: 100000,
+      });
+
+      expect(mockPrisma.nodeBackupRun.update).toHaveBeenCalledWith({
+        where: { id: RUN_ID },
+        data: { lastAckAt: expect.any(Date) },
+      });
+      expect(queryService.getManifest).toHaveBeenCalledWith([CIRCLE_A], CKPT_ID, 1000);
+      expect(result.items[0]).toEqual({
+        id: ITEM_ID_1,
+        contentHash: 'abc',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+        deletedAt: null,
+        archivedAt: null,
+      });
+      expect(result.nextAfterId).toBe(ITEM_ID_1);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('reports hasMore true on a full page', async () => {
+      queryService.getManifest.mockResolvedValue([
+        {
+          id: ITEM_ID_1,
+          contentHash: 'abc',
+          updatedAt: new Date(),
+          deletedAt: null,
+          archivedAt: null,
+        },
+      ]);
+
+      const result = await service.getManifest(USER_ID, NODE_ID, {
+        runId: RUN_ID,
+        limit: 1,
+      });
+      expect(result.hasMore).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // getDimensions
+  // =========================================================================
+
+  describe('getDimensions', () => {
+    it('requires no run/config and returns catalogs plus generatedAt', async () => {
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(null);
+
+      const result = await service.getDimensions(USER_ID, NODE_ID);
+
+      // Unconfigured node: scope defaults to ALL owner circles (empty circleIds).
+      expect(queryService.resolveScope).toHaveBeenCalledWith(OWNER_ID, []);
+      expect(result).toEqual({
+        albums: [],
+        people: [],
+        tags: [],
+        generatedAt: expect.any(String),
+      });
+    });
+  });
+
+  // =========================================================================
+  // markStaleRuns
+  // =========================================================================
+
+  describe('markStaleRuns', () => {
+    it('marks only running runs whose lastAckAt fell outside runStaleMinutes', async () => {
+      mockPrisma.nodeBackupRun.updateMany.mockResolvedValue({ count: 2 });
+
+      const count = await service.markStaleRuns();
+
+      expect(count).toBe(2);
+      const arg = mockPrisma.nodeBackupRun.updateMany.mock.calls[0][0];
+      expect(arg.where.status).toBe('running');
+      const cutoff: Date = arg.where.lastAckAt.lt;
+      const expected = Date.now() - 15 * 60_000;
+      expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(5_000);
+      expect(arg.data).toEqual({ status: 'stale', finishedAt: expect.any(Date) });
+    });
+  });
+
+  // =========================================================================
+  // Serialization — the BigInt-as-string rule
+  // =========================================================================
+
+  describe('response serialization', () => {
+    it('JSON.stringify never throws on any response shape', async () => {
+      // getConfig
+      mockPrisma.nodeBackupConfig.findUnique.mockResolvedValue(makeConfig());
+      mockPrisma.nodeBackupRun.findFirst.mockResolvedValue({ id: RUN_ID });
+      const config = await service.getConfig(USER_ID, NODE_ID);
+      expect(() => JSON.stringify(config)).not.toThrow();
+
+      // startRun
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([]);
+      mockPrisma.nodeBackupRun.create.mockImplementation(async (args: any) =>
+        makeRun({ ...args.data, id: 'new-run-1' }),
+      );
+      mockPrisma.nodeBackupConfig.update.mockResolvedValue(makeConfig());
+      const started = await service.startRun(USER_ID, NODE_ID, {
+        kind: 'incremental',
+        trigger: 'manual',
+        cliVersion: '1.2.0',
+      });
+      expect(() => JSON.stringify(started)).not.toThrow();
+
+      // getChanges (storage.size is a BigInt on the raw row)
+      mockPrisma.nodeBackupRun.findUnique.mockResolvedValue(makeRun());
+      mockPrisma.nodeBackupRun.update.mockResolvedValue(makeRun());
+      queryService.getChanges.mockResolvedValue([makeFeedItem()]);
+      const changes = await service.getChanges(USER_ID, NODE_ID, { runId: RUN_ID });
+      expect(() => JSON.stringify(changes)).not.toThrow();
+
+      // ack
+      const acked = await service.ack(USER_ID, NODE_ID, {
+        runId: RUN_ID,
+        cursor: { updatedAt: '2026-08-02T00:00:00.000Z', id: CKPT_ID },
+        stats: defaultStats,
+      });
+      expect(() => JSON.stringify(acked)).not.toThrow();
+
+      // listRuns (bytesDownloaded BigInt on the raw row)
+      mockPrisma.nodeBackupRun.findMany.mockResolvedValue([makeRun()]);
+      const runs = await service.listRuns(USER_ID, NODE_ID);
+      expect(() => JSON.stringify(runs)).not.toThrow();
+
+      // manifest + dimensions
+      const manifest = await service.getManifest(USER_ID, NODE_ID, { runId: RUN_ID });
+      expect(() => JSON.stringify(manifest)).not.toThrow();
+      const dims = await service.getDimensions(USER_ID, NODE_ID);
+      expect(() => JSON.stringify(dims)).not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/nodes/node-backup.service.ts
+++ b/apps/api/src/nodes/node-backup.service.ts
@@ -1,0 +1,781 @@
+// =============================================================================
+// NodeBackupService (issue #312, epic #308 — Local Media Backup via Worker Nodes)
+// =============================================================================
+//
+// Control plane for the node backup data feed: per-node config (schedule /
+// scope / checkpoint), run lifecycle (start → change-feed pages → acks →
+// finish) with a single-active-run rule and staleness release, the presigned
+// change feed itself, the reconcile manifest, and the dimensions catalog.
+//
+// Layering: this service owns HTTP-facing orchestration + state transitions;
+// all feed/sidecar/lag QUERIES delegate to NodeBackupQueryService (#310).
+// Ownership (404 unknown node / 403 foreign node) funnels through
+// NodesService.assertOwnership, exactly like every other /api/nodes/* route.
+//
+// Serialization rule: every BigInt (bytesAcked, bytesDownloaded, pending
+// bytes, object sizes) leaves this service as a STRING — never let a raw
+// BigInt escape to JSON (see CLAUDE.md gotchas).
+// =============================================================================
+
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  NodeBackupConfig,
+  NodeBackupRun,
+  NodeBackupRunKind,
+  NodeBackupRunStatus,
+  Prisma,
+  WorkerNode,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { NodesService } from './nodes.service';
+import {
+  BackupFeedCursor,
+  NodeBackupQueryService,
+} from './node-backup-query.service';
+import { ObjectsService } from '../storage/objects/objects.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { isValidCron, nextCronDate } from '../workflows/util/cron.util';
+import {
+  BackupRunStats,
+  BackupAckDto,
+  BackupChangesQueryDto,
+  BackupManifestQueryDto,
+  FinishBackupRunDto,
+  StartBackupRunDto,
+  UpdateBackupConfigDto,
+} from './dto/node-backup.dto';
+
+const DEFAULT_RUN_STALE_MINUTES = 15;
+const DEFAULT_MAX_PAGE_SIZE = 200;
+const DEFAULT_FEED_SAFETY_HORIZON_SECONDS = 5;
+const DEFAULT_CHANGES_LIMIT = 100;
+const MANIFEST_MAX_LIMIT = 1000;
+
+const iso = (d: Date | null | undefined): string | null =>
+  d ? d.toISOString() : null;
+
+/**
+ * Valid IANA timezone names. Built lazily; 'UTC' is added explicitly since
+ * some runtimes canonicalize it out of Intl.supportedValuesOf('timeZone').
+ */
+let timezoneSet: Set<string> | null = null;
+function isSupportedTimezone(tz: string): boolean {
+  if (!timezoneSet) {
+    timezoneSet = new Set([...Intl.supportedValuesOf('timeZone'), 'UTC']);
+  }
+  return timezoneSet.has(tz);
+}
+
+@Injectable()
+export class NodeBackupService {
+  private readonly logger = new Logger(NodeBackupService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly nodesService: NodesService,
+    private readonly queryService: NodeBackupQueryService,
+    private readonly objectsService: ObjectsService,
+    private readonly systemSettings: SystemSettingsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Settings helpers
+  // ---------------------------------------------------------------------------
+
+  private async getBackupSettings(): Promise<{
+    maxPageSize: number;
+    feedSafetyHorizonSeconds: number;
+    runStaleMinutes: number;
+  }> {
+    const settings = await this.systemSettings.getSettings();
+    return {
+      maxPageSize: settings.backup?.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE,
+      feedSafetyHorizonSeconds:
+        settings.backup?.feedSafetyHorizonSeconds ??
+        DEFAULT_FEED_SAFETY_HORIZON_SECONDS,
+      runStaleMinutes:
+        settings.backup?.runStaleMinutes ?? DEFAULT_RUN_STALE_MINUTES,
+    };
+  }
+
+  private staleCutoff(runStaleMinutes: number): Date {
+    return new Date(Date.now() - runStaleMinutes * 60_000);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Active-run helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * True when `run` counts as ACTIVE: still `running` with an ack (or page
+   * fetch — both refresh lastAckAt) inside the runStaleMinutes window.
+   */
+  private isRunFresh(run: NodeBackupRun, cutoff: Date): boolean {
+    return (
+      run.status === NodeBackupRunStatus.running &&
+      run.lastAckAt !== null &&
+      run.lastAckAt >= cutoff
+    );
+  }
+
+  /** The node's currently-active run id, or null. */
+  private async findActiveRunId(
+    nodeId: string,
+    runStaleMinutes: number,
+  ): Promise<string | null> {
+    const run = await this.prisma.nodeBackupRun.findFirst({
+      where: {
+        nodeId,
+        status: NodeBackupRunStatus.running,
+        lastAckAt: { gte: this.staleCutoff(runStaleMinutes) },
+      },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true },
+    });
+    return run?.id ?? null;
+  }
+
+  /**
+   * Load `runId` and assert it is THE active running run for `nodeId` (409
+   * otherwise — wrong node, not running, or stale). When `refreshAck` is set,
+   * the run's `lastAckAt` is bumped to now: a page fetch counts as liveness.
+   */
+  private async requireActiveRun(
+    nodeId: string,
+    runId: string,
+    runStaleMinutes: number,
+    opts: { refreshAck: boolean },
+  ): Promise<NodeBackupRun> {
+    const run = await this.prisma.nodeBackupRun.findUnique({
+      where: { id: runId },
+    });
+    if (
+      !run ||
+      run.nodeId !== nodeId ||
+      !this.isRunFresh(run, this.staleCutoff(runStaleMinutes))
+    ) {
+      throw new ConflictException(
+        'runId is not the active running backup run for this node',
+      );
+    }
+    if (opts.refreshAck) {
+      await this.prisma.nodeBackupRun.update({
+        where: { id: run.id },
+        data: { lastAckAt: new Date() },
+      });
+    }
+    return run;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Config serialization
+  // ---------------------------------------------------------------------------
+
+  private async serializeConfig(node: WorkerNode, config: NodeBackupConfig) {
+    const { runStaleMinutes } = await this.getBackupSettings();
+
+    const scope = await this.queryService.resolveScope(
+      node.createdById,
+      config.circleIds,
+    );
+    const cursor: BackupFeedCursor | null =
+      config.checkpointUpdatedAt && config.checkpointId
+        ? { updatedAt: config.checkpointUpdatedAt, id: config.checkpointId }
+        : null;
+    const pending = await this.queryService.getPendingLag(scope, cursor);
+    const activeRunId = await this.findActiveRunId(node.id, runStaleMinutes);
+
+    return {
+      nodeId: config.nodeId,
+      enabled: config.enabled,
+      scheduleCron: config.scheduleCron,
+      timezone: config.timezone,
+      nextRunAt: iso(config.nextRunAt),
+      circleIds: config.circleIds,
+      checkpoint: cursor
+        ? { updatedAt: cursor.updatedAt.toISOString(), id: cursor.id }
+        : null,
+      // BigInt → STRING at the DTO boundary.
+      itemsAcked: config.itemsAcked.toString(),
+      bytesAcked: config.bytesAcked.toString(),
+      lastRunAt: iso(config.lastRunAt),
+      lastCompletedRunAt: iso(config.lastCompletedRunAt),
+      lastReconcileAt: iso(config.lastReconcileAt),
+      pending: { items: pending.items, bytes: pending.bytes.toString() },
+      activeRunId,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /nodes/:id/backup/config
+  // ---------------------------------------------------------------------------
+
+  async getConfig(userId: string, nodeId: string) {
+    const node = await this.nodesService.assertOwnership(userId, nodeId);
+    const config = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+    });
+    if (!config) {
+      return { config: null };
+    }
+    return { config: await this.serializeConfig(node, config) };
+  }
+
+  // ---------------------------------------------------------------------------
+  // PUT /nodes/:id/backup/config
+  // ---------------------------------------------------------------------------
+
+  async updateConfig(userId: string, nodeId: string, dto: UpdateBackupConfigDto) {
+    const node = await this.nodesService.assertOwnership(userId, nodeId);
+
+    if (typeof dto.scheduleCron === 'string' && !isValidCron(dto.scheduleCron)) {
+      throw new BadRequestException(
+        `Invalid cron expression "${dto.scheduleCron}" — expected the 5-field form ` +
+          '"minute hour day-of-month month day-of-week"',
+      );
+    }
+    if (typeof dto.timezone === 'string' && !isSupportedTimezone(dto.timezone)) {
+      throw new BadRequestException(
+        `Unknown timezone "${dto.timezone}" — expected an IANA timezone name ` +
+          '(e.g. "America/Costa_Rica")',
+      );
+    }
+    if (dto.circleIds !== undefined && dto.circleIds.length > 0) {
+      // Every requested circle must be one the node OWNER belongs to.
+      const memberships = await this.prisma.circleMember.findMany({
+        where: { userId: node.createdById, circleId: { in: dto.circleIds } },
+        select: { circleId: true },
+      });
+      const memberIds = new Set(memberships.map((m) => m.circleId));
+      const invalid = dto.circleIds.filter((id) => !memberIds.has(id));
+      if (invalid.length > 0) {
+        throw new BadRequestException(
+          `circleIds contains circles the node owner is not a member of: ${invalid.join(', ')}`,
+        );
+      }
+    }
+
+    const existing = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+    });
+
+    // Effective post-merge values ('key present' distinguishes null from absent).
+    const scheduleCron =
+      dto.scheduleCron !== undefined
+        ? dto.scheduleCron
+        : existing?.scheduleCron ?? null;
+    const timezone =
+      dto.timezone !== undefined ? dto.timezone : existing?.timezone ?? null;
+
+    // Recompute nextRunAt whenever the schedule inputs changed (or the row is
+    // being created); clearing the cron clears nextRunAt.
+    let nextRunAt: Date | null;
+    if (scheduleCron === null) {
+      nextRunAt = null;
+    } else if (
+      dto.scheduleCron !== undefined ||
+      dto.timezone !== undefined ||
+      !existing
+    ) {
+      nextRunAt = nextCronDate(scheduleCron, new Date(), timezone ?? 'UTC');
+    } else {
+      nextRunAt = existing.nextRunAt;
+    }
+
+    const config = await this.prisma.nodeBackupConfig.upsert({
+      where: { nodeId },
+      create: {
+        nodeId,
+        enabled: dto.enabled ?? true,
+        scheduleCron,
+        timezone,
+        nextRunAt,
+        circleIds: dto.circleIds ?? [],
+      },
+      update: {
+        ...(dto.enabled !== undefined ? { enabled: dto.enabled } : {}),
+        scheduleCron,
+        timezone,
+        nextRunAt,
+        ...(dto.circleIds !== undefined ? { circleIds: dto.circleIds } : {}),
+      },
+    });
+
+    return { config: await this.serializeConfig(node, config) };
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /nodes/:id/backup/runs
+  // ---------------------------------------------------------------------------
+
+  async startRun(userId: string, nodeId: string, dto: StartBackupRunDto) {
+    await this.nodesService.assertOwnership(userId, nodeId);
+
+    const config = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+    });
+    if (!config) {
+      throw new BadRequestException('backup is not configured for this node');
+    }
+    if (!config.enabled) {
+      throw new BadRequestException('backup is disabled for this node');
+    }
+
+    const { runStaleMinutes } = await this.getBackupSettings();
+    const now = new Date();
+    const cutoff = this.staleCutoff(runStaleMinutes);
+
+    // Single-active-run rule: a FRESH running run blocks (409); STALE running
+    // runs are released (marked stale) and the new run proceeds.
+    const runningRuns = await this.prisma.nodeBackupRun.findMany({
+      where: { nodeId, status: NodeBackupRunStatus.running },
+      orderBy: { startedAt: 'desc' },
+    });
+    const fresh = runningRuns.find((r) => this.isRunFresh(r, cutoff));
+    if (fresh) {
+      throw new ConflictException({
+        message: 'a backup run is already active for this node',
+        activeRunId: fresh.id,
+      });
+    }
+    if (runningRuns.length > 0) {
+      await this.prisma.nodeBackupRun.updateMany({
+        where: { id: { in: runningRuns.map((r) => r.id) } },
+        data: { status: NodeBackupRunStatus.stale, finishedAt: now },
+      });
+      this.logger.warn(
+        `Released ${runningRuns.length} stale running backup run(s) for node ${nodeId}`,
+      );
+    }
+
+    // Scheduled triggers roll nextRunAt forward AT START (same at-start
+    // pattern as workflow-schedule.task.ts), so a crash mid-run cannot
+    // re-fire the same slot forever.
+    const nextRunAt =
+      dto.trigger === 'scheduled' && config.scheduleCron
+        ? nextCronDate(config.scheduleCron, now, config.timezone ?? 'UTC')
+        : undefined;
+
+    const run = await this.prisma.nodeBackupRun.create({
+      data: {
+        nodeId,
+        kind: dto.kind as NodeBackupRunKind,
+        status: NodeBackupRunStatus.running,
+        trigger: dto.trigger,
+        cliVersion: dto.cliVersion ?? null,
+        startedAt: now,
+        lastAckAt: now,
+        cursorStartUpdatedAt: config.checkpointUpdatedAt,
+        cursorStartId: config.checkpointId,
+      },
+    });
+
+    await this.prisma.nodeBackupConfig.update({
+      where: { nodeId },
+      data: {
+        lastRunAt: now,
+        ...(nextRunAt !== undefined ? { nextRunAt } : {}),
+      },
+    });
+
+    return {
+      run: {
+        id: run.id,
+        kind: run.kind,
+        startedAt: run.startedAt.toISOString(),
+        cursorStart: {
+          updatedAt: iso(run.cursorStartUpdatedAt),
+          id: run.cursorStartId,
+        },
+      },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /nodes/:id/backup/changes
+  // ---------------------------------------------------------------------------
+
+  async getChanges(userId: string, nodeId: string, q: BackupChangesQueryDto) {
+    const node = await this.nodesService.assertOwnership(userId, nodeId);
+
+    const config = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+    });
+    if (!config) {
+      throw new BadRequestException('backup is not configured for this node');
+    }
+
+    const { runStaleMinutes, maxPageSize, feedSafetyHorizonSeconds } =
+      await this.getBackupSettings();
+
+    // The page fetch itself counts as run liveness.
+    await this.requireActiveRun(nodeId, q.runId, runStaleMinutes, {
+      refreshAck: true,
+    });
+
+    // Cursor params are both-or-neither.
+    const hasUpdatedAfter = q.updatedAfter !== undefined;
+    const hasAfterId = q.afterId !== undefined;
+    if (hasUpdatedAfter !== hasAfterId) {
+      throw new BadRequestException(
+        'updatedAfter and afterId must be provided together (or neither)',
+      );
+    }
+    const cursor: BackupFeedCursor | null = hasUpdatedAfter
+      ? { updatedAt: new Date(q.updatedAfter as string), id: q.afterId as string }
+      : null;
+
+    const limit = Math.max(
+      1,
+      Math.min(q.limit ?? DEFAULT_CHANGES_LIMIT, maxPageSize),
+    );
+    const safetyHorizon = new Date(
+      Date.now() - feedSafetyHorizonSeconds * 1000,
+    );
+
+    const scope = await this.queryService.resolveScope(
+      node.createdById,
+      config.circleIds,
+    );
+    const feedItems = await this.queryService.getChanges(scope, cursor, limit);
+
+    const ttlSeconds = this.config.get<number>('storage.signedUrlExpiry', 3600);
+
+    const items = await Promise.all(
+      feedItems.map(async (item) => {
+        const tombstone = item.deletedAt !== null;
+        const storageObject = item.storageObject;
+
+        let downloadUrl: string | null = null;
+        let downloadUrlExpiresAt: string | null = null;
+        if (!tombstone && storageObject && storageObject.status === 'ready') {
+          try {
+            downloadUrl = await this.objectsService.getInternalDownloadUrl(
+              storageObject.id,
+              ttlSeconds,
+            );
+            if (downloadUrl) {
+              downloadUrlExpiresAt = new Date(
+                Date.now() + ttlSeconds * 1000,
+              ).toISOString();
+            }
+          } catch (err) {
+            // Per-item best effort: the item is still returned, URL-less.
+            this.logger.warn(
+              `Failed to presign download URL for object ${storageObject.id} ` +
+                `(media item ${item.id}): ${err instanceof Error ? err.message : String(err)}`,
+            );
+            downloadUrl = null;
+          }
+        }
+
+        return {
+          id: item.id,
+          circleId: item.circleId,
+          updatedAt: item.updatedAt.toISOString(),
+          createdAt: item.createdAt.toISOString(),
+          capturedAt: iso(item.capturedAt),
+          capturedAtOffset: item.capturedAtOffset,
+          type: item.type,
+          deletedAt: iso(item.deletedAt),
+          archivedAt: iso(item.archivedAt),
+          contentHash: item.contentHash,
+          originalFilename: item.originalFilename,
+          storage: storageObject
+            ? {
+                objectId: storageObject.id,
+                // BigInt → STRING at the DTO boundary.
+                size: storageObject.size.toString(),
+                mimeType: storageObject.mimeType,
+                status: storageObject.status,
+              }
+            : null,
+          downloadUrl,
+          downloadUrlExpiresAt,
+          sidecar: this.queryService.composeSidecar(item),
+        };
+      }),
+    );
+
+    const last = feedItems.length > 0 ? feedItems[feedItems.length - 1] : null;
+
+    return {
+      items,
+      // Even a PARTIAL page advances the cursor (the safety horizon means a
+      // short page is normal near "now"); null only on a zero-item page.
+      nextCursor: last
+        ? { updatedAt: last.updatedAt.toISOString(), id: last.id }
+        : null,
+      hasMore: feedItems.length === limit,
+      safetyHorizon: safetyHorizon.toISOString(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /nodes/:id/backup/ack
+  // ---------------------------------------------------------------------------
+
+  async ack(userId: string, nodeId: string, dto: BackupAckDto) {
+    await this.nodesService.assertOwnership(userId, nodeId);
+
+    const config = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+    });
+    if (!config) {
+      throw new BadRequestException('backup is not configured for this node');
+    }
+
+    const { runStaleMinutes } = await this.getBackupSettings();
+    // No pre-refresh — the ack transaction below sets lastAckAt itself.
+    const run = await this.requireActiveRun(nodeId, dto.runId, runStaleMinutes, {
+      refreshAck: false,
+    });
+
+    const cursorUpdatedAt = new Date(dto.cursor.updatedAt);
+    const cursorId = dto.cursor.id;
+
+    // Monotonic checkpoint: a cursor STRICTLY behind the stored checkpoint is
+    // rejected; an equal cursor is an allowed no-op advance.
+    if (config.checkpointUpdatedAt && config.checkpointId) {
+      const behind =
+        cursorUpdatedAt.getTime() < config.checkpointUpdatedAt.getTime() ||
+        (cursorUpdatedAt.getTime() === config.checkpointUpdatedAt.getTime() &&
+          cursorId < config.checkpointId);
+      if (behind) {
+        throw new ConflictException(
+          'ack cursor is behind the stored checkpoint — the checkpoint only moves forward',
+        );
+      }
+    }
+
+    const itemsProcessed = dto.stats.itemsDownloaded + dto.stats.itemsSkipped;
+    const bytesDownloaded = BigInt(dto.stats.bytesDownloaded);
+    const now = new Date();
+
+    await this.prisma.$transaction([
+      this.prisma.nodeBackupConfig.update({
+        where: { nodeId },
+        data: {
+          checkpointUpdatedAt: cursorUpdatedAt,
+          checkpointId: cursorId,
+          itemsAcked: { increment: itemsProcessed },
+          bytesAcked: { increment: bytesDownloaded },
+        },
+      }),
+      this.prisma.nodeBackupRun.update({
+        where: { id: run.id },
+        data: {
+          itemsDownloaded: { increment: dto.stats.itemsDownloaded },
+          itemsSkipped: { increment: dto.stats.itemsSkipped },
+          sidecarsWritten: { increment: dto.stats.sidecarsWritten },
+          bytesDownloaded: { increment: bytesDownloaded },
+          errorCount: { increment: dto.stats.errors },
+          lastAckAt: now,
+          cursorEndUpdatedAt: cursorUpdatedAt,
+          cursorEndId: cursorId,
+        },
+      }),
+    ]);
+
+    return {
+      ok: true as const,
+      checkpoint: { updatedAt: cursorUpdatedAt.toISOString(), id: cursorId },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /nodes/:id/backup/runs/:runId/finish
+  // ---------------------------------------------------------------------------
+
+  async finishRun(
+    userId: string,
+    nodeId: string,
+    runId: string,
+    dto: FinishBackupRunDto,
+  ) {
+    await this.nodesService.assertOwnership(userId, nodeId);
+
+    const run = await this.prisma.nodeBackupRun.findUnique({
+      where: { id: runId },
+    });
+    // A run belonging to another node is a 404, not a 403 — same
+    // enumeration-resistant policy as the notifications :id routes.
+    if (!run || run.nodeId !== nodeId) {
+      throw new NotFoundException(`NodeBackupRun ${runId} not found`);
+    }
+    if (run.status !== NodeBackupRunStatus.running) {
+      throw new BadRequestException(
+        `run is already terminal (status "${run.status}")`,
+      );
+    }
+
+    const now = new Date();
+    const finalStats = dto.finalStats;
+
+    await this.prisma.nodeBackupRun.update({
+      where: { id: run.id },
+      data: {
+        status: dto.status as NodeBackupRunStatus,
+        finishedAt: now,
+        ...(dto.error !== undefined ? { lastError: dto.error } : {}),
+        ...(finalStats
+          ? {
+              itemsDownloaded: { increment: finalStats.itemsDownloaded },
+              itemsSkipped: { increment: finalStats.itemsSkipped },
+              sidecarsWritten: { increment: finalStats.sidecarsWritten },
+              bytesDownloaded: { increment: BigInt(finalStats.bytesDownloaded) },
+              errorCount: { increment: finalStats.errors },
+            }
+          : {}),
+      },
+    });
+
+    if (dto.status === 'completed') {
+      // updateMany, not update: a config deleted mid-run must not 500 here.
+      await this.prisma.nodeBackupConfig.updateMany({
+        where: { nodeId },
+        data: {
+          lastCompletedRunAt: now,
+          ...(run.kind === NodeBackupRunKind.reconcile
+            ? { lastReconcileAt: now }
+            : {}),
+        },
+      });
+    }
+
+    return { ok: true as const };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /nodes/:id/backup/runs
+  // ---------------------------------------------------------------------------
+
+  async listRuns(userId: string, nodeId: string, limit?: number) {
+    await this.nodesService.assertOwnership(userId, nodeId);
+
+    const take = Math.max(1, Math.min(limit ?? 20, 100));
+    const runs = await this.prisma.nodeBackupRun.findMany({
+      where: { nodeId },
+      orderBy: { startedAt: 'desc' },
+      take,
+    });
+
+    return {
+      runs: runs.map((run) => ({
+        id: run.id,
+        kind: run.kind,
+        status: run.status,
+        trigger: run.trigger,
+        startedAt: run.startedAt.toISOString(),
+        finishedAt: iso(run.finishedAt),
+        lastAckAt: iso(run.lastAckAt),
+        itemsDownloaded: run.itemsDownloaded,
+        itemsSkipped: run.itemsSkipped,
+        sidecarsWritten: run.sidecarsWritten,
+        // BigInt → STRING at the DTO boundary.
+        bytesDownloaded: run.bytesDownloaded.toString(),
+        errorCount: run.errorCount,
+        lastError: run.lastError,
+        cliVersion: run.cliVersion,
+      })),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /nodes/:id/backup/manifest
+  // ---------------------------------------------------------------------------
+
+  async getManifest(userId: string, nodeId: string, q: BackupManifestQueryDto) {
+    const node = await this.nodesService.assertOwnership(userId, nodeId);
+
+    const config = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+    });
+    if (!config) {
+      throw new BadRequestException('backup is not configured for this node');
+    }
+
+    const { runStaleMinutes } = await this.getBackupSettings();
+    // A manifest page fetch also counts as run liveness.
+    await this.requireActiveRun(nodeId, q.runId, runStaleMinutes, {
+      refreshAck: true,
+    });
+
+    const limit = Math.max(1, Math.min(q.limit ?? MANIFEST_MAX_LIMIT, MANIFEST_MAX_LIMIT));
+    const scope = await this.queryService.resolveScope(
+      node.createdById,
+      config.circleIds,
+    );
+    const rows = await this.queryService.getManifest(
+      scope,
+      q.afterId ?? null,
+      limit,
+    );
+
+    const last = rows.length > 0 ? rows[rows.length - 1] : null;
+
+    return {
+      items: rows.map((row) => ({
+        id: row.id,
+        contentHash: row.contentHash,
+        updatedAt: row.updatedAt.toISOString(),
+        deletedAt: iso(row.deletedAt),
+        archivedAt: iso(row.archivedAt),
+      })),
+      nextAfterId: last?.id ?? null,
+      hasMore: rows.length === limit,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /nodes/:id/backup/dimensions
+  // ---------------------------------------------------------------------------
+
+  async getDimensions(userId: string, nodeId: string) {
+    const node = await this.nodesService.assertOwnership(userId, nodeId);
+
+    // No run (and no config) required — an unconfigured node reads the
+    // owner's full circle scope (empty circleIds = ALL owner circles).
+    const config = await this.prisma.nodeBackupConfig.findUnique({
+      where: { nodeId },
+      select: { circleIds: true },
+    });
+    const scope = await this.queryService.resolveScope(
+      node.createdById,
+      config?.circleIds ?? [],
+    );
+    const dimensions = await this.queryService.getDimensions(scope);
+
+    return { ...dimensions, generatedAt: new Date().toISOString() };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Staleness sweep (called by NodeBackupStaleTask)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mark every `running` run whose lastAckAt has fallen outside the
+   * runStaleMinutes window as `stale` (with finishedAt). Returns the number of
+   * runs released.
+   */
+  async markStaleRuns(): Promise<number> {
+    const { runStaleMinutes } = await this.getBackupSettings();
+    const result: Prisma.BatchPayload =
+      await this.prisma.nodeBackupRun.updateMany({
+        where: {
+          status: NodeBackupRunStatus.running,
+          lastAckAt: { lt: this.staleCutoff(runStaleMinutes) },
+        },
+        data: { status: NodeBackupRunStatus.stale, finishedAt: new Date() },
+      });
+    return result.count;
+  }
+}

--- a/apps/api/src/nodes/nodes.module.ts
+++ b/apps/api/src/nodes/nodes.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { NodesService } from './nodes.service';
 import { NodeBackupQueryService } from './node-backup-query.service';
+import { NodeBackupService } from './node-backup.service';
+import { NodeBackupController } from './node-backup.controller';
+import { NodeBackupStaleTask } from './node-backup-stale.task';
 import { NodesController } from './nodes.controller';
 import { NodesAdminController } from './nodes-admin.controller';
 import { NodeCredentialsController } from './node-credentials.controller';
@@ -43,8 +46,19 @@ import { TaggingModule } from '../tagging/tagging.module';
     // context, mirroring the PatModule wiring.
     NodeCredentialModule,
   ],
-  controllers: [NodesController, NodesAdminController, NodeCredentialsController],
-  providers: [NodesService, NodeOfflinePruneTask, NodeBackupQueryService],
+  controllers: [
+    NodesController,
+    NodeBackupController,
+    NodesAdminController,
+    NodeCredentialsController,
+  ],
+  providers: [
+    NodesService,
+    NodeOfflinePruneTask,
+    NodeBackupQueryService,
+    NodeBackupService,
+    NodeBackupStaleTask,
+  ],
   exports: [NodeBackupQueryService],
 })
 export class NodesModule {}

--- a/apps/api/src/nodes/nodes.service.ts
+++ b/apps/api/src/nodes/nodes.service.ts
@@ -18,7 +18,13 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import { EnrichmentJob, JobStatus, NodeStatus, WorkerNode } from '@prisma/client';
+import {
+  EnrichmentJob,
+  JobStatus,
+  NodeBackupRunStatus,
+  NodeStatus,
+  WorkerNode,
+} from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { EnrichmentClaimService } from '../enrichment/enrichment-claim.service';
 import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
@@ -89,9 +95,11 @@ export class NodesService {
   /**
    * Load a node and assert the caller owns it. Throws NotFoundException if the
    * node does not exist, ForbiddenException if it belongs to another user.
-   * Every owner-scoped data-plane call funnels through this.
+   * Every owner-scoped data-plane call funnels through this — including the
+   * node backup control plane (NodeBackupService/NodeBackupController), which
+   * is why it is public.
    */
-  private async assertOwnership(userId: string, nodeId: string): Promise<WorkerNode> {
+  async assertOwnership(userId: string, nodeId: string): Promise<WorkerNode> {
     const node = await this.prisma.workerNode.findUnique({ where: { id: nodeId } });
     if (!node) {
       throw new NotFoundException(`WorkerNode ${nodeId} not found`);
@@ -825,10 +833,60 @@ export class NodesService {
   // listNodes
   // -------------------------------------------------------------------------
 
+  /**
+   * Fold a node's joined backup rows into the `backup` summary surfaced on the
+   * fleet endpoints (owner list/detail + admin list). `null` when the node has
+   * no NodeBackupConfig at all. Deliberately NO lag/pending computation here —
+   * that lives only on GET /nodes/:id/backup/config (issue #312).
+   */
+  private summarizeBackup(
+    backupConfig:
+      | {
+          enabled: boolean;
+          lastCompletedRunAt: Date | null;
+          checkpointUpdatedAt: Date | null;
+        }
+      | null
+      | undefined,
+    runningRuns: Array<{ id: string }> | null | undefined,
+  ): {
+    enabled: boolean;
+    lastCompletedRunAt: Date | null;
+    checkpointUpdatedAt: Date | null;
+    activeRun: boolean;
+  } | null {
+    if (!backupConfig) {
+      return null;
+    }
+    return {
+      enabled: backupConfig.enabled,
+      lastCompletedRunAt: backupConfig.lastCompletedRunAt,
+      checkpointUpdatedAt: backupConfig.checkpointUpdatedAt,
+      activeRun: (runningRuns?.length ?? 0) > 0,
+    };
+  }
+
   async listNodes(userId?: string) {
     const nodes = await this.prisma.workerNode.findMany({
       where: userId ? { createdById: userId } : undefined,
       orderBy: { registeredAt: 'desc' },
+      // Single joined query for the fleet backup summary — the narrow select
+      // keeps NodeBackupConfig's BigInt counters (itemsAcked/bytesAcked) out
+      // of the response path entirely (BigInt is not JSON-serializable).
+      include: {
+        backupConfig: {
+          select: {
+            enabled: true,
+            lastCompletedRunAt: true,
+            checkpointUpdatedAt: true,
+          },
+        },
+        backupRuns: {
+          where: { status: NodeBackupRunStatus.running },
+          select: { id: true },
+          take: 1,
+        },
+      },
     });
 
     if (nodes.length === 0) {
@@ -839,11 +897,17 @@ export class NodesService {
     const countsByNode = await this.getJobCountsForNodes(nodeIds);
 
     return nodes.map((node) => {
+      const { backupConfig, backupRuns, ...rest } = node;
       const health = this.deriveNodeHealth(node);
       const jobCounts =
         countsByNode.get(node.id) ?? { running: 0, succeeded: 0, failed: 0 };
 
-      return { ...node, health, jobCounts };
+      return {
+        ...rest,
+        health,
+        jobCounts,
+        backup: this.summarizeBackup(backupConfig, backupRuns),
+      };
     });
   }
 
@@ -860,11 +924,30 @@ export class NodesService {
     const node = await this.assertOwnership(userId, nodeId);
 
     const health = this.deriveNodeHealth(node);
-    const countsByNode = await this.getJobCountsForNodes([nodeId]);
+    const [countsByNode, backupConfig, runningRun] = await Promise.all([
+      this.getJobCountsForNodes([nodeId]),
+      this.prisma.nodeBackupConfig.findUnique({
+        where: { nodeId },
+        select: {
+          enabled: true,
+          lastCompletedRunAt: true,
+          checkpointUpdatedAt: true,
+        },
+      }),
+      this.prisma.nodeBackupRun.findFirst({
+        where: { nodeId, status: NodeBackupRunStatus.running },
+        select: { id: true },
+      }),
+    ]);
     const jobCounts =
       countsByNode.get(nodeId) ?? { running: 0, succeeded: 0, failed: 0 };
 
-    return { ...node, health, jobCounts };
+    return {
+      ...node,
+      health,
+      jobCounts,
+      backup: this.summarizeBackup(backupConfig, runningRun ? [runningRun] : []),
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/workflows/util/cron.util.ts
+++ b/apps/api/src/workflows/util/cron.util.ts
@@ -60,9 +60,15 @@ export function isValidCron(expr: string): boolean {
  * Next fire time of `expr` strictly after `from`, as a plain `Date`. Pure — no
  * scheduling side effects. `expr` must already be a valid cron (guard with
  * `isValidCron` first at save time).
+ *
+ * Optional `timezone` (IANA name, e.g. "America/Costa_Rica") evaluates the
+ * cron's fields in that zone instead of the server's local zone — used by the
+ * node backup schedule (NodeBackupConfig.timezone). Callers must validate the
+ * zone name beforehand (e.g. against Intl.supportedValuesOf('timeZone'));
+ * CronTime throws on an unknown zone.
  */
-export function nextCronDate(expr: string, from: Date): Date {
-  return new CronTime(expr).getNextDateFrom(from).toJSDate();
+export function nextCronDate(expr: string, from: Date, timezone?: string): Date {
+  return new CronTime(expr, timezone).getNextDateFrom(from).toJSDate();
 }
 
 /**

--- a/apps/api/src/workflows/util/cron.util.ts
+++ b/apps/api/src/workflows/util/cron.util.ts
@@ -68,7 +68,11 @@ export function isValidCron(expr: string): boolean {
  * CronTime throws on an unknown zone.
  */
 export function nextCronDate(expr: string, from: Date, timezone?: string): Date {
-  return new CronTime(expr, timezone).getNextDateFrom(from).toJSDate();
+  // NOTE: the zone must be passed to getNextDateFrom, not (only) the CronTime
+  // constructor — the constructor's zone is used by CronJob scheduling, but
+  // getNextDateFrom derives its zone from the start argument unless one is
+  // given explicitly.
+  return new CronTime(expr, timezone).getNextDateFrom(from, timezone).toJSDate();
 }
 
 /**


### PR DESCRIPTION
## Summary

Child 2 of Epic #308. HTTP control plane for backup nodes under `/api/nodes/:id/backup/*` (placed there so `nod_` node credentials pass the JWT guard's `isNodeRoute` allowlist; session JWTs and PATs with `jobs:write` work on the same routes, so web UI and CLI edit the same config). Adds run lifecycle with a single-active-run rule and staleness sweep, the keyset change feed with per-page presigned download URLs, a monotonic server-held checkpoint ack, the reconcile manifest, dimension exports, and fleet backup surfacing on node listings.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #312
Relates to #308

## Changes Made

- `node-backup.controller.ts` — 9 routes (`GET/PUT config`, `POST runs`, `GET changes`, `POST ack`, `POST runs/:runId/finish`, `GET runs`, `GET manifest`, `GET dimensions`), class-level `@Auth({ permissions: [JOBS_WRITE] })`, `assertOwnership` on every handler (404 unknown / 403 foreign), full Swagger annotations.
- `node-backup.service.ts` — config upsert with cron (5-field) + IANA timezone + owner-membership circleIds validation and `nextRunAt` recompute; run start with 409-on-active / stale-release / scheduled `nextRunAt` roll-forward; change feed (limit clamped to `backup.maxPageSize`, per-page presigned GETs via `ObjectsService.getInternalDownloadUrl`, tombstone/not-ready/presign-failure → `downloadUrl: null`); monotonic ack in one transaction; finish transitions; runs list; manifest (cap 1000); dimensions.
- `node-backup-stale.task.ts` — every-10-min sweep marking runs `stale` past `backup.runStaleMinutes` without an ack.
- Fleet surfacing: `NodesService.listNodes`/`getNode` now include `backup: null | { enabled, lastCompletedRunAt, checkpointUpdatedAt, activeRun }` via one joined query; `GET /api/admin/nodes` inherits it.
- Bug fix in `workflows/util/cron.util.ts`: the `cron` package ignores the constructor timezone in `getNextDateFrom` — the zone must be passed to `getNextDateFrom(from, timezone)`; timezone-aware schedules previously computed in the system zone. No-timezone callers unchanged.
- All BigInt byte fields serialized as strings.

## Testing

- [x] Unit tests pass (`npm test`) — 275 suites / 6626 tests, 0 failures (pre-existing DB-gated skips unchanged)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

64 new tests across `node-backup.service.spec.ts`, `node-backup.controller.spec.ts`, `node-backup-stale.task.spec.ts`: run lifecycle (409/stale-release/schedule roll), cursor rules, monotonic ack + `$transaction` accumulation, manifest keyset + cap, JSON.stringify round-trips of every response shape.

## Additional Notes

`itemsAcked += itemsDownloaded + itemsSkipped` (sidecar-only rewrites tracked on the run's `sidecarsWritten` counter, not double-counted into acked items). `cliVersion` optional on run start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ)_