### PR TITLE
feat(web): per-node backup status column, schedule editor, and run history at /admin/settings/nodes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -31,6 +31,7 @@ const EmailSettingsPage = lazy(() => import('./pages/Admin/EmailSettingsPage'));
 const JobsPage = lazy(() => import('./pages/Admin/JobsPage'));
 const JobInsightsPage = lazy(() => import('./pages/Admin/JobInsightsPage'));
 const WorkersPage = lazy(() => import('./pages/Admin/WorkersPage'));
+const NodeBackupPage = lazy(() => import('./pages/Admin/NodeBackupPage'));
 const DoctorPage = lazy(() => import('./pages/Admin/DoctorPage'));
 const WorkflowsSettingsPage = lazy(() => import('./pages/Admin/WorkflowsSettingsPage'));
 const StorageInsightsPage = lazy(() => import('./pages/Admin/StorageInsightsPage'));
@@ -125,6 +126,7 @@ function AppRoutes() {
                 <Route path="/admin/settings/jobs" element={<JobsPage />} />
                 <Route path="/admin/settings/jobs/insights" element={<JobInsightsPage />} />
                 <Route path="/admin/settings/nodes" element={<WorkersPage />} />
+                <Route path="/admin/settings/nodes/:id/backup" element={<NodeBackupPage />} />
                 <Route path="/admin/settings/doctor" element={<DoctorPage />} />
                 <Route path="/admin/settings/workflows" element={<WorkflowsSettingsPage />} />
                 <Route path="/admin/settings/backup" element={<BackupPage />} />

--- a/apps/web/src/__tests__/pages/NodeBackupPage.test.tsx
+++ b/apps/web/src/__tests__/pages/NodeBackupPage.test.tsx
@@ -1,0 +1,507 @@
+/**
+ * Unit tests for NodeBackupPage (`/admin/settings/nodes/:id/backup`, issue
+ * #319, epic #308).
+ *
+ * Services are mocked (not the hook), so the config round-trip exercises
+ * `useNodeBackup` + the page together: PUT payloads, the server's 400 for an
+ * invalid cron surfaced inline on the custom-cron field, and `nextRunAt`
+ * rendering straight from the PUT response.
+ *
+ * Table MECHANICS live in the DataTable conformance suite; the runs-table
+ * tests here only cover this page's column declarations (statuses, durations,
+ * BigInt-safe humanized bytes, lastError via the detail/expansion surface).
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Routes, Route } from 'react-router-dom';
+import { render, mockAdminUser } from '../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+  setInitialContainerWidth,
+} from '../../components/datatable/__tests__/testUtils/layoutStubs';
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared BEFORE imports they affect
+// ---------------------------------------------------------------------------
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../../hooks/useCircles', () => ({
+  useCircles: vi.fn(),
+}));
+
+vi.mock('../../services/nodeBackup', () => ({
+  getNodeBackupConfig: vi.fn(),
+  updateNodeBackupConfig: vi.fn(),
+  getNodeBackupRuns: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import NodeBackupPage, {
+  DAILY_CRON,
+  WEEKLY_CRON,
+  deriveSchedulePreset,
+} from '../../pages/Admin/NodeBackupPage';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useCircles } from '../../hooks/useCircles';
+import {
+  getNodeBackupConfig,
+  getNodeBackupRuns,
+  updateNodeBackupConfig,
+} from '../../services/nodeBackup';
+import type {
+  NodeBackupConfigDto,
+  NodeBackupRunDto,
+} from '../../services/nodeBackup';
+
+const mockUsePermissions = vi.mocked(usePermissions);
+const mockUseCircles = vi.mocked(useCircles);
+const mockGetConfig = vi.mocked(getNodeBackupConfig);
+const mockUpdateConfig = vi.mocked(updateNodeBackupConfig);
+const mockGetRuns = vi.mocked(getNodeBackupRuns);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NODE_ID = 'node-1';
+
+function makePermissions(isAdmin: boolean) {
+  return {
+    permissions: new Set<string>(),
+    roles: new Set<string>(isAdmin ? ['admin'] : ['viewer']),
+    hasPermission: vi.fn().mockReturnValue(isAdmin),
+    hasAnyPermission: vi.fn().mockReturnValue(isAdmin),
+    hasAllPermissions: vi.fn().mockReturnValue(isAdmin),
+    hasRole: vi.fn().mockReturnValue(isAdmin),
+    hasAnyRole: vi.fn().mockReturnValue(isAdmin),
+    isAdmin,
+  };
+}
+
+function makeConfig(overrides: Partial<NodeBackupConfigDto> = {}): NodeBackupConfigDto {
+  return {
+    nodeId: NODE_ID,
+    enabled: true,
+    scheduleCron: DAILY_CRON,
+    timezone: 'UTC',
+    nextRunAt: '2026-08-10T03:00:00Z',
+    circleIds: [],
+    checkpoint: { updatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(), id: 'mi-1' },
+    itemsAcked: '1234',
+    bytesAcked: '1073741824', // 1.00 GB
+    lastRunAt: '2026-08-09T03:00:00Z',
+    lastCompletedRunAt: '2026-08-09T03:05:00Z',
+    lastReconcileAt: null,
+    pending: { items: 42, bytes: '1572864' }, // 1.50 MB
+    activeRunId: null,
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<NodeBackupRunDto> = {}): NodeBackupRunDto {
+  return {
+    id: 'run-1',
+    kind: 'incremental',
+    status: 'completed',
+    trigger: 'manual',
+    startedAt: '2026-08-09T00:00:00Z',
+    finishedAt: '2026-08-09T00:01:30Z', // 1m 30s
+    lastAckAt: '2026-08-09T00:01:00Z',
+    itemsDownloaded: 120,
+    itemsSkipped: 3,
+    sidecarsWritten: 120,
+    bytesDownloaded: '1073741824', // 1.00 GB
+    errorCount: 0,
+    lastError: null,
+    cliVersion: '1.5.0',
+    ...overrides,
+  };
+}
+
+const circleFixtures = [
+  {
+    id: 'circle-1',
+    name: 'Family',
+    description: null,
+    ownerId: 'admin-user-id',
+    isPersonal: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'circle-2',
+    name: 'Travel',
+    description: null,
+    ownerId: 'admin-user-id',
+    isPersonal: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+];
+
+function makeCirclesHook() {
+  return {
+    circles: circleFixtures,
+    loading: false,
+    error: null,
+    fetchCircles: vi.fn().mockResolvedValue(undefined),
+    addCircle: vi.fn(),
+    editCircle: vi.fn(),
+    removeCircle: vi.fn(),
+  };
+}
+
+function renderPage() {
+  return render(
+    <Routes>
+      <Route path="/admin/settings/nodes/:id/backup" element={<NodeBackupPage />} />
+      <Route path="/" element={<div>home page</div>} />
+    </Routes>,
+    {
+      wrapperOptions: {
+        user: mockAdminUser,
+        route: `/admin/settings/nodes/${NODE_ID}/backup`,
+      },
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe('NodeBackupPage', () => {
+  beforeAll(() => {
+    installLayoutStubs();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetContainerWidth(1400);
+    mockUsePermissions.mockReturnValue(makePermissions(true));
+    mockUseCircles.mockReturnValue(makeCirclesHook());
+    mockGetConfig.mockResolvedValue({ config: makeConfig() });
+    mockGetRuns.mockResolvedValue({ runs: [makeRun()] });
+    mockUpdateConfig.mockResolvedValue({ config: makeConfig() });
+  });
+
+  // =========================================================================
+  // Authorization + schedule preset helper
+  // =========================================================================
+
+  it('redirects non-admin users — page content not shown', () => {
+    mockUsePermissions.mockReturnValue(makePermissions(false));
+
+    renderPage();
+
+    expect(screen.queryByText(/node backup/i)).not.toBeInTheDocument();
+    expect(screen.getByText('home page')).toBeInTheDocument();
+  });
+
+  it('derives the schedule preset from the stored cron', () => {
+    expect(deriveSchedulePreset(null)).toBe('none');
+    expect(deriveSchedulePreset(DAILY_CRON)).toBe('daily');
+    expect(deriveSchedulePreset(WEEKLY_CRON)).toBe('weekly');
+    expect(deriveSchedulePreset('*/5 * * * *')).toBe('custom');
+  });
+
+  // =========================================================================
+  // Status card
+  // =========================================================================
+
+  describe('Status card', () => {
+    it('renders enabled state, checkpoint age, pending lag, totals and timestamps', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Enabled')).toBeInTheDocument();
+      });
+      // Checkpoint age — relative.
+      expect(screen.getByText('30m ago')).toBeInTheDocument();
+      // Pending lag: items + BigInt-humanized bytes.
+      expect(screen.getByText(/42 items · 1\.50 MB/)).toBeInTheDocument();
+      // Acked totals.
+      expect(screen.getByText(/1234 items · 1\.00 GB/)).toBeInTheDocument();
+      // Last reconcile never happened.
+      expect(screen.getByText('never')).toBeInTheDocument();
+      // No active run → no indicator.
+      expect(screen.queryByText('Run in progress')).not.toBeInTheDocument();
+    });
+
+    it('shows the active-run indicator when a run is in flight', async () => {
+      mockGetConfig.mockResolvedValue({
+        config: makeConfig({ activeRunId: 'run-live' }),
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Run in progress')).toBeInTheDocument();
+      });
+    });
+
+    it('shows the never-configured notice when config is null', async () => {
+      mockGetConfig.mockResolvedValue({ config: null });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/backup has never been configured for this node/i),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // =========================================================================
+  // Config round-trip
+  // =========================================================================
+
+  describe('Config card', () => {
+    it('initializes the form from the loaded config and PUTs the toggled state, rendering nextRunAt from the PUT response', async () => {
+      mockUpdateConfig.mockResolvedValue({
+        config: makeConfig({ enabled: false, nextRunAt: '2026-09-01T03:00:00Z' }),
+      });
+      const user = userEvent.setup();
+
+      renderPage();
+
+      // Initial nextRunAt from GET.
+      const initialNextRun = new Date('2026-08-10T03:00:00Z').toLocaleString();
+      await waitFor(() => {
+        expect(screen.getByText(`Next run: ${initialNextRun}`)).toBeInTheDocument();
+      });
+
+      // The form initialized from the config: enabled on, preset Daily.
+      const toggle = screen.getByRole('switch', { name: /backup enabled/i });
+      expect(toggle).toBeChecked();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('combobox', { name: /schedule/i }),
+        ).toHaveTextContent('Daily 03:00');
+      });
+
+      // Toggle off and save.
+      await user.click(toggle);
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateConfig).toHaveBeenCalledWith(NODE_ID, {
+          enabled: false,
+          scheduleCron: DAILY_CRON,
+          timezone: 'UTC',
+          circleIds: [],
+        });
+      });
+
+      // nextRunAt re-renders immediately from the PUT response.
+      const savedNextRun = new Date('2026-09-01T03:00:00Z').toLocaleString();
+      await waitFor(() => {
+        expect(screen.getByText(`Next run: ${savedNextRun}`)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/backup settings saved/i)).toBeInTheDocument();
+    });
+
+    it('maps the Weekly preset onto its cron on save', async () => {
+      const user = userEvent.setup();
+
+      renderPage();
+
+      await user.click(await screen.findByRole('combobox', { name: /schedule/i }));
+      await user.click(
+        await screen.findByRole('option', { name: 'Weekly Sun 03:00' }),
+      );
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateConfig).toHaveBeenCalledWith(
+          NODE_ID,
+          expect.objectContaining({ scheduleCron: WEEKLY_CRON }),
+        );
+      });
+    });
+
+    it('surfaces the server 400 for an invalid custom cron inline on the cron field', async () => {
+      mockGetConfig.mockResolvedValue({ config: null });
+      mockUpdateConfig.mockRejectedValue(
+        new Error(
+          'Invalid cron expression "every day" — expected the 5-field form "minute hour day-of-month month day-of-week"',
+        ),
+      );
+      const user = userEvent.setup();
+
+      renderPage();
+
+      await user.click(await screen.findByRole('combobox', { name: /schedule/i }));
+      await user.click(await screen.findByRole('option', { name: 'Custom cron…' }));
+
+      const cronField = await screen.findByLabelText(/cron expression/i);
+      await user.type(cronField, 'every day');
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateConfig).toHaveBeenCalledWith(
+          NODE_ID,
+          expect.objectContaining({ scheduleCron: 'every day' }),
+        );
+      });
+      // Inline, on the field — not just a page-level alert.
+      await waitFor(() => {
+        expect(
+          screen.getByText(/invalid cron expression "every day"/i),
+        ).toBeInTheDocument();
+      });
+      expect(cronField).toHaveAccessibleDescription(/invalid cron expression/i);
+    });
+
+    it('sends a picked IANA timezone on save', async () => {
+      const user = userEvent.setup();
+
+      renderPage();
+
+      const tzInput = await screen.findByRole('combobox', { name: /timezone/i });
+      await user.click(tzInput);
+      await user.clear(tzInput);
+      await user.type(tzInput, 'America/Costa');
+      await user.click(
+        await screen.findByRole('option', { name: 'America/Costa_Rica' }),
+      );
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateConfig).toHaveBeenCalledWith(
+          NODE_ID,
+          expect.objectContaining({ timezone: 'America/Costa_Rica' }),
+        );
+      });
+    });
+
+    it('shows "All my circles" when the scope is empty and sends picked circle ids on save', async () => {
+      const user = userEvent.setup();
+
+      renderPage();
+
+      const circlesInput = await screen.findByRole('combobox', { name: /circles/i });
+      expect(circlesInput).toHaveAttribute('placeholder', 'All my circles');
+
+      await user.click(circlesInput);
+      await user.click(await screen.findByRole('option', { name: 'Family' }));
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateConfig).toHaveBeenCalledWith(
+          NODE_ID,
+          expect.objectContaining({ circleIds: ['circle-1'] }),
+        );
+      });
+    });
+  });
+
+  // =========================================================================
+  // Runs table
+  // =========================================================================
+
+  describe('Runs table', () => {
+    it('renders kind, status chip, duration and humanized bytes from fixtures', async () => {
+      mockGetRuns.mockResolvedValue({
+        runs: [
+          makeRun({ id: 'run-ok' }),
+          makeRun({
+            id: 'run-bad',
+            kind: 'reconcile',
+            status: 'failed',
+            trigger: 'scheduled',
+            finishedAt: '2026-08-09T01:00:00Z', // 1h
+            bytesDownloaded: '1572864', // 1.50 MB
+            itemsDownloaded: 7,
+            itemsSkipped: 5,
+            errorCount: 9,
+            lastError: 'boom: download failed',
+          }),
+        ],
+      });
+
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /backup runs/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('incremental')).toBeInTheDocument();
+      });
+      expect(within(grid).getByText('reconcile')).toBeInTheDocument();
+      expect(within(grid).getByText('completed')).toBeInTheDocument();
+      expect(within(grid).getByText('failed')).toBeInTheDocument();
+      expect(within(grid).getByText('scheduled')).toBeInTheDocument();
+      // Durations: finishedAt - startedAt.
+      expect(within(grid).getByText('1m 30s')).toBeInTheDocument();
+      expect(within(grid).getByText('1h')).toBeInTheDocument();
+      // BigInt-humanized bytes.
+      expect(within(grid).getByText('1.00 GB')).toBeInTheDocument();
+      expect(within(grid).getByText('1.50 MB')).toBeInTheDocument();
+      // Error count from the failing run.
+      expect(within(grid).getByText('9')).toBeInTheDocument();
+    });
+
+    it('shows an em dash duration for a still-running run', async () => {
+      mockGetRuns.mockResolvedValue({
+        runs: [makeRun({ id: 'run-live', status: 'running', finishedAt: null })],
+      });
+
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /backup runs/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('running')).toBeInTheDocument();
+      });
+      // Both the duration cell and the null lastError cell render an em dash.
+      expect(within(grid).getAllByText('—').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('reveals lastError through the row expansion (tablet width)', async () => {
+      setInitialContainerWidth(800);
+      mockGetRuns.mockResolvedValue({
+        runs: [
+          makeRun({
+            id: 'run-bad',
+            kind: 'reconcile',
+            status: 'failed',
+            errorCount: 1,
+            lastError: 'boom: download failed',
+          }),
+        ],
+      });
+      const user = userEvent.setup();
+
+      renderPage();
+
+      // `lastError` is a detail column — folded behind the expander at tablet
+      // width, so it must not be visible before expanding.
+      const expander = await screen.findByRole('button', {
+        name: /show details for reconcile/i,
+      });
+      expect(screen.queryByText('boom: download failed')).not.toBeInTheDocument();
+
+      await user.click(expander);
+
+      await waitFor(() => {
+        expect(screen.getByText('boom: download failed')).toBeInTheDocument();
+      });
+    });
+
+    it('shows the empty state when there are no runs yet', async () => {
+      mockGetRuns.mockResolvedValue({ runs: [] });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText(/no backup runs yet/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/web/src/__tests__/pages/WorkersPage.test.tsx
+++ b/apps/web/src/__tests__/pages/WorkersPage.test.tsx
@@ -39,8 +39,12 @@ vi.mock('../../hooks/useNodeCredentials', () => ({
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
+import { Routes, Route } from 'react-router-dom';
 import WorkersPage from '../../pages/Admin/WorkersPage';
 import {
+  BACKUP_WARNING_AGE_MS,
+  backupChipLabel,
+  backupChipState,
   buildNodeCredentialColumns,
   buildWorkerNodeColumns,
   credentialState,
@@ -53,6 +57,7 @@ import type { UseNodeCredentialsResult } from '../../hooks/useNodeCredentials';
 import type {
   AdminNodeCredentialDto,
   CreatedNodeCredentialDto,
+  WorkerNodeBackupSummary,
   WorkerNodeDto,
 } from '../../services/workers';
 import { api } from '../../services/api';
@@ -285,9 +290,11 @@ describe('WorkersPage', () => {
       const user = userEvent.setup();
 
       renderPage();
+      // Two row actions (Backup settings + Deregister) collapse into a menu.
       await user.click(
-        await screen.findByRole('button', { name: /deregister node for gpu-box-1/i }),
+        await screen.findByRole('button', { name: /row actions for gpu-box-1/i }),
       );
+      await user.click(await screen.findByRole('menuitem', { name: /deregister node/i }));
 
       const dialog = await screen.findByRole('dialog');
       expect(within(dialog).getByText(/deregister worker node\?/i)).toBeInTheDocument();
@@ -310,8 +317,9 @@ describe('WorkersPage', () => {
 
       renderPage();
       await user.click(
-        await screen.findByRole('button', { name: /deregister node for gpu-box-1/i }),
+        await screen.findByRole('button', { name: /row actions for gpu-box-1/i }),
       );
+      await user.click(await screen.findByRole('menuitem', { name: /deregister node/i }));
 
       const dialog = await screen.findByRole('dialog');
       await user.click(within(dialog).getByRole('button', { name: /cancel/i }));
@@ -330,6 +338,138 @@ describe('WorkersPage', () => {
       expect(toggle).toBeChecked();
       await user.click(toggle);
       expect(setAutoRefresh).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // =========================================================================
+  // Backup column (issue #319)
+  // =========================================================================
+
+  describe('Backup column', () => {
+    const HOUR = 60 * 60 * 1000;
+
+    function makeBackup(
+      overrides: Partial<WorkerNodeBackupSummary> = {},
+    ): WorkerNodeBackupSummary {
+      return {
+        enabled: true,
+        lastCompletedRunAt: new Date(Date.now() - 2 * HOUR).toISOString(),
+        checkpointUpdatedAt: new Date(Date.now() - 1 * HOUR).toISOString(),
+        activeRun: false,
+        ...overrides,
+      };
+    }
+
+    describe('backupChipState', () => {
+      it('is "off" when the summary is null (never configured)', () => {
+        expect(backupChipState(null)).toBe('off');
+        expect(backupChipState(undefined)).toBe('off');
+      });
+
+      it('is "off" when disabled — Off wins over an active run', () => {
+        expect(backupChipState(makeBackup({ enabled: false }))).toBe('off');
+        expect(
+          backupChipState(makeBackup({ enabled: false, activeRun: true })),
+        ).toBe('off');
+      });
+
+      it('is "running" while a run is active — Running wins over Warning', () => {
+        expect(backupChipState(makeBackup({ activeRun: true }))).toBe('running');
+        expect(
+          backupChipState(makeBackup({ activeRun: true, lastCompletedRunAt: null })),
+        ).toBe('running');
+      });
+
+      it('is "warning" when enabled but no run has ever completed', () => {
+        expect(backupChipState(makeBackup({ lastCompletedRunAt: null }))).toBe('warning');
+      });
+
+      it('is "warning" when the last completed run is older than 26h (fixed heuristic)', () => {
+        const now = Date.now();
+        const past = new Date(now - BACKUP_WARNING_AGE_MS - 1000).toISOString();
+        expect(backupChipState(makeBackup({ lastCompletedRunAt: past }), now)).toBe(
+          'warning',
+        );
+      });
+
+      it('is "ok" with a recent completed run, and the label includes the relative time', () => {
+        const backup = makeBackup();
+        expect(backupChipState(backup)).toBe('ok');
+        expect(backupChipLabel(backup)).toMatch(/^OK — backed up 2h ago$/);
+      });
+    });
+
+    it('renders a chip per node from the list payload alone (no per-row requests)', async () => {
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({
+          nodes: [
+            makeNode({ id: 'n-off', name: 'node-off', backup: null }),
+            makeNode({
+              id: 'n-run',
+              name: 'node-run',
+              backup: makeBackup({ activeRun: true }),
+            }),
+            makeNode({
+              id: 'n-warn',
+              name: 'node-warn',
+              backup: makeBackup({ lastCompletedRunAt: null }),
+            }),
+            makeNode({ id: 'n-ok', name: 'node-ok', backup: makeBackup() }),
+          ],
+        }),
+      );
+
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /worker nodes/i });
+      // Scope to chip labels — "Running" is also a column header.
+      const chip = { selector: '.MuiChip-label' };
+      await waitFor(() => {
+        expect(within(grid).getByText('Off', chip)).toBeInTheDocument();
+      });
+      expect(within(grid).getByText('Running', chip)).toBeInTheDocument();
+      expect(within(grid).getByText('Warning', chip)).toBeInTheDocument();
+      expect(within(grid).getByText(/OK — backed up/, chip)).toBeInTheDocument();
+    });
+
+    it('renders the table unconditionally while loading (rows stay visible under the overlay)', async () => {
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({ nodes: [makeNode()], loading: true }),
+      );
+
+      renderPage();
+
+      const grid = await screen.findByRole('grid', { name: /worker nodes/i });
+      await waitFor(() => {
+        expect(within(grid).getByText('gpu-box-1')).toBeInTheDocument();
+      });
+    });
+
+    it('navigates to the node backup page from the "Backup settings" row action', async () => {
+      mockUseWorkers.mockReturnValue(
+        makeWorkersHook({ nodes: [makeNode({ id: 'node-uuid-1' })] }),
+      );
+      const user = userEvent.setup();
+
+      render(
+        <Routes>
+          <Route path="/" element={<WorkersPage />} />
+          <Route
+            path="/admin/settings/nodes/:id/backup"
+            element={<div>node backup page target</div>}
+          />
+        </Routes>,
+        { wrapperOptions: { user: mockAdminUser } },
+      );
+
+      await user.click(
+        await screen.findByRole('button', { name: /row actions for gpu-box-1/i }),
+      );
+      await user.click(await screen.findByRole('menuitem', { name: /backup settings/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('node backup page target')).toBeInTheDocument();
+      });
     });
   });
 

--- a/apps/web/src/__tests__/utils/formatBytes.test.ts
+++ b/apps/web/src/__tests__/utils/formatBytes.test.ts
@@ -48,6 +48,24 @@ describe('formatBytes', () => {
     expect(result).toMatch(/^1\.1[0-9] TB$/);
   });
 
+  // Backup byte counters (issue #319) are BigInt-serialized strings that can
+  // legitimately exceed Number.MAX_SAFE_INTEGER — the humanizer must parse via
+  // BigInt, never Number(), so values past 2^53 stay exact.
+  it('is exact at 2^53 (9007199254740992 bytes = 8 PB)', () => {
+    expect(formatBytes('9007199254740992')).toBe('8.00 PB');
+  });
+
+  it('handles 2^53 + 1 ("9007199254740993") via the BigInt path without precision loss', () => {
+    // Number('9007199254740993') would round to 9007199254740992; BigInt keeps
+    // the odd value intact and the division still lands on 8.00 PB.
+    expect(formatBytes('9007199254740993')).toBe('8.00 PB');
+  });
+
+  it('handles values far past 2^53 (~1024 PB stays in the PB unit, no crash)', () => {
+    // 2^60 bytes = 1024 PB — units stop at PB, so the whole part grows instead.
+    expect(formatBytes('1152921504606846976')).toBe('1024.00 PB');
+  });
+
   it('accepts a bigint directly', () => {
     expect(formatBytes(1024n)).toBe('1.00 KB');
   });

--- a/apps/web/src/hooks/useNodeBackup.ts
+++ b/apps/web/src/hooks/useNodeBackup.ts
@@ -1,0 +1,126 @@
+import { useState, useCallback, useEffect } from 'react';
+import {
+  getNodeBackupConfig,
+  getNodeBackupRuns,
+  updateNodeBackupConfig,
+} from '../services/nodeBackup';
+import type {
+  NodeBackupConfigDto,
+  NodeBackupRunDto,
+  UpdateNodeBackupConfigDto,
+} from '../services/nodeBackup';
+import { useIsMounted } from './useIsMounted';
+
+/**
+ * Poll interval for the backup status/runs while the page is mounted.
+ * Backup runs progress on the order of minutes, so 15s (vs. useWorkers' 5s)
+ * is plenty and keeps the two per-node requests cheap.
+ */
+const POLL_INTERVAL_MS = 15000;
+
+interface UseNodeBackupOptions {
+  autoRefresh?: boolean;
+}
+
+export interface UseNodeBackupResult {
+  /** null = backup never configured for this node (or not yet loaded). */
+  config: NodeBackupConfigDto | null;
+  /** True once the first config fetch has resolved (distinguishes "loading" from "unconfigured"). */
+  configLoaded: boolean;
+  runs: NodeBackupRunDto[];
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+
+  refresh: () => Promise<void>;
+  /**
+   * PUT the config. Returns the server's post-save config (GET shape) and
+   * stores it, so `nextRunAt` renders immediately from the PUT response.
+   * Rethrows on failure so the caller can surface the server's 400 message
+   * (invalid cron / timezone / circleIds) inline.
+   */
+  saveConfig: (dto: UpdateNodeBackupConfigDto) => Promise<NodeBackupConfigDto | null>;
+}
+
+/**
+ * Config + run history for one worker node's backup, with a 15s silent poll
+ * while mounted (silent-refresh vs. spinner pattern copied from useWorkers).
+ */
+export function useNodeBackup(
+  nodeId: string | undefined,
+  options: UseNodeBackupOptions = {},
+): UseNodeBackupResult {
+  const autoRefresh = options.autoRefresh ?? true;
+  const [config, setConfig] = useState<NodeBackupConfigDto | null>(null);
+  const [configLoaded, setConfigLoaded] = useState(false);
+  const [runs, setRuns] = useState<NodeBackupRunDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
+
+  // Silent fetch (no loading spinner) — used by the polling interval.
+  const fetchAll = useCallback(async () => {
+    if (!nodeId) return;
+    try {
+      const [configResp, runsResp] = await Promise.all([
+        getNodeBackupConfig(nodeId),
+        getNodeBackupRuns(nodeId, 20),
+      ]);
+      if (!isMounted()) return;
+      setConfig(configResp.config);
+      setConfigLoaded(true);
+      setRuns(runsResp.runs);
+      setError(null);
+    } catch (err) {
+      if (!isMounted()) return;
+      setError(err instanceof Error ? err.message : 'Failed to load backup status');
+    }
+  }, [nodeId, isMounted]);
+
+  // Explicit refresh with a loading indicator.
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      await fetchAll();
+    } finally {
+      if (isMounted()) setLoading(false);
+    }
+  }, [fetchAll, isMounted]);
+
+  // Initial load.
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId]);
+
+  // Auto-refresh polling (silent — no spinner, table stays mounted).
+  useEffect(() => {
+    if (!autoRefresh || !nodeId) return;
+    const id = setInterval(() => {
+      void fetchAll();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [autoRefresh, nodeId, fetchAll]);
+
+  const saveConfig = useCallback(
+    async (dto: UpdateNodeBackupConfigDto) => {
+      if (!nodeId) return null;
+      setSaving(true);
+      try {
+        const resp = await updateNodeBackupConfig(nodeId, dto);
+        if (isMounted()) {
+          setConfig(resp.config);
+          setConfigLoaded(true);
+          setError(null);
+        }
+        return resp.config;
+      } finally {
+        if (isMounted()) setSaving(false);
+      }
+    },
+    [nodeId, isMounted],
+  );
+
+  return { config, configLoaded, runs, loading, saving, error, refresh, saveConfig };
+}

--- a/apps/web/src/pages/Admin/NodeBackupPage.tsx
+++ b/apps/web/src/pages/Admin/NodeBackupPage.tsx
@@ -1,0 +1,505 @@
+/**
+ * Admin → Worker Nodes → Node Backup (`/admin/settings/nodes/:id/backup`).
+ *
+ * Issue #319 (epic #308): per-node backup status + config editor + run history
+ * over the #312 node backup control plane:
+ *
+ *   - Status card — enabled state, checkpoint age, pending lag, acked totals,
+ *     last run / completed / reconcile timestamps, active-run indicator.
+ *   - Config card — enable toggle, schedule presets (daily / weekly / custom
+ *     cron with the server's 400 surfaced inline), IANA timezone, circle
+ *     include-list ("All my circles" when empty). Save = PUT; the returned
+ *     `nextRunAt` renders immediately from the PUT response.
+ *   - Runs table — shared DataTable over GET …/backup/runs?limit=20, rendered
+ *     UNCONDITIONALLY with `loading` (docs/specs/datatable.md §18.4) since
+ *     `useNodeBackup` silently polls every 15s.
+ *
+ * The download throttle is deliberately NOT editable here — it is a node-side
+ * setting (`memoriahub backup set-rate`).
+ *
+ * Byte fields in every backup DTO are BigInt-safe STRINGS; they are humanized
+ * via `formatBytes` (BigInt parsing), never `Number()` on the raw string.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Navigate, Link as RouterLink, useParams } from 'react-router-dom';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  Container,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  Link,
+  MenuItem,
+  Paper,
+  Select,
+  Snackbar,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  SettingsBackupRestore as BackupIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useNodeBackup } from '../../hooks/useNodeBackup';
+import { useCircles } from '../../hooks/useCircles';
+import type { NodeBackupRunDto } from '../../services/nodeBackup';
+import { DataTable } from '../../components/datatable';
+import {
+  NODE_BACKUP_RUNS_TABLE_ID,
+  buildNodeBackupRunColumns,
+} from './nodeBackupTable';
+import { formatBytes, relativeTime } from '../../utils/formatBytes';
+
+// ---------------------------------------------------------------------------
+// Schedule presets
+// ---------------------------------------------------------------------------
+
+export const DAILY_CRON = '0 3 * * *';
+export const WEEKLY_CRON = '0 3 * * 0';
+
+type SchedulePreset = 'none' | 'daily' | 'weekly' | 'custom';
+
+/** Map a stored cron back onto the preset select. */
+export function deriveSchedulePreset(scheduleCron: string | null): SchedulePreset {
+  if (scheduleCron === null || scheduleCron === '') return 'none';
+  if (scheduleCron === DAILY_CRON) return 'daily';
+  if (scheduleCron === WEEKLY_CRON) return 'weekly';
+  return 'custom';
+}
+
+/**
+ * IANA timezone options from `Intl.supportedValuesOf('timeZone')`.
+ *
+ * Typed via a narrow cast because the app's tsconfig lib is ES2020 while
+ * `supportedValuesOf` is ES2022 — every supported runtime has it, but a
+ * fallback keeps the select usable if an ancient browser doesn't.
+ */
+export function supportedTimezones(fallback: string): string[] {
+  const intl = Intl as typeof Intl & {
+    supportedValuesOf?: (key: 'timeZone') => string[];
+  };
+  if (typeof intl.supportedValuesOf === 'function') {
+    return intl.supportedValuesOf('timeZone');
+  }
+  return Array.from(new Set([fallback, 'UTC']));
+}
+
+// ---------------------------------------------------------------------------
+// Small display helpers
+// ---------------------------------------------------------------------------
+
+function StatItem({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Box sx={{ minWidth: 160 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" component="div">
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+function timestampOrNever(iso: string | null): string {
+  return iso ? `${relativeTime(iso)} (${new Date(iso).toLocaleString()})` : 'never';
+}
+
+// ---------------------------------------------------------------------------
+// Main content (admin-gated wrapper below)
+// ---------------------------------------------------------------------------
+
+function NodeBackupPageContent({ nodeId }: { nodeId: string }) {
+  const { config, configLoaded, runs, loading, saving, error, refresh, saveConfig } =
+    useNodeBackup(nodeId, { autoRefresh: true });
+  const { circles, fetchCircles } = useCircles();
+
+  // --- Form state ------------------------------------------------------------
+  const browserTz = useMemo(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+    [],
+  );
+  const timezoneOptions = useMemo<string[]>(
+    () => supportedTimezones(browserTz),
+    [browserTz],
+  );
+
+  const [enabled, setEnabled] = useState(true);
+  const [schedulePreset, setSchedulePreset] = useState<SchedulePreset>('none');
+  const [customCron, setCustomCron] = useState('');
+  const [timezone, setTimezone] = useState<string>(browserTz);
+  const [circleIds, setCircleIds] = useState<string[]>([]);
+
+  const [cronError, setCronError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void fetchCircles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Initialize the form ONCE from the first loaded config — the 15s poll keeps
+  // refreshing the status card, but must never clobber an in-progress edit.
+  const formInitialized = useRef(false);
+  useEffect(() => {
+    if (!configLoaded || formInitialized.current) return;
+    formInitialized.current = true;
+    if (config) {
+      setEnabled(config.enabled);
+      const preset = deriveSchedulePreset(config.scheduleCron);
+      setSchedulePreset(preset);
+      setCustomCron(preset === 'custom' ? (config.scheduleCron ?? '') : '');
+      setTimezone(config.timezone ?? browserTz);
+      setCircleIds(config.circleIds);
+    }
+  }, [configLoaded, config, browserTz]);
+
+  // --- Save ------------------------------------------------------------------
+
+  const handleSave = useCallback(async () => {
+    setCronError(null);
+    setFormError(null);
+
+    let scheduleCron: string | null;
+    switch (schedulePreset) {
+      case 'none':
+        scheduleCron = null;
+        break;
+      case 'daily':
+        scheduleCron = DAILY_CRON;
+        break;
+      case 'weekly':
+        scheduleCron = WEEKLY_CRON;
+        break;
+      case 'custom':
+        scheduleCron = customCron.trim();
+        if (!scheduleCron) {
+          setCronError('Enter a 5-field cron expression');
+          return;
+        }
+        break;
+    }
+
+    try {
+      await saveConfig({
+        enabled,
+        scheduleCron,
+        timezone: timezone || null,
+        circleIds,
+      });
+      setSuccessMessage('Backup settings saved');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save backup settings';
+      // Surface an invalid-cron 400 inline on the cron field; everything else
+      // lands in the form-level alert.
+      if (/cron/i.test(message)) {
+        setCronError(message);
+        setSchedulePreset('custom');
+      } else {
+        setFormError(message);
+      }
+    }
+  }, [schedulePreset, customCron, enabled, timezone, circleIds, saveConfig]);
+
+  // --- Circle multi-select value ---------------------------------------------
+
+  type CircleOption = { id: string; name: string };
+  const circleOptions = useMemo<CircleOption[]>(
+    () => circles.map((c) => ({ id: c.id, name: c.name })),
+    [circles],
+  );
+  const selectedCircles = useMemo<CircleOption[]>(
+    () =>
+      circleIds.map(
+        (id) => circleOptions.find((c) => c.id === id) ?? { id, name: id },
+      ),
+    [circleIds, circleOptions],
+  );
+
+  // --- Runs table ------------------------------------------------------------
+
+  const runColumns = useMemo(() => buildNodeBackupRunColumns(), []);
+
+  return (
+    <Container maxWidth="xl">
+      <Box sx={{ py: 4 }}>
+        {/* Back link */}
+        <Link
+          component={RouterLink}
+          to="/admin/settings/nodes"
+          underline="hover"
+          variant="body2"
+          sx={{ display: 'inline-block', mb: 2 }}
+        >
+          &larr; Back to Worker Nodes
+        </Link>
+
+        {/* Page header */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <BackupIcon color="primary" />
+          <Typography variant="h4" component="h1">
+            Node Backup
+          </Typography>
+        </Box>
+        <Typography color="text.secondary" sx={{ mb: 3 }}>
+          Local backup of this node&apos;s circles — schedule, scope, checkpoint
+          progress, and run history. Node <code>{nodeId}</code>.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Status card                                                         */}
+        {/* ------------------------------------------------------------------ */}
+        <Paper variant="outlined" sx={{ p: 2.5, mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+            <Typography variant="h6" component="h2" sx={{ flexGrow: 1 }}>
+              Status
+            </Typography>
+            {config && (
+              <Chip
+                label={config.enabled ? 'Enabled' : 'Disabled'}
+                color={config.enabled ? 'success' : 'default'}
+                size="small"
+                variant="outlined"
+              />
+            )}
+            {config?.activeRunId && (
+              <Chip label="Run in progress" color="info" size="small" />
+            )}
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<RefreshIcon />}
+              disabled={loading}
+              onClick={() => void refresh()}
+            >
+              Refresh
+            </Button>
+          </Box>
+
+          {!configLoaded ? (
+            <Typography color="text.secondary" variant="body2">
+              Loading backup status…
+            </Typography>
+          ) : !config ? (
+            <Alert severity="info">
+              Backup has never been configured for this node. Choose a schedule
+              and scope below, then save to enable it.
+            </Alert>
+          ) : (
+            <Stack
+              direction="row"
+              spacing={4}
+              useFlexGap
+              sx={{ flexWrap: 'wrap', rowGap: 2 }}
+            >
+              <StatItem label="Checkpoint">
+                {config.checkpoint
+                  ? relativeTime(config.checkpoint.updatedAt)
+                  : 'no checkpoint yet'}
+              </StatItem>
+              <StatItem label="Pending">
+                {config.pending.items} items · {formatBytes(config.pending.bytes)}
+              </StatItem>
+              <StatItem label="Acked total">
+                {config.itemsAcked} items · {formatBytes(config.bytesAcked)}
+              </StatItem>
+              <StatItem label="Last run">{timestampOrNever(config.lastRunAt)}</StatItem>
+              <StatItem label="Last completed">
+                {timestampOrNever(config.lastCompletedRunAt)}
+              </StatItem>
+              <StatItem label="Last reconcile">
+                {timestampOrNever(config.lastReconcileAt)}
+              </StatItem>
+            </Stack>
+          )}
+        </Paper>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Config card                                                         */}
+        {/* ------------------------------------------------------------------ */}
+        <Paper variant="outlined" sx={{ p: 2.5, mb: 3 }}>
+          <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+            Configuration
+          </Typography>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Runs start when the node&apos;s daemon polls in — an offline node runs
+            when it reconnects.
+          </Alert>
+
+          {formError && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setFormError(null)}>
+              {formError}
+            </Alert>
+          )}
+
+          <Stack spacing={2.5} sx={{ maxWidth: 560 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={enabled}
+                  onChange={(e) => setEnabled(e.target.checked)}
+                  disabled={saving}
+                />
+              }
+              label="Backup enabled"
+            />
+
+            <FormControl fullWidth>
+              <InputLabel id="backup-schedule-label">Schedule</InputLabel>
+              <Select
+                labelId="backup-schedule-label"
+                label="Schedule"
+                value={schedulePreset}
+                disabled={saving}
+                onChange={(e) => {
+                  setSchedulePreset(e.target.value as SchedulePreset);
+                  setCronError(null);
+                }}
+              >
+                <MenuItem value="none">No schedule (manual only)</MenuItem>
+                <MenuItem value="daily">Daily 03:00</MenuItem>
+                <MenuItem value="weekly">Weekly Sun 03:00</MenuItem>
+                <MenuItem value="custom">Custom cron…</MenuItem>
+              </Select>
+            </FormControl>
+
+            {schedulePreset === 'custom' && (
+              <TextField
+                label="Cron expression"
+                value={customCron}
+                onChange={(e) => {
+                  setCustomCron(e.target.value);
+                  setCronError(null);
+                }}
+                disabled={saving}
+                error={!!cronError}
+                helperText={
+                  cronError ??
+                  'A 5-field cron expression: minute hour day-of-month month day-of-week'
+                }
+                placeholder="0 3 * * *"
+                fullWidth
+              />
+            )}
+            {schedulePreset !== 'custom' && cronError && (
+              <Alert severity="error">{cronError}</Alert>
+            )}
+
+            <Autocomplete
+              options={timezoneOptions}
+              value={timezone}
+              onChange={(_e, next) => setTimezone(next ?? browserTz)}
+              disabled={saving}
+              disableClearable={false}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Timezone"
+                  helperText="IANA timezone the schedule is evaluated in"
+                />
+              )}
+            />
+
+            <Autocomplete<CircleOption, true>
+              multiple
+              options={circleOptions}
+              getOptionLabel={(option) => option.name}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              value={selectedCircles}
+              onChange={(_e, next) => setCircleIds(next.map((c) => c.id))}
+              disabled={saving}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Circles"
+                  placeholder={circleIds.length === 0 ? 'All my circles' : undefined}
+                  helperText="Leave empty to back up all my circles"
+                />
+              )}
+            />
+
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Button
+                variant="contained"
+                disabled={saving}
+                onClick={() => void handleSave()}
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </Button>
+              <Typography variant="body2" color="text.secondary">
+                {config?.nextRunAt
+                  ? `Next run: ${new Date(config.nextRunAt).toLocaleString()}`
+                  : 'Next run: not scheduled'}
+              </Typography>
+            </Box>
+
+            <Typography variant="caption" color="text.secondary">
+              Download throttle is not editable here — set it on the node with{' '}
+              <code>memoriahub backup set-rate</code>.
+            </Typography>
+          </Stack>
+        </Paper>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Runs table                                                          */}
+        {/* ------------------------------------------------------------------ */}
+        <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+          Recent runs
+        </Typography>
+        <DataTable<NodeBackupRunDto>
+          columns={runColumns}
+          rows={runs}
+          rowId={(run) => run.id}
+          tableId={NODE_BACKUP_RUNS_TABLE_ID}
+          ariaLabel="Backup runs"
+          density="compact"
+          loading={loading}
+          error={null}
+          emptyState={<span>No backup runs yet</span>}
+          csvExport={{ filename: 'node-backup-runs' }}
+        />
+      </Box>
+
+      {/* Success snackbar */}
+      <Snackbar
+        open={!!successMessage}
+        autoHideDuration={3000}
+        onClose={() => setSuccessMessage(null)}
+        message={successMessage}
+      />
+    </Container>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Admin-gated export (mirrors WorkersPage pattern)
+// ---------------------------------------------------------------------------
+
+export default function NodeBackupPage() {
+  const { isAdmin } = usePermissions();
+  const { id } = useParams<{ id: string }>();
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+  if (!id) {
+    return <Navigate to="/admin/settings/nodes" replace />;
+  }
+
+  return <NodeBackupPageContent nodeId={id} />;
+}

--- a/apps/web/src/pages/Admin/WorkersPage.tsx
+++ b/apps/web/src/pages/Admin/WorkersPage.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useCallback, useMemo, useState, FormEvent } from 'react';
-import { Navigate, Link as RouterLink } from 'react-router-dom';
+import { Navigate, Link as RouterLink, useNavigate } from 'react-router-dom';
 import {
   Container,
   Box,
@@ -56,6 +56,7 @@ import {
   Add as AddIcon,
   ContentCopy as ContentCopyIcon,
   Check as CheckIcon,
+  SettingsBackupRestore as BackupSettingsIcon,
 } from '@mui/icons-material';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useWorkers } from '../../hooks/useWorkers';
@@ -288,6 +289,7 @@ function NodeCredentialRevealDialog({ open, onClose, token }: NodeCredentialReve
 // ---------------------------------------------------------------------------
 
 function WorkersPageContent() {
+  const navigate = useNavigate();
   const { nodes, loading, error, autoRefresh, setAutoRefresh, refresh, deleteWorker } = useWorkers({
     autoRefresh: true,
   });
@@ -349,6 +351,12 @@ function WorkersPageContent() {
 
   const nodeActions = useMemo<DataTableRowAction<WorkerNodeDto>[]>(
     () => [
+      {
+        id: 'backup-settings',
+        label: 'Backup settings',
+        icon: <BackupSettingsIcon fontSize="small" />,
+        onClick: (node) => navigate(`/admin/settings/nodes/${node.id}/backup`),
+      },
       {
         id: 'deregister',
         label: 'Deregister node',

--- a/apps/web/src/pages/Admin/nodeBackupTable.tsx
+++ b/apps/web/src/pages/Admin/nodeBackupTable.tsx
@@ -1,0 +1,196 @@
+/**
+ * Node Backup — the runs-history DataTable declaration for
+ * `/admin/settings/nodes/:id/backup` (issue #319, epic #308).
+ *
+ * ## Nothing is `sortable` or `filterable`
+ *
+ * `GET /nodes/:id/backup/runs?limit=20` returns the newest runs with no page,
+ * sort, or filter params — declaring any of those would paint a control the
+ * server cannot honour (docs/specs/datatable.md §4).
+ *
+ * ## `lastError` is a `detail` column
+ *
+ * On a phone/tablet it folds into the card/row expansion; on desktop it is a
+ * truncated column revealing the full text on hover — the contract's own
+ * "expansion/detail" surface, no bespoke drawer needed.
+ */
+
+import { Chip, Typography } from '@mui/material';
+import type { DataTableColumn } from '../../components/datatable';
+import type {
+  NodeBackupRunDto,
+  NodeBackupRunStatus,
+} from '../../services/nodeBackup';
+import { formatBytes, formatDuration, relativeTime } from '../../utils/formatBytes';
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export const NODE_BACKUP_RUNS_TABLE_ID = 'admin-node-backup-runs';
+
+// ---------------------------------------------------------------------------
+// Cell helpers
+// ---------------------------------------------------------------------------
+
+const RUN_STATUS_COLORS: Record<
+  NodeBackupRunStatus,
+  'default' | 'info' | 'success' | 'warning' | 'error'
+> = {
+  running: 'info',
+  completed: 'success',
+  failed: 'error',
+  aborted: 'warning',
+  stale: 'default',
+};
+
+function RunStatusChip({ status }: { status: NodeBackupRunStatus }) {
+  return (
+    <Chip
+      label={status}
+      color={RUN_STATUS_COLORS[status] ?? 'default'}
+      size="small"
+      variant="outlined"
+    />
+  );
+}
+
+/** finishedAt - startedAt in ms; null while the run is still going. */
+export function runDurationMs(run: NodeBackupRunDto): number | null {
+  if (!run.finishedAt) return null;
+  return new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime();
+}
+
+// ---------------------------------------------------------------------------
+// Columns
+// ---------------------------------------------------------------------------
+
+/**
+ * The backup-run history columns.
+ *
+ * Priorities:
+ *   - primary   — Kind, Status
+ *   - secondary — Trigger, Started, Duration, Items downloaded, Bytes, Errors
+ *   - detail    — Items skipped, Last error
+ */
+export function buildNodeBackupRunColumns(): DataTableColumn<NodeBackupRunDto>[] {
+  return [
+    // --- primary ------------------------------------------------------------
+    {
+      id: 'kind',
+      label: 'Kind',
+      priority: 'primary',
+      value: (run) => run.kind,
+      width: 130,
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      priority: 'primary',
+      value: (run) => run.status,
+      render: (run) => <RunStatusChip status={run.status} />,
+      width: 130,
+    },
+
+    // --- secondary ----------------------------------------------------------
+    {
+      id: 'trigger',
+      label: 'Trigger',
+      priority: 'secondary',
+      value: (run) => run.trigger,
+      width: 120,
+    },
+    {
+      id: 'startedAt',
+      label: 'Started',
+      priority: 'secondary',
+      value: (run) => run.startedAt,
+      render: (run) => (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {relativeTime(run.startedAt)}
+        </Typography>
+      ),
+      minWidth: 130,
+    },
+    {
+      id: 'duration',
+      label: 'Duration',
+      priority: 'secondary',
+      value: (run) => runDurationMs(run),
+      render: (run) => {
+        const ms = runDurationMs(run);
+        return (
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {ms === null ? '—' : formatDuration(ms)}
+          </Typography>
+        );
+      },
+      width: 120,
+    },
+    {
+      id: 'itemsDownloaded',
+      label: 'Downloaded',
+      priority: 'secondary',
+      align: 'center',
+      value: (run) => run.itemsDownloaded,
+      width: 130,
+    },
+    {
+      id: 'bytesDownloaded',
+      label: 'Bytes',
+      priority: 'secondary',
+      value: (run) => run.bytesDownloaded,
+      render: (run) => (
+        <Typography variant="body2" noWrap>
+          {formatBytes(run.bytesDownloaded)}
+        </Typography>
+      ),
+      width: 120,
+    },
+    {
+      id: 'errorCount',
+      label: 'Errors',
+      priority: 'secondary',
+      align: 'center',
+      value: (run) => run.errorCount,
+      render: (run) => (
+        <Typography
+          variant="body2"
+          color={run.errorCount > 0 ? 'error.main' : 'text.secondary'}
+        >
+          {run.errorCount}
+        </Typography>
+      ),
+      width: 100,
+    },
+
+    // --- detail -------------------------------------------------------------
+    {
+      id: 'itemsSkipped',
+      label: 'Skipped',
+      priority: 'detail',
+      align: 'center',
+      value: (run) => run.itemsSkipped,
+      width: 110,
+    },
+    {
+      id: 'lastError',
+      label: 'Last error',
+      priority: 'detail',
+      value: (run) => run.lastError,
+      render: (run) =>
+        run.lastError ? (
+          <Typography variant="body2" color="error.main">
+            {run.lastError}
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="text.disabled">
+            —
+          </Typography>
+        ),
+      truncate: true,
+      minWidth: 220,
+      flex: 1,
+    },
+  ];
+}

--- a/apps/web/src/pages/Admin/workersTable.tsx
+++ b/apps/web/src/pages/Admin/workersTable.tsx
@@ -34,6 +34,7 @@ import type {
   AdminNodeCredentialDto,
   NodeHealth,
   NodeStatus,
+  WorkerNodeBackupSummary,
   WorkerNodeDto,
 } from '../../services/workers';
 import { relativeTime } from '../../utils/formatBytes';
@@ -96,6 +97,92 @@ function HeartbeatPill({ node }: { node: WorkerNodeDto }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Backup summary chip (issue #319)
+// ---------------------------------------------------------------------------
+
+/**
+ * Age past which an enabled backup with no recent completed run reads as a
+ * warning. Fixed heuristic — a daily schedule plus slack — deliberately NOT
+ * computed from the node's cron client-side.
+ */
+export const BACKUP_WARNING_AGE_MS = 26 * 60 * 60 * 1000;
+
+/**
+ * Chip states derivable from the fleet list payload.
+ *
+ * There is deliberately NO `failed` state: the list summary
+ * ({@link WorkerNodeBackupSummary}) carries no latest-run status field, so a
+ * failed last run is not derivable without a per-row request — which this
+ * column must never make. Failures surface on the node's backup page instead.
+ *
+ * Precedence: off > running > warning > ok.
+ */
+export type BackupChipState = 'off' | 'running' | 'warning' | 'ok';
+
+export function backupChipState(
+  backup: WorkerNodeBackupSummary | null | undefined,
+  now: number = Date.now(),
+): BackupChipState {
+  if (!backup || !backup.enabled) return 'off';
+  if (backup.activeRun) return 'running';
+  if (!backup.lastCompletedRunAt) return 'warning';
+  if (now - new Date(backup.lastCompletedRunAt).getTime() > BACKUP_WARNING_AGE_MS) {
+    return 'warning';
+  }
+  return 'ok';
+}
+
+const BACKUP_CHIP_META: Record<
+  BackupChipState,
+  { color: 'default' | 'info' | 'warning' | 'success'; label: string }
+> = {
+  off: { color: 'default', label: 'Off' },
+  running: { color: 'info', label: 'Running' },
+  warning: { color: 'warning', label: 'Warning' },
+  ok: { color: 'success', label: 'OK' },
+};
+
+/** The scalar the Backup column sorts/exports (and the chip label for `ok`). */
+export function backupChipLabel(
+  backup: WorkerNodeBackupSummary | null | undefined,
+): string {
+  const state = backupChipState(backup);
+  if (state === 'ok' && backup?.lastCompletedRunAt) {
+    return `OK — backed up ${relativeTime(backup.lastCompletedRunAt)}`;
+  }
+  return BACKUP_CHIP_META[state].label;
+}
+
+function BackupChip({ backup }: { backup: WorkerNodeBackupSummary | null | undefined }) {
+  const state = backupChipState(backup);
+  const meta = BACKUP_CHIP_META[state];
+  const tooltip =
+    state === 'warning'
+      ? backup?.lastCompletedRunAt
+        ? `Enabled, but last completed run was ${relativeTime(backup.lastCompletedRunAt)}`
+        : 'Enabled, but no run has ever completed'
+      : state === 'off'
+        ? 'Backup is not configured or disabled for this node'
+        : undefined;
+  const chip = (
+    <Chip
+      label={backupChipLabel(backup)}
+      color={meta.color}
+      size="small"
+      variant="outlined"
+      sx={tooltip ? { cursor: 'help' } : undefined}
+    />
+  );
+  return tooltip ? (
+    <Tooltip title={tooltip} arrow>
+      {chip}
+    </Tooltip>
+  ) : (
+    chip
+  );
+}
+
 const MAX_TYPE_CHIPS = 3;
 
 /** Eligible job types as chips, truncated with a "+N" overflow chip. */
@@ -128,11 +215,11 @@ function EligibleTypes({ types }: { types: string[] }) {
 // ---------------------------------------------------------------------------
 
 /**
- * The eleven fleet columns.
+ * The twelve fleet columns.
  *
  * Priorities:
  *   - primary   — Node, Status
- *   - secondary — Heartbeat, Running, Failed
+ *   - secondary — Heartbeat, Backup, Running, Failed
  *   - detail    — Platform, CLI version, Eligible types, Concurrency, Succeeded
  */
 export function buildWorkerNodeColumns(): DataTableColumn<WorkerNodeDto>[] {
@@ -173,6 +260,14 @@ export function buildWorkerNodeColumns(): DataTableColumn<WorkerNodeDto>[] {
       value: (node) => node.health,
       render: (node) => <HeartbeatPill node={node} />,
       minWidth: 180,
+    },
+    {
+      id: 'backup',
+      label: 'Backup',
+      priority: 'secondary',
+      value: (node) => backupChipLabel(node.backup),
+      render: (node) => <BackupChip backup={node.backup} />,
+      minWidth: 170,
     },
     {
       id: 'running',

--- a/apps/web/src/services/nodeBackup.ts
+++ b/apps/web/src/services/nodeBackup.ts
@@ -1,0 +1,133 @@
+import { api } from './api';
+
+// ---------------------------------------------------------------------------
+// Types — mirror the API's node backup control plane exactly (issue #312/#319).
+//
+// Every byte counter (`bytesAcked`, `pending.bytes`, `bytesDownloaded`,
+// `itemsAcked`) is a Prisma BigInt serialized as a decimal STRING at the DTO
+// boundary. Never `Number()` these raw — humanize via BigInt parsing
+// (`formatBytes` in utils/formatBytes.ts).
+// ---------------------------------------------------------------------------
+
+/** Backup run kind (mirrors the API's NodeBackupRunKind enum). */
+export type NodeBackupRunKind = 'incremental' | 'reconcile';
+
+/** Backup run lifecycle status (mirrors NodeBackupRunStatus). */
+export type NodeBackupRunStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'aborted'
+  | 'stale';
+
+/** How a run was started. */
+export type NodeBackupRunTrigger = 'manual' | 'scheduled';
+
+/** The config's monotonic change-feed checkpoint. */
+export interface NodeBackupCheckpointDto {
+  updatedAt: string;
+  id: string;
+}
+
+/** Live pending-lag computation: items/bytes not yet acked past the checkpoint. */
+export interface NodeBackupPendingDto {
+  items: number;
+  /** BigInt-safe decimal string. */
+  bytes: string;
+}
+
+/**
+ * A node's backup configuration as returned by
+ * `GET /api/nodes/:id/backup/config` (and by the PUT, whose response matches
+ * the GET shape).
+ */
+export interface NodeBackupConfigDto {
+  nodeId: string;
+  enabled: boolean;
+  /** 5-field cron expression; null = manual-trigger only. */
+  scheduleCron: string | null;
+  /** IANA timezone the cron is evaluated in; null = UTC. */
+  timezone: string | null;
+  nextRunAt: string | null;
+  /** Circle scope; empty array = ALL circles the node owner belongs to. */
+  circleIds: string[];
+  checkpoint: NodeBackupCheckpointDto | null;
+  /** BigInt-safe decimal string. */
+  itemsAcked: string;
+  /** BigInt-safe decimal string. */
+  bytesAcked: string;
+  lastRunAt: string | null;
+  lastCompletedRunAt: string | null;
+  lastReconcileAt: string | null;
+  pending: NodeBackupPendingDto;
+  activeRunId: string | null;
+}
+
+/** Envelope of `GET /api/nodes/:id/backup/config` — null when never configured. */
+export interface NodeBackupConfigResponse {
+  config: NodeBackupConfigDto | null;
+}
+
+/** Partial body for `PUT /api/nodes/:id/backup/config` — only provided keys change. */
+export interface UpdateNodeBackupConfigDto {
+  enabled?: boolean;
+  /** null clears the schedule (and nextRunAt). */
+  scheduleCron?: string | null;
+  /** null clears the timezone (falls back to UTC). */
+  timezone?: string | null;
+  /** Empty array = all owner circles. */
+  circleIds?: string[];
+}
+
+/** One backup run row from `GET /api/nodes/:id/backup/runs`. */
+export interface NodeBackupRunDto {
+  id: string;
+  kind: NodeBackupRunKind;
+  status: NodeBackupRunStatus;
+  trigger: NodeBackupRunTrigger;
+  startedAt: string;
+  finishedAt: string | null;
+  lastAckAt: string | null;
+  itemsDownloaded: number;
+  itemsSkipped: number;
+  sidecarsWritten: number;
+  /** BigInt-safe decimal string. */
+  bytesDownloaded: string;
+  errorCount: number;
+  lastError: string | null;
+  cliVersion: string | null;
+}
+
+/** Envelope of `GET /api/nodes/:id/backup/runs`. */
+export interface NodeBackupRunsResponse {
+  runs: NodeBackupRunDto[];
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+/** Get a node's backup config with live pending lag; `{ config: null }` when unset. */
+export async function getNodeBackupConfig(
+  nodeId: string,
+): Promise<NodeBackupConfigResponse> {
+  return api.get<NodeBackupConfigResponse>(`/nodes/${nodeId}/backup/config`);
+}
+
+/** Create or update a node's backup config (partial upsert). Response matches GET. */
+export async function updateNodeBackupConfig(
+  nodeId: string,
+  dto: UpdateNodeBackupConfigDto,
+): Promise<NodeBackupConfigResponse> {
+  return api.put<NodeBackupConfigResponse>(`/nodes/${nodeId}/backup/config`, dto);
+}
+
+/** List recent backup runs for a node, newest first. */
+export async function getNodeBackupRuns(
+  nodeId: string,
+  limit = 20,
+): Promise<NodeBackupRunsResponse> {
+  return api.get<NodeBackupRunsResponse>(
+    `/nodes/${nodeId}/backup/runs?limit=${limit}`,
+  );
+}

--- a/apps/web/src/services/workers.ts
+++ b/apps/web/src/services/workers.ts
@@ -18,6 +18,20 @@ export interface NodeJobCounts {
 }
 
 /**
+ * Fleet-level backup summary folded onto each node row (issue #312/#319).
+ *
+ * `null` when the node has no NodeBackupConfig at all. Deliberately narrow:
+ * no pending-lag computation and NO latest-run status — those live only on
+ * `GET /nodes/:id/backup/config` / `GET /nodes/:id/backup/runs`.
+ */
+export interface WorkerNodeBackupSummary {
+  enabled: boolean;
+  lastCompletedRunAt: string | null;
+  checkpointUpdatedAt: string | null;
+  activeRun: boolean;
+}
+
+/**
  * A worker node row as returned by `GET /admin/nodes`.
  *
  * Shape matches NodesService.listNodes(): the full WorkerNode record plus a
@@ -40,6 +54,8 @@ export interface WorkerNodeDto {
   health: NodeHealth;
   /** Per-node claimed-job counts by status. */
   jobCounts: NodeJobCounts;
+  /** Backup summary; null when backup was never configured for this node. */
+  backup?: WorkerNodeBackupSummary | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Child 6 of Epic #308. Web admin surface for node backups, built into the existing Worker Nodes fleet UI: a Backup status chip on the workers table (derived purely from the list payload, no per-row requests) and a new per-node backup page at `/admin/settings/nodes/:id/backup` with a status card, schedule/config editor, and run-history DataTable.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #319
Relates to #308

## Changes Made

- `services/nodeBackup.ts` + `hooks/useNodeBackup.ts` — typed DTOs mirroring the #312 API (byte counters typed `string`), config/runs fetch + save with 15 s silent poll (useWorkers pattern); `WorkerNodeDto` gains the optional `backup` summary.
- `workersTable.tsx` / `WorkersPage.tsx` — **Backup** chip column (Off / Running / Warning at 26 h fixed heuristic / `OK — backed up <relative>`; precedence Off > Running > Warning > OK) and a "Backup settings" row action; table still rendered unconditionally with `loading`, 5 s poll untouched. A `Failed` state is not derivable from the list payload (no latest-run status field) — documented in code; failures surface on the detail page's runs table.
- `NodeBackupPage.tsx` + `nodeBackupTable.tsx` + route in `App.tsx` — status card (checkpoint age, pending lag with BigInt-safe byte humanization, acked totals, last run/completed/reconcile, active-run indicator); config card (enable toggle, Daily/Weekly/Custom cron presets with server 400 surfaced inline, IANA timezone autocomplete defaulting to the browser tz, circle include-list with "All my circles", `nextRunAt` rendered from the PUT response, offline-node explanatory copy, `backup set-rate` hint); runs DataTable (`tableId: admin-node-backup-runs`, `lastError` as detail column).

## Testing

- [x] Unit tests pass (`npm test`) — apps/web vitest: 205 files / 4292 tests passed, 0 failed
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

26 new tests: chip state matrix from list-payload fixtures, config round-trip incl. inline server cron error and `nextRunAt` from PUT response, runs table fixtures with row-expansion `lastError`, BigInt byte humanizer past 2^53 (`'9007199254740993' → 8.00 PB`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ)_