### PR TITLE
feat(core): CLI BackupEngine — incremental runs, resumable verified downloads, throttling, crash-safe page commits

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
 import {
   withRetry,
   DEFAULT_RETRY_CONFIG,
@@ -88,6 +91,166 @@ export interface UpdateNodeBackupConfigBody {
   circleIds?: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Node backup run/feed types (issue #316 — the backup engine data plane).
+// Shapes mirror NodeBackupService (apps/api/src/nodes/node-backup.service.ts);
+// every byte-count field crosses the wire as a STRING (BigInt-safe).
+// ---------------------------------------------------------------------------
+
+/** Change-feed keyset cursor: (updatedAt, id), both halves always together. */
+export interface BackupFeedCursor {
+  updatedAt: string;
+  id: string;
+}
+
+/** Response envelope of POST /api/nodes/:id/backup/runs (201). */
+export interface StartBackupRunResult {
+  run: {
+    id: string;
+    kind: string;
+    startedAt: string;
+    /** Snapshot of the server checkpoint at run start; halves are null when
+     * the node has never acked a page. */
+    cursorStart: { updatedAt: string | null; id: string | null };
+  };
+}
+
+export interface StartBackupRunBody {
+  kind: 'incremental' | 'reconcile';
+  trigger: 'manual' | 'scheduled';
+  cliVersion?: string;
+}
+
+/** One change-feed item from GET /api/nodes/:id/backup/changes. */
+export interface BackupChangeItem {
+  id: string;
+  circleId: string;
+  updatedAt: string;
+  createdAt: string;
+  capturedAt: string | null;
+  /** Capture-time UTC offset in MINUTES, or null. */
+  capturedAtOffset: number | null;
+  type: string;
+  deletedAt: string | null;
+  archivedAt: string | null;
+  contentHash: string | null;
+  originalFilename: string;
+  storage: {
+    objectId: string;
+    /** Byte size as a decimal STRING. */
+    size: string;
+    mimeType: string | null;
+    status: string;
+  } | null;
+  /** Presigned GET for the original bytes; null for tombstones, not-ready
+   * objects, or presign failures. Minted per page — expires. */
+  downloadUrl: string | null;
+  downloadUrlExpiresAt: string | null;
+  /** The full server-composed schemaVersion-1 sidecar document. */
+  sidecar: Record<string, unknown>;
+}
+
+/** Response of GET /api/nodes/:id/backup/changes. */
+export interface BackupChangesPage {
+  items: BackupChangeItem[];
+  /** Advances even on a partial page; null only on a zero-item page. */
+  nextCursor: BackupFeedCursor | null;
+  hasMore: boolean;
+  safetyHorizon: string;
+}
+
+/** Wire shape of the shared run stats (ack + finish finalStats). */
+export interface BackupRunStatsBody {
+  itemsDownloaded: number;
+  itemsSkipped: number;
+  sidecarsWritten: number;
+  /** Bytes as a decimal STRING (BigInt-safe). */
+  bytesDownloaded: string;
+  errors: number;
+}
+
+export interface BackupAckBody {
+  runId: string;
+  cursor: BackupFeedCursor;
+  stats: BackupRunStatsBody;
+}
+
+export interface BackupAckResult {
+  ok: true;
+  checkpoint: { updatedAt: string; id: string };
+}
+
+export interface FinishBackupRunBody {
+  status: 'completed' | 'failed' | 'aborted';
+  error?: string;
+  finalStats?: BackupRunStatsBody;
+}
+
+/** One reconcile-manifest row from GET /api/nodes/:id/backup/manifest. */
+export interface BackupManifestItem {
+  id: string;
+  contentHash: string | null;
+  updatedAt: string;
+  deletedAt: string | null;
+  archivedAt: string | null;
+}
+
+export interface BackupManifestPage {
+  items: BackupManifestItem[];
+  nextAfterId: string | null;
+  hasMore: boolean;
+}
+
+/** Response of GET /api/nodes/:id/backup/dimensions. */
+export interface BackupDimensions {
+  albums: Array<{
+    id: string;
+    name: string;
+    description: string | null;
+    itemCount: number;
+    itemIds: string[];
+  }>;
+  people: Array<{
+    id: string;
+    name: string | null;
+    favorite: boolean;
+    faceCount: number;
+  }>;
+  tags: Array<{ name: string; itemCount: number }>;
+  generatedAt: string;
+}
+
+/** Per-attempt configuration for {@link ApiClient.getRaw}. */
+export interface GetRawAttemptConfig {
+  /** Bytes already on disk — requests `Range: bytes=N-` when > 0. */
+  rangeStart?: number;
+  /**
+   * Called once response headers arrive, before any chunk. `resumed` is true
+   * only when rangeStart > 0 AND the server honored the Range request (206);
+   * a 200 means the file is being restarted from zero (the destination is
+   * truncated).
+   */
+  onResponse?: (info: { status: number; resumed: boolean }) => void | Promise<void>;
+  /** Awaited per chunk BEFORE it is written — bandwidth capping + hashing. */
+  onChunk?: (chunk: Buffer) => void | Promise<void>;
+}
+
+export interface GetRawOptions {
+  signal?: AbortSignal;
+  /**
+   * Invoked at the start of EVERY attempt (including internal retries) so
+   * resume state (existing .part size, partial hash) is recomputed per
+   * attempt rather than captured stale from the first try.
+   */
+  attempt?: () => GetRawAttemptConfig | Promise<GetRawAttemptConfig>;
+}
+
+export interface GetRawResult {
+  status: number;
+  /** Bytes written by this call (excludes pre-existing resumed bytes). */
+  bytesWritten: number;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -96,6 +259,10 @@ export class ApiError extends Error {
     public readonly retryAfterMs: number | null = null,
     /** Forces retryability even when `status` is not normally retryable. */
     public readonly retryable: boolean = false,
+    /** Parsed JSON error body, when the response body was JSON (else undefined).
+     * Lets callers read structured error fields beyond `message` — e.g. the
+     * `activeRunId` on a backup-run 409. */
+    public readonly body: unknown = undefined,
   ) {
     super(`API error ${status}: ${serverMessage}`);
     this.name = 'ApiError';
@@ -353,7 +520,7 @@ export class ApiClient {
       }
 
       const msg = extractMessage(bodyText) || res.statusText || 'Request failed';
-      throw new ApiError(res.status, msg, retryAfterMs, bodyThrottle);
+      throw new ApiError(res.status, msg, retryAfterMs, bodyThrottle, parseJsonSafe(bodyText));
     }
 
     this.gate.recordSuccess();
@@ -498,6 +665,146 @@ export class ApiClient {
       `/api/nodes/${encodeURIComponent(nodeId)}/backup/config`,
       body,
     );
+  }
+
+  // -------------------------------------------------------------------------
+  // Node backup data plane (issue #316) — runs / changes / ack / finish /
+  // manifest / dimensions. All envelopes are TOP-LEVEL (no { data } wrapper),
+  // matching NodeBackupController; parseOk passes them through unchanged.
+  // -------------------------------------------------------------------------
+
+  /** Start a backup run. 409 (ApiError with body.activeRunId) when one is active. */
+  startNodeBackupRun(nodeId: string, body: StartBackupRunBody): Promise<StartBackupRunResult> {
+    return this.post<StartBackupRunResult>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/runs`,
+      body,
+    );
+  }
+
+  /** Fetch one keyset page of the change feed. `cursor` null = from the start. */
+  getNodeBackupChanges(
+    nodeId: string,
+    q: { runId: string; cursor?: BackupFeedCursor | null; limit?: number },
+  ): Promise<BackupChangesPage> {
+    const params = new URLSearchParams({ runId: q.runId });
+    if (q.cursor) {
+      params.set('updatedAfter', q.cursor.updatedAt);
+      params.set('afterId', q.cursor.id);
+    }
+    if (q.limit !== undefined) params.set('limit', String(q.limit));
+    return this.get<BackupChangesPage>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/changes?${params.toString()}`,
+    );
+  }
+
+  /** Acknowledge a committed page, advancing the server checkpoint. */
+  ackNodeBackup(nodeId: string, body: BackupAckBody): Promise<BackupAckResult> {
+    return this.post<BackupAckResult>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/ack`,
+      body,
+    );
+  }
+
+  /** Finish a backup run with a terminal status (+ optional finalStats). */
+  finishNodeBackupRun(
+    nodeId: string,
+    runId: string,
+    body: FinishBackupRunBody,
+  ): Promise<{ ok: true }> {
+    return this.post<{ ok: true }>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/runs/${encodeURIComponent(runId)}/finish`,
+      body,
+    );
+  }
+
+  /** Fetch one id-keyset page of the reconcile manifest. */
+  getNodeBackupManifest(
+    nodeId: string,
+    q: { runId: string; afterId?: string; limit?: number },
+  ): Promise<BackupManifestPage> {
+    const params = new URLSearchParams({ runId: q.runId });
+    if (q.afterId !== undefined) params.set('afterId', q.afterId);
+    if (q.limit !== undefined) params.set('limit', String(q.limit));
+    return this.get<BackupManifestPage>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/manifest?${params.toString()}`,
+    );
+  }
+
+  /** Fetch the album/person/tag dimension catalogs for the backup scope. */
+  getNodeBackupDimensions(nodeId: string): Promise<BackupDimensions> {
+    return this.get<BackupDimensions>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/dimensions`,
+    );
+  }
+
+  /**
+   * Stream a presigned GET to a local file (issue #316) — the download
+   * counterpart to {@link putRaw}. NO auth header (the URL is presigned; S3
+   * rejects extra auth). Routed through the shared retry + cooldown-gate
+   * machinery, so 429/503/Retry-After brake every worker sharing this client.
+   *
+   * Resume support: `opts.attempt` is re-invoked on every retry attempt so the
+   * caller can recompute the Range start (and re-hash any partial bytes)
+   * against the CURRENT on-disk state. When the attempt's rangeStart > 0 and
+   * the server honors it (206), the destination is opened in append mode;
+   * a 200 truncates and restarts from zero.
+   */
+  async getRaw(url: string, destPath: string, opts: GetRawOptions = {}): Promise<GetRawResult> {
+    return this.run(async () => {
+      if (opts.signal?.aborted) {
+        // Plain Error (not NetworkError) so an abort is never retried.
+        throw new Error('Download aborted');
+      }
+      const cfg = (await opts.attempt?.()) ?? {};
+      const rangeStart = cfg.rangeStart ?? 0;
+
+      const headers: Record<string, string> = {};
+      if (rangeStart > 0) headers['Range'] = `bytes=${rangeStart}-`;
+
+      const res = await this.fetchWithGate(url, {
+        method: 'GET',
+        headers,
+        signal: opts.signal,
+      });
+
+      const resumed = rangeStart > 0 && res.status === 206;
+      await cfg.onResponse?.({ status: res.status, resumed });
+
+      if (!res.body) {
+        throw new NetworkError('Response has no body');
+      }
+
+      const out = fs.createWriteStream(destPath, { flags: resumed ? 'a' : 'w' });
+      let bytesWritten = 0;
+      const nodeStream = Readable.fromWeb(
+        res.body as unknown as Parameters<typeof Readable.fromWeb>[0],
+      );
+
+      try {
+        for await (const chunk of nodeStream) {
+          const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
+          await cfg.onChunk?.(buf);
+          if (!out.write(buf)) {
+            await once(out, 'drain');
+          }
+          bytesWritten += buf.length;
+        }
+        out.end();
+        await once(out, 'close');
+      } catch (err) {
+        out.destroy();
+        if (opts.signal?.aborted) {
+          throw new Error('Download aborted');
+        }
+        // Mid-stream transport failures are retryable; the next attempt
+        // recomputes its Range from the bytes that DID land on disk.
+        throw err instanceof Error && (err as Partial<NetworkError>).isNetworkError
+          ? err
+          : new NetworkError(err instanceof Error ? err.message : String(err));
+      }
+
+      return { status: res.status, bytesWritten };
+    });
   }
 
   /** Fetch live job queue insights. windowDays defaults to 7 on the server. */
@@ -653,6 +960,16 @@ export class ApiClient {
     }
 
     return parsed as T;
+  }
+}
+
+/** Parse a body as JSON, returning undefined for empty/non-JSON text. */
+function parseJsonSafe(bodyText: string): unknown {
+  if (!bodyText) return undefined;
+  try {
+    return JSON.parse(bodyText) as unknown;
+  } catch {
+    return undefined;
   }
 }
 

--- a/apps/cli/src/backup/backup-engine.ts
+++ b/apps/cli/src/backup/backup-engine.ts
@@ -1,0 +1,749 @@
+/**
+ * backup/backup-engine.ts — Incremental backup run loop (issue #316, epic #308).
+ *
+ * UI-free and event-emitting (see events.ts) — the engine NEVER prints; all
+ * terminal output belongs to render/headless-backup.ts and the command layer.
+ *
+ * One runBackup() per invocation:
+ *   1. POST /runs (kind 'incremental'); 409 → RunAlreadyActiveError.
+ *   2. Page loop over GET /changes, cursor = the LOCAL mirrored checkpoint
+ *      (initially the server's cursorStart). Items are classified against the
+ *      catalog (tombstone / download / sidecar-only / archived-flip move /
+ *      null-URL failure) and processed through a bounded worker pool.
+ *   3. Crash-safe page commit ORDER: all page files renamed into final place →
+ *      ONE catalog transaction (item+dims upserts, statuses, checkpoint
+ *      mirror) → POST /ack with the page's nextCursor + stats. A crash before
+ *      ack re-fetches and re-processes the same page next run — idempotent
+ *      (temp+rename downloads, upserts). The engine NEVER acks ahead of the
+ *      local commit.
+ *   4. Inter-page pacing, then the next page until hasMore is false.
+ *   5. GET /dimensions → catalog/{albums,people,tags,manifest}.json →
+ *      POST /runs/:id/finish. Unrecoverable errors finish the run 'failed'
+ *      (best-effort) and surface through the returned outcome, never a throw.
+ *
+ * Presigned URLs are minted per page and expire: a PresignExpiredError makes
+ * the engine re-fetch the SAME page (cursor unmoved ⇒ idempotent) to re-mint
+ * URLs, capped at MAX_PAGE_REMINTS per page before the remaining items fail.
+ */
+
+import * as fs from 'node:fs';
+import type BetterSqlite3 from 'better-sqlite3';
+import type {
+  ApiClient,
+  BackupChangeItem,
+  BackupChangesPage,
+  BackupFeedCursor,
+  BackupRunStatsBody,
+} from '../api.js';
+import { ApiError } from '../api.js';
+import { runPool } from '../sync/worker-pool.js';
+import { CatalogRepo, type CatalogItem, type CatalogItemStatus, type SidecarDims } from './catalog-repo.js';
+import {
+  BACKUP_EV,
+  BackupTypedEmitter,
+  addStats,
+  emptyStats,
+  type BackupCursor,
+  type BackupEngineStats,
+  type BackupItemOutcome,
+  type BackupRunStatus,
+} from './events.js';
+import {
+  TMP_DIR,
+  CATALOG_DIR,
+  absPathFor,
+  moveItemFiles,
+  planRelPath,
+  planTreeTransition,
+  sidecarRelPathFor,
+  writeSidecar,
+} from './layout.js';
+import { CATALOG_SCHEMA_VERSION } from './catalog-db.js';
+import { TokenBucket } from './rate-limiter.js';
+import { downloadVerified, HashMismatchError, PresignExpiredError } from './download.js';
+
+/** Catalog checkpoint key holding the JSON-encoded mirrored server cursor. */
+export const CHECKPOINT_CURSOR_KEY = 'cursor';
+
+/** Maximum same-page re-fetches to re-mint expired presigned URLs. */
+export const MAX_PAGE_REMINTS = 3;
+
+/** Thrown by runBackup when the server reports an already-active run (409). */
+export class RunAlreadyActiveError extends Error {
+  constructor(public readonly activeRunId: string | null) {
+    super(
+      'A backup run is already active for this node' +
+        (activeRunId ? ` (run ${activeRunId})` : '') +
+        '. Wait for it to finish or go stale before starting another.',
+    );
+    this.name = 'RunAlreadyActiveError';
+  }
+}
+
+export interface BackupEngineOpts {
+  /** Absolute backup root. */
+  root: string;
+  nodeId: string;
+  nodeName?: string;
+  serverUrl: string;
+  trigger: 'manual' | 'scheduled';
+  cliVersion: string;
+  /** Concurrent download workers. */
+  concurrency: number;
+  /** Aggregate bandwidth cap in Mbps; 0 = unlimited. */
+  maxMbps: number;
+  /** Change-feed page size. */
+  pageSize: number;
+  /** Inter-page pacing delay in ms. */
+  pacingMs: number;
+}
+
+/** The slice of ApiClient the engine uses — mockable in tests. */
+export type BackupApi = Pick<
+  ApiClient,
+  | 'startNodeBackupRun'
+  | 'getNodeBackupChanges'
+  | 'ackNodeBackup'
+  | 'finishNodeBackupRun'
+  | 'getNodeBackupDimensions'
+  | 'getRaw'
+>;
+
+export interface BackupEngineDeps {
+  api: BackupApi;
+  /** Open catalog DB for the backup root (caller owns open/close). */
+  db: BetterSqlite3.Database;
+  /** Injectable shared token bucket (defaults to one built from maxMbps). */
+  bucket?: TokenBucket;
+  /** Injectable inter-page sleep (tests pass a no-op). */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => Date;
+}
+
+export interface BackupRunOutcome {
+  runId: string;
+  status: BackupRunStatus;
+  stats: BackupEngineStats;
+  error?: string;
+}
+
+/** Internal per-item processing record. */
+interface ItemResult {
+  id: string;
+  /** 'remint' is transient — resolved by a page re-fetch or the re-mint cap. */
+  outcome: BackupItemOutcome | 'remint';
+  bytes: number;
+  error?: string;
+  sidecarWritten: boolean;
+  /** Catalog mutation, executed inside the single page-commit transaction. */
+  op?: () => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+function toWireStats(stats: BackupEngineStats): BackupRunStatsBody {
+  return {
+    itemsDownloaded: stats.itemsDownloaded,
+    itemsSkipped: stats.itemsSkipped,
+    sidecarsWritten: stats.sidecarsWritten,
+    bytesDownloaded: String(stats.bytesDownloaded),
+    errors: stats.errors,
+  };
+}
+
+function statsFromResults(results: ItemResult[]): BackupEngineStats {
+  const stats = emptyStats();
+  for (const r of results) {
+    switch (r.outcome) {
+      case 'downloaded':
+        stats.itemsDownloaded++;
+        stats.bytesDownloaded += r.bytes;
+        break;
+      case 'sidecar-only':
+      case 'tombstone':
+      case 'moved':
+        stats.itemsSkipped++;
+        break;
+      case 'failed':
+        stats.errors++;
+        break;
+      case 'remint':
+        // Transient — never reaches stats (resolved before the page commits).
+        break;
+    }
+    if (r.sidecarWritten) stats.sidecarsWritten++;
+  }
+  return stats;
+}
+
+export class BackupEngine extends BackupTypedEmitter {
+  private readonly opts: BackupEngineOpts;
+  private readonly api: BackupApi;
+  private readonly repo: CatalogRepo;
+  private readonly bucket: TokenBucket;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => Date;
+
+  private cancelled = false;
+
+  constructor(opts: BackupEngineOpts, deps: BackupEngineDeps) {
+    super();
+    this.opts = opts;
+    this.api = deps.api;
+    this.repo = new CatalogRepo(deps.db);
+    this.bucket = deps.bucket ?? new TokenBucket(opts.maxMbps);
+    this.sleep = deps.sleep ?? defaultSleep;
+    this.now = deps.now ?? ((): Date => new Date());
+  }
+
+  /** Cooperative cancel: in-flight items finish, no further items start, the
+   * current page is ABANDONED uncommitted (re-processed next run), and the
+   * server run is finished as 'aborted'. */
+  cancel(): void {
+    this.cancelled = true;
+  }
+
+  /** Surface a cooldown-gate trip as a typed event (wired by the caller). */
+  emitThrottle(delayMs: number): void {
+    this.emit(BACKUP_EV.THROTTLE, { delayMs });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Run loop
+  // ---------------------------------------------------------------------------
+
+  async runBackup(): Promise<BackupRunOutcome> {
+    const { nodeId, trigger, cliVersion } = this.opts;
+
+    // 1. Start the server-side run (409 → typed RunAlreadyActiveError).
+    let runId: string;
+    let cursorStart: { updatedAt: string | null; id: string | null };
+    try {
+      const res = await this.api.startNodeBackupRun(nodeId, {
+        kind: 'incremental',
+        trigger,
+        cliVersion,
+      });
+      runId = res.run.id;
+      cursorStart = res.run.cursorStart;
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        const body = err.body as { activeRunId?: string } | undefined;
+        throw new RunAlreadyActiveError(body?.activeRunId ?? null);
+      }
+      throw err;
+    }
+
+    const startedAt = this.now().toISOString();
+    this.emit(BACKUP_EV.RUN_STARTED, { runId, kind: 'incremental', trigger });
+
+    // 2. Cursor: local mirrored checkpoint wins (it may be AHEAD of the server
+    //    after a committed-but-unacked page); fall back to the server snapshot.
+    let cursor = this.readLocalCursor();
+    if (!cursor && cursorStart.updatedAt !== null && cursorStart.id !== null) {
+      cursor = { updatedAt: cursorStart.updatedAt, id: cursorStart.id };
+    }
+
+    const totals = emptyStats();
+
+    try {
+      let pageIndex = 0;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if (this.cancelled) {
+          return await this.finishRun(runId, 'aborted', totals, startedAt);
+        }
+
+        const page = await this.api.getNodeBackupChanges(nodeId, {
+          runId,
+          cursor,
+          limit: this.opts.pageSize,
+        });
+        this.emit(BACKUP_EV.PAGE_FETCHED, {
+          pageIndex,
+          items: page.items.length,
+          hasMore: page.hasMore,
+        });
+
+        if (page.items.length > 0) {
+          const results = await this.processPage(runId, cursor, page);
+          if (this.cancelled) {
+            // A partially-processed page is NEVER committed or acked — the
+            // whole page is re-fetched and re-processed next run (idempotent).
+            return await this.finishRun(runId, 'aborted', totals, startedAt);
+          }
+
+          const nextCursor = page.nextCursor as BackupFeedCursor;
+          const pageStats = statsFromResults(results);
+
+          // 3. Crash-safe commit order: files are already in final place →
+          //    ONE catalog transaction → ack. Never ack ahead of the commit.
+          this.repo.transaction(() => {
+            for (const r of results) r.op?.();
+            this.repo.setCheckpoint(CHECKPOINT_CURSOR_KEY, JSON.stringify(nextCursor));
+          });
+
+          await this.api.ackNodeBackup(nodeId, {
+            runId,
+            cursor: nextCursor,
+            stats: toWireStats(pageStats),
+          });
+
+          addStats(totals, pageStats);
+          this.emit(BACKUP_EV.PAGE_COMMITTED, { cursor: nextCursor, stats: pageStats });
+          cursor = nextCursor;
+        }
+
+        if (!page.hasMore) break;
+        await this.sleep(this.opts.pacingMs);
+        pageIndex++;
+      }
+
+      // 4. Dimension catalogs + manifest (completed runs only).
+      await this.writeDimensionCatalogs(cursor, runId, startedAt, totals);
+
+      return await this.finishRun(runId, 'completed', totals, startedAt);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.listenerCount(BACKUP_EV.ERROR) > 0) {
+        this.emit(BACKUP_EV.ERROR, { message });
+      }
+      return await this.finishRun(runId, 'failed', totals, startedAt, message);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Page processing (worker pool + expired-URL re-mint)
+  // ---------------------------------------------------------------------------
+
+  private async processPage(
+    runId: string,
+    cursor: BackupCursor | null,
+    page: BackupChangesPage,
+  ): Promise<ItemResult[]> {
+    // In-page rel_path claims: two NEW items with the same filename+bucket
+    // would otherwise both plan the plain path (neither is in the catalog
+    // yet), collide on the rel_path UNIQUE constraint, and roll the whole
+    // page commit back.
+    const pageClaims = new Map<string, string>();
+
+    let results = await this.processItems(page.items, pageClaims);
+
+    // Expired presigned URLs → re-fetch the SAME page (cursor unmoved ⇒
+    // idempotent; URLs are minted per page), cap MAX_PAGE_REMINTS.
+    let remints = 0;
+    while (results.some((r) => r.outcome === 'remint') && !this.cancelled) {
+      if (remints >= MAX_PAGE_REMINTS) {
+        results = results.map((r) => {
+          if (r.outcome !== 'remint') return r;
+          const item = page.items.find((i) => i.id === r.id);
+          const failed = this.failedResult(
+            item,
+            r.id,
+            'presigned download URL expired (page re-mint cap reached)',
+            pageClaims,
+          );
+          this.emit(BACKUP_EV.ITEM_DONE, {
+            id: r.id,
+            outcome: 'failed',
+            bytes: 0,
+            error: failed.error,
+          });
+          return failed;
+        });
+        break;
+      }
+      remints++;
+
+      const fresh = await this.api.getNodeBackupChanges(this.opts.nodeId, {
+        runId,
+        cursor,
+        limit: this.opts.pageSize,
+      });
+      const freshById = new Map(fresh.items.map((i) => [i.id, i]));
+
+      const redoIds = results.filter((r) => r.outcome === 'remint').map((r) => r.id);
+      const redoItems = redoIds
+        .map((id) => freshById.get(id))
+        .filter((i): i is BackupChangeItem => i !== undefined);
+
+      const redoResults = await this.processItems(redoItems, pageClaims);
+      const redoById = new Map(redoResults.map((r) => [r.id, r]));
+
+      results = results.flatMap((r) => {
+        if (r.outcome !== 'remint') return [r];
+        const redone = redoById.get(r.id);
+        if (redone) return [redone];
+        // The item vanished from the re-fetched page: its updatedAt moved past
+        // this cursor window, so the feed will serve it again at its new
+        // position — drop it from this page entirely (no stats, no op).
+        return [];
+      });
+    }
+
+    return results;
+  }
+
+  private async processItems(
+    items: BackupChangeItem[],
+    pageClaims: Map<string, string>,
+  ): Promise<ItemResult[]> {
+    const results: ItemResult[] = [];
+
+    await runPool(
+      items,
+      Math.max(1, this.opts.concurrency),
+      async (item) => {
+        this.emit(BACKUP_EV.ITEM_STARTED, { id: item.id });
+        let result: ItemResult;
+        try {
+          result = await this.processItem(item, pageClaims);
+        } catch (err) {
+          if (err instanceof PresignExpiredError) {
+            results.push({ id: item.id, outcome: 'remint', bytes: 0, sidecarWritten: false });
+            return;
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          result = this.failedResult(item, item.id, message, pageClaims);
+        }
+        results.push(result);
+        this.emit(BACKUP_EV.ITEM_DONE, {
+          id: result.id,
+          outcome: result.outcome as BackupItemOutcome,
+          bytes: result.bytes,
+          ...(result.error !== undefined ? { error: result.error } : {}),
+        });
+      },
+      () => this.cancelled,
+    );
+
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-item classification + processing
+  // ---------------------------------------------------------------------------
+
+  private async processItem(
+    item: BackupChangeItem,
+    pageClaims: Map<string, string>,
+  ): Promise<ItemResult> {
+    const { root } = this.opts;
+    const existing = this.repo.getById(item.id);
+    const archived = item.archivedAt !== null;
+
+    // --- Tombstone: mark trashed, rewrite sidecar, file stays in place. -----
+    if (item.deletedAt !== null) {
+      const relPath = existing?.relPath ?? this.planPath(item, pageClaims);
+      const sidecarRel = writeSidecar(root, relPath, item.sidecar);
+      const op = (): void =>
+        this.repo.upsertItemWithDims(
+          this.catalogFields(item, relPath, sidecarRel, 'trashed', {
+            downloadedAt: existing?.downloadedAt ?? null,
+            verifiedAt: existing?.verifiedAt ?? null,
+          }),
+          item.sidecar as SidecarDims,
+        );
+      return { id: item.id, outcome: 'tombstone', bytes: 0, sidecarWritten: true, op };
+    }
+
+    // --- Does this item need its bytes (re-)downloaded? ---------------------
+    const expectedSize = item.storage ? Number(item.storage.size) : null;
+    let needsDownload = false;
+    if (!existing) {
+      needsDownload = true;
+    } else if (existing.contentHash !== item.contentHash) {
+      needsDownload = true;
+    } else if (existing.status === 'failed') {
+      needsDownload = true;
+    } else {
+      const abs = absPathFor(root, existing.relPath);
+      let st: fs.Stats | null = null;
+      try {
+        st = fs.statSync(abs);
+      } catch {
+        st = null;
+      }
+      if (!st || !st.isFile()) {
+        needsDownload = true;
+      } else if (expectedSize !== null && st.size !== expectedSize) {
+        needsDownload = true;
+      }
+    }
+
+    if (needsDownload) {
+      // Null URL on an item whose bytes we need: record the failure and move
+      // on — never block the run (the next run retries via status='failed').
+      if (!item.downloadUrl) {
+        return this.failedResult(item, item.id, 'no download URL available for this item', pageClaims);
+      }
+
+      // Download lands directly in the item's CURRENT tree (an archived-flip
+      // and a content change in one update collapse into one download).
+      const relPath = existing
+        ? planTreeTransition(existing.relPath, item.archivedAt).toRelPath
+        : this.planPath(item, pageClaims);
+      const destAbs = absPathFor(root, relPath);
+      const partAbs = absPathFor(root, `${TMP_DIR}/${item.id}.part`);
+
+      let bytes: number;
+      try {
+        const res = await downloadVerified(
+          { url: item.downloadUrl, destAbsPath: destAbs, partAbsPath: partAbs, contentHash: item.contentHash },
+          { api: this.api, bucket: this.bucket },
+        );
+        bytes = res.bytes;
+      } catch (err) {
+        if (err instanceof PresignExpiredError) throw err;
+        const message =
+          err instanceof HashMismatchError
+            ? err.message
+            : `download failed: ${err instanceof Error ? err.message : String(err)}`;
+        return this.failedResult(item, item.id, message, pageClaims);
+      }
+
+      // Tree flip + fresh download: remove the stale copy from the old tree.
+      if (existing && existing.relPath !== relPath) {
+        this.rmSafe(absPathFor(root, existing.relPath));
+        this.rmSafe(absPathFor(root, sidecarRelPathFor(existing.relPath)));
+      }
+
+      const nowIso = this.now().toISOString();
+      const sidecarRel = writeSidecar(root, relPath, item.sidecar);
+      const op = (): void =>
+        this.repo.upsertItemWithDims(
+          this.catalogFields(item, relPath, sidecarRel, 'present', {
+            downloadedAt: nowIso,
+            verifiedAt: item.contentHash !== null ? nowIso : null,
+          }),
+          item.sidecar as SidecarDims,
+        );
+      return { id: item.id, outcome: 'downloaded', bytes, sidecarWritten: true, op };
+    }
+
+    // --- Metadata-only: sidecar rewrite, possibly a tree move. --------------
+    const row = existing as CatalogItem;
+    // Quarantined files are owned by the (later) verify/reconcile child — a
+    // metadata refresh must not resurrect them to 'present'.
+    const keepStatus: CatalogItemStatus = row.status === 'quarantined' ? 'quarantined' : 'present';
+    const transition = planTreeTransition(row.relPath, item.archivedAt);
+
+    if (transition.changed) {
+      const fromAbs = absPathFor(root, transition.fromRelPath);
+      if (fs.existsSync(fromAbs)) {
+        moveItemFiles(root, transition.fromRelPath, transition.toRelPath);
+      }
+      const sidecarRel = writeSidecar(root, transition.toRelPath, item.sidecar);
+      const op = (): void =>
+        this.repo.upsertItemWithDims(
+          this.catalogFields(item, transition.toRelPath, sidecarRel, keepStatus, {
+            downloadedAt: row.downloadedAt,
+            verifiedAt: row.verifiedAt,
+          }),
+          item.sidecar as SidecarDims,
+        );
+      return { id: item.id, outcome: 'moved', bytes: 0, sidecarWritten: true, op };
+    }
+
+    const sidecarRel = writeSidecar(root, row.relPath, item.sidecar);
+    const op = (): void =>
+      this.repo.upsertItemWithDims(
+        this.catalogFields(item, row.relPath, sidecarRel, keepStatus, {
+          downloadedAt: row.downloadedAt,
+          verifiedAt: row.verifiedAt,
+        }),
+        item.sidecar as SidecarDims,
+      );
+    return { id: item.id, outcome: 'sidecar-only', bytes: 0, sidecarWritten: true, op };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Plan (and claim, within this page) a rel_path for an uncataloged item. */
+  private planPath(item: BackupChangeItem, pageClaims: Map<string, string>): string {
+    const relPath = planRelPath(
+      {
+        mediaItemId: item.id,
+        originalFilename: item.originalFilename,
+        capturedAt: item.capturedAt,
+        capturedAtOffset: item.capturedAtOffset,
+        archivedAt: item.archivedAt,
+      },
+      (rel) => pageClaims.get(rel) ?? this.repo.ownerOfPath(rel),
+    );
+    pageClaims.set(relPath, item.id);
+    return relPath;
+  }
+
+  /** Common catalog row fields derived from a feed item. */
+  private catalogFields(
+    item: BackupChangeItem,
+    relPath: string,
+    sidecarRelPath: string,
+    status: CatalogItemStatus,
+    extra: { downloadedAt: string | null; verifiedAt: string | null; lastError?: string | null },
+  ): Omit<CatalogItem, 'updatedAt'> {
+    return {
+      mediaItemId: item.id,
+      circleId: item.circleId,
+      relPath,
+      sidecarRelPath,
+      capturedAt: item.capturedAt,
+      contentHash: item.contentHash,
+      size: item.storage ? Number(item.storage.size) : null,
+      mimeType: item.storage?.mimeType ?? null,
+      serverUpdatedAt: item.updatedAt,
+      status,
+      archived: item.archivedAt !== null,
+      downloadedAt: extra.downloadedAt,
+      verifiedAt: extra.verifiedAt,
+      lastError: extra.lastError ?? null,
+    };
+  }
+
+  /** Build a 'failed' result whose op records the failure in the catalog. */
+  private failedResult(
+    item: BackupChangeItem | undefined,
+    id: string,
+    error: string,
+    pageClaims: Map<string, string>,
+  ): ItemResult {
+    let op: (() => void) | undefined;
+    if (item) {
+      const existing = this.repo.getById(id);
+      if (existing) {
+        op = (): void => this.repo.setStatus(id, 'failed', error);
+      } else {
+        const relPath = this.planPath(item, pageClaims);
+        op = (): void =>
+          this.repo.upsertItemWithDims(
+            this.catalogFields(item, relPath, sidecarRelPathFor(relPath), 'failed', {
+              downloadedAt: null,
+              verifiedAt: null,
+              lastError: error,
+            }),
+            item.sidecar as SidecarDims,
+          );
+      }
+    }
+    return { id, outcome: 'failed', bytes: 0, error, sidecarWritten: false, op };
+  }
+
+  private rmSafe(absPath: string): void {
+    try {
+      fs.rmSync(absPath, { force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  private readLocalCursor(): BackupCursor | null {
+    const raw = this.repo.getCheckpoint(CHECKPOINT_CURSOR_KEY);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as Partial<BackupCursor>;
+      if (typeof parsed.updatedAt === 'string' && typeof parsed.id === 'string') {
+        return { updatedAt: parsed.updatedAt, id: parsed.id };
+      }
+    } catch {
+      /* fall through */
+    }
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension catalogs + manifest (completed runs only)
+  // ---------------------------------------------------------------------------
+
+  private async writeDimensionCatalogs(
+    checkpoint: BackupCursor | null,
+    runId: string,
+    startedAt: string,
+    totals: BackupEngineStats,
+  ): Promise<void> {
+    const dims = await this.api.getNodeBackupDimensions(this.opts.nodeId);
+    this.writeCatalogJson('albums.json', dims.albums);
+    this.writeCatalogJson('people.json', dims.people);
+    this.writeCatalogJson('tags.json', dims.tags);
+
+    this.writeCatalogJson('manifest.json', {
+      serverUrl: this.opts.serverUrl,
+      nodeId: this.opts.nodeId,
+      nodeName: this.opts.nodeName ?? null,
+      catalogSchemaVersion: CATALOG_SCHEMA_VERSION,
+      checkpoint,
+      counts: this.repo.stats(),
+      lastRun: {
+        id: runId,
+        kind: 'incremental',
+        status: 'completed',
+        startedAt,
+        finishedAt: this.now().toISOString(),
+        stats: totals,
+      },
+      generatedAt: this.now().toISOString(),
+    });
+  }
+
+  private writeCatalogJson(fileName: string, payload: unknown): void {
+    const abs = absPathFor(this.opts.root, `${CATALOG_DIR}/${fileName}`);
+    fs.mkdirSync(absPathFor(this.opts.root, CATALOG_DIR), { recursive: true });
+    const tmp = `${abs}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+    fs.renameSync(tmp, abs);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Run finalization
+  // ---------------------------------------------------------------------------
+
+  private async finishRun(
+    runId: string,
+    status: BackupRunStatus,
+    totals: BackupEngineStats,
+    startedAt: string,
+    error?: string,
+  ): Promise<BackupRunOutcome> {
+    const finishedAt = this.now().toISOString();
+
+    // Local run record first — it must survive even when the finish POST fails.
+    try {
+      this.repo.recordRun({
+        id: runId,
+        kind: 'incremental',
+        status,
+        startedAt,
+        finishedAt,
+        itemsDownloaded: totals.itemsDownloaded,
+        itemsSkipped: totals.itemsSkipped,
+        bytesDownloaded: totals.bytesDownloaded,
+        errorCount: totals.errors,
+        lastError: error ?? null,
+      });
+    } catch {
+      /* best-effort */
+    }
+
+    try {
+      await this.api.finishNodeBackupRun(this.opts.nodeId, runId, {
+        status,
+        ...(error !== undefined ? { error: error.slice(0, 4000) } : {}),
+        finalStats: toWireStats(totals),
+      });
+    } catch {
+      // Best-effort: an unreachable server must not mask the real outcome;
+      // the server's stale-run release reclaims the run later.
+    }
+
+    this.emit(BACKUP_EV.RUN_FINISHED, {
+      status,
+      stats: totals,
+      ...(error !== undefined ? { error } : {}),
+    });
+
+    return { runId, status, stats: totals, ...(error !== undefined ? { error } : {}) };
+  }
+}

--- a/apps/cli/src/backup/catalog-repo.ts
+++ b/apps/cli/src/backup/catalog-repo.ts
@@ -113,6 +113,16 @@ function rowToItem(row: ItemRow): CatalogItem {
 export class CatalogRepo {
   constructor(private readonly db: BetterSqlite3.Database) {}
 
+  /**
+   * Run `fn` inside ONE catalog transaction. Repo methods that open their own
+   * transactions (e.g. upsertItemWithDims) nest as savepoints, so the engine's
+   * page commit — every item/dim/status write plus the checkpoint mirror —
+   * lands atomically (issue #316's crash-safe page-commit contract).
+   */
+  transaction(fn: () => void): void {
+    this.db.transaction(fn)();
+  }
+
   // -------------------------------------------------------------------------
   // meta
   // -------------------------------------------------------------------------

--- a/apps/cli/src/backup/download.ts
+++ b/apps/cli/src/backup/download.ts
@@ -1,0 +1,190 @@
+/**
+ * backup/download.ts — Verified, resumable, bandwidth-capped downloads for the
+ * backup engine (issue #316, epic #308).
+ *
+ * Template: the VERIFIED model downloads in src/node/models.ts (temp file →
+ * verify → atomic rename), not the bare src/node/download.ts — plus three
+ * additions that matter for multi-GB media over flaky links:
+ *
+ *  - sha256 computed WHILE streaming (never a second read pass over the file);
+ *  - Range resume: an existing `<id>.part` of size N continues with
+ *    `Range: bytes=N-` after re-hashing the partial bytes; a server that
+ *    answers 200 instead of 206 restarts from zero (truncate + fresh hash);
+ *  - a shared TokenBucket caps the AGGREGATE download rate across the pool.
+ *
+ * Hash mismatch policy: delete the .part and re-download ONCE from zero; a
+ * second mismatch throws HashMismatchError (the engine marks the item failed).
+ *
+ * Expired presigned URLs (403 / AccessDenied) throw PresignExpiredError so the
+ * engine can re-fetch the SAME feed page (URLs are minted per page; the cursor
+ * has not moved, so the re-fetch is idempotent).
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ApiClient, GetRawAttemptConfig } from '../api.js';
+import { ApiError } from '../api.js';
+import { renameWithFallback } from './layout.js';
+import type { TokenBucket } from './rate-limiter.js';
+
+/** Downloaded bytes hash-verified against contentHash and failed twice. */
+export class HashMismatchError extends Error {
+  constructor(
+    public readonly expected: string,
+    public readonly actual: string,
+  ) {
+    super(`Downloaded bytes failed sha256 verification (expected ${expected}, got ${actual})`);
+    this.name = 'HashMismatchError';
+  }
+}
+
+/** The presigned download URL has expired (403 / AccessDenied). */
+export class PresignExpiredError extends Error {
+  constructor(message = 'Presigned download URL expired') {
+    super(message);
+    this.name = 'PresignExpiredError';
+  }
+}
+
+/** Body/message substrings that mean the presigned URL is no longer valid. */
+const PRESIGN_EXPIRED_RE = /AccessDenied|Request has expired|X-Amz-Expires|expired/i;
+
+export interface VerifiedDownloadInput {
+  url: string;
+  /** Absolute FINAL destination path (renamed into place on success). */
+  destAbsPath: string;
+  /** Absolute in-flight `.part` path (same filesystem as the final rename target
+   * is not required — rename falls back to copy+unlink across devices). */
+  partAbsPath: string;
+  /** Expected sha256 hex, or null to skip verification. */
+  contentHash: string | null;
+  signal?: AbortSignal;
+}
+
+export interface VerifiedDownloadDeps {
+  api: Pick<ApiClient, 'getRaw'>;
+  bucket: TokenBucket;
+}
+
+export interface VerifiedDownloadResult {
+  /** Final on-disk byte size. */
+  bytes: number;
+  /** sha256 hex of the full file. */
+  sha256: string;
+}
+
+/** Stream an existing file's bytes into a hash (partial-resume re-hash). */
+function hashFileInto(hash: crypto.Hash, filePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk as Buffer));
+    stream.on('end', () => resolve());
+    stream.on('error', reject);
+  });
+}
+
+function statSizeSafe(filePath: string): number {
+  try {
+    const st = fs.statSync(filePath);
+    return st.isFile() ? st.size : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function rmSafe(filePath: string): void {
+  try {
+    fs.rmSync(filePath, { force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Download `url` into `partAbsPath` (resuming when a partial exists and
+ * `allowResume` is set), returning the sha256 of the complete on-disk bytes.
+ * Each retry ATTEMPT recomputes its Range start and re-hashes whatever bytes
+ * are on disk at that moment, so mid-stream retries never double-hash.
+ */
+async function downloadPass(
+  input: VerifiedDownloadInput,
+  deps: VerifiedDownloadDeps,
+  allowResume: boolean,
+): Promise<string> {
+  // Holder mutated by each attempt so the digest survives getRaw resolving.
+  let hash: crypto.Hash = crypto.createHash('sha256');
+
+  if (!allowResume) rmSafe(input.partAbsPath);
+
+  const attempt = async (): Promise<GetRawAttemptConfig> => {
+    hash = crypto.createHash('sha256');
+    let rangeStart = 0;
+    if (allowResume) {
+      const partial = statSizeSafe(input.partAbsPath);
+      if (partial > 0) {
+        await hashFileInto(hash, input.partAbsPath);
+        rangeStart = partial;
+      }
+    }
+    return {
+      rangeStart,
+      onResponse: ({ resumed }) => {
+        // 200 fallback while a Range was requested: getRaw truncates the file
+        // (flags 'w'); the hash must restart from zero too.
+        if (!resumed) hash = crypto.createHash('sha256');
+      },
+      onChunk: async (chunk) => {
+        await deps.bucket.take(chunk.length);
+        hash.update(chunk);
+      },
+    };
+  };
+
+  try {
+    await deps.api.getRaw(input.url, input.partAbsPath, {
+      signal: input.signal,
+      attempt,
+    });
+  } catch (err) {
+    if (
+      err instanceof ApiError &&
+      (err.status === 403 || PRESIGN_EXPIRED_RE.test(err.serverMessage))
+    ) {
+      throw new PresignExpiredError(
+        `Presigned download URL rejected (HTTP ${err.status}): ${err.serverMessage}`,
+      );
+    }
+    throw err;
+  }
+
+  return hash.digest('hex');
+}
+
+/**
+ * Download with resume + streaming sha256 + hash verification, then atomically
+ * rename the `.part` into its final place. On a hash mismatch the partial is
+ * deleted and ONE full re-download is attempted before HashMismatchError.
+ */
+export async function downloadVerified(
+  input: VerifiedDownloadInput,
+  deps: VerifiedDownloadDeps,
+): Promise<VerifiedDownloadResult> {
+  fs.mkdirSync(path.dirname(input.partAbsPath), { recursive: true });
+
+  let digest = await downloadPass(input, deps, true);
+
+  if (input.contentHash !== null && digest.toLowerCase() !== input.contentHash.toLowerCase()) {
+    // One full retry from zero — a stale/corrupt partial is the common cause.
+    digest = await downloadPass(input, deps, false);
+    if (digest.toLowerCase() !== input.contentHash.toLowerCase()) {
+      rmSafe(input.partAbsPath);
+      throw new HashMismatchError(input.contentHash, digest);
+    }
+  }
+
+  fs.mkdirSync(path.dirname(input.destAbsPath), { recursive: true });
+  renameWithFallback(input.partAbsPath, input.destAbsPath);
+
+  return { bytes: statSizeSafe(input.destAbsPath), sha256: digest };
+}

--- a/apps/cli/src/backup/events.ts
+++ b/apps/cli/src/backup/events.ts
@@ -1,0 +1,147 @@
+/**
+ * backup/events.ts — Typed event contract for the BackupEngine (issue #316,
+ * epic #308).
+ *
+ * Mirrors node/node-events.ts: the engine emits typed events and renderers
+ * (headless printer, `--json` NDJSON, a future TUI) consume them. The engine
+ * never touches the terminal.
+ */
+
+import { EventEmitter } from 'node:events';
+
+export const BACKUP_EV = {
+  RUN_STARTED: 'run-started',
+  PAGE_FETCHED: 'page-fetched',
+  ITEM_STARTED: 'item-started',
+  ITEM_DONE: 'item-done',
+  PAGE_COMMITTED: 'page-committed',
+  THROTTLE: 'throttle',
+  RUN_FINISHED: 'run-finished',
+  ERROR: 'error',
+} as const;
+
+export type BackupEventName = (typeof BACKUP_EV)[keyof typeof BACKUP_EV];
+
+/** Change-feed keyset cursor, as mirrored in the local catalog checkpoint. */
+export interface BackupCursor {
+  updatedAt: string;
+  id: string;
+}
+
+/** Per-item processing outcome. */
+export type BackupItemOutcome =
+  | 'downloaded'
+  | 'sidecar-only'
+  | 'tombstone'
+  | 'moved'
+  | 'failed';
+
+/** Engine-side run statistics (numbers; converted to wire shape at ack time). */
+export interface BackupEngineStats {
+  itemsDownloaded: number;
+  itemsSkipped: number;
+  sidecarsWritten: number;
+  bytesDownloaded: number;
+  errors: number;
+}
+
+export function emptyStats(): BackupEngineStats {
+  return {
+    itemsDownloaded: 0,
+    itemsSkipped: 0,
+    sidecarsWritten: 0,
+    bytesDownloaded: 0,
+    errors: 0,
+  };
+}
+
+export function addStats(into: BackupEngineStats, from: BackupEngineStats): void {
+  into.itemsDownloaded += from.itemsDownloaded;
+  into.itemsSkipped += from.itemsSkipped;
+  into.sidecarsWritten += from.sidecarsWritten;
+  into.bytesDownloaded += from.bytesDownloaded;
+  into.errors += from.errors;
+}
+
+export type BackupRunStatus = 'completed' | 'failed' | 'aborted';
+
+export interface RunStartedPayload {
+  runId: string;
+  kind: string;
+  trigger: string;
+}
+
+export interface PageFetchedPayload {
+  pageIndex: number;
+  /** Items on this page. */
+  items: number;
+  hasMore: boolean;
+}
+
+export interface ItemStartedPayload {
+  id: string;
+}
+
+export interface ItemDonePayload {
+  id: string;
+  outcome: BackupItemOutcome;
+  /** Bytes downloaded for this item (0 unless outcome is 'downloaded'). */
+  bytes: number;
+  /** Present when outcome is 'failed'. */
+  error?: string;
+}
+
+export interface PageCommittedPayload {
+  cursor: BackupCursor;
+  /** Stats for THIS page only. */
+  stats: BackupEngineStats;
+}
+
+/** Emitted when the shared cooldown gate engages (429/503/Retry-After). */
+export interface ThrottlePayload {
+  delayMs: number;
+}
+
+export interface RunFinishedPayload {
+  status: BackupRunStatus;
+  /** Cumulative run totals. */
+  stats: BackupEngineStats;
+  error?: string;
+}
+
+export interface BackupErrorPayload {
+  message: string;
+}
+
+export interface BackupEngineEvents {
+  [BACKUP_EV.RUN_STARTED]: (payload: RunStartedPayload) => void;
+  [BACKUP_EV.PAGE_FETCHED]: (payload: PageFetchedPayload) => void;
+  [BACKUP_EV.ITEM_STARTED]: (payload: ItemStartedPayload) => void;
+  [BACKUP_EV.ITEM_DONE]: (payload: ItemDonePayload) => void;
+  [BACKUP_EV.PAGE_COMMITTED]: (payload: PageCommittedPayload) => void;
+  [BACKUP_EV.THROTTLE]: (payload: ThrottlePayload) => void;
+  [BACKUP_EV.RUN_FINISHED]: (payload: RunFinishedPayload) => void;
+  [BACKUP_EV.ERROR]: (payload: BackupErrorPayload) => void;
+}
+
+/** A thin typed wrapper over Node's EventEmitter for BackupEngine events. */
+export class BackupTypedEmitter extends EventEmitter {
+  on<K extends BackupEventName>(event: K, listener: BackupEngineEvents[K]): this {
+    return super.on(event, listener as (...args: unknown[]) => void);
+  }
+
+  off<K extends BackupEventName>(event: K, listener: BackupEngineEvents[K]): this {
+    return super.off(event, listener as (...args: unknown[]) => void);
+  }
+
+  once<K extends BackupEventName>(event: K, listener: BackupEngineEvents[K]): this {
+    return super.once(event, listener as (...args: unknown[]) => void);
+  }
+
+  emit<K extends BackupEventName>(
+    event: K,
+    payload: Parameters<BackupEngineEvents[K]>[0],
+  ): boolean {
+    return super.emit(event, payload);
+  }
+}

--- a/apps/cli/src/backup/execute-run.ts
+++ b/apps/cli/src/backup/execute-run.ts
@@ -1,0 +1,97 @@
+/**
+ * backup/execute-run.ts — The `backup run` invocation seam (issue #316,
+ * epic #308).
+ *
+ * `memoriahub backup run` calls executeRun() with resolved knobs; the engine
+ * runs EMBEDDED in the command process for now. Child 5 (#317) reroutes this
+ * same seam over the daemon IPC channel without touching the command layer —
+ * which is why the function takes plain data in and returns a typed outcome,
+ * with the renderer attached via a callback rather than imported here.
+ */
+
+import { ApiClient } from '../api.js';
+import { CooldownGate, type CooldownGateConfig, DEFAULT_COOLDOWN_CONFIG } from '../http/cooldown-gate.js';
+import type { RetryConfig } from '../http/retry.js';
+import { openCatalogDb } from './catalog-db.js';
+import { BackupEngine, type BackupRunOutcome } from './backup-engine.js';
+import { TokenBucket } from './rate-limiter.js';
+
+export interface ExecuteRunOptions {
+  serverUrl: string;
+  pat: string;
+  /** Absolute backup root (from settings backup.root). */
+  root: string;
+  /** Worker-node id the root is bound to (from settings backup.nodeId). */
+  nodeId: string;
+  nodeName?: string;
+  trigger: 'manual' | 'scheduled';
+  cliVersion: string;
+  concurrency: number;
+  maxMbps: number;
+  pageSize: number;
+  pacingMs: number;
+  retry?: RetryConfig;
+  cooldown?: CooldownGateConfig;
+  /** Attach a renderer BEFORE the run starts (headless printer, NDJSON, TUI). */
+  attachRenderer?: (engine: BackupEngine) => void;
+}
+
+/**
+ * Open the root's catalog, build the shared HTTP client (retry + cooldown gate
+ * wired to the engine's throttle event) and token bucket, run one incremental
+ * backup, and close the catalog. Throws RunAlreadyActiveError / CatalogOpenError
+ * for the command layer to render; all other failures surface as a 'failed'
+ * outcome (the engine finishes the server run best-effort).
+ */
+export async function executeRun(opts: ExecuteRunOptions): Promise<BackupRunOutcome> {
+  // The gate is created before the engine so the ApiClient can share it; the
+  // trip hook reaches the engine through this holder.
+  let engineRef: BackupEngine | null = null;
+  const gate = new CooldownGate(opts.cooldown ?? DEFAULT_COOLDOWN_CONFIG, {
+    onTrip: (delayMs) => engineRef?.emitThrottle(delayMs),
+  });
+
+  const api = new ApiClient({
+    serverUrl: opts.serverUrl,
+    pat: opts.pat,
+    ...(opts.retry ? { retry: opts.retry } : {}),
+    cooldownGate: gate,
+  });
+
+  const db = openCatalogDb(opts.root);
+  try {
+    const engine = new BackupEngine(
+      {
+        root: opts.root,
+        nodeId: opts.nodeId,
+        ...(opts.nodeName !== undefined ? { nodeName: opts.nodeName } : {}),
+        serverUrl: opts.serverUrl,
+        trigger: opts.trigger,
+        cliVersion: opts.cliVersion,
+        concurrency: opts.concurrency,
+        maxMbps: opts.maxMbps,
+        pageSize: opts.pageSize,
+        pacingMs: opts.pacingMs,
+      },
+      { api, db, bucket: new TokenBucket(opts.maxMbps) },
+    );
+    engineRef = engine;
+    opts.attachRenderer?.(engine);
+    return await engine.runBackup();
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Exit-code policy for `backup run`:
+ *   - a failed run is always non-zero;
+ *   - `--strict` additionally fails the process when ANY item errored,
+ *     even on an otherwise-completed run;
+ *   - an aborted (user-cancelled) run exits zero unless strict + errors.
+ */
+export function resolveBackupExitCode(outcome: BackupRunOutcome, strict: boolean): number {
+  if (outcome.status === 'failed') return 1;
+  if (strict && outcome.stats.errors > 0) return 1;
+  return 0;
+}

--- a/apps/cli/src/backup/layout.ts
+++ b/apps/cli/src/backup/layout.ts
@@ -301,7 +301,7 @@ export function planTreeTransition(currentRelPath: string, archivedAt: string | 
 }
 
 /** Rename with a cross-device (EXDEV) fallback to copy + unlink. */
-function renameWithFallback(from: string, to: string): void {
+export function renameWithFallback(from: string, to: string): void {
   try {
     fs.renameSync(from, to);
   } catch (err) {

--- a/apps/cli/src/backup/rate-limiter.ts
+++ b/apps/cli/src/backup/rate-limiter.ts
@@ -1,0 +1,77 @@
+/**
+ * backup/rate-limiter.ts — Shared token-bucket bandwidth cap (issue #316,
+ * epic #308).
+ *
+ * One bucket is shared across every download worker in the pool: each worker
+ * calls `await bucket.take(chunk.length)` per streamed chunk, so the AGGREGATE
+ * download rate — not the per-worker rate — is bounded by `maxMbps` (megabits
+ * per second, decimal: 1 Mbps = 1e6 bits/s = 125 000 bytes/s).
+ *
+ * `maxMbps <= 0` disables the cap entirely (take() is a synchronous no-op).
+ *
+ * Deficit accounting: a take() larger than the current balance still proceeds
+ * immediately after sleeping the deficit off, which keeps the implementation a
+ * single await with no queue while remaining fair enough under the pool's
+ * small (64 KiB-ish) chunk sizes. The bucket starts EMPTY (no initial burst)
+ * so timing is deterministic. `now`/`sleep` are injectable for fake-clock
+ * tests.
+ */
+
+export interface TokenBucketHooks {
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export class TokenBucket {
+  /** Refill rate in bytes per millisecond; 0 = unlimited. */
+  private readonly ratePerMs: number;
+  /** Maximum accumulated balance (one second's worth) — bounds idle bursts. */
+  private readonly capacity: number;
+  /** Current balance in bytes (can go negative while a deficit is slept off). */
+  private available = 0;
+  private lastRefillAt: number;
+
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(maxMbps: number, hooks: TokenBucketHooks = {}) {
+    this.ratePerMs = maxMbps > 0 ? (maxMbps * 1e6) / 8 / 1000 : 0;
+    this.capacity = this.ratePerMs * 1000;
+    this.now = hooks.now ?? Date.now;
+    this.sleep = hooks.sleep ?? defaultSleep;
+    this.lastRefillAt = this.now();
+  }
+
+  /** True when this bucket enforces no cap (maxMbps <= 0). */
+  get unlimited(): boolean {
+    return this.ratePerMs <= 0;
+  }
+
+  private refill(): void {
+    const t = this.now();
+    const elapsed = t - this.lastRefillAt;
+    if (elapsed > 0) {
+      this.available = Math.min(this.capacity, this.available + elapsed * this.ratePerMs);
+      this.lastRefillAt = t;
+    }
+  }
+
+  /**
+   * Consume `bytes` from the bucket, sleeping until the balance allows it.
+   * A no-op when the bucket is unlimited.
+   */
+  async take(bytes: number): Promise<void> {
+    if (this.unlimited || bytes <= 0) return;
+
+    this.refill();
+    this.available -= bytes;
+    if (this.available < 0) {
+      const waitMs = Math.ceil(-this.available / this.ratePerMs);
+      await this.sleep(waitMs);
+      this.refill();
+    }
+  }
+}

--- a/apps/cli/src/commands/backup.ts
+++ b/apps/cli/src/commands/backup.ts
@@ -9,8 +9,12 @@
  *       enable backup server-side, create the root skeleton + SQLite catalog,
  *       and persist the binding locally. Engine: src/backup/init-backup.ts.
  *
- *   memoriahub backup run
- *       Stub — the sync engine lands in the next release.
+ *   memoriahub backup run [--concurrency N] [--max-mbps X] [--page-size N]
+ *                         [--json] [--strict]
+ *       Run one incremental backup sync (issue #316). The invocation goes
+ *       through the executeRun() seam (src/backup/execute-run.ts) so a later
+ *       child can reroute it over the daemon IPC channel. Rendering:
+ *       src/render/headless-backup.ts (human progress or --json NDJSON).
  *
  * All terminal output lives here; the engines never print.
  */
@@ -32,7 +36,11 @@ import {
 } from '../node/enroll.js';
 import { runDeviceLogin } from '../device-login.js';
 import { runBackupInit, BackupRootConflictError } from '../backup/init-backup.js';
+import { RunAlreadyActiveError } from '../backup/backup-engine.js';
+import { CatalogOpenError } from '../backup/catalog-db.js';
+import { executeRun, resolveBackupExitCode } from '../backup/execute-run.js';
 import { CATALOG_DB_REL_PATH } from '../backup/layout.js';
+import { renderBackupHeadless } from '../render/headless-backup.js';
 import { ui, isTTY } from '../ui.js';
 
 const require = createRequire(import.meta.url);
@@ -203,19 +211,101 @@ function initCmd(): Command {
       );
       ui.dim(`  Catalog     : ${result.root}/${CATALOG_DB_REL_PATH} (plain SQLite — query it directly)`);
       ui.blank();
-      ui.info('Run `memoriahub backup run` once the sync engine ships in the next release.');
+      ui.info('Run `memoriahub backup run` to start the first backup sync.');
     });
+}
+
+/** Parse a numeric flag, exiting with a clear message on garbage input. */
+function parseNumberFlag(value: string | undefined, flag: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    ui.error(`Invalid value for ${flag}: ${value} (expected a non-negative number)`);
+    process.exit(1);
+  }
+  return n;
+}
+
+interface RunCmdOpts {
+  concurrency?: string;
+  maxMbps?: string;
+  pageSize?: string;
+  json?: boolean;
+  strict?: boolean;
+  reconcile?: boolean;
 }
 
 function runCmd(): Command {
   return new Command('run')
-    .description('Run a backup sync (not available yet)')
-    .action(() => {
-      ui.error(
-        '`backup run` is not available yet — the sync engine lands in the next release. ' +
-          'Use `memoriahub backup init` to prepare a backup root now.',
-      );
-      process.exit(1);
+    .description('Run an incremental backup sync into the configured backup root')
+    .option('--concurrency <n>', 'Concurrent download workers (default: backup.concurrency setting, 2)')
+    .option('--max-mbps <x>', 'Aggregate bandwidth cap in Mbps; 0 = unlimited (default: backup.maxMbps setting, 0)')
+    .option('--page-size <n>', 'Change-feed page size (default: backup.pageSize setting, 100)')
+    .option('--json', 'Emit NDJSON events instead of human output')
+    .option('--strict', 'Exit non-zero when any item failed')
+    .option('--reconcile', 'Full reconcile pass (not available yet)')
+    .action(async (opts: RunCmdOpts) => {
+      const cfg = requireConfig();
+
+      if (opts.reconcile) {
+        ui.error('`backup run --reconcile` arrives with verify/reconcile in a later release.');
+        process.exit(1);
+      }
+
+      const settings = new SettingsRepo(getDb());
+      const root = settings.backupRoot();
+      const nodeId = settings.backupNodeId();
+      if (!root || !nodeId) {
+        ui.error(
+          'No backup root is configured on this machine. Run ' +
+            '`memoriahub backup init --dest <dir>` first.',
+        );
+        process.exit(1);
+      }
+
+      const concurrency =
+        parseNumberFlag(opts.concurrency, '--concurrency') ?? settings.backupConcurrency();
+      const maxMbps = parseNumberFlag(opts.maxMbps, '--max-mbps') ?? settings.backupMaxMbps();
+      const pageSize = parseNumberFlag(opts.pageSize, '--page-size') ?? settings.backupPageSize();
+
+      let outcome;
+      try {
+        outcome = await executeRun({
+          serverUrl: cfg.serverUrl,
+          pat: cfg.pat,
+          root,
+          nodeId,
+          trigger: 'manual',
+          cliVersion: cliVersion(),
+          concurrency: Math.max(1, Math.floor(concurrency)),
+          maxMbps,
+          pageSize: Math.max(1, Math.floor(pageSize)),
+          pacingMs: settings.backupPacingMs(),
+          retry: settings.retryConfig(),
+          cooldown: settings.cooldownConfig(),
+          attachRenderer: (engine) =>
+            renderBackupHeadless(engine, { json: opts.json === true }),
+        });
+      } catch (err) {
+        if (err instanceof RunAlreadyActiveError || err instanceof CatalogOpenError) {
+          ui.error(err.message);
+          process.exit(1);
+        }
+        if (err instanceof ApiError) {
+          if (err.status === 403) {
+            ui.error(
+              'This token is not permitted to run worker-node backups (jobs:write required).',
+            );
+          } else {
+            ui.error(`Backup run failed (HTTP ${err.status}): ${err.serverMessage}`);
+          }
+          process.exit(1);
+        }
+        ui.error(`Backup run failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+
+      process.exit(resolveBackupExitCode(outcome, opts.strict === true));
     });
 }
 

--- a/apps/cli/src/render/headless-backup.ts
+++ b/apps/cli/src/render/headless-backup.ts
@@ -1,0 +1,191 @@
+/**
+ * render/headless-backup.ts — Terminal renderer for `memoriahub backup run`
+ * (issue #316, epic #308). Pattern: render/headless-sync.ts.
+ *
+ * Subscribes to BackupEngine events and drives either:
+ *   - human output: a start line, a self-updating progress line (TTY) or
+ *     periodic lines (non-TTY), throttle notices, and a summary on finish; or
+ *   - `--json`: one NDJSON line per event on stdout, nothing else.
+ *
+ * ONLY this file and the command layer print; the engine is UI-free.
+ */
+
+import chalk from 'chalk';
+import { ui, isTTY } from '../ui.js';
+import {
+  BACKUP_EV,
+  type BackupEngineStats,
+  type ItemDonePayload,
+  type PageFetchedPayload,
+  type RunFinishedPayload,
+  type RunStartedPayload,
+  type ThrottlePayload,
+  type BackupErrorPayload,
+} from '../backup/events.js';
+import type { BackupEngine } from '../backup/backup-engine.js';
+
+/** Format a byte count for humans (decimal units, one decimal place). */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1000) return `${bytes} B`;
+  const units = ['kB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = '';
+  for (const u of units) {
+    value /= 1000;
+    unit = u;
+    if (value < 1000) break;
+  }
+  return `${value.toFixed(1)} ${unit}`;
+}
+
+export interface RenderBackupOptions {
+  /** NDJSON event stream instead of human output. */
+  json: boolean;
+  /** Injectable sink (tests capture output; defaults to process.stdout). */
+  write?: (line: string) => void;
+  now?: () => number;
+}
+
+/**
+ * Attach terminal-output listeners to `engine`. Must be called before
+ * `engine.runBackup()`.
+ */
+export function renderBackupHeadless(engine: BackupEngine, opts: RenderBackupOptions): void {
+  const write = opts.write ?? ((line: string): void => void process.stdout.write(line));
+  const now = opts.now ?? Date.now;
+
+  // ---------------------------------------------------------------------------
+  // NDJSON mode: every event becomes one parseable line; nothing else prints.
+  // ---------------------------------------------------------------------------
+  if (opts.json) {
+    const emitLine = (event: string, payload: unknown): void => {
+      write(`${JSON.stringify({ event, ...(payload as Record<string, unknown>) })}\n`);
+    };
+    engine.on(BACKUP_EV.RUN_STARTED, (p) => emitLine('run-started', p));
+    engine.on(BACKUP_EV.PAGE_FETCHED, (p) => emitLine('page-fetched', p));
+    engine.on(BACKUP_EV.ITEM_STARTED, (p) => emitLine('item-started', p));
+    engine.on(BACKUP_EV.ITEM_DONE, (p) => emitLine('item-done', p));
+    engine.on(BACKUP_EV.PAGE_COMMITTED, (p) => emitLine('page-committed', p));
+    engine.on(BACKUP_EV.THROTTLE, (p) => emitLine('throttle', p));
+    engine.on(BACKUP_EV.RUN_FINISHED, (p) => emitLine('run-finished', p));
+    engine.on(BACKUP_EV.ERROR, (p) => emitLine('error', p));
+    return;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Human mode
+  // ---------------------------------------------------------------------------
+  const state = {
+    startedAt: 0,
+    done: 0,
+    downloaded: 0,
+    skipped: 0,
+    errors: 0,
+    bytes: 0,
+    failures: [] as Array<{ id: string; error: string }>,
+  };
+
+  function progressLine(): string {
+    const elapsedSec = Math.max(0.001, (now() - state.startedAt) / 1000);
+    const rate = state.bytes / elapsedSec; // bytes/sec
+    return (
+      `  ${state.done} item(s)  ` +
+      `${chalk.green(`${state.downloaded} downloaded`)}  ` +
+      `${chalk.dim(`${state.skipped} up-to-date`)}  ` +
+      `${state.errors > 0 ? chalk.red(`${state.errors} failed`) : '0 failed'}  ` +
+      `${formatBytes(state.bytes)} @ ${formatBytes(rate)}/s`
+    );
+  }
+
+  function renderProgress(): void {
+    if (isTTY) {
+      write(`\r\x1b[2K${progressLine()}`);
+    } else if (state.done > 0 && state.done % 25 === 0) {
+      write(`${progressLine()}\n`);
+    }
+  }
+
+  engine.on(BACKUP_EV.RUN_STARTED, (p: RunStartedPayload) => {
+    state.startedAt = now();
+    ui.step(`Starting backup run ${p.runId} (${p.kind}, ${p.trigger})`);
+  });
+
+  engine.on(BACKUP_EV.PAGE_FETCHED, (p: PageFetchedPayload) => {
+    if (p.items === 0 && p.pageIndex === 0) {
+      ui.success('Backup is up to date — no changes since the last run.');
+    }
+  });
+
+  engine.on(BACKUP_EV.ITEM_DONE, (p: ItemDonePayload) => {
+    state.done++;
+    switch (p.outcome) {
+      case 'downloaded':
+        state.downloaded++;
+        state.bytes += p.bytes;
+        break;
+      case 'failed':
+        state.errors++;
+        state.failures.push({ id: p.id, error: p.error ?? 'unknown error' });
+        break;
+      default:
+        state.skipped++;
+        break;
+    }
+    renderProgress();
+  });
+
+  engine.on(BACKUP_EV.THROTTLE, (p: ThrottlePayload) => {
+    const secs = (p.delayMs / 1000).toFixed(1);
+    if (isTTY) write('\r\x1b[2K');
+    ui.dim(`  ⏳ Rate limited — slowing down for ${secs}s…`);
+  });
+
+  engine.on(BACKUP_EV.RUN_FINISHED, (p: RunFinishedPayload) => {
+    if (isTTY && state.done > 0) write('\n');
+    ui.blank();
+    printBackupSummary(p.status, p.stats, (now() - state.startedAt) / 1000, write);
+
+    if (state.failures.length > 0) {
+      ui.blank();
+      ui.warn(`${state.failures.length} item(s) failed:`);
+      for (const f of state.failures.slice(0, 20)) {
+        ui.line(`  ${chalk.red('✗')} ${f.id}  ${chalk.dim(f.error.slice(0, 80))}`);
+      }
+      if (state.failures.length > 20) {
+        ui.dim(`  …and ${state.failures.length - 20} more (see the catalog's failed items).`);
+      }
+    }
+
+    if (p.error) {
+      ui.blank();
+      ui.error(p.error);
+    }
+  });
+
+  engine.on(BACKUP_EV.ERROR, (p: BackupErrorPayload) => {
+    if (isTTY) write('\r\x1b[2K');
+    ui.error(p.message);
+  });
+}
+
+/** Summary table shared by TTY and non-TTY output. */
+function printBackupSummary(
+  status: string,
+  stats: BackupEngineStats,
+  durationSec: number,
+  _write: (line: string) => void,
+): void {
+  const statusLabel =
+    status === 'completed'
+      ? chalk.green('completed')
+      : status === 'aborted'
+        ? chalk.yellow('aborted')
+        : chalk.red('failed');
+
+  ui.line(`  Status       : ${statusLabel}`);
+  ui.line(`  Downloaded   : ${stats.itemsDownloaded} item(s), ${formatBytes(stats.bytesDownloaded)}`);
+  ui.line(`  Up to date   : ${stats.itemsSkipped} item(s)`);
+  ui.line(`  Sidecars     : ${stats.sidecarsWritten} written`);
+  ui.line(`  Errors       : ${stats.errors}`);
+  ui.line(`  Duration     : ${durationSec.toFixed(1)}s`);
+}

--- a/apps/cli/src/render/headless-backup.ts
+++ b/apps/cli/src/render/headless-backup.ts
@@ -134,6 +134,12 @@ export function renderBackupHeadless(engine: BackupEngine, opts: RenderBackupOpt
     renderProgress();
   });
 
+  engine.on(BACKUP_EV.PAGE_COMMITTED, () => {
+    // Non-TTY: one progress line per committed page keeps logs readable
+    // without flooding them per item.
+    if (!isTTY && state.done > 0) write(`${progressLine()}\n`);
+  });
+
   engine.on(BACKUP_EV.THROTTLE, (p: ThrottlePayload) => {
     const secs = (p.delayMs / 1000).toFixed(1);
     if (isTTY) write('\r\x1b[2K');

--- a/apps/cli/src/repo/settings.ts
+++ b/apps/cli/src/repo/settings.ts
@@ -135,6 +135,31 @@ export class SettingsRepo {
   }
 
   // ---------------------------------------------------------------------------
+  // Backup engine throttle knobs (issue #316 — all overridable per-run by
+  // `backup run` flags; these are the persistent machine defaults)
+  // ---------------------------------------------------------------------------
+
+  /** Concurrent backup download workers (default: 2). */
+  backupConcurrency(): number {
+    return this.get<number>('backup.concurrency', 2);
+  }
+
+  /** Aggregate download bandwidth cap in Mbps; 0 = unlimited (default: 0). */
+  backupMaxMbps(): number {
+    return this.get<number>('backup.maxMbps', 0);
+  }
+
+  /** Change-feed page size (default: 100; server clamps to backup.maxPageSize). */
+  backupPageSize(): number {
+    return this.get<number>('backup.pageSize', 100);
+  }
+
+  /** Inter-page pacing delay in ms (default: 250). */
+  backupPacingMs(): number {
+    return this.get<number>('backup.pacingMs', 250);
+  }
+
+  // ---------------------------------------------------------------------------
   // Update-check throttle cache (keys: update_check_last_at, update_check_latest_version)
   // ---------------------------------------------------------------------------
 

--- a/apps/cli/test/backup/backup-engine.spec.ts
+++ b/apps/cli/test/backup/backup-engine.spec.ts
@@ -1,0 +1,625 @@
+/**
+ * test/backup/backup-engine.spec.ts — BackupEngine run loop (issue #316).
+ *
+ * Mocked ApiClient slice + a REAL per-root SQLite catalog in a temp dir.
+ * Covers: the 3-page loop with cursor advance and crash-safe commit-then-ack
+ * ordering, the full classification matrix (new / bytes-changed /
+ * metadata-only / tombstone / archived-flip move / null-URL failure),
+ * crash-before-ack replay idempotency, expired-URL page re-mint (cap 3),
+ * hash-mismatch single retry then failed, download concurrency bounding,
+ * dimension/manifest exports, and the 409 → RunAlreadyActiveError mapping.
+ */
+
+import { jest } from '@jest/globals';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type BetterSqlite3 from 'better-sqlite3';
+import {
+  ApiError,
+  type BackupAckBody,
+  type BackupChangeItem,
+  type BackupChangesPage,
+  type FinishBackupRunBody,
+  type GetRawOptions,
+  type GetRawResult,
+} from '../../src/api.js';
+import {
+  BackupEngine,
+  CHECKPOINT_CURSOR_KEY,
+  RunAlreadyActiveError,
+  type BackupApi,
+  type BackupEngineOpts,
+} from '../../src/backup/backup-engine.js';
+import { BACKUP_EV, type ItemDonePayload } from '../../src/backup/events.js';
+import { openCatalogDb } from '../../src/backup/catalog-db.js';
+import { CatalogRepo } from '../../src/backup/catalog-repo.js';
+import { absPathFor } from '../../src/backup/layout.js';
+
+const sha256 = (buf: Buffer): string => crypto.createHash('sha256').update(buf).digest('hex');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+
+/** Build a change-feed item; `updatedAt` auto-increments for cursor ordering. */
+function feedItem(over: Partial<BackupChangeItem> & { id: string }): BackupChangeItem {
+  seq++;
+  const updatedAt = `2024-01-05T00:${String(Math.floor(seq / 60)).padStart(2, '0')}:${String(seq % 60).padStart(2, '0')}.000Z`;
+  return {
+    circleId: 'circle-1',
+    updatedAt,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    capturedAt: '2024-01-05T10:00:00.000Z',
+    capturedAtOffset: 0,
+    type: 'photo',
+    deletedAt: null,
+    archivedAt: null,
+    contentHash: null,
+    originalFilename: `${over.id}.jpg`,
+    storage: { objectId: `obj-${over.id}`, size: '0', mimeType: 'image/jpeg', status: 'ready' },
+    downloadUrl: `https://s3.test/${over.id}`,
+    downloadUrlExpiresAt: null,
+    sidecar: {
+      schemaVersion: 1,
+      mediaItemId: over.id,
+      tags: [],
+      albums: [],
+      people: [],
+    },
+    ...over,
+  };
+}
+
+/** Attach content bytes to an item: hash + size + registered URL body. */
+function withContent(
+  item: BackupChangeItem,
+  contents: Map<string, Buffer>,
+  content: Buffer,
+): BackupChangeItem {
+  contents.set(item.downloadUrl as string, content);
+  return {
+    ...item,
+    contentHash: sha256(content),
+    storage: { ...(item.storage as NonNullable<BackupChangeItem['storage']>), size: String(content.length) },
+  };
+}
+
+/** Chain pages into a cursor-keyed map ('start' for the null cursor). */
+function chainPages(pageItems: BackupChangeItem[][]): Map<string, BackupChangesPage> {
+  const map = new Map<string, BackupChangesPage>();
+  let key = 'start';
+  for (let i = 0; i < pageItems.length; i++) {
+    const items = pageItems[i] as BackupChangeItem[];
+    const last = items.length > 0 ? items[items.length - 1] : undefined;
+    map.set(key, {
+      items,
+      nextCursor: last ? { updatedAt: last.updatedAt, id: last.id } : null,
+      hasMore: i < pageItems.length - 1,
+      safetyHorizon: '2024-01-05T01:00:00.000Z',
+    });
+    if (last) key = last.id;
+  }
+  return map;
+}
+
+const EMPTY_PAGE: BackupChangesPage = {
+  items: [],
+  nextCursor: null,
+  hasMore: false,
+  safetyHorizon: '2024-01-05T01:00:00.000Z',
+};
+
+interface FakeApiState {
+  api: BackupApi;
+  changesCalls: string[];
+  acks: BackupAckBody[];
+  finishes: Array<{ runId: string; body: FinishBackupRunBody }>;
+  getRawCalls: Map<string, number>;
+}
+
+interface FakeApiOverrides {
+  /** URLs that answer 403/AccessDenied (mutable — tests may clear it). */
+  badUrls?: Set<string>;
+  /** Transform a page per fetch: (page, cursorKey, nthCallForKey). */
+  onChanges?: (page: BackupChangesPage, key: string, call: number) => BackupChangesPage;
+  /** Per-download delay + concurrency tracker. */
+  onDownloadStart?: () => Promise<void> | void;
+  onDownloadEnd?: () => void;
+  startRun?: () => Promise<{ run: { id: string; kind: string; startedAt: string; cursorStart: { updatedAt: string | null; id: string | null } } }>;
+}
+
+function makeApi(
+  pages: Map<string, BackupChangesPage>,
+  contents: Map<string, Buffer>,
+  over: FakeApiOverrides = {},
+): FakeApiState {
+  const changesCalls: string[] = [];
+  const acks: BackupAckBody[] = [];
+  const finishes: Array<{ runId: string; body: FinishBackupRunBody }> = [];
+  const getRawCalls = new Map<string, number>();
+  const perKeyCalls = new Map<string, number>();
+  let runCounter = 0;
+
+  const api: BackupApi = {
+    startNodeBackupRun: (over.startRun ??
+      (async () => ({
+        run: {
+          id: `run-${++runCounter}`,
+          kind: 'incremental',
+          startedAt: '2024-01-05T00:00:00.000Z',
+          cursorStart: { updatedAt: null, id: null },
+        },
+      }))) as BackupApi['startNodeBackupRun'],
+
+    getNodeBackupChanges: (async (_nodeId: string, q: { cursor?: { id: string } | null }) => {
+      const key = q.cursor?.id ?? 'start';
+      changesCalls.push(key);
+      const call = perKeyCalls.get(key) ?? 0;
+      perKeyCalls.set(key, call + 1);
+      const page = pages.get(key) ?? EMPTY_PAGE;
+      return over.onChanges ? over.onChanges(page, key, call) : page;
+    }) as BackupApi['getNodeBackupChanges'],
+
+    ackNodeBackup: (async (_nodeId: string, body: BackupAckBody) => {
+      acks.push(body);
+      return { ok: true as const, checkpoint: body.cursor };
+    }) as BackupApi['ackNodeBackup'],
+
+    finishNodeBackupRun: (async (_nodeId: string, runId: string, body: FinishBackupRunBody) => {
+      finishes.push({ runId, body });
+      return { ok: true as const };
+    }) as BackupApi['finishNodeBackupRun'],
+
+    getNodeBackupDimensions: (async () => ({
+      albums: [{ id: 'al-1', name: 'Trip', description: null, itemCount: 2, itemIds: ['a', 'b'] }],
+      people: [{ id: 'p-1', name: 'Ada', favorite: false, faceCount: 3 }],
+      tags: [{ name: 'beach', itemCount: 2 }],
+      generatedAt: '2024-01-05T02:00:00.000Z',
+    })) as BackupApi['getNodeBackupDimensions'],
+
+    getRaw: (async (url: string, destPath: string, opts?: GetRawOptions): Promise<GetRawResult> => {
+      getRawCalls.set(url, (getRawCalls.get(url) ?? 0) + 1);
+      await over.onDownloadStart?.();
+      try {
+        const cfg = (await opts?.attempt?.()) ?? {};
+        if (over.badUrls?.has(url)) {
+          throw new ApiError(403, 'AccessDenied: Request has expired');
+        }
+        const content = contents.get(url);
+        if (!content) throw new Error(`no content registered for ${url}`);
+        const rangeStart = cfg.rangeStart ?? 0;
+        const resumed = rangeStart > 0;
+        await cfg.onResponse?.({ status: resumed ? 206 : 200, resumed });
+        const body = resumed ? content.subarray(rangeStart) : content;
+        await cfg.onChunk?.(Buffer.from(body));
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        if (resumed) fs.appendFileSync(destPath, body);
+        else fs.writeFileSync(destPath, body);
+        return { status: resumed ? 206 : 200, bytesWritten: body.length };
+      } finally {
+        over.onDownloadEnd?.();
+      }
+    }) as BackupApi['getRaw'],
+  };
+
+  return { api, changesCalls, acks, finishes, getRawCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Engine harness
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let root: string;
+const openDbs: BetterSqlite3.Database[] = [];
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-engine-'));
+  root = path.join(tmpDir, 'backup-root');
+});
+
+afterEach(() => {
+  for (const db of openDbs.splice(0)) {
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  }
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeEngine(
+  api: BackupApi,
+  over: Partial<BackupEngineOpts> = {},
+): { engine: BackupEngine; db: BetterSqlite3.Database; itemDone: ItemDonePayload[] } {
+  const db = openCatalogDb(root);
+  openDbs.push(db);
+  const engine = new BackupEngine(
+    {
+      root,
+      nodeId: 'node-1',
+      nodeName: 'test-node',
+      serverUrl: 'https://api.test',
+      trigger: 'manual',
+      cliVersion: '1.2.21',
+      concurrency: 2,
+      maxMbps: 0,
+      pageSize: 2,
+      pacingMs: 0,
+      ...over,
+    },
+    { api, db, sleep: async () => {} },
+  );
+  const itemDone: ItemDonePayload[] = [];
+  engine.on(BACKUP_EV.ITEM_DONE, (p) => itemDone.push(p));
+  engine.on(BACKUP_EV.ERROR, () => {});
+  return { engine, db, itemDone };
+}
+
+/** Recursively list files under root, excluding the .memoriahub state dir. */
+function listFiles(dir: string, prefix = ''): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '.memoriahub') continue;
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...listFiles(path.join(dir, entry.name), rel));
+    else out.push(rel);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BackupEngine.runBackup', () => {
+  it('walks a 3-page feed with cursor advance, commit-then-ack per page', async () => {
+    const contents = new Map<string, Buffer>();
+    const items = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) =>
+      withContent(feedItem({ id }), contents, Buffer.from(`bytes of ${id}`)),
+    );
+    const pages = chainPages([items.slice(0, 2), items.slice(2, 4), items.slice(4, 6)]);
+    const { api, changesCalls, acks, finishes } = makeApi(pages, contents);
+
+    const { engine, db } = makeEngine(api);
+    const outcome = await engine.runBackup();
+
+    expect(outcome.status).toBe('completed');
+    expect(outcome.stats).toMatchObject({
+      itemsDownloaded: 6,
+      itemsSkipped: 0,
+      sidecarsWritten: 6,
+      errors: 0,
+    });
+
+    // Cursor advance: start → last of page1 → last of page2.
+    expect(changesCalls).toEqual(['start', 'b', 'd']);
+    expect(acks.map((a) => a.cursor.id)).toEqual(['b', 'd', 'f']);
+    expect(acks[0]?.stats).toMatchObject({ itemsDownloaded: 2, errors: 0 });
+
+    // Local mirrored checkpoint = final cursor.
+    const repo = new CatalogRepo(db);
+    expect(JSON.parse(repo.getCheckpoint(CHECKPOINT_CURSOR_KEY) as string).id).toBe('f');
+
+    // Files + sidecars in final place; catalog rows present.
+    for (const item of items) {
+      const row = repo.getById(item.id);
+      expect(row?.status).toBe('present');
+      expect(fs.readFileSync(absPathFor(root, row?.relPath as string))).toEqual(
+        contents.get(item.downloadUrl as string),
+      );
+      expect(fs.existsSync(absPathFor(root, row?.sidecarRelPath as string))).toBe(true);
+    }
+
+    // Server run finished as completed with final stats.
+    expect(finishes).toHaveLength(1);
+    expect(finishes[0]?.body.status).toBe('completed');
+    expect(finishes[0]?.body.finalStats?.itemsDownloaded).toBe(6);
+
+    // Dimension catalogs + manifest written.
+    for (const f of ['albums.json', 'people.json', 'tags.json', 'manifest.json']) {
+      expect(fs.existsSync(path.join(root, 'catalog', f))).toBe(true);
+    }
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'catalog', 'manifest.json'), 'utf8'));
+    expect(manifest).toMatchObject({
+      serverUrl: 'https://api.test',
+      nodeId: 'node-1',
+      nodeName: 'test-node',
+      catalogSchemaVersion: 1,
+    });
+    expect(manifest.checkpoint.id).toBe('f');
+    expect(manifest.counts.totalItems).toBe(6);
+    expect(manifest.lastRun.status).toBe('completed');
+  });
+
+  it('classifies new / bytes-changed / metadata-only / tombstone / archived-flip / null-URL', async () => {
+    const contents = new Map<string, Buffer>();
+
+    // --- Run 1: seed four items into the catalog + on disk. -----------------
+    const a1 = withContent(feedItem({ id: 'a' }), contents, Buffer.from('a v1'));
+    const b1 = withContent(feedItem({ id: 'b' }), contents, Buffer.from('b v1'));
+    const c1 = withContent(feedItem({ id: 'c' }), contents, Buffer.from('c v1'));
+    const d1 = withContent(feedItem({ id: 'd' }), contents, Buffer.from('d v1'));
+    {
+      const pages = chainPages([[a1, b1, c1, d1]]);
+      const { api } = makeApi(pages, contents);
+      const { engine } = makeEngine(api, { pageSize: 10 });
+      const res = await engine.runBackup();
+      expect(res.status).toBe('completed');
+      expect(res.stats.itemsDownloaded).toBe(4);
+    }
+
+    // --- Run 2: one page exercising every classification branch. -----------
+    const a2 = { ...a1, ...feedItem({ id: 'a' }), contentHash: a1.contentHash, storage: a1.storage };
+    const b2 = withContent(feedItem({ id: 'b', downloadUrl: 'https://s3.test/b-v2' }), contents, Buffer.from('b v2 changed'));
+    const c2 = { ...c1, ...feedItem({ id: 'c' }), contentHash: c1.contentHash, storage: c1.storage, deletedAt: '2024-01-06T00:00:00.000Z', downloadUrl: null };
+    const d2 = { ...d1, ...feedItem({ id: 'd' }), contentHash: d1.contentHash, storage: d1.storage, archivedAt: '2024-01-06T00:00:00.000Z' };
+    const e2 = withContent(feedItem({ id: 'e' }), contents, Buffer.from('e new'));
+    const f2 = feedItem({ id: 'f', downloadUrl: null, contentHash: 'deadbeef' });
+
+    const db0 = openCatalogDb(root);
+    const repo0 = new CatalogRepo(db0);
+    const page2Key = JSON.parse(repo0.getCheckpoint(CHECKPOINT_CURSOR_KEY) as string).id as string;
+    db0.close();
+
+    const pages = new Map<string, BackupChangesPage>();
+    const page: BackupChangesPage = {
+      items: [a2, b2, c2, d2, e2, f2],
+      nextCursor: { updatedAt: f2.updatedAt, id: f2.id },
+      hasMore: false,
+      safetyHorizon: 'x',
+    };
+    pages.set(page2Key, page);
+
+    const { api } = makeApi(pages, contents);
+    const { engine, db, itemDone } = makeEngine(api, { pageSize: 10 });
+    const outcome = await engine.runBackup();
+
+    const outcomes = Object.fromEntries(itemDone.map((p) => [p.id, p.outcome]));
+    expect(outcomes).toEqual({
+      a: 'sidecar-only',
+      b: 'downloaded',
+      c: 'tombstone',
+      d: 'moved',
+      e: 'downloaded',
+      f: 'failed',
+    });
+    expect(outcome.stats).toMatchObject({
+      itemsDownloaded: 2,
+      itemsSkipped: 3,
+      errors: 1,
+      sidecarsWritten: 5,
+    });
+
+    const repo = new CatalogRepo(db);
+
+    // a: metadata-only — file untouched, still v1 bytes.
+    const rowA = repo.getById('a');
+    expect(rowA?.status).toBe('present');
+    expect(fs.readFileSync(absPathFor(root, rowA?.relPath as string), 'utf8')).toBe('a v1');
+
+    // b: bytes-changed — re-downloaded in place.
+    const rowB = repo.getById('b');
+    expect(rowB?.status).toBe('present');
+    expect(rowB?.contentHash).toBe(b2.contentHash);
+    expect(fs.readFileSync(absPathFor(root, rowB?.relPath as string), 'utf8')).toBe('b v2 changed');
+
+    // c: tombstone — status trashed, file stays in place, sidecar rewritten.
+    const rowC = repo.getById('c');
+    expect(rowC?.status).toBe('trashed');
+    expect(fs.existsSync(absPathFor(root, rowC?.relPath as string))).toBe(true);
+
+    // d: archived flip — moved media/ → archived/, catalog rel_path updated.
+    const rowD = repo.getById('d');
+    expect(rowD?.status).toBe('present');
+    expect(rowD?.archived).toBe(true);
+    expect(rowD?.relPath.startsWith('archived/')).toBe(true);
+    expect(fs.readFileSync(absPathFor(root, rowD?.relPath as string), 'utf8')).toBe('d v1');
+    expect(fs.existsSync(absPathFor(root, (rowD?.relPath as string).replace(/^archived\//, 'media/')))).toBe(false);
+
+    // e: new — downloaded.
+    expect(repo.getById('e')?.status).toBe('present');
+
+    // f: null URL — failed with a recorded error, run NOT blocked.
+    const rowF = repo.getById('f');
+    expect(rowF?.status).toBe('failed');
+    expect(rowF?.lastError).toMatch(/no download URL/);
+    expect(outcome.status).toBe('completed');
+  });
+
+  it('replays a page idempotently after a crash-before-ack (no duplicate files)', async () => {
+    const contents = new Map<string, Buffer>();
+    const items = ['a', 'b', 'c', 'd'].map((id) =>
+      withContent(feedItem({ id }), contents, Buffer.from(`bytes ${id}`)),
+    );
+    const pages = chainPages([items.slice(0, 2), items.slice(2, 4)]);
+
+    // Full first run.
+    {
+      const { api } = makeApi(pages, contents);
+      const { engine } = makeEngine(api);
+      expect((await engine.runBackup()).status).toBe('completed');
+    }
+    const filesAfterRun1 = listFiles(root).sort();
+    const rowCount = (): number => {
+      const db = openCatalogDb(root);
+      const n = new CatalogRepo(db).stats().totalItems;
+      db.close();
+      return n;
+    };
+    expect(rowCount()).toBe(4);
+
+    // Simulate a crash BEFORE page 2's local commit + ack: rewind the local
+    // checkpoint to page 1's cursor. Page 2 must be re-fetched and
+    // re-processed — idempotently.
+    {
+      const db = openCatalogDb(root);
+      new CatalogRepo(db).setCheckpoint(
+        CHECKPOINT_CURSOR_KEY,
+        JSON.stringify({ updatedAt: (items[1] as BackupChangeItem).updatedAt, id: 'b' }),
+      );
+      db.close();
+    }
+
+    const { api, changesCalls, acks } = makeApi(pages, contents);
+    const { engine, itemDone } = makeEngine(api);
+    const outcome = await engine.runBackup();
+
+    expect(outcome.status).toBe('completed');
+    // Page 2 was re-fetched from the rewound cursor…
+    expect(changesCalls[0]).toBe('b');
+    // …and re-processed as up-to-date (bytes already on disk, hashes equal).
+    expect(itemDone.map((p) => p.outcome)).toEqual(['sidecar-only', 'sidecar-only']);
+    expect(outcome.stats).toMatchObject({ itemsDownloaded: 0, itemsSkipped: 2, errors: 0 });
+    // The ack re-advanced the server cursor to the same place.
+    expect(acks.map((a) => a.cursor.id)).toEqual(['d']);
+    // No duplicate files, no duplicate rows.
+    expect(listFiles(root).sort()).toEqual(filesAfterRun1);
+    expect(rowCount()).toBe(4);
+  });
+
+  it('re-fetches the SAME page to re-mint expired presigned URLs', async () => {
+    const contents = new Map<string, Buffer>();
+    const good = withContent(feedItem({ id: 'ok' }), contents, Buffer.from('fine'));
+    const expiring = withContent(feedItem({ id: 'exp' }), contents, Buffer.from('slow one'));
+    const badUrls = new Set<string>([expiring.downloadUrl as string]);
+
+    const pages = chainPages([[good, expiring]]);
+    const freshUrl = 'https://s3.test/exp-reminted';
+    contents.set(freshUrl, Buffer.from('slow one'));
+
+    const { api, changesCalls } = makeApi(pages, contents, {
+      badUrls,
+      onChanges: (page, key, call) => {
+        if (key !== 'start' || call === 0) return page;
+        // The re-fetch re-mints: same items, fresh URL for the expired one.
+        return {
+          ...page,
+          items: page.items.map((i) => (i.id === 'exp' ? { ...i, downloadUrl: freshUrl } : i)),
+        };
+      },
+    });
+
+    const { engine, itemDone } = makeEngine(api, { pageSize: 10 });
+    const outcome = await engine.runBackup();
+
+    expect(outcome.status).toBe('completed');
+    expect(changesCalls).toEqual(['start', 'start']); // one re-mint fetch
+    const byId = Object.fromEntries(itemDone.map((p) => [p.id, p.outcome]));
+    expect(byId).toEqual({ ok: 'downloaded', exp: 'downloaded' });
+    expect(outcome.stats).toMatchObject({ itemsDownloaded: 2, errors: 0 });
+  });
+
+  it('caps page re-mints at 3, then fails the remaining items without blocking', async () => {
+    const contents = new Map<string, Buffer>();
+    const good = withContent(feedItem({ id: 'ok' }), contents, Buffer.from('fine'));
+    const doomed = withContent(feedItem({ id: 'doom' }), contents, Buffer.from('never'));
+    const badUrls = new Set<string>([doomed.downloadUrl as string]);
+
+    const pages = chainPages([[good, doomed]]);
+    const { api, changesCalls } = makeApi(pages, contents, { badUrls });
+
+    const { engine, itemDone } = makeEngine(api, { pageSize: 10 });
+    const outcome = await engine.runBackup();
+
+    expect(outcome.status).toBe('completed');
+    // 1 initial fetch + 3 re-mint fetches.
+    expect(changesCalls).toEqual(['start', 'start', 'start', 'start']);
+    const doomDone = itemDone.find((p) => p.id === 'doom');
+    expect(doomDone?.outcome).toBe('failed');
+    expect(doomDone?.error).toMatch(/re-mint cap/);
+    expect(outcome.stats).toMatchObject({ itemsDownloaded: 1, errors: 1 });
+
+    const db = openCatalogDb(root);
+    const row = new CatalogRepo(db).getById('doom');
+    db.close();
+    expect(row?.status).toBe('failed');
+    expect(row?.lastError).toMatch(/expired/);
+  });
+
+  it('retries a hash mismatch exactly once, then marks the item failed', async () => {
+    const contents = new Map<string, Buffer>();
+    const item = withContent(feedItem({ id: 'bad' }), contents, Buffer.from('expected bytes'));
+    // Serve DIFFERENT bytes than the advertised hash, every time.
+    contents.set(item.downloadUrl as string, Buffer.from('corrupt bytes'));
+
+    const pages = chainPages([[item]]);
+    const { api, getRawCalls } = makeApi(pages, contents);
+    const { engine, itemDone } = makeEngine(api, { pageSize: 10 });
+    const outcome = await engine.runBackup();
+
+    expect(outcome.status).toBe('completed');
+    expect(getRawCalls.get(item.downloadUrl as string)).toBe(2); // initial + ONE retry
+    expect(itemDone[0]?.outcome).toBe('failed');
+    expect(itemDone[0]?.error).toMatch(/sha256/);
+
+    const db = openCatalogDb(root);
+    const row = new CatalogRepo(db).getById('bad');
+    db.close();
+    expect(row?.status).toBe('failed');
+    expect(row?.lastError).toMatch(/sha256/);
+  });
+
+  it('bounds concurrent downloads to the configured pool size', async () => {
+    const contents = new Map<string, Buffer>();
+    const items = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) =>
+      withContent(feedItem({ id }), contents, Buffer.from(`bytes ${id}`)),
+    );
+    let active = 0;
+    let maxActive = 0;
+    const pages = chainPages([items]);
+    const { api } = makeApi(pages, contents, {
+      onDownloadStart: async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 10));
+      },
+      onDownloadEnd: () => {
+        active--;
+      },
+    });
+
+    const { engine } = makeEngine(api, { pageSize: 10, concurrency: 2 });
+    const outcome = await engine.runBackup();
+
+    expect(outcome.stats.itemsDownloaded).toBe(6);
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(maxActive).toBeGreaterThan(1); // the pool did actually parallelize
+  });
+
+  it('maps a 409 on run start to RunAlreadyActiveError with the active run id', async () => {
+    const { api } = makeApi(new Map(), new Map(), {
+      startRun: async () => {
+        throw new ApiError(409, 'a backup run is already active for this node', null, false, {
+          message: 'a backup run is already active for this node',
+          activeRunId: 'run-elsewhere',
+        });
+      },
+    });
+
+    const { engine } = makeEngine(api);
+    const err = await engine.runBackup().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RunAlreadyActiveError);
+    expect((err as RunAlreadyActiveError).activeRunId).toBe('run-elsewhere');
+  });
+
+  it('finishes the run failed (best-effort) when the feed itself breaks', async () => {
+    const { api, finishes } = makeApi(new Map(), new Map());
+    (api as { getNodeBackupChanges: unknown }).getNodeBackupChanges = jest.fn(async () => {
+      throw new ApiError(500, 'boom');
+    });
+
+    const { engine } = makeEngine(api);
+    const outcome = await engine.runBackup();
+
+    expect(outcome.status).toBe('failed');
+    expect(outcome.error).toMatch(/boom/);
+    expect(finishes[0]?.body.status).toBe('failed');
+    expect(finishes[0]?.body.error).toMatch(/boom/);
+  });
+});

--- a/apps/cli/test/backup/download.spec.ts
+++ b/apps/cli/test/backup/download.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * test/backup/download.spec.ts — Verified resumable downloads (issue #316).
+ *
+ * Exercises the REAL ApiClient.getRaw against a mocked global fetch (so the
+ * Range header, 206-vs-200 handling, cooldown-gate trip, and retry routing are
+ * all covered), with downloadVerified layered on top for hashing/resume/
+ * mismatch policy.
+ */
+
+import { jest } from '@jest/globals';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ApiClient } from '../../src/api.js';
+import { CooldownGate } from '../../src/http/cooldown-gate.js';
+import {
+  downloadVerified,
+  HashMismatchError,
+  PresignExpiredError,
+} from '../../src/backup/download.js';
+import { TokenBucket } from '../../src/backup/rate-limiter.js';
+
+const sha256 = (buf: Buffer): string => crypto.createHash('sha256').update(buf).digest('hex');
+
+type FetchArgs = { url: string; headers: Record<string, string> };
+
+/**
+ * Range-aware fake origin. Each call to handler() may override behavior; by
+ * default serves `content`, honoring Range with a 206.
+ */
+function makeFetchMock(
+  content: Buffer,
+  overrides: Array<(args: FetchArgs, call: number) => Response | null> = [],
+): { fetchMock: jest.Mock; calls: FetchArgs[] } {
+  const calls: FetchArgs[] = [];
+  let call = 0;
+  const fetchMock = jest.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+    const url = String(input);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const args = { url, headers };
+    calls.push(args);
+    const n = call++;
+    for (const override of overrides) {
+      const res = override(args, n);
+      if (res) return res;
+    }
+    const range = headers['Range'];
+    if (range) {
+      const start = Number(/^bytes=(\d+)-$/.exec(range)?.[1] ?? 0);
+      return new Response(new Uint8Array(content.subarray(start)), { status: 206 });
+    }
+    return new Response(new Uint8Array(content), { status: 200 });
+  });
+  return { fetchMock, calls };
+}
+
+function makeClient(gate?: CooldownGate): ApiClient {
+  return new ApiClient({
+    serverUrl: 'https://api.example.test',
+    pat: 'pat_test',
+    retry: { maxRetries: 2, baseMs: 1, maxMs: 2 },
+    ...(gate ? { cooldownGate: gate } : {}),
+  });
+}
+
+let tmpDir: string;
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-dl-'));
+});
+
+afterEach(() => {
+  global.fetch = realFetch;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function paths(): { dest: string; part: string } {
+  return {
+    dest: path.join(tmpDir, 'media', '2024', '01', 'photo.jpg'),
+    part: path.join(tmpDir, 'tmp', 'item-1.part'),
+  };
+}
+
+describe('downloadVerified', () => {
+  const content = Buffer.from('the quick brown fox jumps over the lazy backup engine', 'utf8');
+
+  it('downloads, verifies sha256 while streaming, and renames into place', async () => {
+    const { fetchMock } = makeFetchMock(content);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    const res = await downloadVerified(
+      { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+      { api: makeClient(), bucket: new TokenBucket(0) },
+    );
+
+    expect(res.sha256).toBe(sha256(content));
+    expect(res.bytes).toBe(content.length);
+    expect(fs.readFileSync(dest)).toEqual(content);
+    expect(fs.existsSync(part)).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes an existing .part with Range: bytes=N- and re-hashes the partial', async () => {
+    const { fetchMock, calls } = makeFetchMock(content);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    // Pre-seed the first 20 bytes as a truncated .part.
+    fs.mkdirSync(path.dirname(part), { recursive: true });
+    fs.writeFileSync(part, content.subarray(0, 20));
+
+    const res = await downloadVerified(
+      { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+      { api: makeClient(), bucket: new TokenBucket(0) },
+    );
+
+    expect(calls[0]?.headers['Range']).toBe('bytes=20-');
+    expect(res.sha256).toBe(sha256(content));
+    expect(fs.readFileSync(dest)).toEqual(content);
+  });
+
+  it('restarts cleanly from zero when the server answers 200 instead of 206', async () => {
+    // Overrides: always serve the FULL body with 200, ignoring Range.
+    const { fetchMock, calls } = makeFetchMock(content, [
+      () => new Response(new Uint8Array(content), { status: 200 }),
+    ]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    fs.mkdirSync(path.dirname(part), { recursive: true });
+    fs.writeFileSync(part, content.subarray(0, 20));
+
+    const res = await downloadVerified(
+      { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+      { api: makeClient(), bucket: new TokenBucket(0) },
+    );
+
+    // Range was REQUESTED but not honored — file and hash restart from zero.
+    expect(calls[0]?.headers['Range']).toBe('bytes=20-');
+    expect(res.sha256).toBe(sha256(content));
+    expect(fs.readFileSync(dest)).toEqual(content); // not doubled
+  });
+
+  it('retries ONCE from zero on hash mismatch, then succeeds when bytes are good', async () => {
+    const corrupt = Buffer.from('corrupted bytes that hash differently', 'utf8');
+    const { fetchMock } = makeFetchMock(content, [
+      (_args, call) => (call === 0 ? new Response(new Uint8Array(corrupt), { status: 200 }) : null),
+    ]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    const res = await downloadVerified(
+      { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+      { api: makeClient(), bucket: new TokenBucket(0) },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.sha256).toBe(sha256(content));
+    expect(fs.readFileSync(dest)).toEqual(content);
+  });
+
+  it('fails with HashMismatchError after exactly one full re-download', async () => {
+    const corrupt = Buffer.from('always corrupt', 'utf8');
+    const { fetchMock } = makeFetchMock(corrupt);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    await expect(
+      downloadVerified(
+        { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+        { api: makeClient(), bucket: new TokenBucket(0) },
+      ),
+    ).rejects.toThrow(HashMismatchError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // initial + ONE retry
+    expect(fs.existsSync(dest)).toBe(false);
+    expect(fs.existsSync(part)).toBe(false); // partial cleaned up
+  });
+
+  it('maps a 403/AccessDenied response to PresignExpiredError', async () => {
+    const { fetchMock } = makeFetchMock(content, [
+      () =>
+        new Response('<Error><Code>AccessDenied</Code><Message>Request has expired</Message></Error>', {
+          status: 403,
+        }),
+    ]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    await expect(
+      downloadVerified(
+        { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+        { api: makeClient(), bucket: new TokenBucket(0) },
+      ),
+    ).rejects.toThrow(PresignExpiredError);
+
+    // 403 is not retryable — a single request only.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes chunks through the shared token bucket', async () => {
+    const { fetchMock } = makeFetchMock(content);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { dest, part } = paths();
+
+    const taken: number[] = [];
+    const bucket = new TokenBucket(0);
+    const origTake = bucket.take.bind(bucket);
+    bucket.take = async (bytes: number): Promise<void> => {
+      taken.push(bytes);
+      return origTake(bytes);
+    };
+
+    await downloadVerified(
+      { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: null },
+      { api: makeClient(), bucket },
+    );
+
+    expect(taken.reduce((a, b) => a + b, 0)).toBe(content.length);
+  });
+});
+
+describe('cooldown gate integration (429 brakes the whole engine)', () => {
+  const content = Buffer.from('rate limited payload', 'utf8');
+
+  it('trips the shared gate on 429, honors Retry-After, and pauses the next acquire', async () => {
+    let t = 0;
+    const gateSleeps: number[] = [];
+    const trips: number[] = [];
+    const gate = new CooldownGate(
+      { cooldownMs: 100, maxCooldownMs: 1000 },
+      {
+        now: () => t,
+        sleep: async (ms: number): Promise<void> => {
+          gateSleeps.push(ms);
+          t += ms;
+        },
+        onTrip: (ms) => trips.push(ms),
+      },
+    );
+
+    const { fetchMock } = makeFetchMock(content, [
+      (_args, call) =>
+        call === 0
+          ? new Response('Too Many Requests', { status: 429, headers: { 'Retry-After': '2' } })
+          : null,
+    ]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { dest, part } = paths();
+    const res = await downloadVerified(
+      { url: 'https://s3.test/obj', destAbsPath: dest, partAbsPath: part, contentHash: sha256(content) },
+      { api: makeClient(gate), bucket: new TokenBucket(0) },
+    );
+
+    // Retry-After: 2 → a 2000 ms cooldown window was opened…
+    expect(trips).toEqual([2000]);
+    // …and the retry's acquire waited the window out before re-requesting.
+    expect(gateSleeps).toContain(2000);
+    expect(res.sha256).toBe(sha256(content));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/cli/test/backup/headless-backup.spec.ts
+++ b/apps/cli/test/backup/headless-backup.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * test/backup/headless-backup.spec.ts — `backup run` presentation layer
+ * (issue #316): human start/progress/summary output, `--json` NDJSON event
+ * stream, and the `--strict` exit-code policy.
+ */
+
+import { jest } from '@jest/globals';
+import { BackupTypedEmitter, BACKUP_EV, emptyStats } from '../../src/backup/events.js';
+import type { BackupEngine } from '../../src/backup/backup-engine.js';
+import { renderBackupHeadless, formatBytes } from '../../src/render/headless-backup.js';
+import { resolveBackupExitCode } from '../../src/backup/execute-run.js';
+
+/** The renderer only uses `.on`; a bare typed emitter stands in for the engine. */
+function fakeEngine(): BackupTypedEmitter {
+  return new BackupTypedEmitter();
+}
+
+function emitTypicalRun(engine: BackupTypedEmitter, errors = 0): void {
+  engine.emit(BACKUP_EV.RUN_STARTED, { runId: 'run-1', kind: 'incremental', trigger: 'manual' });
+  engine.emit(BACKUP_EV.PAGE_FETCHED, { pageIndex: 0, items: 2, hasMore: false });
+  engine.emit(BACKUP_EV.ITEM_STARTED, { id: 'a' });
+  engine.emit(BACKUP_EV.ITEM_DONE, { id: 'a', outcome: 'downloaded', bytes: 1500 });
+  engine.emit(BACKUP_EV.ITEM_DONE, { id: 'b', outcome: 'sidecar-only', bytes: 0 });
+  if (errors > 0) {
+    engine.emit(BACKUP_EV.ITEM_DONE, { id: 'c', outcome: 'failed', bytes: 0, error: 'boom' });
+  }
+  engine.emit(BACKUP_EV.PAGE_COMMITTED, {
+    cursor: { updatedAt: '2024-01-05T00:00:01.000Z', id: 'b' },
+    stats: { ...emptyStats(), itemsDownloaded: 1, itemsSkipped: 1, bytesDownloaded: 1500, errors },
+  });
+  engine.emit(BACKUP_EV.THROTTLE, { delayMs: 2000 });
+  engine.emit(BACKUP_EV.RUN_FINISHED, {
+    status: 'completed',
+    stats: { ...emptyStats(), itemsDownloaded: 1, itemsSkipped: 1, sidecarsWritten: 2, bytesDownloaded: 1500, errors },
+  });
+}
+
+describe('renderBackupHeadless (human mode)', () => {
+  let out: string[];
+  let spy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    out = [];
+    spy = jest.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    }) as never);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('prints start, progress, throttle notice, and a summary', () => {
+    const engine = fakeEngine();
+    renderBackupHeadless(engine as unknown as BackupEngine, { json: false, now: () => 1000 });
+    emitTypicalRun(engine);
+
+    const text = out.join('');
+    expect(text).toContain('Starting backup run run-1');
+    expect(text).toContain('1 downloaded');
+    expect(text).toContain('Rate limited');
+    expect(text).toContain('Status');
+    expect(text).toContain('completed');
+    expect(text).toContain('1.5 kB'); // bytes in the summary
+    expect(text).toContain('Errors       : 0');
+  });
+
+  it('lists failed items in the summary', () => {
+    const engine = fakeEngine();
+    renderBackupHeadless(engine as unknown as BackupEngine, { json: false, now: () => 1000 });
+    emitTypicalRun(engine, 1);
+
+    const text = out.join('');
+    expect(text).toContain('1 item(s) failed');
+    expect(text).toContain('boom');
+  });
+});
+
+describe('renderBackupHeadless (--json NDJSON mode)', () => {
+  it('emits one parseable JSON line per event and nothing else', () => {
+    const lines: string[] = [];
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation((() => true) as never);
+    try {
+      const engine = fakeEngine();
+      renderBackupHeadless(engine as unknown as BackupEngine, {
+        json: true,
+        write: (line) => lines.push(line),
+      });
+      emitTypicalRun(engine);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // stdout untouched — everything went through the injected sink.
+    expect(spy).not.toHaveBeenCalled();
+
+    const parsed = lines.map((l) => {
+      expect(l.endsWith('\n')).toBe(true);
+      return JSON.parse(l) as Record<string, unknown>;
+    });
+    expect(parsed.map((p) => p['event'])).toEqual([
+      'run-started',
+      'page-fetched',
+      'item-started',
+      'item-done',
+      'item-done',
+      'page-committed',
+      'throttle',
+      'run-finished',
+    ]);
+    const done = parsed.find((p) => p['event'] === 'item-done');
+    expect(done).toMatchObject({ id: 'a', outcome: 'downloaded', bytes: 1500 });
+    const finished = parsed[parsed.length - 1];
+    expect(finished).toMatchObject({ event: 'run-finished', status: 'completed' });
+  });
+});
+
+describe('resolveBackupExitCode (--strict policy)', () => {
+  const stats = (errors: number): ReturnType<typeof emptyStats> => ({ ...emptyStats(), errors });
+
+  it('exits 0 on a clean completed run, strict or not', () => {
+    expect(resolveBackupExitCode({ runId: 'r', status: 'completed', stats: stats(0) }, false)).toBe(0);
+    expect(resolveBackupExitCode({ runId: 'r', status: 'completed', stats: stats(0) }, true)).toBe(0);
+  });
+
+  it('exits 0 on item errors without --strict, 1 with --strict', () => {
+    expect(resolveBackupExitCode({ runId: 'r', status: 'completed', stats: stats(3) }, false)).toBe(0);
+    expect(resolveBackupExitCode({ runId: 'r', status: 'completed', stats: stats(3) }, true)).toBe(1);
+  });
+
+  it('always exits non-zero on a failed run', () => {
+    expect(resolveBackupExitCode({ runId: 'r', status: 'failed', stats: stats(0) }, false)).toBe(1);
+    expect(resolveBackupExitCode({ runId: 'r', status: 'failed', stats: stats(0) }, true)).toBe(1);
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats decimal units', () => {
+    expect(formatBytes(999)).toBe('999 B');
+    expect(formatBytes(1500)).toBe('1.5 kB');
+    expect(formatBytes(2_500_000)).toBe('2.5 MB');
+    expect(formatBytes(3_200_000_000)).toBe('3.2 GB');
+  });
+});

--- a/apps/cli/test/backup/rate-limiter.spec.ts
+++ b/apps/cli/test/backup/rate-limiter.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * test/backup/rate-limiter.spec.ts — TokenBucket bandwidth cap (issue #316).
+ *
+ * Uses an injected fake clock (now/sleep) so the timing assertions are exact
+ * and CI-proof: total slept time — not wall time — is the assertion target.
+ */
+
+import { TokenBucket } from '../../src/backup/rate-limiter.js';
+
+interface FakeClock {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  sleeps: number[];
+  total: () => number;
+}
+
+function makeClock(): FakeClock {
+  let t = 0;
+  const sleeps: number[] = [];
+  return {
+    now: () => t,
+    sleep: async (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      t += ms;
+    },
+    sleeps,
+    total: () => sleeps.reduce((a, b) => a + b, 0),
+  };
+}
+
+describe('TokenBucket', () => {
+  it('paces 1 MB at 4 Mbps to ~2 seconds of accumulated sleep', async () => {
+    const clock = makeClock();
+    const bucket = new TokenBucket(4, { now: clock.now, sleep: clock.sleep });
+
+    // 1 MB in 16 × 64 KiB chunks. 4 Mbps = 500 000 bytes/s.
+    const chunk = 64 * 1024;
+    for (let i = 0; i < 16; i++) {
+      await bucket.take(chunk);
+    }
+
+    const expectedMs = (16 * chunk) / 500; // bytes / (bytes per ms) ≈ 2097
+    // Generous tolerance: within ±25% of the ideal pacing.
+    expect(clock.total()).toBeGreaterThanOrEqual(expectedMs * 0.75);
+    expect(clock.total()).toBeLessThanOrEqual(expectedMs * 1.25);
+  });
+
+  it('accumulates deficit across concurrent takers (shared across a pool)', async () => {
+    const clock = makeClock();
+    const bucket = new TokenBucket(8, { now: clock.now, sleep: clock.sleep });
+
+    // Two "workers" each pushing 500 KB concurrently: 1 MB total at 1 MB/s.
+    const chunk = 50 * 1000;
+    const worker = async (): Promise<void> => {
+      for (let i = 0; i < 10; i++) {
+        await bucket.take(chunk);
+      }
+    };
+    await Promise.all([worker(), worker()]);
+
+    const expectedMs = (20 * chunk) / 1000; // 1000 bytes/ms at 8 Mbps
+    expect(clock.total()).toBeGreaterThanOrEqual(expectedMs * 0.7);
+  });
+
+  it('maxMbps 0 disables the cap entirely (no sleeps)', async () => {
+    const clock = makeClock();
+    const bucket = new TokenBucket(0, { now: clock.now, sleep: clock.sleep });
+
+    expect(bucket.unlimited).toBe(true);
+    for (let i = 0; i < 100; i++) {
+      await bucket.take(10 * 1024 * 1024);
+    }
+    expect(clock.sleeps).toHaveLength(0);
+  });
+
+  it('refills over elapsed time so idle periods earn a burst allowance', async () => {
+    const clock = makeClock();
+    const bucket = new TokenBucket(8, { now: clock.now, sleep: clock.sleep });
+
+    await bucket.take(1000); // deficit 1000 → sleeps ~1 ms, balance repaid
+    // Idle for 5 s: the balance refills (capped at one second's worth).
+    await clock.sleep(5000);
+    const sleepsBefore = clock.sleeps.length;
+    await bucket.take(1000); // fully covered by the refilled balance
+    expect(clock.sleeps.length).toBe(sleepsBefore);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

Child 4 of Epic #308. The actual sync engine: pages the change feed, classifies bytes-vs-metadata per item, downloads with retry/Range-resume/sha256 verification under strict throttle control, commits each page crash-safely (files → one catalog transaction → server ack, never ack ahead of local commit), and advances the server checkpoint. Replaces the `backup run` stub from #314 with the real command and a headless renderer.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #316
Relates to #308

## Changes Made

- `apps/cli/src/backup/backup-engine.ts` — UI-free, evented run loop: start run (409 → typed `RunAlreadyActiveError`), classification (tombstone → `trashed` + sidecar rewrite; missing row / hash change / missing-or-mismatched local file / prior `failed` → download; else sidecar-only with archive-flip tree moves), per-page presigned-URL re-mint on expiry (cap 3), cooperative cancel, dimension + `manifest.json` exports, best-effort server finish.
- `apps/cli/src/backup/download.ts` — verified downloads: `.part` streaming sha256, `Range: bytes=N-` resume with partial re-hash, 200-fallback restart, one full re-download on hash mismatch then failed, atomic rename with EXDEV fallback.
- `apps/cli/src/backup/rate-limiter.ts` — shared token bucket (`maxMbps × 1e6/8` bytes/s; 0 = unlimited).
- `apps/cli/src/api.ts` — `getRaw` (presigned GET streaming, AbortSignal, `withRetry` + shared `CooldownGate` so 429/503/Retry-After brake the engine) + typed `startNodeBackupRun`/`getNodeBackupChanges`/`ackNodeBackup`/`finishNodeBackupRun`/`getNodeBackupManifest`/`getNodeBackupDimensions`; `ApiError` carries the parsed error body (`activeRunId`).
- Throttle knobs in the settings KV: `backup.concurrency`=2, `backup.maxMbps`=0, `backup.pageSize`=100, `backup.pacingMs`=250 — all overridable per run.
- `backup run [--concurrency] [--max-mbps] [--page-size] [--json] [--strict]` behind an `executeRun(opts)` seam (daemon delegation arrives in #318); `--reconcile` reserved; headless renderer `render/headless-backup.ts` (progress, throttle notices, summary, NDJSON).
- Catalog: composable `CatalogRepo.transaction` (savepoint nesting) for one-transaction page commits.
- CLI version 1.2.20 → 1.2.21 + lockfile sync.

## Testing

- [x] Unit tests pass (`npm test`) — CLI `test:ci`: 109 suites / 1398 tests, all passing (baseline 105/1370, zero regressions)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

28 new tests: 3-page cursor walk, classification matrix, crash-before-ack idempotent replay (no duplicate files), re-mint success + cap, hash-mismatch retry-once-then-failed, concurrency bound, real Range-request assertion, 429/Retry-After gate trip, fake-clock token-bucket timing, NDJSON parseability, `--strict` exit codes.

## Additional Notes

The local checkpoint mirror may legitimately be ahead of the server after a committed-but-unacked crash; the next run's first ack catches the server up (allowed by the control plane's monotonic rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ)_