### PR TITLE
feat(core): daemon-hosted BackupEngine, pull-based scheduling, and backup status/schedule/set-rate commands

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -69,9 +69,44 @@ export interface NodeBackupConfig {
   enabled: boolean;
   scheduleCron: string | null;
   timezone: string | null;
+  /**
+   * SERVER-computed next scheduled fire time (ISO), null when no cron is set.
+   * The client never computes cron — the scheduler poll (issue #318) fires a
+   * run when this timestamp is due, and the server rolls it forward at run
+   * start for trigger='scheduled'.
+   */
+  nextRunAt?: string | null;
   /** Empty array = ALL circles the node owner belongs to. */
   circleIds: string[];
+  /** Server-side acked checkpoint cursor; null before the first acked page. */
+  checkpoint?: { updatedAt: string; id: string } | null;
+  /** Lifetime acked counters (bytes as a decimal STRING). */
+  itemsAcked?: string;
+  bytesAcked?: string;
+  lastRunAt?: string | null;
+  lastCompletedRunAt?: string | null;
+  /** Change-feed lag past the checkpoint (bytes as a decimal STRING). */
+  pending?: { items: number; bytes: string };
+  activeRunId?: string | null;
   [key: string]: unknown;
+}
+
+/** One run row from GET /api/nodes/:id/backup/runs (byte fields are STRINGS). */
+export interface NodeBackupRunSummary {
+  id: string;
+  kind: string;
+  status: string;
+  trigger: string;
+  startedAt: string;
+  finishedAt: string | null;
+  lastAckAt: string | null;
+  itemsDownloaded: number;
+  itemsSkipped: number;
+  sidecarsWritten: number;
+  bytesDownloaded: string;
+  errorCount: number;
+  lastError: string | null;
+  cliVersion: string | null;
 }
 
 /**
@@ -734,6 +769,17 @@ export class ApiClient {
   getNodeBackupDimensions(nodeId: string): Promise<BackupDimensions> {
     return this.get<BackupDimensions>(
       `/api/nodes/${encodeURIComponent(nodeId)}/backup/dimensions`,
+    );
+  }
+
+  /** List recent backup runs for a node (`backup status`'s server section). */
+  listNodeBackupRuns(
+    nodeId: string,
+    limit?: number,
+  ): Promise<{ runs: NodeBackupRunSummary[] }> {
+    const qs = limit !== undefined ? `?limit=${encodeURIComponent(String(limit))}` : '';
+    return this.get<{ runs: NodeBackupRunSummary[] }>(
+      `/api/nodes/${encodeURIComponent(nodeId)}/backup/runs${qs}`,
     );
   }
 

--- a/apps/cli/src/backup/backup-host.ts
+++ b/apps/cli/src/backup/backup-host.ts
@@ -1,0 +1,421 @@
+/**
+ * backup/backup-host.ts — Daemon-side owner of the backup engine (issue #318,
+ * epic #308).
+ *
+ * When the central settings KV has a backup root bound (backup.root +
+ * backup.nodeId), `node start` constructs a BackupHost NEXT TO the enrichment
+ * NodeEngine and hands it to the daemon host (node/daemon.ts), which exposes
+ * it over the IPC socket (backup-status / backup-run-now / backup-cancel /
+ * backup-set-rate) and re-broadcasts engine events as
+ * `{ kind: 'backup-event', ev, payload, ts }` frames.
+ *
+ * Isolation contract — backup and enrichment share ONLY the process:
+ *   - Independent concurrency: the backup download pool is sized by the
+ *     backup.concurrency setting, entirely separate from the NodeEngine's
+ *     enrichment worker slots.
+ *   - Independent HTTP braking: the CooldownGate is per-ApiClient, so the
+ *     BackupHost builds its OWN ApiClient. An enrichment provider cooldown
+ *     (429 from an AI provider, say) must never brake backup downloads, and a
+ *     storage 503 hitting backup must never brake enrichment claims.
+ *
+ * Responsibilities:
+ *   - Own AT MOST ONE BackupEngine run at a time — a second trigger while a
+ *     run is active is rejected with BackupBusyError ('busy').
+ *   - Re-emit every engine event as a single 'backup-event' host event that
+ *     the daemon broadcasts over IPC.
+ *   - Run the pull-based scheduler poll (backup-scheduler.ts) that fires
+ *     trigger='scheduled' runs when the server-computed nextRunAt is due.
+ *   - Apply set-rate changes LIVE: the engine re-reads its opts.concurrency
+ *     per page (worker pool size) and the shared TokenBucket re-reads its
+ *     rate per take(), so the host mutates the ACTIVE run's opts holder and
+ *     bucket in place — the next page/chunk uses the new values — while also
+ *     persisting to the settings KV for future runs.
+ */
+
+import { EventEmitter } from 'node:events';
+import type BetterSqlite3 from 'better-sqlite3';
+import { ApiClient } from '../api.js';
+import {
+  CooldownGate,
+  DEFAULT_COOLDOWN_CONFIG,
+  type CooldownGateConfig,
+} from '../http/cooldown-gate.js';
+import type { RetryConfig } from '../http/retry.js';
+import type { NodeLogger } from '../node/logger.js';
+import type { SettingsRepo } from '../repo/settings.js';
+import { openCatalogDb } from './catalog-db.js';
+import { CatalogRepo, type CatalogRun, type CatalogStats } from './catalog-repo.js';
+import {
+  BackupEngine,
+  CHECKPOINT_CURSOR_KEY,
+  type BackupApi,
+  type BackupEngineOpts,
+  type BackupRunOutcome,
+} from './backup-engine.js';
+import { BACKUP_EV, BackupTypedEmitter, type BackupCursor, type BackupEventName } from './events.js';
+import { TokenBucket } from './rate-limiter.js';
+import {
+  BackupScheduler,
+  type BackupSchedulerApi,
+  type BackupSchedulerOpts,
+} from './backup-scheduler.js';
+
+/** Host event name: every engine event re-emitted as one host-level event. */
+export const BACKUP_HOST_EVENT = 'backup-event';
+
+/** Payload of the host's 'backup-event' emission (daemon adds kind + ts). */
+export interface BackupHostEventFrame {
+  ev: BackupEventName;
+  payload: unknown;
+}
+
+/** Thrown by startRun() when a run is already active (serialized host). */
+export class BackupBusyError extends Error {
+  readonly code = 'busy';
+  constructor() {
+    super('a backup run is already active on this daemon');
+    this.name = 'BackupBusyError';
+  }
+}
+
+/** What the host needs from an engine: typed events + cooperative controls. */
+export type AttachableBackupEngine = BackupTypedEmitter & {
+  cancel(): void;
+  emitThrottle?(delayMs: number): void;
+};
+
+/** The seam an injected test run implements (default: a real BackupEngine). */
+export interface BackupRunContext {
+  trigger: 'manual' | 'scheduled';
+  /**
+   * MUTABLE knob holder: the engine keeps this exact object reference and
+   * reads `concurrency` per page, so a live set-rate takes effect on the
+   * next page without restarting the run.
+   */
+  engineOpts: BackupEngineOpts;
+  /** Shared bandwidth bucket; setRate() applies live to the next take(). */
+  bucket: TokenBucket;
+  /** Called with the engine once built, BEFORE the run starts. */
+  attachEngine: (engine: AttachableBackupEngine) => void;
+}
+
+export interface BackupHostConfig {
+  serverUrl: string;
+  pat: string;
+  /** Absolute backup root (settings backup.root). */
+  root: string;
+  /** Worker-node id the root is bound to (settings backup.nodeId). */
+  nodeId: string;
+  nodeName?: string;
+  cliVersion: string;
+}
+
+/** API surface the host needs (engine data plane + scheduler config poll). */
+export type BackupHostApi = BackupApi & BackupSchedulerApi;
+
+export interface BackupHostDeps {
+  settings: SettingsRepo;
+  logger: NodeLogger;
+  retry?: RetryConfig;
+  cooldown?: CooldownGateConfig;
+  /** Injectable API client (tests); default: an OWN ApiClient (see header). */
+  api?: BackupHostApi;
+  /** Injectable run seam (tests replace the whole engine). */
+  runBackupFn?: (ctx: BackupRunContext) => Promise<BackupRunOutcome>;
+  /** Injectable catalog opener for status snapshots. */
+  openDb?: (root: string) => BetterSqlite3.Database;
+  /** Scheduler cadence overrides (tests). */
+  scheduler?: Omit<BackupSchedulerOpts, 'nodeId'>;
+  now?: () => Date;
+}
+
+/** Snapshot served over IPC as `{ kind: 'backup-status', ...snapshot }`. */
+export interface BackupHostSnapshot {
+  configured: boolean;
+  running: { trigger: 'manual' | 'scheduled'; startedAt: string } | null;
+  lastRun: CatalogRun | null;
+  checkpoint: BackupCursor | null;
+  counters: CatalogStats | null;
+  rate: { concurrency: number; maxMbps: number };
+}
+
+interface ActiveRun {
+  trigger: 'manual' | 'scheduled';
+  startedAt: string;
+  engineOpts: BackupEngineOpts;
+  bucket: TokenBucket;
+  engine: AttachableBackupEngine | null;
+  cancelRequested: boolean;
+  promise: Promise<BackupRunOutcome | null>;
+}
+
+export class BackupHost extends EventEmitter {
+  private readonly cfg: BackupHostConfig;
+  private readonly settings: SettingsRepo;
+  private readonly logger: NodeLogger;
+  private readonly api: BackupHostApi;
+  private readonly runBackupFn: (ctx: BackupRunContext) => Promise<BackupRunOutcome>;
+  private readonly openDb: (root: string) => BetterSqlite3.Database;
+  private readonly scheduler: BackupScheduler;
+  private readonly now: () => Date;
+
+  private active: ActiveRun | null = null;
+
+  constructor(cfg: BackupHostConfig, deps: BackupHostDeps) {
+    super();
+    this.cfg = cfg;
+    this.settings = deps.settings;
+    this.logger = deps.logger;
+    this.openDb = deps.openDb ?? openCatalogDb;
+    this.now = deps.now ?? ((): Date => new Date());
+
+    // OWN ApiClient + OWN CooldownGate: the gate is per-client, and sharing
+    // the NodeEngine's client would couple backup braking to enrichment
+    // braking (and vice versa). The trip hook surfaces on the ACTIVE engine
+    // as a typed throttle event, mirroring execute-run.ts.
+    const gate = new CooldownGate(deps.cooldown ?? DEFAULT_COOLDOWN_CONFIG, {
+      onTrip: (delayMs) => this.active?.engine?.emitThrottle?.(delayMs),
+    });
+    this.api =
+      deps.api ??
+      (new ApiClient({
+        serverUrl: cfg.serverUrl,
+        pat: cfg.pat,
+        ...(deps.retry ? { retry: deps.retry } : {}),
+        cooldownGate: gate,
+      }) as BackupHostApi);
+
+    this.runBackupFn = deps.runBackupFn ?? ((ctx): Promise<BackupRunOutcome> => this.executeEngineRun(ctx));
+
+    this.scheduler = new BackupScheduler(
+      { nodeId: cfg.nodeId, ...(deps.scheduler ?? {}) },
+      {
+        api: this.api,
+        logger: this.logger,
+        isRunActive: () => this.isRunning(),
+        startRun: (trigger) => {
+          try {
+            this.startRun(trigger);
+          } catch (err) {
+            // 'busy' race with a manual run — the next poll retries.
+            this.logger.warn('scheduled backup run rejected', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        },
+        ...(deps.now ? { now: (): number => this.now().getTime() } : {}),
+      },
+    );
+  }
+
+  /** Begin the scheduler poll (immediate check + 60s cadence). */
+  startScheduler(): void {
+    this.scheduler.start();
+  }
+
+  /** Stop the scheduler poll. An in-flight backup run completes untouched. */
+  stopScheduler(): void {
+    this.scheduler.stop();
+  }
+
+  isRunning(): boolean {
+    return this.active !== null;
+  }
+
+  /** Resolves when the active run (if any) settles — used by tests/shutdown. */
+  async waitForIdle(): Promise<void> {
+    await this.active?.promise;
+  }
+
+  /**
+   * Start one backup run. Rejects with BackupBusyError while a run is active
+   * (the host serializes runs). Returns immediately — progress streams as
+   * 'backup-event' emissions and the outcome is logged.
+   */
+  startRun(trigger: 'manual' | 'scheduled'): void {
+    if (this.active) throw new BackupBusyError();
+
+    const engineOpts: BackupEngineOpts = {
+      root: this.cfg.root,
+      nodeId: this.cfg.nodeId,
+      ...(this.cfg.nodeName !== undefined ? { nodeName: this.cfg.nodeName } : {}),
+      serverUrl: this.cfg.serverUrl,
+      trigger,
+      cliVersion: this.cfg.cliVersion,
+      concurrency: Math.max(1, Math.floor(this.settings.backupConcurrency())),
+      maxMbps: this.settings.backupMaxMbps(),
+      pageSize: Math.max(1, Math.floor(this.settings.backupPageSize())),
+      pacingMs: this.settings.backupPacingMs(),
+    };
+    const bucket = new TokenBucket(engineOpts.maxMbps);
+
+    const active: ActiveRun = {
+      trigger,
+      startedAt: this.now().toISOString(),
+      engineOpts,
+      bucket,
+      engine: null,
+      cancelRequested: false,
+      promise: Promise.resolve(null),
+    };
+    this.active = active;
+
+    const ctx: BackupRunContext = {
+      trigger,
+      engineOpts,
+      bucket,
+      attachEngine: (engine) => {
+        active.engine = engine;
+        for (const ev of Object.values(BACKUP_EV)) {
+          engine.on(ev, (payload: unknown) => {
+            this.emit(BACKUP_HOST_EVENT, { ev, payload } satisfies BackupHostEventFrame);
+          });
+        }
+        // A cancel that raced engine construction still lands.
+        if (active.cancelRequested) engine.cancel();
+      },
+    };
+
+    this.logger.info('backup run starting', { trigger, root: this.cfg.root });
+    active.promise = this.runBackupFn(ctx)
+      .then((outcome) => {
+        this.logger.info('backup run finished', {
+          trigger,
+          status: outcome.status,
+          items: outcome.stats.itemsDownloaded,
+          errors: outcome.stats.errors,
+          ...(outcome.error !== undefined ? { error: outcome.error } : {}),
+        });
+        return outcome as BackupRunOutcome | null;
+      })
+      .catch((err: unknown) => {
+        // RunAlreadyActiveError (another machine's run), catalog-open
+        // failures, etc. — logged, never thrown out of the daemon.
+        this.logger.warn('backup run failed', {
+          trigger,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      })
+      .finally(() => {
+        if (this.active === active) this.active = null;
+      });
+  }
+
+  /** Cooperative cancel of the active run; false when nothing is running. */
+  cancel(): boolean {
+    const active = this.active;
+    if (!active) return false;
+    active.cancelRequested = true;
+    active.engine?.cancel();
+    this.logger.info('backup run cancel requested');
+    return true;
+  }
+
+  /**
+   * Persist new throttle knobs to the settings KV AND apply them to the
+   * active run (if any) live: the engine reads opts.concurrency per page and
+   * the bucket re-reads its rate per chunk, so the NEXT page/chunk uses the
+   * new values. Returns the effective persisted values.
+   */
+  setRate(update: { concurrency?: number; maxMbps?: number }): {
+    concurrency: number;
+    maxMbps: number;
+  } {
+    if (update.concurrency !== undefined) {
+      this.settings.setBackupConcurrency(update.concurrency);
+    }
+    if (update.maxMbps !== undefined) {
+      this.settings.setBackupMaxMbps(update.maxMbps);
+    }
+    if (this.active) {
+      if (update.concurrency !== undefined) {
+        this.active.engineOpts.concurrency = update.concurrency;
+      }
+      if (update.maxMbps !== undefined) {
+        this.active.bucket.setRate(update.maxMbps);
+      }
+    }
+    const effective = {
+      concurrency: this.settings.backupConcurrency(),
+      maxMbps: this.settings.backupMaxMbps(),
+    };
+    this.logger.info('backup rate updated', {
+      ...effective,
+      appliedLive: this.active !== null,
+    });
+    return effective;
+  }
+
+  /**
+   * Status snapshot for the `backup-status` IPC verb. Catalog reads open a
+   * fresh (WAL-safe) connection so an in-flight run's connection is never
+   * shared; an unreadable catalog degrades to null sections, never a throw.
+   */
+  getSnapshot(): BackupHostSnapshot {
+    let counters: CatalogStats | null = null;
+    let checkpoint: BackupCursor | null = null;
+    let lastRun: CatalogRun | null = null;
+    try {
+      const db = this.openDb(this.cfg.root);
+      try {
+        const repo = new CatalogRepo(db);
+        counters = repo.stats();
+        lastRun = repo.latestRun();
+        const raw = repo.getCheckpoint(CHECKPOINT_CURSOR_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as Partial<BackupCursor>;
+          if (typeof parsed.updatedAt === 'string' && typeof parsed.id === 'string') {
+            checkpoint = { updatedAt: parsed.updatedAt, id: parsed.id };
+          }
+        }
+      } finally {
+        db.close();
+      }
+    } catch (err) {
+      this.logger.warn('backup status catalog read failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const rate = this.active
+      ? {
+          concurrency: this.active.engineOpts.concurrency,
+          maxMbps: this.active.bucket.maxMbps,
+        }
+      : {
+          concurrency: this.settings.backupConcurrency(),
+          maxMbps: this.settings.backupMaxMbps(),
+        };
+
+    return {
+      configured: true,
+      running: this.active
+        ? { trigger: this.active.trigger, startedAt: this.active.startedAt }
+        : null,
+      lastRun,
+      checkpoint,
+      counters,
+      rate,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Default run seam: a real BackupEngine over the host's own ApiClient
+  // ---------------------------------------------------------------------------
+
+  private async executeEngineRun(ctx: BackupRunContext): Promise<BackupRunOutcome> {
+    const db = this.openDb(this.cfg.root);
+    try {
+      const engine = new BackupEngine(ctx.engineOpts, {
+        api: this.api,
+        db,
+        bucket: ctx.bucket,
+      });
+      ctx.attachEngine(engine);
+      return await engine.runBackup();
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/apps/cli/src/backup/backup-host.ts
+++ b/apps/cli/src/backup/backup-host.ts
@@ -52,7 +52,13 @@ import {
   type BackupEngineOpts,
   type BackupRunOutcome,
 } from './backup-engine.js';
-import { BACKUP_EV, BackupTypedEmitter, type BackupCursor, type BackupEventName } from './events.js';
+import {
+  BACKUP_EV,
+  BACKUP_HOST_EVENT,
+  BackupTypedEmitter,
+  type BackupCursor,
+  type BackupHostEventFrame,
+} from './events.js';
 import { TokenBucket } from './rate-limiter.js';
 import {
   BackupScheduler,
@@ -60,14 +66,11 @@ import {
   type BackupSchedulerOpts,
 } from './backup-scheduler.js';
 
-/** Host event name: every engine event re-emitted as one host-level event. */
-export const BACKUP_HOST_EVENT = 'backup-event';
-
-/** Payload of the host's 'backup-event' emission (daemon adds kind + ts). */
-export interface BackupHostEventFrame {
-  ev: BackupEventName;
-  payload: unknown;
-}
+// Re-exported for existing consumers; the canonical definition lives in
+// events.ts so daemon.ts can subscribe without importing this module's
+// runtime graph (see the note there).
+export { BACKUP_HOST_EVENT } from './events.js';
+export type { BackupHostEventFrame } from './events.js';
 
 /** Thrown by startRun() when a run is already active (serialized host). */
 export class BackupBusyError extends Error {

--- a/apps/cli/src/backup/backup-scheduler.ts
+++ b/apps/cli/src/backup/backup-scheduler.ts
@@ -1,0 +1,178 @@
+/**
+ * backup/backup-scheduler.ts — Pull-based backup schedule poller (issue #318,
+ * epic #308).
+ *
+ * The SERVER owns the schedule: cron parsing, timezone math, and rolling
+ * `nextRunAt` forward all happen server-side (NodeBackupService rolls it
+ * forward AT RUN START for trigger='scheduled'). This client never computes
+ * cron — it only polls `GET /api/nodes/:id/backup/config` and fires a run
+ * when the server-computed `nextRunAt` is due.
+ *
+ * Poll cadence: every `pollIntervalMs` (default 60 s), plus one IMMEDIATE
+ * check when the scheduler starts. Offline-at-schedule self-heals for free:
+ * a missed firing leaves `nextRunAt` in the past, and the next successful
+ * poll — including the immediate one right after daemon start — fires it
+ * then; the fired run's at-start roll-forward clears the past-due state.
+ *
+ * Failure posture: a failed poll is logged through the daemon logger and
+ * polling continues; after `failureThreshold` (default 5) CONSECUTIVE
+ * failures the cadence backs off to `backoffIntervalMs` (default 5 min)
+ * until a poll succeeds again, which resets the cadence.
+ *
+ * `enabled: false` on the config is the kill switch — no future scheduled
+ * run fires (an in-flight run is left alone to complete). A due schedule is
+ * also skipped while a local run is already active (`isRunActive`); since
+ * `nextRunAt` only rolls forward when a scheduled run STARTS, the still
+ * past-due timestamp makes a later poll fire it once the active run ends.
+ *
+ * All timers are unref'd — the scheduler never keeps the daemon process
+ * alive on its own.
+ */
+
+import type { NodeBackupConfigResult } from '../api.js';
+import type { NodeLogger } from '../node/logger.js';
+
+/** Normal poll cadence. */
+export const SCHEDULER_POLL_INTERVAL_MS = 60_000;
+/** Backed-off cadence after `SCHEDULER_FAILURE_THRESHOLD` consecutive failures. */
+export const SCHEDULER_BACKOFF_INTERVAL_MS = 300_000;
+/** Consecutive poll failures before backing off. */
+export const SCHEDULER_FAILURE_THRESHOLD = 5;
+
+/** The one API call the scheduler makes — mockable in tests. */
+export interface BackupSchedulerApi {
+  getNodeBackupConfig(nodeId: string): Promise<NodeBackupConfigResult>;
+}
+
+export interface BackupSchedulerOpts {
+  nodeId: string;
+  pollIntervalMs?: number;
+  backoffIntervalMs?: number;
+  failureThreshold?: number;
+}
+
+export interface BackupSchedulerDeps {
+  api: BackupSchedulerApi;
+  logger: NodeLogger;
+  /** True while a local backup run is active — a due schedule is skipped. */
+  isRunActive: () => boolean;
+  /**
+   * Fire a scheduled run. Guarded by `isRunActive` in the tick, but the
+   * implementation must still tolerate a 'busy' race (log, never throw out).
+   */
+  startRun: (trigger: 'scheduled') => void;
+  now?: () => number;
+}
+
+export class BackupScheduler {
+  private readonly nodeId: string;
+  private readonly pollIntervalMs: number;
+  private readonly backoffIntervalMs: number;
+  private readonly failureThreshold: number;
+  private readonly deps: BackupSchedulerDeps;
+  private readonly now: () => number;
+
+  private timer: NodeJS.Timeout | null = null;
+  private started = false;
+  private ticking = false;
+  private consecutiveFailures = 0;
+
+  constructor(opts: BackupSchedulerOpts, deps: BackupSchedulerDeps) {
+    this.nodeId = opts.nodeId;
+    this.pollIntervalMs = opts.pollIntervalMs ?? SCHEDULER_POLL_INTERVAL_MS;
+    this.backoffIntervalMs = opts.backoffIntervalMs ?? SCHEDULER_BACKOFF_INTERVAL_MS;
+    this.failureThreshold = opts.failureThreshold ?? SCHEDULER_FAILURE_THRESHOLD;
+    this.deps = deps;
+    this.now = deps.now ?? Date.now;
+  }
+
+  /** Start polling: one immediate check, then the timer chain. Idempotent. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    void this.runTickAndRearm();
+  }
+
+  /** Stop polling. An in-flight tick finishes; no further ticks are armed. */
+  stop(): void {
+    this.started = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Delay until the next poll — backed off after repeated failures. */
+  nextDelayMs(): number {
+    return this.consecutiveFailures >= this.failureThreshold
+      ? this.backoffIntervalMs
+      : this.pollIntervalMs;
+  }
+
+  /** Current consecutive-failure count (observable for tests/status). */
+  get failures(): number {
+    return this.consecutiveFailures;
+  }
+
+  private async runTickAndRearm(): Promise<void> {
+    await this.tick();
+    if (!this.started) return;
+    this.timer = setTimeout(() => {
+      void this.runTickAndRearm();
+    }, this.nextDelayMs());
+    this.timer.unref?.();
+  }
+
+  /**
+   * One poll: fetch the config and fire a scheduled run when due. Exposed
+   * (rather than private) so tests can drive polls without real timers.
+   * Never throws — poll failures are logged and counted.
+   */
+  async tick(): Promise<void> {
+    if (this.ticking) return;
+    this.ticking = true;
+    try {
+      const { config } = await this.deps.api.getNodeBackupConfig(this.nodeId);
+      if (this.consecutiveFailures >= this.failureThreshold) {
+        this.deps.logger.info('backup schedule poll recovered', {
+          afterFailures: this.consecutiveFailures,
+        });
+      }
+      this.consecutiveFailures = 0;
+
+      // Kill switch: disabled config stops future scheduled runs entirely.
+      if (!config || !config.enabled) return;
+
+      const nextRunAt = typeof config.nextRunAt === 'string' ? config.nextRunAt : null;
+      if (!nextRunAt) return;
+
+      const dueAt = Date.parse(nextRunAt);
+      if (!Number.isFinite(dueAt) || dueAt > this.now()) return;
+
+      // A local run is already active: skip. nextRunAt stays past-due (it
+      // only rolls forward when a SCHEDULED run starts), so a later poll
+      // fires it once the active run ends.
+      if (this.deps.isRunActive()) return;
+
+      this.deps.logger.info('backup schedule due — starting scheduled run', { nextRunAt });
+      try {
+        this.deps.startRun('scheduled');
+      } catch (err) {
+        // 'busy' race or a start failure — log and let the next poll retry.
+        this.deps.logger.warn('scheduled backup run failed to start', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } catch (err) {
+      this.consecutiveFailures += 1;
+      const backingOff = this.consecutiveFailures >= this.failureThreshold;
+      this.deps.logger.warn('backup schedule poll failed', {
+        error: err instanceof Error ? err.message : String(err),
+        consecutiveFailures: this.consecutiveFailures,
+        ...(backingOff ? { backoffMs: this.backoffIntervalMs } : {}),
+      });
+    } finally {
+      this.ticking = false;
+    }
+  }
+}

--- a/apps/cli/src/backup/catalog-repo.ts
+++ b/apps/cli/src/backup/catalog-repo.ts
@@ -309,6 +309,40 @@ export class CatalogRepo {
       );
   }
 
+  /** Most recent locally-recorded run (by started_at), for `backup status`. */
+  latestRun(): CatalogRun | null {
+    const row = this.db
+      .prepare<
+        [],
+        {
+          id: string;
+          kind: string | null;
+          status: string | null;
+          started_at: string | null;
+          finished_at: string | null;
+          items_downloaded: number;
+          items_skipped: number;
+          bytes_downloaded: number;
+          error_count: number;
+          last_error: string | null;
+        }
+      >('SELECT * FROM runs ORDER BY started_at DESC LIMIT 1')
+      .get();
+    if (!row) return null;
+    return {
+      id: row.id,
+      kind: row.kind ?? 'incremental',
+      status: row.status ?? 'unknown',
+      startedAt: row.started_at ?? '',
+      finishedAt: row.finished_at,
+      itemsDownloaded: row.items_downloaded,
+      itemsSkipped: row.items_skipped,
+      bytesDownloaded: row.bytes_downloaded,
+      errorCount: row.error_count,
+      lastError: row.last_error,
+    };
+  }
+
   // -------------------------------------------------------------------------
   // checkpoint (mirrored server cursor — offline cache)
   // -------------------------------------------------------------------------

--- a/apps/cli/src/backup/events.ts
+++ b/apps/cli/src/backup/events.ts
@@ -22,6 +22,22 @@ export const BACKUP_EV = {
 
 export type BackupEventName = (typeof BACKUP_EV)[keyof typeof BACKUP_EV];
 
+/**
+ * BackupHost-level event name: the host re-emits every engine event as one
+ * 'backup-event' emission that the daemon frames for IPC (issue #318). Lives
+ * HERE (not in backup-host.ts) so node/daemon.ts can subscribe without a
+ * runtime import of the backup engine graph — NodeDashboard imports
+ * daemon.ts's readPidFile, and dragging ApiClient/ApiError into that module
+ * graph would break every consumer that mocks '../api.js' partially.
+ */
+export const BACKUP_HOST_EVENT = 'backup-event';
+
+/** Payload of the host's 'backup-event' emission (daemon adds kind + ts). */
+export interface BackupHostEventFrame {
+  ev: BackupEventName;
+  payload: unknown;
+}
+
 /** Change-feed keyset cursor, as mirrored in the local catalog checkpoint. */
 export interface BackupCursor {
   updatedAt: string;

--- a/apps/cli/src/backup/rate-limiter.ts
+++ b/apps/cli/src/backup/rate-limiter.ts
@@ -26,10 +26,12 @@ const defaultSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 export class TokenBucket {
-  /** Refill rate in bytes per millisecond; 0 = unlimited. */
-  private readonly ratePerMs: number;
+  /** Refill rate in bytes per millisecond; 0 = unlimited. Mutable via setRate(). */
+  private ratePerMs: number;
   /** Maximum accumulated balance (one second's worth) — bounds idle bursts. */
-  private readonly capacity: number;
+  private capacity: number;
+  /** The configured cap in Mbps, kept for reporting (`backup-status`). */
+  private maxMbpsValue: number;
   /** Current balance in bytes (can go negative while a deficit is slept off). */
   private available = 0;
   private lastRefillAt: number;
@@ -38,6 +40,7 @@ export class TokenBucket {
   private readonly sleep: (ms: number) => Promise<void>;
 
   constructor(maxMbps: number, hooks: TokenBucketHooks = {}) {
+    this.maxMbpsValue = maxMbps;
     this.ratePerMs = maxMbps > 0 ? (maxMbps * 1e6) / 8 / 1000 : 0;
     this.capacity = this.ratePerMs * 1000;
     this.now = hooks.now ?? Date.now;
@@ -48,6 +51,25 @@ export class TokenBucket {
   /** True when this bucket enforces no cap (maxMbps <= 0). */
   get unlimited(): boolean {
     return this.ratePerMs <= 0;
+  }
+
+  /** The currently configured cap in Mbps (0 = unlimited). */
+  get maxMbps(): number {
+    return this.maxMbpsValue;
+  }
+
+  /**
+   * Change the cap LIVE (issue #318 — `backup set-rate` on a running daemon):
+   * the new rate applies from the next take(). The balance is settled at the
+   * old rate first, then clamped to the new capacity so a rate cut cannot
+   * carry over a large old-rate burst.
+   */
+  setRate(maxMbps: number): void {
+    this.refill();
+    this.maxMbpsValue = maxMbps;
+    this.ratePerMs = maxMbps > 0 ? (maxMbps * 1e6) / 8 / 1000 : 0;
+    this.capacity = this.ratePerMs * 1000;
+    if (this.available > this.capacity) this.available = this.capacity;
   }
 
   private refill(): void {

--- a/apps/cli/src/backup/run-via-daemon.ts
+++ b/apps/cli/src/backup/run-via-daemon.ts
@@ -1,0 +1,136 @@
+/**
+ * backup/run-via-daemon.ts — `backup run` delegation over the daemon IPC
+ * channel (issue #318, epic #308).
+ *
+ * When a worker-node daemon is running, `backup run` does NOT start an
+ * embedded engine (two engines would fight over the run lock and the daemon
+ * owns the scheduler anyway). Instead it connects to the IPC socket, sends
+ * `backup-run-now`, and streams the daemon's `backup-event` frames into the
+ * SAME headless renderer the embedded path uses — the terminal output is
+ * indistinguishable. `--embedded` forces the in-process engine.
+ *
+ * Frame discipline: everything before our command's ack is ignored (a
+ * previous or scheduled run's tail events must not be attributed to this
+ * invocation); once accepted, `backup-event` frames are re-emitted on a local
+ * BackupTypedEmitter proxy until the run-finished event arrives.
+ */
+
+import type { DaemonClient, DaemonMessage } from '../node/ipc-client.js';
+import {
+  BACKUP_EV,
+  BackupTypedEmitter,
+  type BackupEventName,
+  type RunFinishedPayload,
+} from './events.js';
+import type { BackupRunOutcome } from './backup-engine.js';
+
+/** The daemon rejected the run because one is already active. */
+export class DaemonBackupBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaemonBackupBusyError';
+  }
+}
+
+/**
+ * The daemon has no BackupHost (started before `backup init` bound a root).
+ * The caller falls back to the embedded engine.
+ */
+export class DaemonBackupUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaemonBackupUnavailableError';
+  }
+}
+
+/** Delegate to the daemon unless --embedded was passed or no daemon is up. */
+export function shouldDelegateToDaemon(embedded: boolean, daemonUp: boolean): boolean {
+  return !embedded && daemonUp;
+}
+
+const VALID_EVENTS = new Set<string>(Object.values(BACKUP_EV));
+
+export interface RunViaDaemonOptions {
+  /** Attach the renderer to the event proxy BEFORE the run is requested. */
+  attachRenderer: (emitter: BackupTypedEmitter) => void;
+  /** Timeout for the daemon to accept/reject the run (default 10 s). */
+  acceptTimeoutMs?: number;
+}
+
+/**
+ * Request a manual run from the daemon and stream its events until finished.
+ * Resolves with an outcome shaped like the embedded engine's (runId is not
+ * carried over IPC frames and is reported as '(daemon)').
+ */
+export function runViaDaemon(
+  client: DaemonClient,
+  opts: RunViaDaemonOptions,
+): Promise<BackupRunOutcome> {
+  const proxy = new BackupTypedEmitter();
+  opts.attachRenderer(proxy);
+
+  return new Promise<BackupRunOutcome>((resolve, reject) => {
+    let accepted = false;
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(acceptTimer);
+      fn();
+    };
+
+    const acceptTimer = setTimeout(() => {
+      settle(() => reject(new Error('timed out waiting for the daemon to accept the backup run')));
+    }, opts.acceptTimeoutMs ?? 10_000);
+    acceptTimer.unref?.();
+
+    client.onMessage((msg: DaemonMessage) => {
+      if (!accepted) {
+        if ((msg.kind === 'ack' || msg.kind === 'error') && msg['cmd'] === 'backup-run-now') {
+          if (msg.kind === 'error') {
+            const message = String(msg['message'] ?? 'daemon rejected the backup run');
+            settle(() =>
+              reject(
+                msg['code'] === 'busy'
+                  ? new DaemonBackupBusyError(message)
+                  : msg['code'] === 'not-configured'
+                    ? new DaemonBackupUnavailableError(message)
+                    : new Error(message),
+              ),
+            );
+            return;
+          }
+          clearTimeout(acceptTimer);
+          accepted = true;
+        }
+        // Everything before our ack — including a previous run's tail
+        // events — is deliberately ignored.
+        return;
+      }
+
+      if (msg.kind !== 'backup-event') return;
+      const ev = msg['ev'];
+      if (typeof ev !== 'string' || !VALID_EVENTS.has(ev)) return;
+      const payload = msg['payload'];
+      proxy.emit(ev as BackupEventName, payload as never);
+
+      if (ev === BACKUP_EV.RUN_FINISHED) {
+        const fin = payload as RunFinishedPayload;
+        settle(() =>
+          resolve({
+            runId: '(daemon)',
+            status: fin.status,
+            stats: fin.stats,
+            ...(fin.error !== undefined ? { error: fin.error } : {}),
+          }),
+        );
+      }
+    });
+
+    client.onClose(() => {
+      settle(() => reject(new Error('daemon connection closed before the backup run finished')));
+    });
+
+    client.send({ cmd: 'backup-run-now' });
+  });
+}

--- a/apps/cli/src/backup/status-report.ts
+++ b/apps/cli/src/backup/status-report.ts
@@ -1,0 +1,196 @@
+/**
+ * backup/status-report.ts — Merged three-source status for `backup status`
+ * (issue #318, epic #308).
+ *
+ * Three independently-sourced sections, each clearly labeled and each
+ * degrading GRACEFULLY (a human-readable `error` string, never a stack
+ * trace, never a throw):
+ *
+ *   local  — the backup root's SQLite catalog: item counters, the mirrored
+ *            checkpoint cursor, and the last locally-recorded run. Fully
+ *            offline-capable — this section works with no daemon and no
+ *            server.
+ *   daemon — the running daemon's live snapshot over IPC (is a run active,
+ *            live rate knobs). Absent daemon → `running: false`, no error.
+ *   server — GET /backup/config (enabled, schedule, nextRunAt, pending lag)
+ *            plus the 5 most recent server-side runs. Unreachable server →
+ *            `reachable: false` with the reason.
+ *
+ * Every I/O dependency is injectable so tests can exercise degradation
+ * without sockets, catalogs, or HTTP.
+ */
+
+import type BetterSqlite3 from 'better-sqlite3';
+import type { NodeBackupConfig, NodeBackupRunSummary } from '../api.js';
+import { ApiError } from '../api.js';
+import type { DaemonClient } from '../node/ipc-client.js';
+import { openCatalogDb } from './catalog-db.js';
+import { CatalogRepo, type CatalogRun, type CatalogStats } from './catalog-repo.js';
+import { CHECKPOINT_CURSOR_KEY } from './backup-engine.js';
+import type { BackupCursor } from './events.js';
+
+export interface BackupStatusLocalSection {
+  source: 'local catalog';
+  configured: boolean;
+  root: string | null;
+  nodeId: string | null;
+  counters: CatalogStats | null;
+  checkpoint: BackupCursor | null;
+  lastRun: CatalogRun | null;
+  error: string | null;
+}
+
+export interface BackupStatusDaemonSection {
+  source: 'daemon (IPC)';
+  running: boolean;
+  /** The daemon's backup-status frame minus the kind tag; null when down. */
+  snapshot: Record<string, unknown> | null;
+  error: string | null;
+}
+
+export interface BackupStatusServerSection {
+  source: 'server';
+  reachable: boolean;
+  config: NodeBackupConfig | null;
+  runs: NodeBackupRunSummary[];
+  error: string | null;
+}
+
+export interface BackupStatusReport {
+  local: BackupStatusLocalSection;
+  daemon: BackupStatusDaemonSection;
+  server: BackupStatusServerSection;
+}
+
+export interface CollectBackupStatusDeps {
+  settings: {
+    backupRoot(): string | null;
+    backupNodeId(): string | null;
+  };
+  /** Null when no credentials are stored — the server section degrades. */
+  api: {
+    getNodeBackupConfig(nodeId: string): Promise<{ config: NodeBackupConfig | null }>;
+    listNodeBackupRuns(nodeId: string, limit?: number): Promise<{ runs: NodeBackupRunSummary[] }>;
+  } | null;
+  openDb?: (root: string) => BetterSqlite3.Database;
+  isDaemonRunningFn?: () => Promise<boolean>;
+  connectFn?: () => Promise<DaemonClient>;
+  /** IPC reply budget in ms (default 3000). */
+  ipcTimeoutMs?: number;
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof ApiError) return `HTTP ${err.status}: ${err.serverMessage}`;
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function collectLocal(deps: CollectBackupStatusDeps): Promise<BackupStatusLocalSection> {
+  const root = deps.settings.backupRoot();
+  const nodeId = deps.settings.backupNodeId();
+  const section: BackupStatusLocalSection = {
+    source: 'local catalog',
+    configured: Boolean(root && nodeId),
+    root,
+    nodeId,
+    counters: null,
+    checkpoint: null,
+    lastRun: null,
+    error: null,
+  };
+  if (!root || !nodeId) {
+    section.error = 'no backup root configured (run `memoriahub backup init --dest <dir>`)';
+    return section;
+  }
+  try {
+    const db = (deps.openDb ?? openCatalogDb)(root);
+    try {
+      const repo = new CatalogRepo(db);
+      section.counters = repo.stats();
+      section.lastRun = repo.latestRun();
+      const raw = repo.getCheckpoint(CHECKPOINT_CURSOR_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<BackupCursor>;
+        if (typeof parsed.updatedAt === 'string' && typeof parsed.id === 'string') {
+          section.checkpoint = { updatedAt: parsed.updatedAt, id: parsed.id };
+        }
+      }
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    section.error = `could not read the backup catalog: ${errMessage(err)}`;
+  }
+  return section;
+}
+
+async function collectDaemon(deps: CollectBackupStatusDeps): Promise<BackupStatusDaemonSection> {
+  const section: BackupStatusDaemonSection = {
+    source: 'daemon (IPC)',
+    running: false,
+    snapshot: null,
+    error: null,
+  };
+  if (!deps.isDaemonRunningFn || !deps.connectFn) return section;
+  try {
+    if (!(await deps.isDaemonRunningFn())) return section;
+    const client = await deps.connectFn();
+    try {
+      client.send({ cmd: 'backup-status' });
+      const reply = await client.waitFor(
+        (m) => m.kind === 'backup-status',
+        deps.ipcTimeoutMs ?? 3000,
+      );
+      const { kind: _kind, ...snapshot } = reply;
+      section.running = true;
+      section.snapshot = snapshot;
+    } finally {
+      client.close();
+    }
+  } catch (err) {
+    section.error = `daemon did not answer: ${errMessage(err)}`;
+  }
+  return section;
+}
+
+async function collectServer(deps: CollectBackupStatusDeps): Promise<BackupStatusServerSection> {
+  const section: BackupStatusServerSection = {
+    source: 'server',
+    reachable: false,
+    config: null,
+    runs: [],
+    error: null,
+  };
+  const nodeId = deps.settings.backupNodeId();
+  if (!deps.api) {
+    section.error = 'not logged in (run `memoriahub login`)';
+    return section;
+  }
+  if (!nodeId) {
+    section.error = 'no backup node bound on this machine';
+    return section;
+  }
+  try {
+    const [cfgRes, runsRes] = await Promise.all([
+      deps.api.getNodeBackupConfig(nodeId),
+      deps.api.listNodeBackupRuns(nodeId, 5),
+    ]);
+    section.reachable = true;
+    section.config = cfgRes.config;
+    section.runs = runsRes.runs;
+  } catch (err) {
+    section.error = `server unreachable: ${errMessage(err)}`;
+  }
+  return section;
+}
+
+/** Collect all three sections; each degrades independently, never throws. */
+export async function collectBackupStatus(
+  deps: CollectBackupStatusDeps,
+): Promise<BackupStatusReport> {
+  const [local, daemon, server] = await Promise.all([
+    collectLocal(deps),
+    collectDaemon(deps),
+    collectServer(deps),
+  ]);
+  return { local, daemon, server };
+}

--- a/apps/cli/src/commands/backup.ts
+++ b/apps/cli/src/commands/backup.ts
@@ -39,8 +39,16 @@ import { runBackupInit, BackupRootConflictError } from '../backup/init-backup.js
 import { RunAlreadyActiveError } from '../backup/backup-engine.js';
 import { CatalogOpenError } from '../backup/catalog-db.js';
 import { executeRun, resolveBackupExitCode } from '../backup/execute-run.js';
+import {
+  runViaDaemon,
+  shouldDelegateToDaemon,
+  DaemonBackupBusyError,
+  DaemonBackupUnavailableError,
+} from '../backup/run-via-daemon.js';
+import { collectBackupStatus, type BackupStatusReport } from '../backup/status-report.js';
 import { CATALOG_DB_REL_PATH } from '../backup/layout.js';
-import { renderBackupHeadless } from '../render/headless-backup.js';
+import { connectToDaemon, isDaemonRunning } from '../node/ipc-client.js';
+import { renderBackupHeadless, formatBytes } from '../render/headless-backup.js';
 import { ui, isTTY } from '../ui.js';
 
 const require = createRequire(import.meta.url);
@@ -233,6 +241,7 @@ interface RunCmdOpts {
   json?: boolean;
   strict?: boolean;
   reconcile?: boolean;
+  embedded?: boolean;
 }
 
 function runCmd(): Command {
@@ -244,6 +253,7 @@ function runCmd(): Command {
     .option('--json', 'Emit NDJSON events instead of human output')
     .option('--strict', 'Exit non-zero when any item failed')
     .option('--reconcile', 'Full reconcile pass (not available yet)')
+    .option('--embedded', 'Force the in-process engine even when a daemon is running')
     .action(async (opts: RunCmdOpts) => {
       const cfg = requireConfig();
 
@@ -261,6 +271,41 @@ function runCmd(): Command {
             '`memoriahub backup init --dest <dir>` first.',
         );
         process.exit(1);
+      }
+
+      // Delegate to a running daemon (issue #318): the daemon owns the run
+      // lock and the scheduler, so an embedded engine next to it would only
+      // race the 409 guard. Events stream back over IPC into the SAME
+      // renderer; --embedded forces the in-process engine.
+      if (shouldDelegateToDaemon(opts.embedded === true, await isDaemonRunning())) {
+        try {
+          const client = await connectToDaemon();
+          try {
+            if (!opts.json) ui.dim('Worker-node daemon detected — delegating the run over IPC.');
+            const outcome = await runViaDaemon(client, {
+              attachRenderer: (emitter) =>
+                renderBackupHeadless(emitter, { json: opts.json === true }),
+            });
+            process.exit(resolveBackupExitCode(outcome, opts.strict === true));
+          } finally {
+            client.close();
+          }
+        } catch (err) {
+          if (err instanceof DaemonBackupBusyError) {
+            ui.error(err.message);
+            process.exit(1);
+          }
+          if (err instanceof DaemonBackupUnavailableError) {
+            // Daemon started before this machine's backup root was bound —
+            // fall through to the embedded engine.
+            ui.warn(`${err.message} — running the embedded engine instead.`);
+          } else {
+            ui.warn(
+              `Daemon delegation failed (${err instanceof Error ? err.message : String(err)}) ` +
+                '— running the embedded engine instead.',
+            );
+          }
+        }
       }
 
       const concurrency =
@@ -309,11 +354,283 @@ function runCmd(): Command {
     });
 }
 
+// ---------------------------------------------------------------------------
+// backup status (issue #318)
+// ---------------------------------------------------------------------------
+
+function renderStatusReport(report: BackupStatusReport): void {
+  const { local, daemon, server } = report;
+
+  // --- Local catalog (offline-capable) --------------------------------------
+  ui.line(`Local catalog${local.root ? ` (${local.root})` : ''}  [${local.source}]`);
+  if (!local.configured) {
+    ui.dim(`  ${local.error ?? 'not configured'}`);
+  } else if (local.error) {
+    ui.dim(`  ${local.error}`);
+  } else {
+    const c = local.counters;
+    if (c) {
+      ui.line(
+        `  Items      : ${c.totalItems} (${formatBytes(c.totalBytes)}) — ` +
+          `${c.byStatus.present.count} present, ${c.byStatus.failed.count} failed, ` +
+          `${c.byStatus.trashed.count} trashed, ${c.archivedCount} archived`,
+      );
+    }
+    ui.line(`  Checkpoint : ${local.checkpoint ? local.checkpoint.updatedAt : '(none — never synced)'}`);
+    if (local.lastRun) {
+      ui.line(
+        `  Last run   : ${local.lastRun.status} at ${local.lastRun.startedAt} — ` +
+          `${local.lastRun.itemsDownloaded ?? 0} downloaded, ${local.lastRun.errorCount ?? 0} error(s)`,
+      );
+    } else {
+      ui.line('  Last run   : (none recorded)');
+    }
+  }
+  ui.blank();
+
+  // --- Daemon (live, via IPC) ------------------------------------------------
+  ui.line(`Daemon  [${daemon.source}]`);
+  if (daemon.error) {
+    ui.dim(`  ${daemon.error}`);
+  } else if (!daemon.running) {
+    ui.dim('  not running (runs execute embedded; schedules fire only while a daemon is up)');
+  } else if (daemon.snapshot) {
+    const snap = daemon.snapshot as {
+      configured?: boolean;
+      running?: { trigger?: string; startedAt?: string } | null;
+      rate?: { concurrency?: number; maxMbps?: number } | null;
+    };
+    if (snap.configured === false) {
+      ui.dim('  running, but backup hosting is not active (daemon started before `backup init`)');
+    } else if (snap.running) {
+      ui.line(
+        `  Run active : ${snap.running.trigger ?? 'manual'} (since ${snap.running.startedAt ?? '?'})`,
+      );
+    } else {
+      ui.line('  Run active : no (idle)');
+    }
+    if (snap.rate) {
+      ui.line(
+        `  Rate       : concurrency ${snap.rate.concurrency ?? '?'}, ` +
+          `max ${snap.rate.maxMbps && snap.rate.maxMbps > 0 ? `${snap.rate.maxMbps} Mbps` : 'unlimited'}`,
+      );
+    }
+  }
+  ui.blank();
+
+  // --- Server ---------------------------------------------------------------
+  ui.line(`Server  [${server.source}]`);
+  if (!server.reachable) {
+    ui.dim(`  ${server.error ?? 'unreachable'}`);
+    return;
+  }
+  const cfg = server.config;
+  if (!cfg) {
+    ui.dim('  backup has never been configured for this node server-side');
+    return;
+  }
+  ui.line(`  Enabled    : ${cfg.enabled ? 'yes' : 'no'}`);
+  ui.line(
+    `  Schedule   : ${cfg.scheduleCron ?? '(none)'}${cfg.timezone ? ` (${cfg.timezone})` : ''}`,
+  );
+  ui.line(`  Next run   : ${cfg.nextRunAt ?? '(not scheduled)'}`);
+  if (cfg.pending) {
+    ui.line(
+      `  Pending    : ${cfg.pending.items} item(s), ${formatBytes(Number(cfg.pending.bytes))} behind the checkpoint`,
+    );
+  }
+  if (server.runs.length > 0) {
+    ui.line('  Recent runs:');
+    for (const run of server.runs) {
+      ui.line(
+        `    ${run.startedAt}  ${run.status.padEnd(9)} (${run.trigger}) — ` +
+          `${run.itemsDownloaded} downloaded, ${run.errorCount} error(s)`,
+      );
+    }
+  }
+}
+
+function statusCmd(): Command {
+  return new Command('status')
+    .description('Show backup status: local catalog, running daemon, and server')
+    .option('--json', 'Emit the merged status report as JSON')
+    .action(async (opts: { json?: boolean }) => {
+      const settings = new SettingsRepo(getDb());
+      const cfg = loadConfig();
+      const report = await collectBackupStatus({
+        settings,
+        api: cfg ? new ApiClient({ serverUrl: cfg.serverUrl, pat: cfg.pat }) : null,
+        isDaemonRunningFn: isDaemonRunning,
+        connectFn: () => connectToDaemon(),
+      });
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        return;
+      }
+      renderStatusReport(report);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// backup schedule (issue #318 — the SERVER computes cron/nextRunAt)
+// ---------------------------------------------------------------------------
+
+function requireBackupNodeId(settings: SettingsRepo): string {
+  const nodeId = settings.backupNodeId();
+  if (!nodeId) {
+    ui.error(
+      'No backup root is configured on this machine. Run ' +
+        '`memoriahub backup init --dest <dir>` first.',
+    );
+    process.exit(1);
+  }
+  return nodeId;
+}
+
+function scheduleCmd(): Command {
+  return new Command('schedule')
+    .description('Manage the automatic backup schedule (cron is computed server-side)')
+    .argument('[cron]', '5-field cron expression, e.g. "0 3 * * *"')
+    .option('--tz <iana>', 'IANA timezone for the schedule (e.g. America/Costa_Rica)')
+    .option('--show', 'Show the current schedule')
+    .option('--disable', 'Clear the schedule (no more scheduled runs)')
+    .addHelpText(
+      'after',
+      '\nScheduled runs fire from a RUNNING worker-node daemon (`memoriahub node start`),\n' +
+        'which polls the server every minute and starts a run when the server-computed\n' +
+        'nextRunAt is due. A machine offline at the scheduled time self-heals: the run\n' +
+        'fires on the first poll after the daemon is back up.',
+    )
+    .action(async (cron: string | undefined, opts: { tz?: string; show?: boolean; disable?: boolean }) => {
+      const cfg = requireConfig();
+      const settings = new SettingsRepo(getDb());
+      const nodeId = requireBackupNodeId(settings);
+      const api = new ApiClient({ serverUrl: cfg.serverUrl, pat: cfg.pat });
+
+      try {
+        if (opts.show) {
+          const { config } = await api.getNodeBackupConfig(nodeId);
+          if (!config) {
+            ui.info('Backup has never been configured for this node server-side.');
+            return;
+          }
+          ui.line(`Schedule : ${config.scheduleCron ?? '(none)'}`);
+          ui.line(`Timezone : ${config.timezone ?? '(server default, UTC)'}`);
+          ui.line(`Enabled  : ${config.enabled ? 'yes' : 'no'}`);
+          ui.line(`Next run : ${config.nextRunAt ?? '(not scheduled)'}`);
+          return;
+        }
+
+        if (opts.disable) {
+          await api.putNodeBackupConfig(nodeId, { scheduleCron: null });
+          ui.success('Backup schedule cleared — no more scheduled runs.');
+          return;
+        }
+
+        if (!cron) {
+          ui.error('Provide a cron expression, or use --show / --disable.');
+          process.exit(1);
+        }
+
+        const res = await api.putNodeBackupConfig(nodeId, {
+          scheduleCron: cron,
+          ...(opts.tz !== undefined ? { timezone: opts.tz } : {}),
+        });
+        ui.success(`Backup schedule set: ${cron}${opts.tz ? ` (${opts.tz})` : ''}`);
+        ui.line(`Next run : ${res.config?.nextRunAt ?? '(unknown)'}`);
+        if (!res.config?.enabled) {
+          ui.warn('Backup is currently DISABLED server-side — the schedule will not fire.');
+        }
+        ui.dim('Scheduled runs fire from a running daemon (`memoriahub node start`).');
+      } catch (err) {
+        if (err instanceof ApiError) {
+          // Surface server validation (bad cron / bad timezone) verbatim.
+          ui.error(err.serverMessage);
+          process.exit(1);
+        }
+        ui.error(`Schedule update failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// backup set-rate (issue #318 — persists to settings KV + live IPC push)
+// ---------------------------------------------------------------------------
+
+function setRateCmd(): Command {
+  return new Command('set-rate')
+    .description('Set backup throttle knobs (persisted; applied live to a running daemon)')
+    .option('--concurrency <n>', 'Concurrent download workers (1-32)')
+    .option('--max-mbps <x>', 'Aggregate bandwidth cap in Mbps; 0 = unlimited')
+    .action(async (opts: { concurrency?: string; maxMbps?: string }) => {
+      if (opts.concurrency === undefined && opts.maxMbps === undefined) {
+        ui.error('Provide --concurrency and/or --max-mbps.');
+        process.exit(1);
+      }
+
+      let concurrency: number | undefined;
+      if (opts.concurrency !== undefined) {
+        const n = Number(opts.concurrency);
+        if (!Number.isInteger(n) || n < 1 || n > 32) {
+          ui.error(`Invalid --concurrency: ${opts.concurrency} (expected an integer 1-32)`);
+          process.exit(1);
+        }
+        concurrency = n;
+      }
+      const maxMbps = parseNumberFlag(opts.maxMbps, '--max-mbps');
+
+      const settings = new SettingsRepo(getDb());
+      requireBackupNodeId(settings);
+      if (concurrency !== undefined) settings.setBackupConcurrency(concurrency);
+      if (maxMbps !== undefined) settings.setBackupMaxMbps(maxMbps);
+      ui.success(
+        `Backup rate saved: concurrency ${settings.backupConcurrency()}, ` +
+          `max ${settings.backupMaxMbps() > 0 ? `${settings.backupMaxMbps()} Mbps` : 'unlimited'}`,
+      );
+
+      // Live push: a running daemon applies the change on its next page/chunk.
+      if (await isDaemonRunning()) {
+        try {
+          const client = await connectToDaemon();
+          try {
+            client.send({
+              cmd: 'backup-set-rate',
+              ...(concurrency !== undefined ? { concurrency } : {}),
+              ...(maxMbps !== undefined ? { maxMbps } : {}),
+            });
+            const reply = await client.waitFor(
+              (m) => (m.kind === 'ack' || m.kind === 'error') && m['cmd'] === 'backup-set-rate',
+              5000,
+            );
+            if (reply.kind === 'ack') {
+              ui.success('Applied live to the running daemon (next page uses the new rate).');
+            } else {
+              ui.warn(`Daemon did not apply the rate: ${String(reply['message'])}`);
+            }
+          } finally {
+            client.close();
+          }
+        } catch (err) {
+          ui.warn(
+            `Could not push the rate to the running daemon: ` +
+              `${err instanceof Error ? err.message : String(err)} (it will pick it up next run).`,
+          );
+        }
+      } else {
+        ui.dim('No daemon running — the new rate applies from the next run.');
+      }
+    });
+}
+
 export function backupCommand(): Command {
   const cmd = new Command('backup');
   cmd
     .description('Local media backup to a folder on this machine (node-based)')
     .addCommand(initCmd())
-    .addCommand(runCmd());
+    .addCommand(runCmd())
+    .addCommand(statusCmd())
+    .addCommand(scheduleCmd())
+    .addCommand(setRateCmd());
   return cmd;
 }

--- a/apps/cli/src/commands/node.ts
+++ b/apps/cli/src/commands/node.ts
@@ -81,6 +81,9 @@ import {
   nodeLogPath,
 } from '../node/logger.js';
 import { startDaemonHost, readPidFile, isPidAlive } from '../node/daemon.js';
+import { BackupHost } from '../backup/backup-host.js';
+import { getDb } from '../db/database.js';
+import { SettingsRepo } from '../repo/settings.js';
 import { connectToDaemon, isDaemonRunning, type DaemonMessage } from '../node/ipc-client.js';
 import { checkNodeAlreadyRunning } from '../node/daemon-launch.js';
 import {
@@ -682,9 +685,47 @@ function startCmd(): Command {
         attachEngineLogging(logger, engine);
         attachHeadlessPrinter(engine);
 
+        // Backup hosting (issue #318): when this machine has a backup root
+        // bound (settings backup.root + backup.nodeId), the daemon ALSO hosts
+        // the backup engine + scheduler next to the enrichment engine — no
+        // flag needed, presence of the binding activates hosting. The two
+        // engines share ONLY the process: independent concurrency, and the
+        // BackupHost builds its OWN ApiClient because the CooldownGate is
+        // per-ApiClient — an enrichment provider cooldown must never brake
+        // backup downloads, and a storage throttle hitting backup must never
+        // brake enrichment claims.
+        let backupHost: BackupHost | undefined;
+        try {
+          const settings = new SettingsRepo(getDb());
+          const backupRoot = settings.backupRoot();
+          const backupNodeId = settings.backupNodeId();
+          if (backupRoot && backupNodeId) {
+            backupHost = new BackupHost(
+              {
+                serverUrl: cfg.serverUrl,
+                pat: cfg.pat,
+                root: backupRoot,
+                nodeId: backupNodeId,
+                ...(cfg.node?.name !== undefined ? { nodeName: cfg.node.name } : {}),
+                cliVersion: cliVersion(),
+              },
+              {
+                settings,
+                logger,
+                retry: settings.retryConfig(),
+                cooldown: settings.cooldownConfig(),
+              },
+            );
+            backupHost.startScheduler();
+            ui.info(`Backup hosting active — root ${backupRoot} (node ${backupNodeId}).`);
+          }
+        } catch (err) {
+          ui.warn(`Backup hosting unavailable: ${(err as Error).message}`);
+        }
+
         let host;
         try {
-          host = await startDaemonHost(engine, logger);
+          host = await startDaemonHost(engine, logger, backupHost ? { backupHost } : {});
         } catch (err) {
           ui.error(`Cannot start worker node: ${(err as Error).message}`);
           process.exit(1);

--- a/apps/cli/src/node/daemon.ts
+++ b/apps/cli/src/node/daemon.ts
@@ -11,13 +11,33 @@
  *   { kind: 'snapshot', ...EngineSnapshot }        — sent once on connect
  *   { kind: 'log-tail', lines: string[] }          — recent log lines on connect
  *   { kind: 'event', ev, payload, ts }             — every engine event, live
+ *   { kind: 'backup-event', ev, payload, ts }      — every BackupEngine event,
+ *                                                    live (issue #318; only when
+ *                                                    a BackupHost is attached)
  *   { kind: 'status', ...EngineSnapshot }          — reply to { cmd: 'status' }
+ *   { kind: 'backup-status', ...BackupHostSnapshot } — reply to
+ *                                                    { cmd: 'backup-status' }
  *   { kind: 'ack', cmd, ... }                      — command acknowledged
- *   { kind: 'error', message }                     — malformed/unknown command
+ *   { kind: 'error', message, cmd?, code? }        — malformed/unknown command,
+ *                                                    or a command-scoped failure
+ *                                                    (code 'busy' /
+ *                                                    'not-configured' for the
+ *                                                    backup verbs)
  *
  * Client → server commands (one JSON per line):
  *   { cmd: 'status' } | { cmd: 'set-concurrency', value } |
- *   { cmd: 'drain' } | { cmd: 'stop' } | { cmd: 'heap-snapshot' }
+ *   { cmd: 'drain' } | { cmd: 'stop' } | { cmd: 'heap-snapshot' } |
+ *   { cmd: 'backup-status' } | { cmd: 'backup-run-now' } |
+ *   { cmd: 'backup-cancel' } | { cmd: 'backup-set-rate', concurrency?, maxMbps? }
+ *
+ * Backup hosting (issue #318): when `node start` finds a bound backup root it
+ * passes a BackupHost in DaemonHostOptions. The daemon then serves the four
+ * backup-* verbs and re-broadcasts the host's engine events. Backup and
+ * enrichment share ONLY the process — independent concurrency, and the
+ * BackupHost uses its OWN ApiClient because the CooldownGate is per-client
+ * (an enrichment provider cooldown must never brake backup, or vice versa).
+ * Without a BackupHost, backup-status answers { configured: false } and the
+ * other backup verbs reply with a 'not-configured' error frame.
  *
  * `heap-snapshot` is the diagnostic escape hatch for issue #156: it makes the
  * LIVE daemon serialize its V8 heap to a file so a slow leak can be pinned
@@ -50,6 +70,12 @@ import {
 } from './heap-snapshot.js';
 import type { NodeEngine } from './node-engine.js';
 import type { NodeLogger } from './logger.js';
+import {
+  BACKUP_HOST_EVENT,
+  BackupBusyError,
+  type BackupHost,
+  type BackupHostEventFrame,
+} from '../backup/backup-host.js';
 
 /**
  * Maximum bytes allowed to queue in one IPC client's socket before the daemon
@@ -93,6 +119,12 @@ export interface DaemonHostOptions {
    * without serializing a real multi-hundred-MB Jest heap to disk.
    */
   heapSnapshotFn?: (opts?: HeapSnapshotOptions) => HeapSnapshotResult;
+  /**
+   * Backup hosting (issue #318): serve the backup-* IPC verbs and
+   * re-broadcast BackupEngine events. Absent when no backup root is bound —
+   * the daemon then runs enrichment-only.
+   */
+  backupHost?: BackupHost;
 }
 
 export interface DaemonHost {
@@ -173,6 +205,7 @@ export async function startDaemonHost(
   const persistConcurrency = opts.persistConcurrency ?? defaultPersistConcurrency;
   const exit = opts.exit ?? ((code: number) => process.exit(code));
   const writeHeapSnapshot = opts.heapSnapshotFn ?? writeWorkerHeapSnapshot;
+  const backupHost = opts.backupHost;
   const isWindows = os.platform() === 'win32';
 
   // ---- Stale-instance detection -------------------------------------------
@@ -287,6 +320,120 @@ export async function startDaemonHost(
         });
         break;
       }
+      // ---- Backup verbs (issue #318) --------------------------------------
+      case 'backup-status': {
+        if (!backupHost) {
+          send(socket, {
+            kind: 'backup-status',
+            configured: false,
+            running: null,
+            lastRun: null,
+            checkpoint: null,
+            counters: null,
+            rate: null,
+          });
+          break;
+        }
+        send(socket, { kind: 'backup-status', ...backupHost.getSnapshot() });
+        break;
+      }
+      case 'backup-run-now': {
+        if (!backupHost) {
+          send(socket, {
+            kind: 'error',
+            cmd: 'backup-run-now',
+            code: 'not-configured',
+            message:
+              'backup is not configured on this daemon (run `memoriahub backup init` and restart the node)',
+          });
+          break;
+        }
+        try {
+          backupHost.startRun('manual');
+          logger.info('backup run started via ipc');
+          send(socket, { kind: 'ack', cmd: 'backup-run-now' });
+        } catch (err) {
+          if (err instanceof BackupBusyError) {
+            send(socket, {
+              kind: 'error',
+              cmd: 'backup-run-now',
+              code: 'busy',
+              message: err.message,
+            });
+          } else {
+            send(socket, {
+              kind: 'error',
+              cmd: 'backup-run-now',
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        break;
+      }
+      case 'backup-cancel': {
+        if (!backupHost) {
+          send(socket, {
+            kind: 'error',
+            cmd: 'backup-cancel',
+            code: 'not-configured',
+            message: 'backup is not configured on this daemon',
+          });
+          break;
+        }
+        const cancelled = backupHost.cancel();
+        if (cancelled) logger.info('backup run cancel requested via ipc');
+        send(socket, { kind: 'ack', cmd: 'backup-cancel', cancelled });
+        break;
+      }
+      case 'backup-set-rate': {
+        if (!backupHost) {
+          send(socket, {
+            kind: 'error',
+            cmd: 'backup-set-rate',
+            code: 'not-configured',
+            message: 'backup is not configured on this daemon',
+          });
+          break;
+        }
+        const body = msg as { concurrency?: unknown; maxMbps?: unknown };
+        const update: { concurrency?: number; maxMbps?: number } = {};
+        if (body.concurrency !== undefined) {
+          const value = Number(body.concurrency);
+          if (!Number.isInteger(value) || value < 1 || value > 32) {
+            send(socket, {
+              kind: 'error',
+              cmd: 'backup-set-rate',
+              message: 'backup-set-rate requires an integer concurrency between 1 and 32',
+            });
+            break;
+          }
+          update.concurrency = value;
+        }
+        if (body.maxMbps !== undefined) {
+          const value = Number(body.maxMbps);
+          if (!Number.isFinite(value) || value < 0) {
+            send(socket, {
+              kind: 'error',
+              cmd: 'backup-set-rate',
+              message: 'backup-set-rate requires a non-negative maxMbps (0 = unlimited)',
+            });
+            break;
+          }
+          update.maxMbps = value;
+        }
+        if (update.concurrency === undefined && update.maxMbps === undefined) {
+          send(socket, {
+            kind: 'error',
+            cmd: 'backup-set-rate',
+            message: 'backup-set-rate requires concurrency and/or maxMbps',
+          });
+          break;
+        }
+        const effective = backupHost.setRate(update);
+        logger.info('backup rate changed via ipc', { ...effective });
+        send(socket, { kind: 'ack', cmd: 'backup-set-rate', ...effective });
+        break;
+      }
       case 'drain': {
         engine.drain();
         logger.info('drain requested via ipc');
@@ -363,6 +510,18 @@ export async function startDaemonHost(
     subscriptions.push([ev, listener]);
   }
 
+  // BackupHost events (issue #318): the host re-emits every BackupEngine
+  // event as one 'backup-event' emission; the daemon frames it for IPC.
+  const backupListener = (frame: BackupHostEventFrame): void => {
+    broadcast({
+      kind: 'backup-event',
+      ev: frame.ev,
+      payload: frame.payload,
+      ts: new Date().toISOString(),
+    });
+  };
+  backupHost?.on(BACKUP_HOST_EVENT, backupListener);
+
   // ---- Cleanup --------------------------------------------------------------
   const cleanupFiles = (): void => {
     if (!isWindows) {
@@ -385,6 +544,12 @@ export async function startDaemonHost(
     if (closed) return Promise.resolve();
     closed = true;
     for (const [ev, listener] of subscriptions) emitter.off(ev, listener);
+    if (backupHost) {
+      backupHost.off(BACKUP_HOST_EVENT, backupListener);
+      // Stop the scheduler poll; an in-flight backup run completes on its own
+      // (its timers/sockets are what keep the process alive if needed).
+      backupHost.stopScheduler();
+    }
     for (const socket of clients) socket.destroy();
     clients.clear();
     process.removeListener('exit', cleanupFiles);

--- a/apps/cli/src/node/daemon.ts
+++ b/apps/cli/src/node/daemon.ts
@@ -70,12 +70,13 @@ import {
 } from './heap-snapshot.js';
 import type { NodeEngine } from './node-engine.js';
 import type { NodeLogger } from './logger.js';
-import {
-  BACKUP_HOST_EVENT,
-  BackupBusyError,
-  type BackupHost,
-  type BackupHostEventFrame,
-} from '../backup/backup-host.js';
+// Deliberately type-only + events-only: daemon.ts is imported by the TUI
+// dashboard (readPidFile), so it must NOT pull the backup engine's runtime
+// graph (ApiClient/ApiError/better-sqlite3) into every consumer's module
+// graph. The BackupHost VALUE is constructed by `node start` and injected
+// via DaemonHostOptions; events.ts has no runtime dependencies.
+import { BACKUP_HOST_EVENT, type BackupHostEventFrame } from '../backup/events.js';
+import type { BackupHost } from '../backup/backup-host.js';
 
 /**
  * Maximum bytes allowed to queue in one IPC client's socket before the daemon
@@ -353,12 +354,14 @@ export async function startDaemonHost(
           logger.info('backup run started via ipc');
           send(socket, { kind: 'ack', cmd: 'backup-run-now' });
         } catch (err) {
-          if (err instanceof BackupBusyError) {
+          // Duck-typed (not instanceof BackupBusyError) so this module never
+          // needs a runtime import from backup-host.js — see the import note.
+          if ((err as { code?: unknown })?.code === 'busy') {
             send(socket, {
               kind: 'error',
               cmd: 'backup-run-now',
               code: 'busy',
-              message: err.message,
+              message: err instanceof Error ? err.message : String(err),
             });
           } else {
             send(socket, {

--- a/apps/cli/src/render/headless-backup.ts
+++ b/apps/cli/src/render/headless-backup.ts
@@ -14,6 +14,7 @@ import chalk from 'chalk';
 import { ui, isTTY } from '../ui.js';
 import {
   BACKUP_EV,
+  type BackupTypedEmitter,
   type BackupEngineStats,
   type ItemDonePayload,
   type PageFetchedPayload,
@@ -22,7 +23,6 @@ import {
   type ThrottlePayload,
   type BackupErrorPayload,
 } from '../backup/events.js';
-import type { BackupEngine } from '../backup/backup-engine.js';
 
 /** Format a byte count for humans (decimal units, one decimal place). */
 export function formatBytes(bytes: number): string {
@@ -48,9 +48,10 @@ export interface RenderBackupOptions {
 
 /**
  * Attach terminal-output listeners to `engine`. Must be called before
- * `engine.runBackup()`.
+ * `engine.runBackup()`. Accepts any BackupTypedEmitter — the embedded
+ * BackupEngine or the IPC event proxy used by daemon delegation (#318).
  */
-export function renderBackupHeadless(engine: BackupEngine, opts: RenderBackupOptions): void {
+export function renderBackupHeadless(engine: BackupTypedEmitter, opts: RenderBackupOptions): void {
   const write = opts.write ?? ((line: string): void => void process.stdout.write(line));
   const now = opts.now ?? Date.now;
 

--- a/apps/cli/src/repo/settings.ts
+++ b/apps/cli/src/repo/settings.ts
@@ -144,9 +144,17 @@ export class SettingsRepo {
     return this.get<number>('backup.concurrency', 2);
   }
 
+  setBackupConcurrency(n: number): void {
+    this.set('backup.concurrency', n);
+  }
+
   /** Aggregate download bandwidth cap in Mbps; 0 = unlimited (default: 0). */
   backupMaxMbps(): number {
     return this.get<number>('backup.maxMbps', 0);
+  }
+
+  setBackupMaxMbps(mbps: number): void {
+    this.set('backup.maxMbps', mbps);
   }
 
   /** Change-feed page size (default: 100; server clamps to backup.maxPageSize). */

--- a/apps/cli/test/backup/backup-daemon-ipc.spec.ts
+++ b/apps/cli/test/backup/backup-daemon-ipc.spec.ts
@@ -1,0 +1,286 @@
+/**
+ * test/backup/backup-daemon-ipc.spec.ts — Backup IPC verbs over a REAL daemon
+ * host + unix socket (issue #318). Mirrors test/node/daemon-heap-snapshot.spec.ts.
+ *
+ * Covers: backup-status snapshot round-trip (and the configured:false answer
+ * when no BackupHost is attached), backup-run-now with busy rejection,
+ * backup-cancel cooperative stop, backup-set-rate validation + live apply,
+ * and the { kind:'backup-event', ev, payload, ts } re-broadcast frames.
+ */
+
+import { jest } from '@jest/globals';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { startDaemonHost, type DaemonHost } from '../../src/node/daemon.js';
+import { NodeEngine } from '../../src/node/node-engine.js';
+import { connectToDaemon, type DaemonClient, type DaemonMessage } from '../../src/node/ipc-client.js';
+import type { ApiClient, ClaimedNodeJob } from '../../src/api.js';
+import type { ComputeDispatcher } from '../../src/node/capabilities.js';
+import type { NodeLogger } from '../../src/node/logger.js';
+import {
+  BackupHost,
+  type BackupRunContext,
+} from '../../src/backup/backup-host.js';
+import type { BackupRunOutcome } from '../../src/backup/backup-engine.js';
+import { BACKUP_EV, BackupTypedEmitter, emptyStats } from '../../src/backup/events.js';
+import type { SettingsRepo } from '../../src/repo/settings.js';
+
+function stubApi(): ApiClient {
+  return {
+    claimNodeJobs: async () => ({ jobs: [] as ClaimedNodeJob[] }),
+    heartbeatNode: async () => ({}),
+    deregisterNode: async () => ({}),
+    renewLease: async () => ({}),
+    submitJobResult: async () => ({}),
+    reportJobFailure: async () => ({}),
+  } as unknown as ApiClient;
+}
+
+function stubDispatcher(): ComputeDispatcher {
+  return { compute: async () => ({ ok: true }) } as unknown as ComputeDispatcher;
+}
+
+function stubLogger(): NodeLogger & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logPath: '(stub)',
+    log: (level, fields) => lines.push(JSON.stringify({ level, ...fields })),
+    info: (msg) => lines.push(`info: ${msg}`),
+    warn: (msg) => lines.push(`warn: ${msg}`),
+    error: (msg) => lines.push(`error: ${msg}`),
+    tail: (n) => lines.slice(-n),
+  };
+}
+
+function stubSettings(): SettingsRepo {
+  const values = new Map<string, number>([
+    ['backup.concurrency', 2],
+    ['backup.maxMbps', 0],
+    ['backup.pageSize', 100],
+    ['backup.pacingMs', 0],
+  ]);
+  return {
+    backupConcurrency: () => values.get('backup.concurrency')!,
+    backupMaxMbps: () => values.get('backup.maxMbps')!,
+    backupPageSize: () => values.get('backup.pageSize')!,
+    backupPacingMs: () => values.get('backup.pacingMs')!,
+    setBackupConcurrency: (n: number) => void values.set('backup.concurrency', n),
+    setBackupMaxMbps: (m: number) => void values.set('backup.maxMbps', m),
+  } as unknown as SettingsRepo;
+}
+
+class FakeEngine extends BackupTypedEmitter {
+  cancelled = false;
+  cancel(): void {
+    this.cancelled = true;
+  }
+}
+
+function tmpDirPath(name: string): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'mh-backup-ipc-')), name);
+}
+
+async function sendCommand(client: DaemonClient, cmd: Record<string, unknown>): Promise<DaemonMessage> {
+  client.send(cmd);
+  return client.waitFor(
+    (m) =>
+      (m.kind === 'ack' || m.kind === 'error' || m.kind === 'backup-status') &&
+      (m.kind === 'backup-status' || m['cmd'] === cmd['cmd']),
+    3000,
+  );
+}
+
+describe('daemon backup IPC verbs', () => {
+  let engine: NodeEngine;
+  let host: DaemonHost;
+  let socketPath: string;
+  let backupHost: BackupHost | undefined;
+  let engines: FakeEngine[];
+  let resolveRun: ((o: BackupRunOutcome) => void) | null;
+
+  async function startHost(withBackup: boolean): Promise<void> {
+    socketPath = tmpDirPath('node.sock');
+    engines = [];
+    resolveRun = null;
+
+    engine = new NodeEngine({
+      api: stubApi(),
+      dispatcher: stubDispatcher(),
+      nodeId: 'node-ipc-1',
+      options: {
+        concurrency: 1,
+        eligibleTypes: ['face_detection'],
+        pollIntervalMs: 60_000,
+        heartbeatIntervalMs: 60_000,
+      },
+      detectFn: async () => ({}),
+      downloadFn: async () => {
+        throw new Error('no downloads expected');
+      },
+    });
+
+    backupHost = withBackup
+      ? new BackupHost(
+          {
+            serverUrl: 'http://server.test',
+            pat: 'nod_test',
+            root: '/tmp/backup-root',
+            nodeId: 'backup-node-1',
+            cliVersion: '1.2.22',
+          },
+          {
+            settings: stubSettings(),
+            logger: stubLogger(),
+            api: { getNodeBackupConfig: async () => ({ config: null }) } as never,
+            runBackupFn: jest.fn<(ctx: BackupRunContext) => Promise<BackupRunOutcome>>((ctx) => {
+              const fake = new FakeEngine();
+              engines.push(fake);
+              ctx.attachEngine(fake);
+              return new Promise<BackupRunOutcome>((resolve) => {
+                resolveRun = resolve;
+              });
+            }),
+            openDb: () => {
+              throw new Error('no catalog in this test');
+            },
+          },
+        )
+      : undefined;
+
+    host = await startDaemonHost(engine, stubLogger(), {
+      socketPath,
+      pidPath: tmpDirPath('node.pid'),
+      persistConcurrency: () => {},
+      exit: () => {},
+      ...(backupHost ? { backupHost } : {}),
+    });
+  }
+
+  afterEach(async () => {
+    resolveRun?.({ runId: 'r', status: 'aborted', stats: emptyStats() });
+    await backupHost?.waitForIdle();
+    await host.close();
+    try {
+      await engine.stop('test-cleanup');
+    } catch {
+      /* engine never started */
+    }
+  });
+
+  it('backup-status answers configured:false when no BackupHost is attached', async () => {
+    await startHost(false);
+    const client = await connectToDaemon(socketPath);
+    try {
+      const reply = await sendCommand(client, { cmd: 'backup-status' });
+      expect(reply.kind).toBe('backup-status');
+      expect(reply['configured']).toBe(false);
+      expect(reply['running']).toBeNull();
+      expect(reply['rate']).toBeNull();
+    } finally {
+      client.close();
+    }
+  });
+
+  it('backup-run-now without a BackupHost replies not-configured', async () => {
+    await startHost(false);
+    const client = await connectToDaemon(socketPath);
+    try {
+      const reply = await sendCommand(client, { cmd: 'backup-run-now' });
+      expect(reply.kind).toBe('error');
+      expect(reply['code']).toBe('not-configured');
+    } finally {
+      client.close();
+    }
+  });
+
+  it('backup-status round-trips the host snapshot', async () => {
+    await startHost(true);
+    const client = await connectToDaemon(socketPath);
+    try {
+      const reply = await sendCommand(client, { cmd: 'backup-status' });
+      expect(reply.kind).toBe('backup-status');
+      expect(reply['configured']).toBe(true);
+      expect(reply['running']).toBeNull();
+      expect(reply['rate']).toEqual({ concurrency: 2, maxMbps: 0 });
+      // Unreadable catalog degrades to nulls, never an error frame.
+      expect(reply['counters']).toBeNull();
+      expect(reply['checkpoint']).toBeNull();
+      expect(reply['lastRun']).toBeNull();
+    } finally {
+      client.close();
+    }
+  });
+
+  it('backup-run-now starts a run; a second request is rejected busy; cancel stops it', async () => {
+    await startHost(true);
+    const client = await connectToDaemon(socketPath);
+    try {
+      const first = await sendCommand(client, { cmd: 'backup-run-now' });
+      expect(first.kind).toBe('ack');
+
+      const status = await sendCommand(client, { cmd: 'backup-status' });
+      expect((status['running'] as { trigger: string }).trigger).toBe('manual');
+
+      const second = await sendCommand(client, { cmd: 'backup-run-now' });
+      expect(second.kind).toBe('error');
+      expect(second['code']).toBe('busy');
+
+      const cancel = await sendCommand(client, { cmd: 'backup-cancel' });
+      expect(cancel.kind).toBe('ack');
+      expect(cancel['cancelled']).toBe(true);
+      expect(engines[0]!.cancelled).toBe(true);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('backup-set-rate validates input, persists, and applies live', async () => {
+    await startHost(true);
+    const client = await connectToDaemon(socketPath);
+    try {
+      // Run active so the live-apply path is exercised.
+      await sendCommand(client, { cmd: 'backup-run-now' });
+
+      const bad = await sendCommand(client, { cmd: 'backup-set-rate', concurrency: 0 });
+      expect(bad.kind).toBe('error');
+
+      const empty = await sendCommand(client, { cmd: 'backup-set-rate' });
+      expect(empty.kind).toBe('error');
+
+      const ok = await sendCommand(client, { cmd: 'backup-set-rate', concurrency: 4, maxMbps: 8 });
+      expect(ok.kind).toBe('ack');
+      expect(ok['concurrency']).toBe(4);
+      expect(ok['maxMbps']).toBe(8);
+
+      const status = await sendCommand(client, { cmd: 'backup-status' });
+      expect(status['rate']).toEqual({ concurrency: 4, maxMbps: 8 });
+    } finally {
+      client.close();
+    }
+  });
+
+  it('re-broadcasts engine events as { kind: backup-event, ev, payload, ts } frames', async () => {
+    await startHost(true);
+    const client = await connectToDaemon(socketPath);
+    try {
+      const frames: DaemonMessage[] = [];
+      client.onMessage((m) => {
+        if (m.kind === 'backup-event') frames.push(m);
+      });
+
+      await sendCommand(client, { cmd: 'backup-run-now' });
+      engines[0]!.emit(BACKUP_EV.ITEM_DONE, { id: 'item-1', outcome: 'downloaded', bytes: 7 });
+
+      const frame = await client.waitFor((m) => m.kind === 'backup-event', 3000);
+      expect(frame['ev']).toBe('item-done');
+      expect(frame['payload']).toEqual({ id: 'item-1', outcome: 'downloaded', bytes: 7 });
+      expect(typeof frame['ts']).toBe('string');
+      expect(Number.isFinite(Date.parse(frame['ts'] as string))).toBe(true);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/apps/cli/test/backup/backup-host.spec.ts
+++ b/apps/cli/test/backup/backup-host.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * test/backup/backup-host.spec.ts — BackupHost run ownership (issue #318).
+ *
+ * The engine-run seam is injected, so these tests exercise the HOST contract
+ * without a real BackupEngine: single-run serialization (busy rejection),
+ * 'backup-event' re-broadcast frame shape, LIVE set-rate application (the
+ * mutable engineOpts holder + TokenBucket.setRate — the next page/chunk uses
+ * the new values), cooperative cancel (including a cancel racing engine
+ * construction), and the status snapshot.
+ */
+
+import { jest } from '@jest/globals';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  BackupHost,
+  BackupBusyError,
+  BACKUP_HOST_EVENT,
+  type BackupHostDeps,
+  type BackupHostEventFrame,
+  type BackupRunContext,
+} from '../../src/backup/backup-host.js';
+import type { BackupRunOutcome } from '../../src/backup/backup-engine.js';
+import { BACKUP_EV, BackupTypedEmitter, emptyStats } from '../../src/backup/events.js';
+import { openCatalogDb } from '../../src/backup/catalog-db.js';
+import { CatalogRepo } from '../../src/backup/catalog-repo.js';
+import { CHECKPOINT_CURSOR_KEY } from '../../src/backup/backup-engine.js';
+import type { NodeLogger } from '../../src/node/logger.js';
+import type { SettingsRepo } from '../../src/repo/settings.js';
+
+function stubLogger(): NodeLogger & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logPath: '(stub)',
+    log: (level, fields) => lines.push(JSON.stringify({ level, ...fields })),
+    info: (msg, payload) => lines.push(`info: ${msg} ${JSON.stringify(payload ?? {})}`),
+    warn: (msg, payload) => lines.push(`warn: ${msg} ${JSON.stringify(payload ?? {})}`),
+    error: (msg, payload) => lines.push(`error: ${msg} ${JSON.stringify(payload ?? {})}`),
+    tail: (n) => lines.slice(-n),
+  };
+}
+
+/** In-memory stand-in for the settings KV throttle knobs. */
+function stubSettings(): SettingsRepo & { values: Map<string, number> } {
+  const values = new Map<string, number>([
+    ['backup.concurrency', 2],
+    ['backup.maxMbps', 0],
+    ['backup.pageSize', 100],
+    ['backup.pacingMs', 0],
+  ]);
+  return {
+    values,
+    backupConcurrency: () => values.get('backup.concurrency')!,
+    backupMaxMbps: () => values.get('backup.maxMbps')!,
+    backupPageSize: () => values.get('backup.pageSize')!,
+    backupPacingMs: () => values.get('backup.pacingMs')!,
+    setBackupConcurrency: (n: number) => void values.set('backup.concurrency', n),
+    setBackupMaxMbps: (m: number) => void values.set('backup.maxMbps', m),
+  } as unknown as SettingsRepo & { values: Map<string, number> };
+}
+
+/** A fake attachable engine: typed emitter + cancel spy. */
+class FakeEngine extends BackupTypedEmitter {
+  cancelled = false;
+  cancel(): void {
+    this.cancelled = true;
+  }
+}
+
+interface Harness {
+  host: BackupHost;
+  settings: ReturnType<typeof stubSettings>;
+  logger: ReturnType<typeof stubLogger>;
+  contexts: BackupRunContext[];
+  engines: FakeEngine[];
+  /** Resolve the currently-pending injected run. */
+  finishRun: (outcome?: Partial<BackupRunOutcome>) => void;
+}
+
+function makeHost(depsOver: Partial<BackupHostDeps> = {}, root = '/tmp/backup-root'): Harness {
+  const settings = stubSettings();
+  const logger = stubLogger();
+  const contexts: BackupRunContext[] = [];
+  const engines: FakeEngine[] = [];
+  let resolveRun: ((o: BackupRunOutcome) => void) | null = null;
+
+  const runBackupFn = jest.fn<(ctx: BackupRunContext) => Promise<BackupRunOutcome>>((ctx) => {
+    contexts.push(ctx);
+    const engine = new FakeEngine();
+    engines.push(engine);
+    ctx.attachEngine(engine);
+    return new Promise<BackupRunOutcome>((resolve) => {
+      resolveRun = resolve;
+    });
+  });
+
+  const host = new BackupHost(
+    {
+      serverUrl: 'http://server.test',
+      pat: 'nod_test',
+      root,
+      nodeId: 'node-1',
+      cliVersion: '1.2.22',
+    },
+    {
+      settings,
+      logger,
+      api: { getNodeBackupConfig: async () => ({ config: null }) } as never,
+      runBackupFn,
+      ...depsOver,
+    },
+  );
+
+  return {
+    host,
+    settings,
+    logger,
+    contexts,
+    engines,
+    finishRun: (outcome = {}) =>
+      resolveRun?.({
+        runId: 'run-1',
+        status: 'completed',
+        stats: emptyStats(),
+        ...outcome,
+      }),
+  };
+}
+
+describe('BackupHost', () => {
+  it('serializes runs: a second trigger while one is active is rejected busy', async () => {
+    const h = makeHost();
+    h.host.startRun('manual');
+    expect(h.host.isRunning()).toBe(true);
+
+    expect(() => h.host.startRun('manual')).toThrow(BackupBusyError);
+    expect(() => h.host.startRun('scheduled')).toThrow(BackupBusyError);
+
+    h.finishRun();
+    await h.host.waitForIdle();
+    expect(h.host.isRunning()).toBe(false);
+
+    // A fresh run is accepted once the previous one settled.
+    expect(() => h.host.startRun('scheduled')).not.toThrow();
+    h.finishRun();
+    await h.host.waitForIdle();
+  });
+
+  it('re-broadcasts every engine event as a { ev, payload } backup-event frame', async () => {
+    const h = makeHost();
+    const frames: BackupHostEventFrame[] = [];
+    h.host.on(BACKUP_HOST_EVENT, (frame: BackupHostEventFrame) => frames.push(frame));
+
+    h.host.startRun('manual');
+    const engine = h.engines[0]!;
+    engine.emit(BACKUP_EV.RUN_STARTED, { runId: 'r1', kind: 'incremental', trigger: 'manual' });
+    engine.emit(BACKUP_EV.ITEM_DONE, { id: 'item-1', outcome: 'downloaded', bytes: 42 });
+    engine.emit(BACKUP_EV.RUN_FINISHED, { status: 'completed', stats: emptyStats() });
+
+    expect(frames).toEqual([
+      { ev: 'run-started', payload: { runId: 'r1', kind: 'incremental', trigger: 'manual' } },
+      { ev: 'item-done', payload: { id: 'item-1', outcome: 'downloaded', bytes: 42 } },
+      { ev: 'run-finished', payload: { status: 'completed', stats: emptyStats() } },
+    ]);
+
+    h.finishRun();
+    await h.host.waitForIdle();
+  });
+
+  it('set-rate persists to the settings KV and applies LIVE to the active run', async () => {
+    const h = makeHost();
+    h.host.startRun('manual');
+    const ctx = h.contexts[0]!;
+    expect(ctx.engineOpts.concurrency).toBe(2);
+    expect(ctx.bucket.maxMbps).toBe(0);
+    const setRateSpy = jest.spyOn(ctx.bucket, 'setRate');
+
+    const effective = h.host.setRate({ concurrency: 6, maxMbps: 12.5 });
+
+    // Persisted for future runs…
+    expect(effective).toEqual({ concurrency: 6, maxMbps: 12.5 });
+    expect(h.settings.values.get('backup.concurrency')).toBe(6);
+    expect(h.settings.values.get('backup.maxMbps')).toBe(12.5);
+    // …AND applied to the live holders the engine re-reads per page/chunk.
+    expect(ctx.engineOpts.concurrency).toBe(6);
+    expect(setRateSpy).toHaveBeenCalledWith(12.5);
+    expect(ctx.bucket.maxMbps).toBe(12.5);
+
+    h.finishRun();
+    await h.host.waitForIdle();
+  });
+
+  it('set-rate with no active run persists only (next run picks it up)', () => {
+    const h = makeHost();
+    const effective = h.host.setRate({ concurrency: 3 });
+    expect(effective.concurrency).toBe(3);
+    expect(h.settings.values.get('backup.concurrency')).toBe(3);
+    // A later run reads the new value from settings.
+    h.host.startRun('manual');
+    expect(h.contexts[0]!.engineOpts.concurrency).toBe(3);
+    h.finishRun();
+  });
+
+  it('cancel is cooperative and reports whether a run was active', async () => {
+    const h = makeHost();
+    expect(h.host.cancel()).toBe(false);
+
+    h.host.startRun('manual');
+    expect(h.host.cancel()).toBe(true);
+    expect(h.engines[0]!.cancelled).toBe(true);
+
+    h.finishRun({ status: 'aborted' });
+    await h.host.waitForIdle();
+  });
+
+  it('a cancel racing engine construction still lands via attachEngine', async () => {
+    // Run seam that attaches the engine only AFTER cancel was requested.
+    let attach: (() => void) | null = null;
+    const engine = new FakeEngine();
+    const h = makeHost({
+      runBackupFn: (ctx) => {
+        attach = () => ctx.attachEngine(engine);
+        return new Promise<BackupRunOutcome>(() => {});
+      },
+    });
+    h.host.startRun('manual');
+    expect(h.host.cancel()).toBe(true);
+    expect(engine.cancelled).toBe(false);
+    attach!();
+    expect(engine.cancelled).toBe(true);
+  });
+
+  it('a rejected run (e.g. server 409) is logged and frees the slot', async () => {
+    const h = makeHost({
+      runBackupFn: async () => {
+        throw new Error('A backup run is already active for this node');
+      },
+    });
+    h.host.startRun('manual');
+    await h.host.waitForIdle();
+    expect(h.host.isRunning()).toBe(false);
+    expect(h.logger.lines.some((l) => l.includes('backup run failed'))).toBe(true);
+  });
+
+  it('getSnapshot reads catalog counters/checkpoint/lastRun and reflects run state', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-backup-host-'));
+    // Seed a real catalog: one run + a checkpoint.
+    const db = openCatalogDb(root);
+    const repo = new CatalogRepo(db);
+    repo.recordRun({
+      id: 'run-9',
+      kind: 'incremental',
+      status: 'completed',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      finishedAt: '2026-08-01T00:01:00.000Z',
+      itemsDownloaded: 7,
+      errorCount: 1,
+    });
+    repo.setCheckpoint(
+      CHECKPOINT_CURSOR_KEY,
+      JSON.stringify({ updatedAt: '2026-08-01T00:00:59.000Z', id: 'item-x' }),
+    );
+    db.close();
+
+    const h = makeHost({}, root);
+    const idle = h.host.getSnapshot();
+    expect(idle.configured).toBe(true);
+    expect(idle.running).toBeNull();
+    expect(idle.lastRun?.id).toBe('run-9');
+    expect(idle.checkpoint).toEqual({ updatedAt: '2026-08-01T00:00:59.000Z', id: 'item-x' });
+    expect(idle.counters?.totalItems).toBe(0);
+    expect(idle.rate).toEqual({ concurrency: 2, maxMbps: 0 });
+
+    h.host.startRun('scheduled');
+    const busy = h.host.getSnapshot();
+    expect(busy.running?.trigger).toBe('scheduled');
+    h.finishRun();
+    await h.host.waitForIdle();
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('getSnapshot degrades to null sections when the catalog is unreadable', () => {
+    const h = makeHost({
+      openDb: () => {
+        throw new Error('disk unplugged');
+      },
+    });
+    const snap = h.host.getSnapshot();
+    expect(snap.configured).toBe(true);
+    expect(snap.counters).toBeNull();
+    expect(snap.checkpoint).toBeNull();
+    expect(snap.lastRun).toBeNull();
+    expect(h.logger.lines.some((l) => l.includes('backup status catalog read failed'))).toBe(true);
+  });
+});

--- a/apps/cli/test/backup/backup-scheduler.spec.ts
+++ b/apps/cli/test/backup/backup-scheduler.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * test/backup/backup-scheduler.spec.ts — Pull-based schedule poller (issue #318).
+ *
+ * Covers: overdue nextRunAt at startup fires immediately (offline-at-schedule
+ * self-heal); not-due / disabled / unconfigured do nothing; a due schedule is
+ * skipped while a run is active; fired runs carry trigger='scheduled'; poll
+ * failures log + keep polling and back off to 5 min after 5 consecutive
+ * failures, resetting on success; the recurring 60s cadence (fake timers).
+ */
+
+import { jest } from '@jest/globals';
+import type { NodeBackupConfigResult } from '../../src/api.js';
+import type { NodeLogger } from '../../src/node/logger.js';
+import {
+  BackupScheduler,
+  SCHEDULER_BACKOFF_INTERVAL_MS,
+  SCHEDULER_FAILURE_THRESHOLD,
+  SCHEDULER_POLL_INTERVAL_MS,
+  type BackupSchedulerDeps,
+} from '../../src/backup/backup-scheduler.js';
+
+const NOW = Date.parse('2026-08-09T12:00:00.000Z');
+
+function stubLogger(): NodeLogger & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logPath: '(stub)',
+    log: (level, fields) => lines.push(JSON.stringify({ level, ...fields })),
+    info: (msg, payload) => lines.push(`info: ${msg} ${JSON.stringify(payload ?? {})}`),
+    warn: (msg, payload) => lines.push(`warn: ${msg} ${JSON.stringify(payload ?? {})}`),
+    error: (msg, payload) => lines.push(`error: ${msg} ${JSON.stringify(payload ?? {})}`),
+    tail: (n) => lines.slice(-n),
+  };
+}
+
+function config(over: Partial<{ enabled: boolean; nextRunAt: string | null }> = {}): NodeBackupConfigResult {
+  return {
+    config: {
+      nodeId: 'node-1',
+      enabled: over.enabled ?? true,
+      scheduleCron: '0 3 * * *',
+      timezone: 'UTC',
+      nextRunAt: over.nextRunAt === undefined ? new Date(NOW - 60_000).toISOString() : over.nextRunAt,
+      circleIds: [],
+    },
+  };
+}
+
+interface Harness {
+  scheduler: BackupScheduler;
+  startRun: jest.Mock<(trigger: 'scheduled') => void>;
+  logger: ReturnType<typeof stubLogger>;
+  getConfig: jest.Mock<(nodeId: string) => Promise<NodeBackupConfigResult>>;
+}
+
+function makeScheduler(
+  results: () => Promise<NodeBackupConfigResult>,
+  depsOver: Partial<BackupSchedulerDeps> = {},
+): Harness {
+  const startRun = jest.fn<(trigger: 'scheduled') => void>();
+  const logger = stubLogger();
+  const getConfig = jest.fn<(nodeId: string) => Promise<NodeBackupConfigResult>>(() => results());
+  const scheduler = new BackupScheduler(
+    { nodeId: 'node-1' },
+    {
+      api: { getNodeBackupConfig: getConfig },
+      logger,
+      isRunActive: () => false,
+      startRun,
+      now: () => NOW,
+      ...depsOver,
+    },
+  );
+  return { scheduler, startRun, logger, getConfig };
+}
+
+describe('BackupScheduler', () => {
+  it('fires immediately at startup when nextRunAt is overdue (offline self-heal)', async () => {
+    const h = makeScheduler(async () => config());
+    h.scheduler.start();
+    // start() runs an immediate tick; flush its microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    h.scheduler.stop();
+
+    expect(h.getConfig).toHaveBeenCalledWith('node-1');
+    expect(h.startRun).toHaveBeenCalledTimes(1);
+    expect(h.startRun).toHaveBeenCalledWith('scheduled');
+  });
+
+  it('does nothing when nextRunAt is in the future', async () => {
+    const h = makeScheduler(async () =>
+      config({ nextRunAt: new Date(NOW + 3_600_000).toISOString() }),
+    );
+    await h.scheduler.tick();
+    expect(h.startRun).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the schedule is cleared (nextRunAt null)', async () => {
+    const h = makeScheduler(async () => config({ nextRunAt: null }));
+    await h.scheduler.tick();
+    expect(h.startRun).not.toHaveBeenCalled();
+  });
+
+  it('enabled:false is a kill switch — an overdue schedule never fires', async () => {
+    const h = makeScheduler(async () => config({ enabled: false }));
+    await h.scheduler.tick();
+    expect(h.startRun).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when backup has never been configured (config null)', async () => {
+    const h = makeScheduler(async () => ({ config: null }));
+    await h.scheduler.tick();
+    expect(h.startRun).not.toHaveBeenCalled();
+  });
+
+  it('skips a due schedule while a local run is active', async () => {
+    const h = makeScheduler(async () => config(), { isRunActive: () => true });
+    await h.scheduler.tick();
+    expect(h.startRun).not.toHaveBeenCalled();
+  });
+
+  it('logs and keeps polling on failure; backs off to 5 min after 5 consecutive failures; resets on success', async () => {
+    let fail = true;
+    const h = makeScheduler(async () => {
+      if (fail) throw new Error('ECONNREFUSED');
+      return config({ nextRunAt: null });
+    });
+
+    expect(h.scheduler.nextDelayMs()).toBe(SCHEDULER_POLL_INTERVAL_MS);
+
+    for (let i = 1; i <= SCHEDULER_FAILURE_THRESHOLD; i += 1) {
+      await h.scheduler.tick();
+      expect(h.scheduler.failures).toBe(i);
+      expect(h.scheduler.nextDelayMs()).toBe(
+        i >= SCHEDULER_FAILURE_THRESHOLD ? SCHEDULER_BACKOFF_INTERVAL_MS : SCHEDULER_POLL_INTERVAL_MS,
+      );
+    }
+    expect(h.logger.lines.some((l) => l.includes('backup schedule poll failed'))).toBe(true);
+    expect(h.logger.lines.some((l) => l.includes('ECONNREFUSED'))).toBe(true);
+
+    // A successful poll resets the cadence.
+    fail = false;
+    await h.scheduler.tick();
+    expect(h.scheduler.failures).toBe(0);
+    expect(h.scheduler.nextDelayMs()).toBe(SCHEDULER_POLL_INTERVAL_MS);
+  });
+
+  it('a startRun that throws (busy race) is logged, never thrown out', async () => {
+    const h = makeScheduler(async () => config());
+    h.startRun.mockImplementation(() => {
+      throw new Error('a backup run is already active on this daemon');
+    });
+    await expect(h.scheduler.tick()).resolves.toBeUndefined();
+    expect(h.logger.lines.some((l) => l.includes('scheduled backup run failed to start'))).toBe(true);
+  });
+
+  it('polls on the 60s cadence after the immediate startup check (fake timers)', async () => {
+    jest.useFakeTimers();
+    try {
+      const h = makeScheduler(async () => config({ nextRunAt: null }));
+      h.scheduler.start();
+      await jest.advanceTimersByTimeAsync(0); // immediate tick
+      expect(h.getConfig).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(SCHEDULER_POLL_INTERVAL_MS);
+      expect(h.getConfig).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(SCHEDULER_POLL_INTERVAL_MS);
+      expect(h.getConfig).toHaveBeenCalledTimes(3);
+
+      // stop() disarms the chain.
+      h.scheduler.stop();
+      await jest.advanceTimersByTimeAsync(SCHEDULER_POLL_INTERVAL_MS * 3);
+      expect(h.getConfig).toHaveBeenCalledTimes(3);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/cli/test/backup/run-via-daemon.spec.ts
+++ b/apps/cli/test/backup/run-via-daemon.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * test/backup/run-via-daemon.spec.ts — `backup run` daemon delegation
+ * (issue #318) against a MOCKED DaemonClient.
+ *
+ * Covers: shouldDelegateToDaemon (daemon present delegates; --embedded
+ * bypasses), the happy path (events streamed into the renderer proxy, outcome
+ * assembled from run-finished), busy + not-configured rejections, the
+ * ignore-everything-before-ack discipline (a previous run's tail events must
+ * not be misattributed), and the connection-closed failure.
+ */
+
+import type { DaemonClient, DaemonMessage } from '../../src/node/ipc-client.js';
+import {
+  runViaDaemon,
+  shouldDelegateToDaemon,
+  DaemonBackupBusyError,
+  DaemonBackupUnavailableError,
+} from '../../src/backup/run-via-daemon.js';
+import { BACKUP_EV, emptyStats, type BackupTypedEmitter } from '../../src/backup/events.js';
+
+interface FakeClientHarness {
+  client: DaemonClient;
+  sent: Array<Record<string, unknown>>;
+  deliver: (msg: DaemonMessage) => void;
+  closeConn: () => void;
+}
+
+function fakeClient(onSend?: (cmd: Record<string, unknown>) => void): FakeClientHarness {
+  const sent: Array<Record<string, unknown>> = [];
+  const msgCbs = new Set<(m: DaemonMessage) => void>();
+  const closeCbs = new Set<() => void>();
+  const client: DaemonClient = {
+    send: (cmd) => {
+      sent.push(cmd);
+      onSend?.(cmd);
+    },
+    onMessage: (cb) => msgCbs.add(cb),
+    onClose: (cb) => closeCbs.add(cb),
+    waitFor: () => Promise.reject(new Error('unused in these tests')),
+    close: () => {},
+  };
+  return {
+    client,
+    sent,
+    deliver: (msg) => {
+      for (const cb of msgCbs) cb(msg);
+    },
+    closeConn: () => {
+      for (const cb of closeCbs) cb();
+    },
+  };
+}
+
+/** Renderer stand-in: records every event the proxy re-emits. */
+function recordingRenderer(): {
+  attach: (emitter: BackupTypedEmitter) => void;
+  events: Array<{ ev: string; payload: unknown }>;
+} {
+  const events: Array<{ ev: string; payload: unknown }> = [];
+  return {
+    events,
+    attach: (emitter) => {
+      for (const ev of Object.values(BACKUP_EV)) {
+        emitter.on(ev, (payload: unknown) => events.push({ ev, payload }));
+      }
+    },
+  };
+}
+
+describe('shouldDelegateToDaemon', () => {
+  it('delegates when a daemon is up and --embedded was not passed', () => {
+    expect(shouldDelegateToDaemon(false, true)).toBe(true);
+  });
+  it('--embedded bypasses a running daemon', () => {
+    expect(shouldDelegateToDaemon(true, true)).toBe(false);
+  });
+  it('runs embedded when no daemon is up', () => {
+    expect(shouldDelegateToDaemon(false, false)).toBe(false);
+    expect(shouldDelegateToDaemon(true, false)).toBe(false);
+  });
+});
+
+describe('runViaDaemon', () => {
+  it('sends backup-run-now and streams events into the renderer until run-finished', async () => {
+    const h = fakeClient((cmd) => {
+      // Ack, then the run's event stream, delivered synchronously on send.
+      h.deliver({ kind: 'ack', cmd: String(cmd['cmd']) });
+      h.deliver({
+        kind: 'backup-event',
+        ev: 'run-started',
+        payload: { runId: 'r1', kind: 'incremental', trigger: 'manual' },
+        ts: 't',
+      });
+      h.deliver({
+        kind: 'backup-event',
+        ev: 'item-done',
+        payload: { id: 'i1', outcome: 'downloaded', bytes: 5 },
+        ts: 't',
+      });
+      h.deliver({
+        kind: 'backup-event',
+        ev: 'run-finished',
+        payload: { status: 'completed', stats: { ...emptyStats(), itemsDownloaded: 1 } },
+        ts: 't',
+      });
+    });
+    const renderer = recordingRenderer();
+
+    const outcome = await runViaDaemon(h.client, { attachRenderer: renderer.attach });
+
+    expect(h.sent).toEqual([{ cmd: 'backup-run-now' }]);
+    expect(outcome.status).toBe('completed');
+    expect(outcome.stats.itemsDownloaded).toBe(1);
+    expect(renderer.events.map((e) => e.ev)).toEqual(['run-started', 'item-done', 'run-finished']);
+  });
+
+  it('rejects with DaemonBackupBusyError on a busy error frame', async () => {
+    const h = fakeClient(() => {
+      h.deliver({
+        kind: 'error',
+        cmd: 'backup-run-now',
+        code: 'busy',
+        message: 'a backup run is already active on this daemon',
+      });
+    });
+    await expect(
+      runViaDaemon(h.client, { attachRenderer: () => {} }),
+    ).rejects.toBeInstanceOf(DaemonBackupBusyError);
+  });
+
+  it('rejects with DaemonBackupUnavailableError on not-configured (caller falls back embedded)', async () => {
+    const h = fakeClient(() => {
+      h.deliver({
+        kind: 'error',
+        cmd: 'backup-run-now',
+        code: 'not-configured',
+        message: 'backup is not configured on this daemon',
+      });
+    });
+    await expect(
+      runViaDaemon(h.client, { attachRenderer: () => {} }),
+    ).rejects.toBeInstanceOf(DaemonBackupUnavailableError);
+  });
+
+  it('ignores backup-events that arrive BEFORE our ack (a previous run tail)', async () => {
+    const h = fakeClient(() => {
+      // Tail of a previous (e.g. scheduled) run, arriving before the ack:
+      h.deliver({
+        kind: 'backup-event',
+        ev: 'run-finished',
+        payload: { status: 'failed', stats: emptyStats(), error: 'stale' },
+        ts: 't',
+      });
+      h.deliver({ kind: 'ack', cmd: 'backup-run-now' });
+      h.deliver({
+        kind: 'backup-event',
+        ev: 'run-finished',
+        payload: { status: 'completed', stats: emptyStats() },
+        ts: 't',
+      });
+    });
+    const renderer = recordingRenderer();
+
+    const outcome = await runViaDaemon(h.client, { attachRenderer: renderer.attach });
+    expect(outcome.status).toBe('completed');
+    expect(outcome.error).toBeUndefined();
+    // The stale pre-ack frame never reached the renderer.
+    expect(renderer.events).toHaveLength(1);
+  });
+
+  it('rejects when the connection closes before the run finished', async () => {
+    const h = fakeClient(() => {
+      h.deliver({ kind: 'ack', cmd: 'backup-run-now' });
+      h.closeConn();
+    });
+    await expect(runViaDaemon(h.client, { attachRenderer: () => {} })).rejects.toThrow(
+      /connection closed/,
+    );
+  });
+});

--- a/apps/cli/test/backup/status-report.spec.ts
+++ b/apps/cli/test/backup/status-report.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * test/backup/status-report.spec.ts — `backup status` three-source report
+ * (issue #318).
+ *
+ * Covers: all three sections populated (real temp catalog + fake daemon IPC +
+ * fake server), and graceful degradation of EACH section independently —
+ * unconfigured machine, unreadable catalog, no daemon, daemon IPC failure,
+ * logged-out server section, and an unreachable server. collectBackupStatus
+ * must never throw and must report plain error strings, not stacks.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { collectBackupStatus, type CollectBackupStatusDeps } from '../../src/backup/status-report.js';
+import { CHECKPOINT_CURSOR_KEY } from '../../src/backup/backup-engine.js';
+import { openCatalogDb } from '../../src/backup/catalog-db.js';
+import { CatalogRepo } from '../../src/backup/catalog-repo.js';
+import type { DaemonClient, DaemonMessage } from '../../src/node/ipc-client.js';
+import type { NodeBackupConfig, NodeBackupRunSummary } from '../../src/api.js';
+
+function settingsStub(root: string | null, nodeId: string | null): CollectBackupStatusDeps['settings'] {
+  return { backupRoot: () => root, backupNodeId: () => nodeId };
+}
+
+function serverConfig(): NodeBackupConfig {
+  return {
+    nodeId: 'node-1',
+    enabled: true,
+    scheduleCron: '0 3 * * *',
+    timezone: 'UTC',
+    nextRunAt: '2026-08-10T03:00:00.000Z',
+    circleIds: [],
+    pending: { items: 12, bytes: '345678' },
+  };
+}
+
+function serverRun(): NodeBackupRunSummary {
+  return {
+    id: 'srv-run-1',
+    kind: 'incremental',
+    status: 'completed',
+    trigger: 'scheduled',
+    startedAt: '2026-08-09T03:00:00.000Z',
+    finishedAt: '2026-08-09T03:05:00.000Z',
+    lastAckAt: '2026-08-09T03:04:00.000Z',
+    itemsDownloaded: 10,
+    itemsSkipped: 2,
+    sidecarsWritten: 12,
+    bytesDownloaded: '1024',
+    errorCount: 0,
+    lastError: null,
+    cliVersion: '1.2.22',
+  };
+}
+
+/** Daemon client stub answering backup-status via waitFor. */
+function daemonClientStub(snapshot: Record<string, unknown>): DaemonClient {
+  return {
+    send: () => {},
+    onMessage: () => {},
+    onClose: () => {},
+    waitFor: async () => ({ kind: 'backup-status', ...snapshot }) as DaemonMessage,
+    close: () => {},
+  };
+}
+
+describe('collectBackupStatus', () => {
+  it('populates all three sections when everything is reachable', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-status-'));
+    const db = openCatalogDb(root);
+    const repo = new CatalogRepo(db);
+    repo.recordRun({
+      id: 'run-local',
+      kind: 'incremental',
+      status: 'completed',
+      startedAt: '2026-08-09T01:00:00.000Z',
+      itemsDownloaded: 3,
+    });
+    repo.setCheckpoint(
+      CHECKPOINT_CURSOR_KEY,
+      JSON.stringify({ updatedAt: '2026-08-09T01:00:59.000Z', id: 'item-c' }),
+    );
+    db.close();
+
+    const report = await collectBackupStatus({
+      settings: settingsStub(root, 'node-1'),
+      api: {
+        getNodeBackupConfig: async () => ({ config: serverConfig() }),
+        listNodeBackupRuns: async (_nodeId, limit) => {
+          expect(limit).toBe(5);
+          return { runs: [serverRun()] };
+        },
+      },
+      isDaemonRunningFn: async () => true,
+      connectFn: async () =>
+        daemonClientStub({
+          configured: true,
+          running: { trigger: 'manual', startedAt: '2026-08-09T02:00:00.000Z' },
+          rate: { concurrency: 2, maxMbps: 0 },
+        }),
+    });
+
+    // Local (offline-capable) section.
+    expect(report.local.source).toBe('local catalog');
+    expect(report.local.configured).toBe(true);
+    expect(report.local.error).toBeNull();
+    expect(report.local.lastRun?.id).toBe('run-local');
+    expect(report.local.checkpoint?.id).toBe('item-c');
+    expect(report.local.counters?.totalItems).toBe(0);
+
+    // Daemon section.
+    expect(report.daemon.source).toBe('daemon (IPC)');
+    expect(report.daemon.running).toBe(true);
+    expect(report.daemon.snapshot?.['configured']).toBe(true);
+    expect(report.daemon.error).toBeNull();
+
+    // Server section.
+    expect(report.server.source).toBe('server');
+    expect(report.server.reachable).toBe(true);
+    expect(report.server.config?.nextRunAt).toBe('2026-08-10T03:00:00.000Z');
+    expect(report.server.runs).toHaveLength(1);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('degrades every section when fully offline and unconfigured', async () => {
+    const report = await collectBackupStatus({
+      settings: settingsStub(null, null),
+      api: null,
+      isDaemonRunningFn: async () => false,
+      connectFn: async () => {
+        throw new Error('should not connect');
+      },
+    });
+
+    expect(report.local.configured).toBe(false);
+    expect(report.local.error).toContain('no backup root configured');
+    expect(report.daemon.running).toBe(false);
+    expect(report.daemon.error).toBeNull();
+    expect(report.server.reachable).toBe(false);
+    expect(report.server.error).toContain('not logged in');
+  });
+
+  it('an unreachable server and a failing daemon degrade to error strings, never a throw', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-status-off-'));
+    openCatalogDb(root).close();
+
+    const report = await collectBackupStatus({
+      settings: settingsStub(root, 'node-1'),
+      api: {
+        getNodeBackupConfig: async () => {
+          throw new Error('connect ECONNREFUSED 127.0.0.1:3535');
+        },
+        listNodeBackupRuns: async () => ({ runs: [] }),
+      },
+      isDaemonRunningFn: async () => true,
+      connectFn: async () => {
+        throw new Error('socket vanished');
+      },
+    });
+
+    expect(report.local.error).toBeNull();
+    expect(report.daemon.error).toContain('socket vanished');
+    expect(report.server.reachable).toBe(false);
+    expect(report.server.error).toContain('server unreachable');
+    expect(report.server.error).toContain('ECONNREFUSED');
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('an unreadable catalog degrades the local section only', async () => {
+    const report = await collectBackupStatus({
+      settings: settingsStub('/backup/root', 'node-1'),
+      api: null,
+      openDb: () => {
+        throw new Error('drive not mounted');
+      },
+    });
+    expect(report.local.configured).toBe(true);
+    expect(report.local.counters).toBeNull();
+    expect(report.local.error).toContain('could not read the backup catalog');
+    expect(report.local.error).toContain('drive not mounted');
+  });
+
+  it('omitting the daemon probes yields a quiet not-running section', async () => {
+    const report = await collectBackupStatus({
+      settings: settingsStub(null, null),
+      api: null,
+    });
+    expect(report.daemon.running).toBe(false);
+    expect(report.daemon.snapshot).toBeNull();
+    expect(report.daemon.error).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.21",
+      "version": "1.2.22",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

Child 5 of Epic #308. Hosts the BackupEngine inside the existing node daemon beside `NodeEngine` (a machine can be enrichment-only, backup-only, or both), adds the pull-based scheduler that fires server-computed `nextRunAt` schedules (overdue runs fire on reconnect), extends the NDJSON unix-socket IPC with backup verbs, and ships the `backup status` / `schedule` / `set-rate` commands plus daemon delegation for `backup run`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #318
Relates to #308

## Changes Made

- `backup-host.ts` — daemon-side owner of a single serialized BackupEngine run (`busy` rejection on concurrent trigger), event re-broadcast over IPC as `{ kind: 'backup-event', ev, payload, ts }`, live rate application (engine re-reads concurrency per page; `TokenBucket.setRate()` applies on the next chunk). Own `ApiClient` + `CooldownGate`, so an enrichment provider cooldown never brakes backup and vice versa.
- `backup-scheduler.ts` — 60 s unref'd poll of `GET …/backup/config` with an immediate tick on daemon start; fires `trigger: 'scheduled'` when `enabled && nextRunAt <= now && no local run active` (client never computes cron — the server rolls `nextRunAt` at run start, so offline-at-schedule self-heals); `enabled:false` kill switch; 5-failure → 5-min backoff.
- IPC verbs in `daemon.ts`: `backup-status`, `backup-run-now` (`busy`/`not-configured` errors), `backup-cancel` (cooperative), `backup-set-rate` (validated, persisted + applied live). `node start` activates hosting purely from the presence of `backup.root`/`backup.nodeId` in the settings KV — no new flags.
- Commands: `backup run` now delegates to a running daemon (streams `backup-event` frames into the unchanged headless renderer; `--embedded` bypasses), `backup status [--json]` merges catalog (offline-capable) + daemon IPC + server sections with graceful degradation, `backup schedule "<cron>" [--tz]` / `--show` / `--disable`, `backup set-rate [--concurrency] [--max-mbps]` with "applied live" when a daemon is up.
- CLI version 1.2.21 → 1.2.22 + lockfile sync.

## Testing

- [x] Unit tests pass (`npm test`) — CLI `test:ci`: 114 suites / 1435 tests, 0 failures (baseline 109/1398, zero regressions)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

43 new tests across scheduler (overdue-at-start fires, not-due no-op, disabled suppresses, backoff), host (busy rejection, event frames, live set-rate), real-socket daemon IPC round-trips, run-via-daemon delegation (frame discipline ignores a prior run's tail), and the three-source status report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ)_