### PR TITLE
feat(core): memoriahub backup restore — rebuild a server library from a backup root

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -29,6 +29,67 @@ export interface Circle {
   // other fields may be present but we only need these
 }
 
+// ---------------------------------------------------------------------------
+// Restore types (issue #321) — only the fields the CLI relies on are typed;
+// extra server fields pass through untouched.
+// ---------------------------------------------------------------------------
+
+/** A MediaItem as returned by POST /api/media and GET /api/media/:id. */
+export interface MediaItemRecord {
+  id: string;
+  circleId?: string;
+  capturedAt?: string | null;
+  favorite?: boolean;
+  description?: string | null;
+  archivedAt?: string | null;
+  /** True when the server matched an existing (circleId, contentHash) row. */
+  deduplicated?: boolean;
+  [key: string]: unknown;
+}
+
+/** Body of POST /api/media (mirrors createMediaSchema in the API). */
+export interface CreateMediaItemBody {
+  storageObjectId: string;
+  type: 'photo' | 'video';
+  source: 'web' | 'cli' | 'android' | 'import' | 'sync';
+  originalFilename: string;
+  circleId: string;
+  contentHash?: string;
+  capturedAt?: string;
+  capturedAtOffset?: number;
+  description?: string;
+  favorite?: boolean;
+  originalCreatedAt?: string;
+  sourcePath?: string;
+  sourceDeviceId?: string;
+  sourceDeviceName?: string;
+  /** Client-supplied FALLBACK location; the server restricts this to 'manual'. */
+  takenLat?: number;
+  takenLng?: number;
+  takenAltitude?: number;
+  coordSource?: 'manual';
+}
+
+/** Body of PATCH /api/media/bulk (1–500 ids; `set` needs ≥1 field). */
+export interface BulkUpdateMediaBody {
+  circleId: string;
+  ids: string[];
+  set: {
+    location?: { lat: number; lng: number; altitude?: number } | null;
+    favorite?: boolean;
+    capturedAt?: string | null;
+  };
+}
+
+/** An album row from GET /api/media/albums / POST /api/media/albums. */
+export interface AlbumSummary {
+  id: string;
+  name: string;
+  circleId?: string;
+  itemCount?: number;
+  [key: string]: unknown;
+}
+
 /** Minimal Media Workflow Automation summary (issue #144 — thin CLI surface). */
 export interface WorkflowSummary {
   id: string;
@@ -612,6 +673,21 @@ export class ApiClient {
     });
   }
 
+  async patch<T>(path: string, body: unknown): Promise<T> {
+    return this.run(async () => {
+      const res = await this.fetchWithGate(`${this.baseUrl}${path}`, {
+        method: 'PATCH',
+        headers: {
+          ...this.authHeaders(),
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      return this.parseOk<T>(res);
+    });
+  }
+
   /**
    * PUT a raw buffer directly to a presigned URL.
    * No auth header — the URL is pre-signed, and S3 rejects extra auth headers.
@@ -642,6 +718,96 @@ export class ApiClient {
     const res = await this.get<Circle[] | { items?: Circle[] }>('/api/circles');
     if (Array.isArray(res)) return res;
     return res?.items ?? [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Restore surface (issue #321) — every call here is a NORMAL user-auth
+  // endpoint (media:write / circles:write), never an /api/nodes/* route, so a
+  // `nod_` node credential can not reach any of them by design. Envelopes:
+  // parseOk already strips a `{ data }` wrapper, so each method describes the
+  // shape the controller returns underneath it.
+  // -------------------------------------------------------------------------
+
+  /** Create a circle (POST /api/circles) — returns the created circle record. */
+  createCircle(body: { name: string; description?: string }): Promise<Circle> {
+    return this.post<Circle>('/api/circles', body);
+  }
+
+  /** Fetch one media item; a 404 surfaces as ApiError(404). */
+  getMediaItem(id: string): Promise<MediaItemRecord> {
+    return this.get<MediaItemRecord>(`/api/media/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * Register an uploaded StorageObject as a MediaItem (POST /api/media).
+   * `deduplicated: true` means the server matched an existing
+   * (circle_id, content_hash) row and returned it — the restore engine treats
+   * that as "already there", not an error.
+   */
+  createMediaItem(body: CreateMediaItemBody): Promise<MediaItemRecord> {
+    return this.post<MediaItemRecord>('/api/media', body);
+  }
+
+  /** Bulk set location / favorite / capturedAt on 1–500 items. */
+  bulkUpdateMedia(body: BulkUpdateMediaBody): Promise<unknown> {
+    return this.patch<unknown>('/api/media/bulk', body);
+  }
+
+  /** Bulk add/remove tag NAMES on 1–500 items (tags are found-or-created server-side). */
+  bulkTags(body: {
+    circleId: string;
+    ids: string[];
+    add?: string[];
+    remove?: string[];
+  }): Promise<unknown> {
+    return this.post<unknown>('/api/media/bulk/tags', body);
+  }
+
+  /** Bulk archive 1–500 items (PATCH /api/media/bulk/archive). */
+  bulkArchiveMedia(body: { circleId: string; ids: string[] }): Promise<unknown> {
+    return this.patch<unknown>('/api/media/bulk/archive', body);
+  }
+
+  /** List a circle's albums (paginated; the envelope is `{ items, meta }`). */
+  async listAlbums(circleId: string, page = 1, pageSize = 100): Promise<AlbumSummary[]> {
+    const res = await this.get<AlbumSummary[] | { items?: AlbumSummary[] }>(
+      `/api/media/albums?circleId=${encodeURIComponent(circleId)}` +
+        `&page=${page}&pageSize=${pageSize}`,
+    );
+    if (Array.isArray(res)) return res;
+    return res?.items ?? [];
+  }
+
+  /** Create an album in a circle; returns the created album record. */
+  createAlbum(body: {
+    circleId: string;
+    name: string;
+    description?: string;
+  }): Promise<AlbumSummary> {
+    return this.post<AlbumSummary>('/api/media/albums', body);
+  }
+
+  /** Add media items to an album (idempotent server-side, ≤500 per call). */
+  addAlbumItems(albumId: string, mediaItemIds: string[]): Promise<unknown> {
+    return this.post<unknown>(
+      `/api/media/albums/${encodeURIComponent(albumId)}/items`,
+      { mediaItemIds },
+    );
+  }
+
+  /**
+   * Manually associate a person with a media item by NAME (find-or-create,
+   * idempotent). Detected faces / bounding boxes / embeddings are NOT
+   * restorable — enrichment re-detects them.
+   */
+  addPersonToMedia(
+    mediaItemId: string,
+    body: { personId?: string; name?: string },
+  ): Promise<{ personId: string; personName: string | null; faceId: string }> {
+    return this.post<{ personId: string; personName: string | null; faceId: string }>(
+      `/api/media/${encodeURIComponent(mediaItemId)}/people`,
+      body,
+    );
   }
 
   // -------------------------------------------------------------------------

--- a/apps/cli/src/backup/catalog-db.ts
+++ b/apps/cli/src/backup/catalog-db.ts
@@ -26,7 +26,7 @@ const require = createRequire(import.meta.url);
 const Database = require('better-sqlite3') as typeof BetterSqlite3;
 
 /** Highest catalog schema version this build understands. */
-export const CATALOG_SCHEMA_VERSION = 1;
+export const CATALOG_SCHEMA_VERSION = 2;
 
 /** Thrown when the catalog was written by a newer CLI, or is not a SQLite file. */
 export class CatalogOpenError extends Error {
@@ -66,6 +66,23 @@ CREATE TABLE runs(id TEXT PRIMARY KEY, kind TEXT, status TEXT, started_at TEXT, 
 CREATE TABLE checkpoint(key TEXT PRIMARY KEY, value TEXT);
 `;
 
+/**
+ * v2 (issue #321) — restore tracking.
+ *
+ * `items.restored_media_item_id` records the MediaItem id a backed-up item was
+ * restored INTO on some server, so `memoriahub backup restore` is re-runnable:
+ * a row that already carries an id is verified (GET /api/media/:id) and skipped
+ * rather than re-uploaded. Deliberately a plain nullable column with no index —
+ * restore scans the whole catalog anyway, and every other lookup is by id.
+ *
+ * ALTER TABLE ... ADD COLUMN is the only statement here, so the migration
+ * applies cleanly to an existing v1 catalog (all data intact) and is a no-op
+ * for anything created after it.
+ */
+const DDL_V2 = `
+ALTER TABLE items ADD COLUMN restored_media_item_id TEXT;
+`;
+
 interface CatalogMigration {
   version: number;
   up: (db: BetterSqlite3.Database) => void;
@@ -76,6 +93,12 @@ const MIGRATIONS: CatalogMigration[] = [
     version: 1,
     up(db: BetterSqlite3.Database): void {
       db.exec(DDL_V1);
+    },
+  },
+  {
+    version: 2,
+    up(db: BetterSqlite3.Database): void {
+      db.exec(DDL_V2);
     },
   },
 ];

--- a/apps/cli/src/backup/catalog-repo.ts
+++ b/apps/cli/src/backup/catalog-repo.ts
@@ -35,6 +35,13 @@ export interface CatalogItem {
   verifiedAt: string | null;
   lastError: string | null;
   updatedAt: string;
+  /**
+   * MediaItem id this backed-up item was restored INTO (catalog v2, issue
+   * #321), or null when it has never been restored. Set by the restore engine
+   * only — the backup engine never writes it, and upsertItemWithDims
+   * deliberately preserves it (see the COALESCE in that INSERT).
+   */
+  restoredMediaItemId?: string | null;
 }
 
 /**
@@ -84,6 +91,8 @@ interface ItemRow {
   verified_at: string | null;
   last_error: string | null;
   updated_at: string;
+  /** Present from catalog schema v2 onwards. */
+  restored_media_item_id?: string | null;
 }
 
 function rowToItem(row: ItemRow): CatalogItem {
@@ -103,6 +112,7 @@ function rowToItem(row: ItemRow): CatalogItem {
     verifiedAt: row.verified_at,
     lastError: row.last_error,
     updatedAt: row.updated_at,
+    restoredMediaItemId: row.restored_media_item_id ?? null,
   };
 }
 
@@ -157,11 +167,17 @@ export class CatalogRepo {
     const upsert = this.db.transaction(() => {
       this.db
         .prepare(
+          // INSERT OR REPLACE is a delete+insert, so restored_media_item_id
+          // (catalog v2) would be silently dropped on every backup run unless
+          // it is carried forward explicitly — hence the self-subselect. The
+          // restore engine is its only writer; backup must never clear it.
           `INSERT OR REPLACE INTO items (
              media_item_id, circle_id, rel_path, sidecar_rel_path,
              captured_at, content_hash, size, mime_type, server_updated_at,
-             status, archived, downloaded_at, verified_at, last_error, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             status, archived, downloaded_at, verified_at, last_error, updated_at,
+             restored_media_item_id
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+             (SELECT restored_media_item_id FROM items WHERE media_item_id = ?))`,
         )
         .run(
           item.mediaItemId,
@@ -179,6 +195,7 @@ export class CatalogRepo {
           item.verifiedAt,
           item.lastError,
           new Date().toISOString(),
+          item.mediaItemId,
         );
 
       for (const table of ['item_tags', 'item_albums', 'item_people']) {
@@ -316,6 +333,87 @@ export class CatalogRepo {
            updated_at = ? WHERE media_item_id = ?`,
       )
       .run(lastError, new Date().toISOString(), mediaItemId);
+  }
+
+  // -------------------------------------------------------------------------
+  // restore (catalog v2, issue #321)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Items eligible for a restore pass, in a deterministic order.
+   *
+   * `quarantined` and `failed` rows are NEVER selectable: a quarantined file is
+   * one the server no longer lists (restoring it would resurrect deleted
+   * content), and a failed row's local bytes are known-bad. The caller passes
+   * `['present']` (the default scope — active AND archived items, since
+   * `archived` is a flag on a present row) plus `'trashed'` under
+   * `--include trashed`.
+   */
+  listForRestore(statuses: CatalogItemStatus[]): CatalogItem[] {
+    const allowed = statuses.filter((s) => s === 'present' || s === 'trashed');
+    if (allowed.length === 0) return [];
+    const placeholders = allowed.map(() => '?').join(', ');
+    const rows = this.db
+      .prepare<string[], ItemRow>(
+        `SELECT * FROM items WHERE status IN (${placeholders})
+           ORDER BY captured_at IS NULL, captured_at, media_item_id`,
+      )
+      .all(...allowed);
+    return rows.map(rowToItem);
+  }
+
+  /** Record (or clear, with null) the MediaItem id an item was restored into. */
+  setRestoredMediaItemId(mediaItemId: string, restoredId: string | null): void {
+    this.db
+      .prepare(
+        'UPDATE items SET restored_media_item_id = ?, updated_at = ? WHERE media_item_id = ?',
+      )
+      .run(restoredId, new Date().toISOString(), mediaItemId);
+  }
+
+  /** Distinct tag names attached to one item (restore reapplies all of them). */
+  tagsFor(mediaItemId: string): string[] {
+    return this.db
+      .prepare<[string], { tag: string }>(
+        'SELECT tag FROM item_tags WHERE media_item_id = ? ORDER BY tag',
+      )
+      .all(mediaItemId)
+      .map((r) => r.tag);
+  }
+
+  /**
+   * Dimension totals for a set of circles, used by the restore plan (and the
+   * `--dry-run` report): distinct album names / person names / tag names
+   * reachable from the items in scope, per source circle.
+   */
+  restoreDimensionCounts(
+    statuses: CatalogItemStatus[],
+  ): Map<string, { albums: number; people: number; tags: number }> {
+    const allowed = statuses.filter((s) => s === 'present' || s === 'trashed');
+    const out = new Map<string, { albums: number; people: number; tags: number }>();
+    if (allowed.length === 0) return out;
+    const placeholders = allowed.map(() => '?').join(', ');
+
+    const tally = (table: string, column: string, key: 'albums' | 'people' | 'tags'): void => {
+      const rows = this.db
+        .prepare<string[], { circle_id: string; n: number }>(
+          `SELECT i.circle_id AS circle_id, COUNT(DISTINCT d.${column}) AS n
+             FROM items i JOIN ${table} d ON d.media_item_id = i.media_item_id
+            WHERE i.status IN (${placeholders})
+            GROUP BY i.circle_id`,
+        )
+        .all(...allowed);
+      for (const row of rows) {
+        const entry = out.get(row.circle_id) ?? { albums: 0, people: 0, tags: 0 };
+        entry[key] = row.n;
+        out.set(row.circle_id, entry);
+      }
+    };
+
+    tally('item_albums', 'album_name', 'albums');
+    tally('item_people', 'person_name', 'people');
+    tally('item_tags', 'tag', 'tags');
+    return out;
   }
 
   /** Hard-delete an item row AND its dimension rows (prune) in one transaction. */

--- a/apps/cli/src/backup/restore-engine.ts
+++ b/apps/cli/src/backup/restore-engine.ts
@@ -1,0 +1,1006 @@
+/**
+ * backup/restore-engine.ts — Restore a backup root back into a MemoriaHub
+ * server (issue #321, epic #308).
+ *
+ * UI-free and event-emitting, like backup-engine.ts and verify.ts: this module
+ * NEVER prints — commands/backup.ts and render/headless-restore.ts own every
+ * byte of terminal output.
+ *
+ * WHAT A RESTORE IS
+ * -----------------
+ * A backup root holds the ORIGINAL bytes plus a per-item sidecar. Restoring
+ * therefore means: re-upload the original through the normal resumable upload
+ * path, register it as a MediaItem, then reapply the user-authored metadata the
+ * sidecar recorded (description, favorite, capture date, manual location, tags,
+ * album membership, people associations, archive state).
+ *
+ * Everything DERIVED is deliberately not restored — thumbnails, EXIF-extracted
+ * columns, detected faces (bounding boxes / embeddings), AI tags' provenance,
+ * perceptual hashes, duplicate/burst grouping. Those regenerate from the bytes
+ * via the server's enrichment pipeline, which is exactly why the restore is a
+ * plain upload rather than a privileged DB import.
+ *
+ * AUTH
+ * ----
+ * A restore writes media, albums, tags and people — none of which a `nod_` node
+ * credential can reach (it is accepted ONLY on /api/nodes/* routes). Restore
+ * therefore requires a normal user PAT/session, and refuses a node credential
+ * up front rather than failing item-by-item with 401s (assertRestoreCredential).
+ *
+ * IDEMPOTENCE / RESUMABILITY
+ * --------------------------
+ * Two independent mechanisms make a restore re-runnable:
+ *   1. `items.restored_media_item_id` (catalog v2) — recorded immediately after
+ *      the MediaItem is created, so a crash mid-metadata still resumes. A row
+ *      carrying an id is VERIFIED against the server (GET /api/media/:id) and
+ *      skipped; a 404 (restored into a server that has since lost the item)
+ *      clears the marker and re-uploads.
+ *   2. Server-side content-hash dedup on (circle_id, content_hash) — a re-upload
+ *      of the same bytes returns the existing MediaItem with
+ *      `deduplicated: true`. That is a SKIP, never an error.
+ *
+ * SCOPE
+ * -----
+ * Default: `status='present'` rows — active AND archived items, since
+ * `archived` is a flag on a present row (archived items are restored, then
+ * re-archived at the end through PATCH /api/media/bulk/archive).
+ * `--include trashed` adds `trashed` rows; they land as ACTIVE items, because
+ * no public API can put an item into the server's Trash.
+ * `quarantined` items are NEVER restored (the server no longer lists them —
+ * restoring would resurrect deleted content), and neither are `failed` rows
+ * (their local bytes are known-bad).
+ */
+
+import * as fs from 'node:fs';
+import { EventEmitter } from 'node:events';
+import type BetterSqlite3 from 'better-sqlite3';
+import type {
+  AlbumSummary,
+  ApiClient,
+  Circle,
+  CreateMediaItemBody,
+  MediaItemRecord,
+} from '../api.js';
+import { ApiError } from '../api.js';
+import { runPool } from '../sync/worker-pool.js';
+import { CatalogRepo, type CatalogItem, type CatalogItemStatus } from './catalog-repo.js';
+import { CATALOG_DIR, absPathFor } from './layout.js';
+
+/** Default concurrent upload workers — restore is upload-bound, keep it gentle. */
+export const DEFAULT_RESTORE_CONCURRENCY = 2;
+
+/** Max ids per PATCH /api/media/bulk call (server cap is 500; 100 keeps sets tight). */
+export const BULK_UPDATE_BATCH = 100;
+
+/** Max ids per bulk tags / album-items / bulk archive call (server cap). */
+export const BULK_IDS_BATCH = 500;
+
+export const RESTORE_EV = {
+  PLAN: 'restore-plan',
+  ITEM_STARTED: 'restore-item-started',
+  ITEM_DONE: 'restore-item-done',
+  METADATA: 'restore-metadata',
+  FINISHED: 'restore-finished',
+} as const;
+
+export type RestoreEventName = (typeof RESTORE_EV)[keyof typeof RESTORE_EV];
+
+/** Typed emitter for restore progress (renderers subscribe; engine never prints). */
+export class RestoreEmitter extends EventEmitter {}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** Thrown when the configured token is a `nod_` node credential. */
+export class NodeCredentialNotAllowedError extends Error {
+  constructor() {
+    super(
+      'Restore needs a normal account login — the stored token is a node ' +
+        'credential (nod_…), which the server accepts ONLY on /api/nodes/* ' +
+        'routes and can never use to write media, albums, tags or people. ' +
+        'Run `memoriahub login` with your own account (or set MEMORIAHUB_TOKEN ' +
+        'to a personal access token) and retry.',
+    );
+    this.name = 'NodeCredentialNotAllowedError';
+  }
+}
+
+/**
+ * Thrown for an unresolvable circle mapping. ALWAYS raised before the first
+ * write — an unknown --map-circle/--into-circle target must not be discovered
+ * halfway through an upload run.
+ */
+export class RestoreMappingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RestoreMappingError';
+  }
+}
+
+/** Reject a `nod_` node credential up front (see the auth note in the header). */
+export function assertRestoreCredential(token: string): void {
+  if (token.startsWith('nod_')) throw new NodeCredentialNotAllowedError();
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar (structural subset of the server's schemaVersion-1 document)
+// ---------------------------------------------------------------------------
+
+export interface RestoreSidecar {
+  mediaItemId?: string;
+  circleId?: string;
+  circleName?: string | null;
+  type?: string;
+  originalFilename?: string;
+  capturedAt?: string | null;
+  capturedAtOffset?: number | null;
+  mimeType?: string | null;
+  description?: string | null;
+  favorite?: boolean;
+  archivedAt?: string | null;
+  geo?: {
+    takenLat?: number | null;
+    takenLng?: number | null;
+    takenAltitude?: number | null;
+    coordSource?: string | null;
+  } | null;
+  tags?: Array<{ name: string; source?: string }>;
+  albums?: Array<{ id: string; name: string | null }>;
+  people?: Array<{ personId: string; name: string | null }>;
+  sourcePath?: string | null;
+  sourceDeviceId?: string | null;
+  sourceDeviceName?: string | null;
+  [key: string]: unknown;
+}
+
+/** One entry of catalog/albums.json (written by every completed backup run). */
+interface AlbumCatalogEntry {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+export type CircleResolution =
+  | 'mapped'
+  | 'into-circle'
+  | 'matched-by-name'
+  | 'create';
+
+export interface RestoreCirclePlan {
+  sourceCircleId: string;
+  /** From the first sidecar of that circle; null when unreadable. */
+  sourceCircleName: string | null;
+  /** Null only in --dry-run for a circle that WOULD be created. */
+  targetCircleId: string | null;
+  targetCircleName: string;
+  resolution: CircleResolution;
+  items: number;
+  bytes: number;
+  albums: number;
+  people: number;
+  tags: number;
+  /** Items already carrying a restored_media_item_id (skipped unless gone). */
+  alreadyRestored: number;
+}
+
+export interface RestorePlan {
+  dryRun: boolean;
+  includeTrashed: boolean;
+  skipMetadata: boolean;
+  concurrency: number;
+  circles: RestoreCirclePlan[];
+  totalItems: number;
+  totalBytes: number;
+  alreadyRestored: number;
+}
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+
+export type RestoreOutcome = 'uploaded' | 'skipped-existing' | 'failed';
+
+export interface RestoreItemResult {
+  mediaItemId: string;
+  relPath: string;
+  outcome: RestoreOutcome;
+  /** Server MediaItem id (absent only on failure). */
+  restoredMediaItemId?: string;
+  bytes: number;
+  /** True when the skip came from server-side content-hash dedup. */
+  deduplicated?: boolean;
+  error?: string;
+}
+
+export interface RestoreFailure {
+  /** 'item' or the metadata phase that failed ('tags', 'albums', …). */
+  scope: string;
+  relPath?: string;
+  error: string;
+}
+
+export interface RestoreSummary {
+  dryRun: boolean;
+  plan: RestorePlan;
+  uploaded: number;
+  skippedExisting: number;
+  failed: number;
+  /** Items that had at least one piece of sidecar metadata reapplied. */
+  metadataApplied: number;
+  tagLinks: number;
+  albumLinks: number;
+  albumsCreated: number;
+  peopleLinks: number;
+  archived: number;
+  circlesCreated: number;
+  bytesUploaded: number;
+  failures: RestoreFailure[];
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Options / deps
+// ---------------------------------------------------------------------------
+
+export interface RestoreOptions {
+  /** Absolute backup root. */
+  root: string;
+  /** Compute and report the plan; write NOTHING (no circles, no uploads). */
+  dryRun?: boolean;
+  /** Map every source circle into this existing circle id. */
+  intoCircle?: string | null;
+  /** Explicit per-circle mapping: sourceCircleId -> targetCircleId. */
+  mapCircle?: Map<string, string>;
+  /** Also restore `trashed` catalog rows (they land ACTIVE). */
+  includeTrashed?: boolean;
+  concurrency?: number;
+  /** Upload originals only; reapply no sidecar metadata at all. */
+  skipMetadata?: boolean;
+}
+
+/** Upload one local file through the resumable path; returns the object id. */
+export type RestoreUploadFn = (
+  filePath: string,
+  mimeType: string,
+  onProgress?: (fraction: number) => void,
+) => Promise<{ objectId: string }>;
+
+/** The slice of ApiClient a restore uses — mockable wholesale in tests. */
+export type RestoreApi = Pick<
+  ApiClient,
+  | 'listCircles'
+  | 'createCircle'
+  | 'getMediaItem'
+  | 'createMediaItem'
+  | 'bulkUpdateMedia'
+  | 'bulkTags'
+  | 'bulkArchiveMedia'
+  | 'listAlbums'
+  | 'createAlbum'
+  | 'addAlbumItems'
+  | 'addPersonToMedia'
+>;
+
+export interface RestoreDeps {
+  db: BetterSqlite3.Database;
+  api: RestoreApi;
+  upload: RestoreUploadFn;
+  now?: () => Date;
+  isCancelled?: () => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse repeated `--map-circle <src>=<dst>` values into a source→target map.
+ * A malformed pair is a hard error (never a silently ignored mapping).
+ */
+export function parseMapCircle(pairs: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const raw of pairs) {
+    const idx = raw.indexOf('=');
+    if (idx <= 0 || idx === raw.length - 1) {
+      throw new RestoreMappingError(
+        `Invalid --map-circle value "${raw}" — expected <sourceCircleId>=<targetCircleId>.`,
+      );
+    }
+    map.set(raw.slice(0, idx).trim(), raw.slice(idx + 1).trim());
+  }
+  return map;
+}
+
+/** Read and parse an item's sidecar; null when missing or unparseable. */
+export function readSidecar(root: string, sidecarRelPath: string): RestoreSidecar | null {
+  try {
+    const raw = fs.readFileSync(absPathFor(root, sidecarRelPath), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object') return parsed as RestoreSidecar;
+  } catch {
+    /* missing / unreadable / not JSON — restore falls back to catalog data */
+  }
+  return null;
+}
+
+/** Load catalog/albums.json (album descriptions) — best-effort, [] when absent. */
+function readAlbumCatalog(root: string): Map<string, AlbumCatalogEntry> {
+  const out = new Map<string, AlbumCatalogEntry>();
+  try {
+    const raw = fs.readFileSync(absPathFor(root, `${CATALOG_DIR}/albums.json`), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      for (const entry of parsed as AlbumCatalogEntry[]) {
+        if (entry && typeof entry.id === 'string') out.set(entry.id, entry);
+      }
+    }
+  } catch {
+    /* no dimension catalog yet — album descriptions are simply not restored */
+  }
+  return out;
+}
+
+/** Media type for POST /api/media: the sidecar's own value, else the mime type. */
+export function resolveMediaType(
+  sidecar: RestoreSidecar | null,
+  mimeType: string | null,
+): 'photo' | 'video' {
+  if (sidecar?.type === 'video' || sidecar?.type === 'photo') return sidecar.type;
+  return (mimeType ?? '').startsWith('video/') ? 'video' : 'photo';
+}
+
+// ---------------------------------------------------------------------------
+// Circle mapping
+// ---------------------------------------------------------------------------
+
+export interface CircleMappingInput {
+  /** Distinct source circle ids in the restore set, with a display name. */
+  sources: Array<{ circleId: string; circleName: string | null }>;
+  intoCircle?: string | null;
+  mapCircle?: Map<string, string>;
+  /** When true, a circle that would be created is only PLANNED, never created. */
+  dryRun: boolean;
+}
+
+export interface CircleMappingResult {
+  /** sourceCircleId -> resolved target (targetCircleId null only in dry-run). */
+  entries: Map<
+    string,
+    { targetCircleId: string | null; targetCircleName: string; resolution: CircleResolution }
+  >;
+  circlesCreated: number;
+}
+
+/**
+ * Resolve every source circle to a target circle, in strict precedence order:
+ *   1. `--map-circle <src>=<dst>`
+ *   2. `--into-circle <dst>` (everything lands there)
+ *   3. find-or-create by the sidecar's circleName among the caller's circles
+ *      (exact name match; ambiguous duplicates resolve to the first listed).
+ *
+ * An unknown --map-circle / --into-circle TARGET throws RestoreMappingError —
+ * validated against the caller's own circle list BEFORE any write happens.
+ */
+export async function resolveCircleMapping(
+  api: Pick<RestoreApi, 'listCircles' | 'createCircle'>,
+  input: CircleMappingInput,
+): Promise<CircleMappingResult> {
+  const existing: Circle[] = await api.listCircles();
+  const byId = new Map(existing.map((c) => [c.id, c]));
+  const byName = new Map<string, Circle>();
+  for (const circle of existing) {
+    if (!byName.has(circle.name)) byName.set(circle.name, circle);
+  }
+
+  // Validate every explicitly-requested target FIRST — before a single write.
+  if (input.intoCircle && !byId.has(input.intoCircle)) {
+    throw new RestoreMappingError(
+      `--into-circle target ${input.intoCircle} is not a circle you belong to. ` +
+        `Available: ${describeCircles(existing)}`,
+    );
+  }
+  for (const [source, target] of input.mapCircle ?? []) {
+    if (!byId.has(target)) {
+      throw new RestoreMappingError(
+        `--map-circle target ${target} (for source circle ${source}) is not a ` +
+          `circle you belong to. Available: ${describeCircles(existing)}`,
+      );
+    }
+  }
+
+  const entries: CircleMappingResult['entries'] = new Map();
+  let circlesCreated = 0;
+
+  for (const source of input.sources) {
+    const mapped = input.mapCircle?.get(source.circleId);
+    if (mapped) {
+      entries.set(source.circleId, {
+        targetCircleId: mapped,
+        targetCircleName: byId.get(mapped)?.name ?? mapped,
+        resolution: 'mapped',
+      });
+      continue;
+    }
+
+    if (input.intoCircle) {
+      entries.set(source.circleId, {
+        targetCircleId: input.intoCircle,
+        targetCircleName: byId.get(input.intoCircle)?.name ?? input.intoCircle,
+        resolution: 'into-circle',
+      });
+      continue;
+    }
+
+    const name = source.circleName?.trim();
+    if (!name) {
+      throw new RestoreMappingError(
+        `Source circle ${source.circleId} has no recorded circle name in its ` +
+          'sidecars, so it cannot be matched or created by name. Pass ' +
+          `--map-circle ${source.circleId}=<targetCircleId> or --into-circle <id>.`,
+      );
+    }
+
+    const match = byName.get(name);
+    if (match) {
+      entries.set(source.circleId, {
+        targetCircleId: match.id,
+        targetCircleName: match.name,
+        resolution: 'matched-by-name',
+      });
+      continue;
+    }
+
+    if (input.dryRun) {
+      entries.set(source.circleId, {
+        targetCircleId: null,
+        targetCircleName: name,
+        resolution: 'create',
+      });
+      continue;
+    }
+
+    const created = await api.createCircle({ name });
+    circlesCreated++;
+    byId.set(created.id, created);
+    byName.set(created.name, created);
+    entries.set(source.circleId, {
+      targetCircleId: created.id,
+      targetCircleName: created.name,
+      resolution: 'create',
+    });
+  }
+
+  return { entries, circlesCreated };
+}
+
+function describeCircles(circles: Circle[]): string {
+  if (circles.length === 0) return '(none)';
+  return circles
+    .slice(0, 10)
+    .map((c) => `${c.name} (${c.id})`)
+    .join(', ');
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+interface BulkSet {
+  location?: { lat: number; lng: number; altitude?: number };
+  favorite?: boolean;
+  capturedAt?: string;
+}
+
+interface UpdateBatch {
+  circleId: string;
+  set: BulkSet;
+  ids: string[];
+}
+
+interface TagBatch {
+  circleId: string;
+  tags: string[];
+  ids: string[];
+}
+
+interface AlbumBatch {
+  circleId: string;
+  albumName: string;
+  albumDescription?: string;
+  ids: string[];
+}
+
+/**
+ * Run one restore pass. Never throws for a per-item failure (those land in the
+ * summary); throws only for a pre-flight condition that makes the whole run
+ * meaningless — RestoreMappingError, or an API failure while listing circles.
+ */
+export async function runRestore(
+  opts: RestoreOptions,
+  deps: RestoreDeps,
+  emitter: RestoreEmitter = new RestoreEmitter(),
+): Promise<RestoreSummary> {
+  const now = deps.now ?? ((): Date => new Date());
+  const startedAt = now().getTime();
+  const dryRun = opts.dryRun === true;
+  const skipMetadata = opts.skipMetadata === true;
+  const concurrency = Math.max(1, Math.floor(opts.concurrency ?? DEFAULT_RESTORE_CONCURRENCY));
+
+  const repo = new CatalogRepo(deps.db);
+  const statuses: CatalogItemStatus[] = opts.includeTrashed
+    ? ['present', 'trashed']
+    : ['present'];
+
+  const items = repo.listForRestore(statuses);
+  const dims = repo.restoreDimensionCounts(statuses);
+  const albumCatalog = readAlbumCatalog(opts.root);
+
+  // ---- Plan -----------------------------------------------------------------
+  const perCircle = new Map<
+    string,
+    { items: number; bytes: number; alreadyRestored: number; name: string | null }
+  >();
+  for (const item of items) {
+    const entry = perCircle.get(item.circleId) ?? {
+      items: 0,
+      bytes: 0,
+      alreadyRestored: 0,
+      name: null,
+    };
+    entry.items++;
+    entry.bytes += item.size ?? 0;
+    if (item.restoredMediaItemId) entry.alreadyRestored++;
+    if (entry.name === null) {
+      // One sidecar read per circle is enough to learn its name — the plan must
+      // not load every sidecar into memory on a 100k-item root.
+      entry.name = readSidecar(opts.root, item.sidecarRelPath)?.circleName ?? null;
+    }
+    perCircle.set(item.circleId, entry);
+  }
+
+  const mapping = await resolveCircleMapping(deps.api, {
+    sources: [...perCircle].map(([circleId, e]) => ({ circleId, circleName: e.name })),
+    ...(opts.intoCircle !== undefined ? { intoCircle: opts.intoCircle } : {}),
+    ...(opts.mapCircle !== undefined ? { mapCircle: opts.mapCircle } : {}),
+    dryRun,
+  });
+
+  const circlePlans: RestoreCirclePlan[] = [...perCircle].map(([circleId, e]) => {
+    const target = mapping.entries.get(circleId)!;
+    const dim = dims.get(circleId) ?? { albums: 0, people: 0, tags: 0 };
+    return {
+      sourceCircleId: circleId,
+      sourceCircleName: e.name,
+      targetCircleId: target.targetCircleId,
+      targetCircleName: target.targetCircleName,
+      resolution: target.resolution,
+      items: e.items,
+      bytes: e.bytes,
+      albums: dim.albums,
+      people: dim.people,
+      tags: dim.tags,
+      alreadyRestored: e.alreadyRestored,
+    };
+  });
+
+  const plan: RestorePlan = {
+    dryRun,
+    includeTrashed: opts.includeTrashed === true,
+    skipMetadata,
+    concurrency,
+    circles: circlePlans,
+    totalItems: items.length,
+    totalBytes: circlePlans.reduce((sum, c) => sum + c.bytes, 0),
+    alreadyRestored: circlePlans.reduce((sum, c) => sum + c.alreadyRestored, 0),
+  };
+  emitter.emit(RESTORE_EV.PLAN, plan);
+
+  const summary: RestoreSummary = {
+    dryRun,
+    plan,
+    uploaded: 0,
+    skippedExisting: 0,
+    failed: 0,
+    metadataApplied: 0,
+    tagLinks: 0,
+    albumLinks: 0,
+    albumsCreated: 0,
+    peopleLinks: 0,
+    archived: 0,
+    circlesCreated: mapping.circlesCreated,
+    bytesUploaded: 0,
+    failures: [],
+    durationMs: 0,
+  };
+
+  if (dryRun) {
+    summary.durationMs = now().getTime() - startedAt;
+    emitter.emit(RESTORE_EV.FINISHED, { summary });
+    return summary;
+  }
+
+  // ---- Batch state ----------------------------------------------------------
+  const updateBatches = new Map<string, UpdateBatch>();
+  const tagBatches = new Map<string, TagBatch>();
+  const albumBatches = new Map<string, AlbumBatch>();
+  const archiveBatches = new Map<string, string[]>();
+  /** circleId -> (albumName -> albumId), lazily filled from the server. */
+  const albumIdCache = new Map<string, Map<string, string>>();
+
+  const recordFailure = (scope: string, relPath: string | undefined, err: unknown): void => {
+    summary.failures.push({
+      scope,
+      ...(relPath !== undefined ? { relPath } : {}),
+      error: err instanceof Error ? err.message : String(err),
+    });
+  };
+
+  async function resolveAlbumId(
+    circleId: string,
+    name: string,
+    description?: string,
+  ): Promise<string> {
+    let cache = albumIdCache.get(circleId);
+    if (!cache) {
+      cache = new Map();
+      // Page through the circle's albums once; names are display-only and not
+      // unique server-side, so the FIRST match wins (stable and deterministic).
+      for (let page = 1; page <= 50; page++) {
+        const albums: AlbumSummary[] = await deps.api.listAlbums(circleId, page, 100);
+        for (const album of albums) {
+          if (!cache.has(album.name)) cache.set(album.name, album.id);
+        }
+        if (albums.length < 100) break;
+      }
+      albumIdCache.set(circleId, cache);
+    }
+
+    const hit = cache.get(name);
+    if (hit) return hit;
+
+    const created = await deps.api.createAlbum({
+      circleId,
+      name,
+      ...(description ? { description } : {}),
+    });
+    cache.set(name, created.id);
+    summary.albumsCreated++;
+    return created.id;
+  }
+
+  async function flushUpdate(batch: UpdateBatch, all: boolean): Promise<void> {
+    while (batch.ids.length >= (all ? 1 : BULK_UPDATE_BATCH)) {
+      const ids = batch.ids.splice(0, BULK_UPDATE_BATCH);
+      try {
+        await deps.api.bulkUpdateMedia({ circleId: batch.circleId, ids, set: batch.set });
+        emitter.emit(RESTORE_EV.METADATA, { kind: 'update', applied: ids.length });
+      } catch (err) {
+        recordFailure('metadata:update', undefined, err);
+      }
+    }
+  }
+
+  async function flushTags(batch: TagBatch, all: boolean): Promise<void> {
+    while (batch.ids.length >= (all ? 1 : BULK_IDS_BATCH)) {
+      const ids = batch.ids.splice(0, BULK_IDS_BATCH);
+      try {
+        await deps.api.bulkTags({ circleId: batch.circleId, ids, add: batch.tags });
+        summary.tagLinks += ids.length * batch.tags.length;
+        emitter.emit(RESTORE_EV.METADATA, { kind: 'tags', applied: ids.length });
+      } catch (err) {
+        recordFailure('metadata:tags', undefined, err);
+      }
+    }
+  }
+
+  async function flushAlbum(batch: AlbumBatch, all: boolean): Promise<void> {
+    while (batch.ids.length >= (all ? 1 : BULK_IDS_BATCH)) {
+      const ids = batch.ids.splice(0, BULK_IDS_BATCH);
+      try {
+        const albumId = await resolveAlbumId(
+          batch.circleId,
+          batch.albumName,
+          batch.albumDescription,
+        );
+        await deps.api.addAlbumItems(albumId, ids);
+        summary.albumLinks += ids.length;
+        emitter.emit(RESTORE_EV.METADATA, { kind: 'albums', applied: ids.length });
+      } catch (err) {
+        recordFailure('metadata:albums', undefined, err);
+      }
+    }
+  }
+
+  async function flushArchive(circleId: string, ids: string[], all: boolean): Promise<void> {
+    while (ids.length >= (all ? 1 : BULK_IDS_BATCH)) {
+      const chunk = ids.splice(0, BULK_IDS_BATCH);
+      try {
+        await deps.api.bulkArchiveMedia({ circleId, ids: chunk });
+        summary.archived += chunk.length;
+        emitter.emit(RESTORE_EV.METADATA, { kind: 'archive', applied: chunk.length });
+      } catch (err) {
+        recordFailure('metadata:archive', undefined, err);
+      }
+    }
+  }
+
+  /**
+   * Queue (and opportunistically flush) every batched metadata write implied by
+   * one restored item, and apply the unbatchable ones (people) inline.
+   */
+  async function applyMetadata(
+    sidecar: RestoreSidecar,
+    created: MediaItemRecord,
+    circleId: string,
+    relPath: string,
+    catalogTags: string[],
+  ): Promise<boolean> {
+    let applied = false;
+
+    // --- favorite / capturedAt / manual location (PATCH /api/media/bulk) ---
+    const set: BulkSet = {};
+    if (sidecar.favorite === true && created.favorite !== true) set.favorite = true;
+    // Only patch the capture date when the upload did not already land on it —
+    // a server-extracted EXIF date is authoritative and identical anyway.
+    if (
+      typeof sidecar.capturedAt === 'string' &&
+      normalizeInstant(created.capturedAt) !== normalizeInstant(sidecar.capturedAt)
+    ) {
+      set.capturedAt = sidecar.capturedAt;
+    }
+    const geo = sidecar.geo;
+    if (
+      geo?.coordSource === 'manual' &&
+      typeof geo.takenLat === 'number' &&
+      typeof geo.takenLng === 'number'
+    ) {
+      set.location = {
+        lat: geo.takenLat,
+        lng: geo.takenLng,
+        ...(typeof geo.takenAltitude === 'number' ? { altitude: geo.takenAltitude } : {}),
+      };
+    }
+    if (Object.keys(set).length > 0) {
+      const key = `${circleId}|${JSON.stringify(set)}`;
+      const batch = updateBatches.get(key) ?? { circleId, set, ids: [] };
+      batch.ids.push(created.id);
+      updateBatches.set(key, batch);
+      applied = true;
+      await flushUpdate(batch, false);
+    }
+
+    // --- tags (POST /api/media/bulk/tags; ALL sidecar tags, any source) ---
+    const tags = (
+      sidecar.tags?.map((t) => t.name).filter((n): n is string => typeof n === 'string' && n.length > 0) ??
+      catalogTags
+    )
+      .slice()
+      .sort();
+    if (tags.length > 0) {
+      // Grouped by identical tag SET: bulk tags applies one add[] to many ids,
+      // so items sharing a tag set collapse into a single call.
+      const key = `${circleId}|${tags.join(' ')}`;
+      const batch = tagBatches.get(key) ?? { circleId, tags, ids: [] };
+      batch.ids.push(created.id);
+      tagBatches.set(key, batch);
+      applied = true;
+      await flushTags(batch, false);
+    }
+
+    // --- albums (find-or-create by NAME, then add items) ---
+    for (const album of sidecar.albums ?? []) {
+      const name = album.name?.trim();
+      if (!name) continue;
+      const key = `${circleId}|${name}`;
+      const description = albumCatalog.get(album.id)?.description ?? undefined;
+      const batch = albumBatches.get(key) ?? {
+        circleId,
+        albumName: name,
+        ...(description ? { albumDescription: description } : {}),
+        ids: [],
+      };
+      batch.ids.push(created.id);
+      albumBatches.set(key, batch);
+      applied = true;
+      await flushAlbum(batch, false);
+    }
+
+    // --- people (per item; find-or-create by name, idempotent server-side) ---
+    for (const person of sidecar.people ?? []) {
+      const name = person.name?.trim();
+      if (!name) continue;
+      try {
+        await deps.api.addPersonToMedia(created.id, { name });
+        summary.peopleLinks++;
+        applied = true;
+      } catch (err) {
+        recordFailure('metadata:people', relPath, err);
+      }
+    }
+
+    // --- archive state (applied at the very end, after everything else) ---
+    if (typeof sidecar.archivedAt === 'string' && sidecar.archivedAt.length > 0) {
+      const ids = archiveBatches.get(circleId) ?? [];
+      ids.push(created.id);
+      archiveBatches.set(circleId, ids);
+      applied = true;
+    }
+
+    return applied;
+  }
+
+  // ---- Per-item worker ------------------------------------------------------
+  async function restoreItem(item: CatalogItem): Promise<void> {
+    const target = mapping.entries.get(item.circleId);
+    const circleId = target?.targetCircleId;
+    emitter.emit(RESTORE_EV.ITEM_STARTED, {
+      mediaItemId: item.mediaItemId,
+      relPath: item.relPath,
+    });
+
+    const finish = (result: RestoreItemResult): void => {
+      if (result.outcome === 'uploaded') {
+        summary.uploaded++;
+        summary.bytesUploaded += result.bytes;
+      } else if (result.outcome === 'skipped-existing') {
+        summary.skippedExisting++;
+      } else {
+        summary.failed++;
+        recordFailure('item', result.relPath, result.error ?? 'unknown error');
+      }
+      emitter.emit(RESTORE_EV.ITEM_DONE, result);
+    };
+
+    if (!circleId) {
+      finish({
+        mediaItemId: item.mediaItemId,
+        relPath: item.relPath,
+        outcome: 'failed',
+        bytes: 0,
+        error: `No target circle resolved for source circle ${item.circleId}`,
+      });
+      return;
+    }
+
+    try {
+      // 1. Already restored? Verify server-side, then skip.
+      if (item.restoredMediaItemId) {
+        const stillThere = await mediaItemExists(deps.api, item.restoredMediaItemId);
+        if (stillThere) {
+          finish({
+            mediaItemId: item.mediaItemId,
+            relPath: item.relPath,
+            outcome: 'skipped-existing',
+            restoredMediaItemId: item.restoredMediaItemId,
+            bytes: 0,
+          });
+          return;
+        }
+        // The server no longer has it — drop the stale marker and re-upload.
+        repo.setRestoredMediaItemId(item.mediaItemId, null);
+      }
+
+      const absPath = absPathFor(opts.root, item.relPath);
+      if (!fs.existsSync(absPath)) {
+        finish({
+          mediaItemId: item.mediaItemId,
+          relPath: item.relPath,
+          outcome: 'failed',
+          bytes: 0,
+          error: 'local file is missing from the backup root',
+        });
+        return;
+      }
+
+      const sidecar = readSidecar(opts.root, item.sidecarRelPath);
+      const mimeType = item.mimeType ?? sidecar?.mimeType ?? 'application/octet-stream';
+
+      // 2. Upload the original bytes (resumable multipart, same path as sync).
+      const { objectId } = await deps.upload(absPath, mimeType);
+
+      // 3. Register the MediaItem. contentHash drives server-side dedup, which
+      //    is what makes a re-run of an interrupted restore idempotent.
+      const body: CreateMediaItemBody = {
+        storageObjectId: objectId,
+        type: resolveMediaType(sidecar, item.mimeType),
+        source: 'cli',
+        originalFilename:
+          sidecar?.originalFilename ?? item.relPath.split('/').pop() ?? 'restored-file',
+        circleId,
+        ...(item.contentHash ? { contentHash: item.contentHash } : {}),
+      };
+      if (!skipMetadata && sidecar) {
+        if (typeof sidecar.capturedAt === 'string') body.capturedAt = sidecar.capturedAt;
+        if (typeof sidecar.capturedAtOffset === 'number') {
+          body.capturedAtOffset = sidecar.capturedAtOffset;
+        }
+        // description has no bulk endpoint, so it rides along on creation.
+        if (typeof sidecar.description === 'string' && sidecar.description.length > 0) {
+          body.description = sidecar.description;
+        }
+        if (sidecar.favorite === true) body.favorite = true;
+        if (typeof sidecar.sourcePath === 'string') body.sourcePath = sidecar.sourcePath;
+        if (typeof sidecar.sourceDeviceId === 'string') {
+          body.sourceDeviceId = sidecar.sourceDeviceId;
+        }
+        if (typeof sidecar.sourceDeviceName === 'string') {
+          body.sourceDeviceName = sidecar.sourceDeviceName;
+        }
+      }
+
+      const created = await deps.api.createMediaItem(body);
+      repo.setRestoredMediaItemId(item.mediaItemId, created.id);
+
+      // 4. Reapply the sidecar metadata (batched where the API allows it).
+      if (!skipMetadata && sidecar) {
+        const applied = await applyMetadata(
+          sidecar,
+          created,
+          circleId,
+          item.relPath,
+          repo.tagsFor(item.mediaItemId),
+        );
+        if (applied) summary.metadataApplied++;
+      }
+
+      finish({
+        mediaItemId: item.mediaItemId,
+        relPath: item.relPath,
+        outcome: created.deduplicated === true ? 'skipped-existing' : 'uploaded',
+        restoredMediaItemId: created.id,
+        bytes: created.deduplicated === true ? 0 : item.size ?? 0,
+        ...(created.deduplicated === true ? { deduplicated: true } : {}),
+      });
+    } catch (err) {
+      finish({
+        mediaItemId: item.mediaItemId,
+        relPath: item.relPath,
+        outcome: 'failed',
+        bytes: 0,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await runPool(items, concurrency, (item) => restoreItem(item), deps.isCancelled);
+
+  // ---- Drain every partially-filled batch -----------------------------------
+  for (const batch of updateBatches.values()) await flushUpdate(batch, true);
+  for (const batch of tagBatches.values()) await flushTags(batch, true);
+  for (const batch of albumBatches.values()) await flushAlbum(batch, true);
+  // Archive last: an item must exist (and carry its metadata) before it is
+  // hidden from every browse surface.
+  for (const [circleId, ids] of archiveBatches) await flushArchive(circleId, ids, true);
+
+  summary.durationMs = now().getTime() - startedAt;
+  emitter.emit(RESTORE_EV.FINISHED, { summary });
+  return summary;
+}
+
+/** True when GET /api/media/:id answers 200; false on 404. Other errors throw. */
+async function mediaItemExists(api: RestoreApi, id: string): Promise<boolean> {
+  try {
+    await api.getMediaItem(id);
+    return true;
+  } catch (err) {
+    if (err instanceof ApiError && (err.status === 404 || err.status === 403)) return false;
+    throw err;
+  }
+}
+
+/** Compare two ISO instants for equality without tripping over formatting. */
+function normalizeInstant(value: string | null | undefined): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? value : new Date(ms).toISOString();
+}
+
+/** Exit-code policy for `backup restore`: any failure is non-zero. */
+export function resolveRestoreExitCode(summary: RestoreSummary): number {
+  return summary.failed > 0 || summary.failures.length > 0 ? 1 : 0;
+}

--- a/apps/cli/src/commands/backup.ts
+++ b/apps/cli/src/commands/backup.ts
@@ -56,6 +56,19 @@ import {
   renderVerifyHeadless,
 } from '../render/headless-verify.js';
 import {
+  DEFAULT_RESTORE_CONCURRENCY,
+  NodeCredentialNotAllowedError,
+  RestoreEmitter,
+  RestoreMappingError,
+  assertRestoreCredential,
+  parseMapCircle,
+  resolveRestoreExitCode,
+  runRestore,
+} from '../backup/restore-engine.js';
+import { renderRestoreHeadless } from '../render/headless-restore.js';
+import { uploadFile } from '../upload.js';
+import { CooldownGate } from '../http/cooldown-gate.js';
+import {
   runViaDaemon,
   shouldDelegateToDaemon,
   DaemonBackupBusyError,
@@ -827,6 +840,179 @@ function pruneCmd(): Command {
     });
 }
 
+// ---------------------------------------------------------------------------
+// backup restore (issue #321) — the read-back half of the whole epic
+// ---------------------------------------------------------------------------
+
+interface RestoreCmdOpts {
+  root: string;
+  dryRun?: boolean;
+  intoCircle?: string;
+  mapCircle?: string[];
+  include?: string[];
+  concurrency?: string;
+  skipMetadata?: boolean;
+  json?: boolean;
+}
+
+/** Collect a repeatable option into an array (commander's accumulator idiom). */
+function collectOption(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+function restoreCmd(): Command {
+  return new Command('restore')
+    .description('Restore a backup root back into a MemoriaHub server')
+    .requiredOption('--root <dir>', 'Backup root to restore FROM (the folder `backup init --dest` created)')
+    .option('--dry-run', 'Print the full plan (circle mapping + totals) and write nothing')
+    .option('--into-circle <id>', 'Restore every source circle into this existing circle')
+    .option(
+      '--map-circle <src=dst>',
+      'Map one source circle id to a target circle id (repeatable)',
+      collectOption,
+    )
+    .option(
+      '--include <what>',
+      'Extra scope: "trashed" (restored as ACTIVE items). Repeatable.',
+      collectOption,
+    )
+    .option('--concurrency <n>', `Concurrent upload workers (default: ${DEFAULT_RESTORE_CONCURRENCY})`)
+    .option('--skip-metadata', 'Upload originals only — reapply no sidecar metadata')
+    .option('--json', 'Emit NDJSON events instead of human output')
+    .addHelpText(
+      'after',
+      '\nAUTHENTICATION\n' +
+        '  Restore writes media, albums, tags and people, so it needs a NORMAL account\n' +
+        '  login (`memoriahub login`) or a personal access token. A `nod_` node\n' +
+        '  credential is refused up front: the server accepts it ONLY on /api/nodes/*\n' +
+        '  routes, so it can never reach any endpoint a restore needs.\n\n' +
+        'CIRCLE MAPPING (precedence)\n' +
+        '  1. --map-circle <sourceCircleId>=<targetCircleId>\n' +
+        '  2. --into-circle <targetCircleId>  (everything lands there)\n' +
+        '  3. find-or-create a circle matching the sidecar\'s circle name\n' +
+        '  The resolved mapping is printed before anything is written; an unknown\n' +
+        '  --map-circle/--into-circle target is a hard error BEFORE the first write.\n\n' +
+        'SCOPE\n' +
+        '  Default: every `present` item — active AND archived (archived items are\n' +
+        '  restored, then re-archived at the end). --include trashed additionally\n' +
+        '  restores trashed rows, but they land as ACTIVE items: no public API can\n' +
+        '  put an item back into the server\'s Trash. Quarantined items are NEVER\n' +
+        '  restored — the server no longer lists them.\n\n' +
+        'WHAT IS NOT RESTORED\n' +
+        '  Detected faces (bounding boxes / embeddings), thumbnails, EXIF-derived\n' +
+        '  columns, perceptual hashes and burst/duplicate grouping are DERIVED data:\n' +
+        '  enrichment regenerates them from the restored bytes. People associations\n' +
+        '  ARE restored, by name.\n\n' +
+        'RE-RUNNABLE\n' +
+        '  Every restored item records the MediaItem id it landed on. A second run\n' +
+        '  verifies those ids and skips them; anything else is caught by server-side\n' +
+        '  content-hash dedup. Interrupt it freely and re-run.',
+    )
+    .action(async (opts: RestoreCmdOpts) => {
+      const cfg = requireConfig();
+
+      // A node credential can never write media — fail before touching the disk.
+      try {
+        assertRestoreCredential(cfg.pat);
+      } catch (err) {
+        if (err instanceof NodeCredentialNotAllowedError) {
+          ui.error(err.message);
+          process.exit(1);
+        }
+        throw err;
+      }
+
+      let mapCircle: Map<string, string> | undefined;
+      try {
+        mapCircle = opts.mapCircle ? parseMapCircle(opts.mapCircle) : undefined;
+      } catch (err) {
+        ui.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
+      let includeTrashed = false;
+      for (const value of opts.include ?? []) {
+        for (const token of value.split(',').map((s) => s.trim()).filter(Boolean)) {
+          if (token === 'trashed') includeTrashed = true;
+          else if (token === 'archived') {
+            // Accepted and documented as a no-op: archived items are a flag on
+            // a `present` row and are always in scope.
+            ui.dim('--include archived is redundant — archived items are restored by default.');
+          } else {
+            ui.error(`Unknown --include value "${token}" (expected: archived, trashed)`);
+            process.exit(1);
+          }
+        }
+      }
+
+      const concurrency =
+        parseNumberFlag(opts.concurrency, '--concurrency') ?? DEFAULT_RESTORE_CONCURRENCY;
+
+      let db;
+      try {
+        db = openCatalogDb(opts.root);
+      } catch (err) {
+        if (err instanceof CatalogOpenError) {
+          ui.error(err.message);
+          process.exit(1);
+        }
+        throw err;
+      }
+
+      const settings = new SettingsRepo(getDb());
+      const api = new ApiClient({
+        serverUrl: cfg.serverUrl,
+        pat: cfg.pat,
+        retry: settings.retryConfig(),
+        cooldownGate: new CooldownGate(settings.cooldownConfig()),
+      });
+
+      try {
+        const emitter = new RestoreEmitter();
+        renderRestoreHeadless(emitter, { json: opts.json === true });
+        const summary = await runRestore(
+          {
+            root: opts.root,
+            dryRun: opts.dryRun === true,
+            ...(opts.intoCircle !== undefined ? { intoCircle: opts.intoCircle } : {}),
+            ...(mapCircle !== undefined ? { mapCircle } : {}),
+            includeTrashed,
+            concurrency: Math.max(1, Math.floor(concurrency)),
+            skipMetadata: opts.skipMetadata === true,
+          },
+          {
+            db,
+            api,
+            upload: (filePath, mimeType, onProgress) =>
+              uploadFile(api, filePath, mimeType, onProgress),
+          },
+          emitter,
+        );
+        process.exit(resolveRestoreExitCode(summary));
+      } catch (err) {
+        if (err instanceof RestoreMappingError) {
+          ui.error(err.message);
+          process.exit(1);
+        }
+        if (err instanceof ApiError) {
+          if (err.status === 401 || err.status === 403) {
+            ui.error(
+              `This token is not permitted to restore media (HTTP ${err.status}): ` +
+                `${err.serverMessage}. Restore needs a normal account login, not a node credential.`,
+            );
+          } else {
+            ui.error(`Restore failed (HTTP ${err.status}): ${err.serverMessage}`);
+          }
+          process.exit(1);
+        }
+        ui.error(`Restore failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      } finally {
+        db.close();
+      }
+    });
+}
+
 export function backupCommand(): Command {
   const cmd = new Command('backup');
   cmd
@@ -836,6 +1022,7 @@ export function backupCommand(): Command {
     .addCommand(statusCmd())
     .addCommand(verifyCmd())
     .addCommand(pruneCmd())
+    .addCommand(restoreCmd())
     .addCommand(scheduleCmd())
     .addCommand(setRateCmd());
   return cmd;

--- a/apps/cli/src/render/headless-restore.ts
+++ b/apps/cli/src/render/headless-restore.ts
@@ -1,0 +1,181 @@
+/**
+ * render/headless-restore.ts — Terminal renderer for `memoriahub backup
+ * restore` (issue #321, epic #308).
+ *
+ * Same split as render/headless-backup.ts and headless-verify.ts: the restore
+ * engine is UI-free and emits typed events; ONLY this file and the command
+ * layer print. `--json` emits NDJSON, one line per event.
+ */
+
+import chalk from 'chalk';
+import { ui, isTTY } from '../ui.js';
+import { formatBytes } from './headless-backup.js';
+import {
+  RESTORE_EV,
+  type RestoreEmitter,
+  type RestoreItemResult,
+  type RestorePlan,
+  type RestoreSummary,
+} from '../backup/restore-engine.js';
+
+export interface RenderRestoreOptions {
+  /** NDJSON event stream instead of human output. */
+  json: boolean;
+  /** Injectable sink (tests capture output; defaults to process.stdout). */
+  write?: (line: string) => void;
+}
+
+/**
+ * Attach terminal-output listeners to a restore emitter. Must be called before
+ * runRestore() so the plan event is not missed.
+ */
+export function renderRestoreHeadless(
+  emitter: RestoreEmitter,
+  opts: RenderRestoreOptions,
+): void {
+  const write = opts.write ?? ((line: string): void => void process.stdout.write(line));
+
+  if (opts.json) {
+    const emitLine = (event: string, payload: unknown): void => {
+      write(`${JSON.stringify({ event, ...(payload as Record<string, unknown>) })}\n`);
+    };
+    emitter.on(RESTORE_EV.PLAN, (p: RestorePlan) => emitLine('restore-plan', { plan: p }));
+    emitter.on(RESTORE_EV.ITEM_DONE, (p: RestoreItemResult) => emitLine('restore-item-done', p));
+    emitter.on(RESTORE_EV.METADATA, (p: unknown) => emitLine('restore-metadata', p));
+    emitter.on(RESTORE_EV.FINISHED, (p: { summary: RestoreSummary }) =>
+      emitLine('restore-finished', p),
+    );
+    return;
+  }
+
+  const state = { total: 0, done: 0, failed: 0 };
+
+  function progressLine(): string {
+    const pct = state.total > 0 ? Math.floor((state.done / state.total) * 100) : 0;
+    return (
+      `  ${state.done}/${state.total} (${pct}%)  ` +
+      `${state.failed > 0 ? chalk.red(`${state.failed} failed`) : '0 failed'}`
+    );
+  }
+
+  emitter.on(RESTORE_EV.PLAN, (plan: RestorePlan) => {
+    printRestorePlan(plan);
+    state.total = plan.totalItems;
+    if (!plan.dryRun && plan.totalItems > 0) {
+      ui.blank();
+      ui.step(`Restoring ${plan.totalItems} item(s) with ${plan.concurrency} worker(s)…`);
+    }
+  });
+
+  emitter.on(RESTORE_EV.ITEM_DONE, (result: RestoreItemResult) => {
+    state.done++;
+    if (result.outcome === 'failed') state.failed++;
+    if (isTTY) {
+      write(`\r\x1b[2K${progressLine()}`);
+    } else if (state.done % 100 === 0) {
+      write(`${progressLine()}\n`);
+    }
+  });
+
+  emitter.on(RESTORE_EV.FINISHED, (payload: { summary: RestoreSummary }) => {
+    if (isTTY && state.done > 0) write('\n');
+    ui.blank();
+    printRestoreSummary(payload.summary);
+  });
+}
+
+/** The circle mapping + per-circle totals — also the whole of `--dry-run`. */
+export function printRestorePlan(plan: RestorePlan): void {
+  ui.line(
+    plan.dryRun
+      ? chalk.bold('Restore plan (dry run — nothing will be written)')
+      : chalk.bold('Restore plan'),
+  );
+  ui.line(
+    `  Scope        : status=present${plan.includeTrashed ? ' + trashed (restored as ACTIVE)' : ''}` +
+      ' · quarantined items are never restored',
+  );
+  ui.line(`  Metadata     : ${plan.skipMetadata ? 'skipped (--skip-metadata)' : 'reapplied from sidecars'}`);
+  ui.blank();
+
+  if (plan.circles.length === 0) {
+    ui.warn('Nothing to restore — no eligible items in this backup root.');
+    return;
+  }
+
+  ui.line('  Circle mapping:');
+  for (const circle of plan.circles) {
+    const source = `${circle.sourceCircleName ?? '(unnamed)'} (${circle.sourceCircleId})`;
+    const target =
+      circle.targetCircleId === null
+        ? `${circle.targetCircleName} ${chalk.yellow('(would be created)')}`
+        : `${circle.targetCircleName} (${circle.targetCircleId})`;
+    ui.line(`    ${source}`);
+    ui.line(`      → ${target}  ${chalk.dim(`[${circle.resolution}]`)}`);
+    ui.line(
+      chalk.dim(
+        `      ${circle.items} item(s), ${formatBytes(circle.bytes)} · ` +
+          `${circle.albums} album(s), ${circle.people} person(s), ${circle.tags} tag(s)` +
+          (circle.alreadyRestored > 0
+            ? ` · ${circle.alreadyRestored} already restored (will be skipped)`
+            : ''),
+      ),
+    );
+  }
+
+  ui.blank();
+  ui.line(
+    `  Totals       : ${plan.totalItems} item(s), ${formatBytes(plan.totalBytes)}` +
+      (plan.alreadyRestored > 0 ? ` (${plan.alreadyRestored} already restored)` : ''),
+  );
+
+  if (plan.dryRun) {
+    ui.blank();
+    ui.info('Dry run — no circles were created, no bytes uploaded, no metadata written.');
+  }
+}
+
+/** Final report: counts, failures with reasons, and the enrichment reminder. */
+export function printRestoreSummary(summary: RestoreSummary): void {
+  if (summary.dryRun) return;
+
+  ui.line(chalk.bold('Restore summary'));
+  ui.line(`  Uploaded         : ${summary.uploaded} item(s), ${formatBytes(summary.bytesUploaded)}`);
+  ui.line(`  Skipped (exists) : ${summary.skippedExisting}`);
+  ui.line(`  Metadata applied : ${summary.metadataApplied} item(s)`);
+  ui.line(
+    `  Dimensions       : ${summary.tagLinks} tag link(s), ${summary.albumLinks} album link(s) ` +
+      `(${summary.albumsCreated} album(s) created), ${summary.peopleLinks} person link(s), ` +
+      `${summary.archived} re-archived`,
+  );
+  if (summary.circlesCreated > 0) {
+    ui.line(`  Circles created  : ${summary.circlesCreated}`);
+  }
+  ui.line(
+    `  Failed           : ${summary.failed > 0 ? chalk.red(String(summary.failed)) : '0'}`,
+  );
+  ui.line(`  Duration         : ${(summary.durationMs / 1000).toFixed(1)}s`);
+
+  if (summary.failures.length > 0) {
+    ui.blank();
+    ui.warn(`${summary.failures.length} failure(s):`);
+    for (const failure of summary.failures.slice(0, 20)) {
+      ui.line(
+        `  ${chalk.red('✗')} ${failure.relPath ?? failure.scope}  ` +
+          chalk.dim(`${failure.scope}: ${failure.error}`.slice(0, 110)),
+      );
+    }
+    if (summary.failures.length > 20) {
+      ui.dim(`  …and ${summary.failures.length - 20} more.`);
+    }
+    ui.blank();
+    ui.info('Re-run `memoriahub backup restore --root <dir>` — restored items are skipped, only the rest retry.');
+  }
+
+  ui.blank();
+  ui.info(
+    'Detected faces are NOT restorable — they will be re-detected by enrichment, ' +
+      'along with thumbnails, AI tagging and duplicate detection. Expect the job ' +
+      'queue to churn for a while (watch it at /admin/settings/jobs).',
+  );
+}

--- a/apps/cli/test/backup/backup-engine.spec.ts
+++ b/apps/cli/test/backup/backup-engine.spec.ts
@@ -34,7 +34,7 @@ import {
   type BackupEngineOpts,
 } from '../../src/backup/backup-engine.js';
 import { BACKUP_EV, type ItemDonePayload } from '../../src/backup/events.js';
-import { openCatalogDb } from '../../src/backup/catalog-db.js';
+import { CATALOG_SCHEMA_VERSION, openCatalogDb } from '../../src/backup/catalog-db.js';
 import { CatalogRepo } from '../../src/backup/catalog-repo.js';
 import { absPathFor } from '../../src/backup/layout.js';
 
@@ -354,7 +354,7 @@ describe('BackupEngine.runBackup', () => {
       serverUrl: 'https://api.test',
       nodeId: 'node-1',
       nodeName: 'test-node',
-      catalogSchemaVersion: 1,
+      catalogSchemaVersion: CATALOG_SCHEMA_VERSION,
     });
     expect(manifest.checkpoint.id).toBe('f');
     expect(manifest.counts.totalItems).toBe(6);

--- a/apps/cli/test/backup/catalog-db.spec.ts
+++ b/apps/cli/test/backup/catalog-db.spec.ts
@@ -1,7 +1,7 @@
 /**
  * test/backup/catalog-db.spec.ts — Per-root catalog migration runner.
  *
- * Covers: fresh create reaches user_version 1 with the full v1 schema; a
+ * Covers: fresh create reaches the current user_version with the full schema; a
  * reopen applies nothing; a catalog stamped with a NEWER user_version errors
  * cleanly; a non-SQLite file errors cleanly; and a seeded catalog answers
  * plain SQL (SELECT count(*) FROM items) via better-sqlite3 directly.
@@ -36,11 +36,11 @@ afterEach(() => {
 });
 
 describe('catalog migrations', () => {
-  it('fresh create reaches user_version 1 with the v1 tables', () => {
+  it('fresh create reaches the current user_version with the full schema', () => {
     const db = openCatalogDb(tmpRoot);
     const version = db.pragma('user_version', { simple: true }) as number;
-    expect(version).toBe(1);
-    expect(CATALOG_SCHEMA_VERSION).toBe(1);
+    expect(version).toBe(2);
+    expect(CATALOG_SCHEMA_VERSION).toBe(2);
 
     const tables = db
       .prepare<[], { name: string }>(
@@ -63,7 +63,7 @@ describe('catalog migrations', () => {
     db1.close();
 
     const db2 = openCatalogDb(tmpRoot);
-    expect(db2.pragma('user_version', { simple: true })).toBe(1);
+    expect(db2.pragma('user_version', { simple: true })).toBe(2);
     const row = db2
       .prepare<[string], { value: string }>('SELECT value FROM meta WHERE key = ?')
       .get('probe');
@@ -77,7 +77,7 @@ describe('catalog migrations', () => {
     db.close();
 
     expect(() => openCatalogDb(tmpRoot)).toThrow(CatalogOpenError);
-    expect(() => openCatalogDb(tmpRoot)).toThrow(/schema version 2/);
+    expect(() => openCatalogDb(tmpRoot)).toThrow(/schema version 3/);
     expect(() => openCatalogDb(tmpRoot)).toThrow(/Upgrade the CLI/);
   });
 
@@ -86,6 +86,99 @@ describe('catalog migrations', () => {
     raw.exec(`PRAGMA user_version = ${CATALOG_SCHEMA_VERSION + 5}`);
     expect(() => runCatalogMigrations(raw)).toThrow(CatalogOpenError);
     raw.close();
+  });
+
+  it('upgrades an existing v1 catalog to v2 in place (column added, data intact)', () => {
+    // Hand-build a genuine v1 catalog: the exact v1 DDL, user_version = 1, and
+    // a seeded item + dimension rows — the state a root backed up by a
+    // pre-#321 CLI is in on disk.
+    const filePath = path.join(tmpRoot, '.memoriahub', 'backup.db');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const v1 = new RawDatabase(filePath) as BetterSqlite3.Database;
+    v1.exec(`
+CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE items(
+  media_item_id TEXT PRIMARY KEY, circle_id TEXT NOT NULL,
+  rel_path TEXT NOT NULL UNIQUE, sidecar_rel_path TEXT NOT NULL,
+  captured_at TEXT, content_hash TEXT, size INTEGER, mime_type TEXT,
+  server_updated_at TEXT NOT NULL,
+  status TEXT NOT NULL CHECK(status IN ('present','trashed','quarantined','failed')),
+  archived INTEGER NOT NULL DEFAULT 0,
+  downloaded_at TEXT, verified_at TEXT, last_error TEXT,
+  updated_at TEXT NOT NULL);
+CREATE INDEX idx_items_status ON items(status);
+CREATE INDEX idx_items_hash ON items(content_hash);
+CREATE INDEX idx_items_captured ON items(captured_at);
+CREATE TABLE item_tags(media_item_id TEXT NOT NULL, tag TEXT NOT NULL, source TEXT,
+  PRIMARY KEY(media_item_id, tag));
+CREATE TABLE item_albums(media_item_id TEXT NOT NULL, album_id TEXT NOT NULL, album_name TEXT,
+  PRIMARY KEY(media_item_id, album_id));
+CREATE TABLE item_people(media_item_id TEXT NOT NULL, person_id TEXT NOT NULL, person_name TEXT,
+  PRIMARY KEY(media_item_id, person_id));
+CREATE TABLE runs(id TEXT PRIMARY KEY, kind TEXT, status TEXT, started_at TEXT, finished_at TEXT,
+  items_downloaded INTEGER DEFAULT 0, items_skipped INTEGER DEFAULT 0,
+  bytes_downloaded INTEGER DEFAULT 0, error_count INTEGER DEFAULT 0, last_error TEXT);
+CREATE TABLE checkpoint(key TEXT PRIMARY KEY, value TEXT);
+PRAGMA user_version = 1;
+    `);
+    v1.prepare(
+      `INSERT INTO items (media_item_id, circle_id, rel_path, sidecar_rel_path,
+         captured_at, content_hash, size, mime_type, server_updated_at, status,
+         archived, downloaded_at, verified_at, last_error, updated_at)
+       VALUES ('legacy-1','circle-1','media/2023/01/OLD.jpg','media/2023/01/OLD.jpg.json',
+         '2023-01-02T03:04:05.000Z','oldhash',4242,'image/jpeg','2023-01-03T00:00:00.000Z',
+         'present',0,NULL,NULL,NULL,'2023-01-03T00:00:00.000Z')`,
+    ).run();
+    v1.prepare("INSERT INTO item_tags VALUES ('legacy-1','beach','ai')").run();
+    v1.prepare("INSERT INTO meta (key, value) VALUES ('created_at','2023-01-01T00:00:00.000Z')").run();
+    expect(v1.pragma('user_version', { simple: true })).toBe(1);
+    v1.close();
+
+    // Opening it with this build applies v2 only.
+    const upgraded = openCatalogDbFile(filePath);
+    expect(upgraded.pragma('user_version', { simple: true })).toBe(2);
+
+    const columns = upgraded
+      .prepare<[], { name: string }>('PRAGMA table_info(items)')
+      .all()
+      .map((c) => c.name);
+    expect(columns).toContain('restored_media_item_id');
+
+    const repo = new CatalogRepo(upgraded);
+    const item = repo.getById('legacy-1');
+    expect(item).not.toBeNull();
+    expect(item?.contentHash).toBe('oldhash');
+    expect(item?.size).toBe(4242);
+    expect(item?.relPath).toBe('media/2023/01/OLD.jpg');
+    // The new column defaults to NULL for every pre-existing row.
+    expect(item?.restoredMediaItemId).toBeNull();
+    expect(repo.tagsFor('legacy-1')).toEqual(['beach']);
+    expect(repo.getMeta('created_at')).toBe('2023-01-01T00:00:00.000Z');
+
+    // And it is writable + preserved across a later backup-style upsert.
+    repo.setRestoredMediaItemId('legacy-1', 'server-media-1');
+    repo.upsertItemWithDims(
+      {
+        mediaItemId: 'legacy-1',
+        circleId: 'circle-1',
+        relPath: 'media/2023/01/OLD.jpg',
+        sidecarRelPath: 'media/2023/01/OLD.jpg.json',
+        capturedAt: '2023-01-02T03:04:05.000Z',
+        contentHash: 'oldhash',
+        size: 4242,
+        mimeType: 'image/jpeg',
+        serverUpdatedAt: '2023-02-01T00:00:00.000Z',
+        status: 'present',
+        archived: false,
+        downloadedAt: null,
+        verifiedAt: null,
+        lastError: null,
+      },
+      { tags: [{ name: 'beach', source: 'ai' }] },
+    );
+    expect(repo.getById('legacy-1')?.restoredMediaItemId).toBe('server-media-1');
+
+    upgraded.close();
   });
 
   it('errors cleanly when the file is not a SQLite database', () => {

--- a/apps/cli/test/backup/headless-restore.spec.ts
+++ b/apps/cli/test/backup/headless-restore.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * test/backup/headless-restore.spec.ts — `backup restore` presentation layer
+ * (issue #321): the human plan/summary blocks and the `--json` NDJSON stream.
+ *
+ * Mirrors headless-backup.spec.ts: the renderer only consumes events, so a
+ * bare RestoreEmitter stands in for the engine.
+ */
+
+import { jest } from '@jest/globals';
+import {
+  RESTORE_EV,
+  RestoreEmitter,
+  type RestorePlan,
+  type RestoreSummary,
+} from '../../src/backup/restore-engine.js';
+import { renderRestoreHeadless } from '../../src/render/headless-restore.js';
+
+function samplePlan(overrides: Partial<RestorePlan> = {}): RestorePlan {
+  return {
+    dryRun: false,
+    includeTrashed: false,
+    skipMetadata: false,
+    concurrency: 2,
+    totalItems: 3,
+    totalBytes: 3072,
+    alreadyRestored: 0,
+    circles: [
+      {
+        sourceCircleId: 'src-1',
+        sourceCircleName: 'Family',
+        targetCircleId: 'circle-family',
+        targetCircleName: 'Family',
+        resolution: 'matched-by-name',
+        items: 2,
+        bytes: 2048,
+        albums: 1,
+        people: 2,
+        tags: 3,
+        alreadyRestored: 0,
+      },
+      {
+        sourceCircleId: 'src-2',
+        sourceCircleName: 'Work',
+        targetCircleId: null,
+        targetCircleName: 'Work',
+        resolution: 'create',
+        items: 1,
+        bytes: 1024,
+        albums: 0,
+        people: 0,
+        tags: 0,
+        alreadyRestored: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function sampleSummary(overrides: Partial<RestoreSummary> = {}): RestoreSummary {
+  return {
+    dryRun: false,
+    plan: samplePlan(),
+    uploaded: 2,
+    skippedExisting: 1,
+    failed: 0,
+    metadataApplied: 2,
+    tagLinks: 4,
+    albumLinks: 2,
+    albumsCreated: 1,
+    peopleLinks: 2,
+    archived: 1,
+    circlesCreated: 1,
+    bytesUploaded: 2048,
+    failures: [],
+    durationMs: 4200,
+    ...overrides,
+  };
+}
+
+describe('renderRestoreHeadless (human mode)', () => {
+  let out: string[];
+  let spy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    out = [];
+    spy = jest.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    }) as never);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('prints the circle mapping and per-circle totals from the plan', () => {
+    const emitter = new RestoreEmitter();
+    renderRestoreHeadless(emitter, { json: false });
+    emitter.emit(RESTORE_EV.PLAN, samplePlan({ dryRun: true }));
+
+    const text = out.join('');
+    expect(text).toContain('dry run');
+    expect(text).toContain('Family (src-1)');
+    expect(text).toContain('circle-family');
+    expect(text).toContain('matched-by-name');
+    expect(text).toContain('would be created');
+    expect(text).toContain('2 item(s)');
+    expect(text).toContain('1 album(s), 2 person(s), 3 tag(s)');
+    expect(text).toContain('quarantined items are never restored');
+    expect(text).toContain('no bytes uploaded');
+  });
+
+  it('prints a summary with the enrichment reminder', () => {
+    const emitter = new RestoreEmitter();
+    renderRestoreHeadless(emitter, { json: false });
+    emitter.emit(RESTORE_EV.FINISHED, { summary: sampleSummary() });
+
+    const text = out.join('');
+    expect(text).toContain('Uploaded');
+    expect(text).toContain('Skipped (exists) : 1');
+    expect(text).toContain('Metadata applied : 2');
+    expect(text).toContain('4 tag link(s)');
+    expect(text).toContain('1 re-archived');
+    expect(text).toContain('Circles created  : 1');
+    // Faces are not restorable — the summary has to say so.
+    expect(text).toContain('re-detected by enrichment');
+  });
+
+  it('lists failures with their reasons', () => {
+    const emitter = new RestoreEmitter();
+    renderRestoreHeadless(emitter, { json: false });
+    emitter.emit(RESTORE_EV.FINISHED, {
+      summary: sampleSummary({
+        failed: 1,
+        failures: [{ scope: 'item', relPath: 'media/2024/03/A.jpg', error: 'upload exploded' }],
+      }),
+    });
+
+    const text = out.join('');
+    expect(text).toContain('1 failure(s)');
+    expect(text).toContain('media/2024/03/A.jpg');
+    expect(text).toContain('upload exploded');
+    expect(text).toContain('restored items are skipped');
+  });
+
+  it('prints nothing but the plan for a dry run summary', () => {
+    const emitter = new RestoreEmitter();
+    renderRestoreHeadless(emitter, { json: false });
+    out.length = 0;
+    emitter.emit(RESTORE_EV.FINISHED, { summary: sampleSummary({ dryRun: true }) });
+    expect(out.join('')).not.toContain('Restore summary');
+  });
+});
+
+describe('renderRestoreHeadless (--json NDJSON mode)', () => {
+  it('emits one parseable JSON line per event and never touches stdout', () => {
+    const lines: string[] = [];
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation((() => true) as never);
+    try {
+      const emitter = new RestoreEmitter();
+      renderRestoreHeadless(emitter, { json: true, write: (line) => lines.push(line) });
+      emitter.emit(RESTORE_EV.PLAN, samplePlan());
+      emitter.emit(RESTORE_EV.ITEM_DONE, {
+        mediaItemId: 'i1',
+        relPath: 'media/2024/03/A.jpg',
+        outcome: 'uploaded',
+        bytes: 1024,
+      });
+      emitter.emit(RESTORE_EV.METADATA, { kind: 'tags', applied: 2 });
+      emitter.emit(RESTORE_EV.FINISHED, { summary: sampleSummary() });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(spy).not.toHaveBeenCalled();
+    const parsed = lines.map((l) => {
+      expect(l.endsWith('\n')).toBe(true);
+      return JSON.parse(l) as Record<string, unknown>;
+    });
+    expect(parsed.map((p) => p['event'])).toEqual([
+      'restore-plan',
+      'restore-item-done',
+      'restore-metadata',
+      'restore-finished',
+    ]);
+    expect((parsed[0]!['plan'] as RestorePlan).totalItems).toBe(3);
+    expect(parsed[1]!['outcome']).toBe('uploaded');
+    expect((parsed[3]!['summary'] as RestoreSummary).uploaded).toBe(2);
+  });
+});

--- a/apps/cli/test/backup/restore-engine.spec.ts
+++ b/apps/cli/test/backup/restore-engine.spec.ts
@@ -1,0 +1,850 @@
+/**
+ * test/backup/restore-engine.spec.ts — `memoriahub backup restore` (issue #321).
+ *
+ * Covers the contract that makes a restore trustworthy:
+ *   - --dry-run produces a COMPLETE plan (circle mapping + per-circle totals)
+ *     and writes nothing at all;
+ *   - a fresh restore uploads originals, registers MediaItems, and reapplies
+ *     tags / albums / people / archive state from the sidecars;
+ *   - a second invocation is a no-op (restored_media_item_id + server dedup);
+ *   - a dedup response counts as skipped-existing, not an error;
+ *   - circle-mapping precedence (--map-circle > --into-circle > by name), and
+ *     an unknown --map-circle target hard-erroring BEFORE any write;
+ *   - --include trashed restores trashed rows as ACTIVE; quarantined never;
+ *   - a run killed mid-way resumes and only finishes the remaining items;
+ *   - a `nod_` node credential is refused up front.
+ *
+ * Everything runs against a real on-disk backup root (files + sidecars + a
+ * real SQLite catalog) and a fully mocked ApiClient surface.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type BetterSqlite3 from 'better-sqlite3';
+import { openCatalogDb } from '../../src/backup/catalog-db.js';
+import { CatalogRepo, type CatalogItemStatus } from '../../src/backup/catalog-repo.js';
+import { absPathFor, sidecarRelPathFor } from '../../src/backup/layout.js';
+import { ApiError, type Circle } from '../../src/api.js';
+import {
+  NodeCredentialNotAllowedError,
+  RestoreEmitter,
+  RestoreMappingError,
+  assertRestoreCredential,
+  parseMapCircle,
+  resolveRestoreExitCode,
+  runRestore,
+  type RestoreApi,
+  type RestorePlan,
+  type RestoreSummary,
+  type RestoreUploadFn,
+} from '../../src/backup/restore-engine.js';
+
+// ---------------------------------------------------------------------------
+// Fixture: a real backup root on disk
+// ---------------------------------------------------------------------------
+
+interface SeedItem {
+  id: string;
+  circleId: string;
+  circleName: string;
+  fileName: string;
+  status?: CatalogItemStatus;
+  archivedAt?: string | null;
+  capturedAt?: string | null;
+  favorite?: boolean;
+  description?: string;
+  tags?: string[];
+  albums?: Array<{ id: string; name: string }>;
+  people?: Array<{ personId: string; name: string }>;
+  geo?: { takenLat: number; takenLng: number; coordSource: string };
+  /** Skip writing the original bytes (simulates a damaged root). */
+  omitFile?: boolean;
+}
+
+let tmpRoot: string;
+let db: BetterSqlite3.Database;
+let repo: CatalogRepo;
+
+function seed(item: SeedItem): void {
+  const archived = typeof item.archivedAt === 'string';
+  const relPath = `${archived ? 'archived' : 'media'}/2024/03/${item.fileName}`;
+  const abs = absPathFor(tmpRoot, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  if (!item.omitFile) fs.writeFileSync(abs, `bytes-of-${item.id}`);
+
+  const sidecar = {
+    schemaVersion: 1,
+    mediaItemId: item.id,
+    circleId: item.circleId,
+    circleName: item.circleName,
+    type: 'photo',
+    originalFilename: item.fileName,
+    capturedAt: item.capturedAt ?? '2024-03-10T12:00:00.000Z',
+    capturedAtOffset: -360,
+    mimeType: 'image/jpeg',
+    description: item.description ?? null,
+    favorite: item.favorite ?? false,
+    archivedAt: item.archivedAt ?? null,
+    deletedAt: item.status === 'trashed' ? '2024-04-01T00:00:00.000Z' : null,
+    geo: item.geo ?? { takenLat: null, takenLng: null, coordSource: null },
+    tags: (item.tags ?? []).map((name) => ({ name, source: 'ai' })),
+    albums: item.albums ?? [],
+    people: item.people ?? [],
+    faces: [],
+  };
+  fs.mkdirSync(path.dirname(absPathFor(tmpRoot, sidecarRelPathFor(relPath))), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    absPathFor(tmpRoot, sidecarRelPathFor(relPath)),
+    JSON.stringify(sidecar, null, 2),
+  );
+
+  repo.upsertItemWithDims(
+    {
+      mediaItemId: item.id,
+      circleId: item.circleId,
+      relPath,
+      sidecarRelPath: sidecarRelPathFor(relPath),
+      capturedAt: item.capturedAt ?? '2024-03-10T12:00:00.000Z',
+      contentHash: `hash-${item.id}`,
+      size: 1024,
+      mimeType: 'image/jpeg',
+      serverUpdatedAt: '2024-03-11T00:00:00.000Z',
+      status: item.status ?? 'present',
+      archived,
+      downloadedAt: '2024-03-11T00:00:00.000Z',
+      verifiedAt: null,
+      lastError: null,
+    },
+    {
+      tags: (item.tags ?? []).map((name) => ({ name, source: 'ai' })),
+      albums: item.albums ?? [],
+      people: item.people ?? [],
+    },
+  );
+}
+
+/** Write catalog/albums.json (the dimension file restore reads descriptions from). */
+function seedAlbumCatalog(entries: Array<{ id: string; name: string; description?: string }>): void {
+  const dir = absPathFor(tmpRoot, 'catalog');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'albums.json'), JSON.stringify(entries, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: a recording fake ApiClient
+// ---------------------------------------------------------------------------
+
+interface FakeApiOptions {
+  circles?: Circle[];
+  /** Ids the server still knows about (drives getMediaItem 200 vs 404). */
+  knownMediaIds?: Set<string>;
+  /** Content hashes the server ALREADY holds → createMediaItem dedups. */
+  dedupHashes?: Set<string>;
+}
+
+interface FakeApi {
+  api: RestoreApi;
+  calls: {
+    circlesCreated: Array<{ name: string }>;
+    mediaCreated: Array<Record<string, unknown>>;
+    mediaGets: string[];
+    bulkUpdates: Array<{ circleId: string; ids: string[]; set: Record<string, unknown> }>;
+    bulkTags: Array<{ circleId: string; ids: string[]; add?: string[] }>;
+    albumsCreated: Array<{ circleId: string; name: string; description?: string }>;
+    albumItems: Array<{ albumId: string; mediaItemIds: string[] }>;
+    archives: Array<{ circleId: string; ids: string[] }>;
+    people: Array<{ mediaItemId: string; name?: string }>;
+  };
+}
+
+function makeApi(opts: FakeApiOptions = {}): FakeApi {
+  const circles: Circle[] = opts.circles ?? [];
+  const known = opts.knownMediaIds ?? new Set<string>();
+  const dedupHashes = opts.dedupHashes ?? new Set<string>();
+  let mediaSeq = 0;
+  let circleSeq = 0;
+  let albumSeq = 0;
+  const albumsByCircle = new Map<string, Array<{ id: string; name: string }>>();
+
+  const calls: FakeApi['calls'] = {
+    circlesCreated: [],
+    mediaCreated: [],
+    mediaGets: [],
+    bulkUpdates: [],
+    bulkTags: [],
+    albumsCreated: [],
+    albumItems: [],
+    archives: [],
+    people: [],
+  };
+
+  const api = {
+    listCircles: async () => circles.slice(),
+    createCircle: async (body: { name: string; description?: string }) => {
+      calls.circlesCreated.push({ name: body.name });
+      const created: Circle = {
+        id: `new-circle-${++circleSeq}`,
+        name: body.name,
+        isPersonal: false,
+      };
+      circles.push(created);
+      return created;
+    },
+    getMediaItem: async (id: string) => {
+      calls.mediaGets.push(id);
+      if (!known.has(id)) throw new ApiError(404, 'Media item not found');
+      return { id };
+    },
+    createMediaItem: async (body: Record<string, unknown>) => {
+      calls.mediaCreated.push(body);
+      const hash = body['contentHash'] as string | undefined;
+      if (hash && dedupHashes.has(hash)) {
+        const id = `dedup-${hash}`;
+        known.add(id);
+        return { id, deduplicated: true };
+      }
+      const id = `srv-${++mediaSeq}`;
+      known.add(id);
+      return {
+        id,
+        capturedAt: (body['capturedAt'] as string | undefined) ?? null,
+        favorite: body['favorite'] === true,
+      };
+    },
+    bulkUpdateMedia: async (body: {
+      circleId: string;
+      ids: string[];
+      set: Record<string, unknown>;
+    }) => {
+      calls.bulkUpdates.push({ circleId: body.circleId, ids: [...body.ids], set: body.set });
+      return {};
+    },
+    bulkTags: async (body: { circleId: string; ids: string[]; add?: string[] }) => {
+      calls.bulkTags.push({
+        circleId: body.circleId,
+        ids: [...body.ids],
+        ...(body.add ? { add: [...body.add] } : {}),
+      });
+      return {};
+    },
+    bulkArchiveMedia: async (body: { circleId: string; ids: string[] }) => {
+      calls.archives.push({ circleId: body.circleId, ids: [...body.ids] });
+      return {};
+    },
+    listAlbums: async (circleId: string) => (albumsByCircle.get(circleId) ?? []).slice(),
+    createAlbum: async (body: { circleId: string; name: string; description?: string }) => {
+      calls.albumsCreated.push({
+        circleId: body.circleId,
+        name: body.name,
+        ...(body.description ? { description: body.description } : {}),
+      });
+      const album = { id: `album-${++albumSeq}`, name: body.name };
+      const list = albumsByCircle.get(body.circleId) ?? [];
+      list.push(album);
+      albumsByCircle.set(body.circleId, list);
+      return album;
+    },
+    addAlbumItems: async (albumId: string, mediaItemIds: string[]) => {
+      calls.albumItems.push({ albumId, mediaItemIds: [...mediaItemIds] });
+      return {};
+    },
+    addPersonToMedia: async (mediaItemId: string, body: { personId?: string; name?: string }) => {
+      calls.people.push({
+        mediaItemId,
+        ...(body.name !== undefined ? { name: body.name } : {}),
+      });
+      return { personId: `person-${body.name ?? body.personId}`, personName: body.name ?? null, faceId: 'face-1' };
+    },
+  } as unknown as RestoreApi;
+
+  return { api, calls };
+}
+
+/** Recording upload stub; `failFor` makes specific rel paths blow up. */
+function makeUpload(failFor: (filePath: string) => boolean = () => false): {
+  upload: RestoreUploadFn;
+  uploaded: string[];
+} {
+  const uploaded: string[] = [];
+  let seq = 0;
+  const upload: RestoreUploadFn = async (filePath) => {
+    if (failFor(filePath)) throw new Error('simulated upload kill');
+    uploaded.push(path.basename(filePath));
+    return { objectId: `obj-${++seq}` };
+  };
+  return { upload, uploaded };
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-restore-'));
+  db = openCatalogDb(tmpRoot);
+  repo = new CatalogRepo(db);
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Credential guard
+// ---------------------------------------------------------------------------
+
+describe('restore credential guard', () => {
+  it('rejects a `nod_` node credential up front', () => {
+    expect(() => assertRestoreCredential('nod_abcdef')).toThrow(NodeCredentialNotAllowedError);
+    expect(() => assertRestoreCredential('nod_abcdef')).toThrow(/node credential/i);
+    // The message must point at the fix, not just the symptom.
+    expect(() => assertRestoreCredential('nod_abcdef')).toThrow(/memoriahub login/);
+  });
+
+  it('accepts a normal PAT / session token', () => {
+    expect(() => assertRestoreCredential('mhp_live_token')).not.toThrow();
+    expect(() => assertRestoreCredential('eyJhbGciOi.jwt.token')).not.toThrow();
+  });
+});
+
+describe('parseMapCircle', () => {
+  it('parses repeated src=dst pairs', () => {
+    const map = parseMapCircle(['a=b', ' c = d ']);
+    expect(map.get('a')).toBe('b');
+    expect(map.get('c')).toBe('d');
+  });
+
+  it('rejects a malformed pair instead of silently dropping the mapping', () => {
+    expect(() => parseMapCircle(['no-equals'])).toThrow(RestoreMappingError);
+    expect(() => parseMapCircle(['=missing-source'])).toThrow(RestoreMappingError);
+    expect(() => parseMapCircle(['missing-target='])).toThrow(RestoreMappingError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dry run
+// ---------------------------------------------------------------------------
+
+describe('restore --dry-run', () => {
+  it('produces a complete, write-free plan including the circle mapping', async () => {
+    seed({
+      id: 'i1',
+      circleId: 'src-circle',
+      circleName: 'Family',
+      fileName: 'A.jpg',
+      tags: ['beach', 'sunset'],
+      albums: [{ id: 'alb-1', name: 'Summer' }],
+      people: [{ personId: 'p1', name: 'Ana' }],
+    });
+    seed({
+      id: 'i2',
+      circleId: 'src-circle',
+      circleName: 'Family',
+      fileName: 'B.jpg',
+      archivedAt: '2024-05-01T00:00:00.000Z',
+      tags: ['beach'],
+    });
+    seed({ id: 'i3', circleId: 'other-circle', circleName: 'Work', fileName: 'C.jpg' });
+
+    const { api, calls } = makeApi({
+      circles: [{ id: 'existing-1', name: 'Family', isPersonal: false }],
+    });
+    const { upload, uploaded } = makeUpload();
+
+    const emitter = new RestoreEmitter();
+    const plans: RestorePlan[] = [];
+    emitter.on('restore-plan', (p: RestorePlan) => plans.push(p));
+
+    const summary = await runRestore(
+      { root: tmpRoot, dryRun: true },
+      { db, api, upload },
+      emitter,
+    );
+
+    // Nothing was written: no uploads, no circles, no media, no metadata.
+    expect(uploaded).toEqual([]);
+    expect(calls.circlesCreated).toEqual([]);
+    expect(calls.mediaCreated).toEqual([]);
+    expect(calls.bulkTags).toEqual([]);
+    expect(calls.albumItems).toEqual([]);
+    expect(calls.archives).toEqual([]);
+    expect(summary.uploaded).toBe(0);
+
+    // The plan is complete.
+    expect(plans).toHaveLength(1);
+    const plan = plans[0]!;
+    expect(plan.dryRun).toBe(true);
+    expect(plan.totalItems).toBe(3);
+    expect(plan.totalBytes).toBe(3 * 1024);
+
+    const family = plan.circles.find((c) => c.sourceCircleId === 'src-circle')!;
+    expect(family.sourceCircleName).toBe('Family');
+    expect(family.resolution).toBe('matched-by-name');
+    expect(family.targetCircleId).toBe('existing-1');
+    expect(family.items).toBe(2);
+    expect(family.bytes).toBe(2048);
+    expect(family.albums).toBe(1);
+    expect(family.people).toBe(1);
+    expect(family.tags).toBe(2);
+
+    // A circle with no name match is planned as a CREATE, with no target id
+    // (nothing is created during a dry run).
+    const work = plan.circles.find((c) => c.sourceCircleId === 'other-circle')!;
+    expect(work.resolution).toBe('create');
+    expect(work.targetCircleId).toBeNull();
+    expect(work.targetCircleName).toBe('Work');
+
+    expect(resolveRestoreExitCode(summary)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end restore
+// ---------------------------------------------------------------------------
+
+describe('restore end-to-end', () => {
+  it('uploads originals, creates albums/tags/people, and re-archives archived items', async () => {
+    seedAlbumCatalog([{ id: 'alb-1', name: 'Summer', description: 'Beach trip' }]);
+    seed({
+      id: 'i1',
+      circleId: 'src',
+      circleName: 'Family',
+      fileName: 'A.jpg',
+      favorite: true,
+      description: 'A sunny day',
+      tags: ['beach', 'sunset'],
+      albums: [{ id: 'alb-1', name: 'Summer' }],
+      people: [{ personId: 'p1', name: 'Ana' }, { personId: 'p2', name: 'Bruno' }],
+      geo: { takenLat: 9.9, takenLng: -84.1, coordSource: 'manual' },
+    });
+    seed({
+      id: 'i2',
+      circleId: 'src',
+      circleName: 'Family',
+      fileName: 'B.jpg',
+      archivedAt: '2024-05-01T00:00:00.000Z',
+      tags: ['beach', 'sunset'],
+    });
+
+    const { api, calls } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+    });
+    const { upload, uploaded } = makeUpload();
+
+    const summary = await runRestore(
+      { root: tmpRoot, concurrency: 1 },
+      { db, api, upload },
+    );
+
+    // Originals uploaded and registered into the name-matched circle.
+    expect(uploaded.sort()).toEqual(['A.jpg', 'B.jpg']);
+    expect(summary.uploaded).toBe(2);
+    expect(summary.failed).toBe(0);
+    expect(calls.mediaCreated).toHaveLength(2);
+    for (const body of calls.mediaCreated) {
+      expect(body['circleId']).toBe('circle-family');
+      expect(body['source']).toBe('cli');
+      expect(body['type']).toBe('photo');
+      expect(String(body['contentHash'])).toMatch(/^hash-i/);
+    }
+    // description has no bulk endpoint, so it rides along on creation.
+    expect(calls.mediaCreated.find((b) => b['originalFilename'] === 'A.jpg')?.['description']).toBe(
+      'A sunny day',
+    );
+
+    // Tags: both items share one tag SET, so they collapse into ONE bulk call.
+    expect(calls.bulkTags).toHaveLength(1);
+    expect(calls.bulkTags[0]!.add).toEqual(['beach', 'sunset']);
+    expect(calls.bulkTags[0]!.ids).toHaveLength(2);
+
+    // Album: found-or-created by name (with the catalog description) + members.
+    expect(calls.albumsCreated).toEqual([
+      { circleId: 'circle-family', name: 'Summer', description: 'Beach trip' },
+    ]);
+    expect(calls.albumItems).toHaveLength(1);
+    expect(calls.albumItems[0]!.mediaItemIds).toHaveLength(1);
+    expect(summary.albumsCreated).toBe(1);
+
+    // People restored by NAME (faces themselves are re-detected by enrichment).
+    expect(calls.people.map((p) => p.name).sort()).toEqual(['Ana', 'Bruno']);
+    expect(summary.peopleLinks).toBe(2);
+
+    // Manual location came back through the bulk update path.
+    const withLocation = calls.bulkUpdates.find((u) => u.set['location'] !== undefined);
+    expect(withLocation?.set['location']).toEqual({ lat: 9.9, lng: -84.1 });
+
+    // The archived item was restored, then re-archived at the very end.
+    expect(calls.archives).toHaveLength(1);
+    expect(calls.archives[0]!.ids).toHaveLength(1);
+    expect(summary.archived).toBe(1);
+
+    // Both restored ids are recorded in the catalog.
+    expect(repo.getById('i1')?.restoredMediaItemId).toMatch(/^srv-/);
+    expect(repo.getById('i2')?.restoredMediaItemId).toMatch(/^srv-/);
+    expect(resolveRestoreExitCode(summary)).toBe(0);
+  });
+
+  it('is a no-op on a second invocation (restored ids verified, nothing re-uploaded)', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg', tags: ['beach'] });
+    seed({ id: 'i2', circleId: 'src', circleName: 'Family', fileName: 'B.jpg' });
+
+    const known = new Set<string>();
+    const first = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+      knownMediaIds: known,
+    });
+    const firstUpload = makeUpload();
+    await runRestore({ root: tmpRoot }, { db, api: first.api, upload: firstUpload.upload });
+    expect(firstUpload.uploaded).toHaveLength(2);
+
+    // Second run: the same server still knows both items.
+    const second = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+      knownMediaIds: known,
+    });
+    const secondUpload = makeUpload();
+    const summary = await runRestore(
+      { root: tmpRoot },
+      { db, api: second.api, upload: secondUpload.upload },
+    );
+
+    expect(secondUpload.uploaded).toEqual([]);
+    expect(second.calls.mediaCreated).toEqual([]);
+    expect(second.calls.bulkTags).toEqual([]);
+    expect(second.calls.people).toEqual([]);
+    expect(summary.uploaded).toBe(0);
+    expect(summary.skippedExisting).toBe(2);
+    expect(summary.failed).toBe(0);
+    // Each skip was a real server verification, not a blind trust of the catalog.
+    expect(second.calls.mediaGets).toHaveLength(2);
+  });
+
+  it('records a dedup response as skipped-existing (not an error) and captures its id', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+
+    const { api, calls } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+      dedupHashes: new Set(['hash-i1']),
+    });
+    const { upload, uploaded } = makeUpload();
+
+    const summary = await runRestore({ root: tmpRoot }, { db, api, upload });
+
+    // The upload still happened (the server decides dedup), but the outcome is
+    // a skip and the EXISTING id is what lands in the catalog.
+    expect(uploaded).toEqual(['A.jpg']);
+    expect(calls.mediaCreated).toHaveLength(1);
+    expect(summary.uploaded).toBe(0);
+    expect(summary.skippedExisting).toBe(1);
+    expect(summary.failed).toBe(0);
+    expect(repo.getById('i1')?.restoredMediaItemId).toBe('dedup-hash-i1');
+    expect(resolveRestoreExitCode(summary)).toBe(0);
+  });
+
+  it('reports a missing local file as a failure without aborting the run', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg', omitFile: true });
+    seed({ id: 'i2', circleId: 'src', circleName: 'Family', fileName: 'B.jpg' });
+
+    const { api } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+    });
+    const { upload, uploaded } = makeUpload();
+
+    const summary = await runRestore({ root: tmpRoot }, { db, api, upload });
+
+    expect(uploaded).toEqual(['B.jpg']);
+    expect(summary.uploaded).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.failures[0]!.error).toMatch(/missing/);
+    expect(resolveRestoreExitCode(summary)).toBe(1);
+  });
+
+  it('--skip-metadata uploads originals only', async () => {
+    seed({
+      id: 'i1',
+      circleId: 'src',
+      circleName: 'Family',
+      fileName: 'A.jpg',
+      tags: ['beach'],
+      albums: [{ id: 'alb-1', name: 'Summer' }],
+      people: [{ personId: 'p1', name: 'Ana' }],
+      archivedAt: '2024-05-01T00:00:00.000Z',
+    });
+
+    const { api, calls } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+    });
+    const { upload, uploaded } = makeUpload();
+
+    const summary = await runRestore(
+      { root: tmpRoot, skipMetadata: true },
+      { db, api, upload },
+    );
+
+    expect(uploaded).toEqual(['A.jpg']);
+    expect(calls.bulkTags).toEqual([]);
+    expect(calls.albumItems).toEqual([]);
+    expect(calls.people).toEqual([]);
+    expect(calls.archives).toEqual([]);
+    expect(calls.mediaCreated[0]!['description']).toBeUndefined();
+    expect(summary.metadataApplied).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circle mapping
+// ---------------------------------------------------------------------------
+
+describe('restore circle mapping', () => {
+  it('honours precedence: --map-circle > --into-circle > name match', async () => {
+    seed({ id: 'i1', circleId: 'src-a', circleName: 'Family', fileName: 'A.jpg' });
+    seed({ id: 'i2', circleId: 'src-b', circleName: 'Work', fileName: 'B.jpg' });
+
+    const { api, calls } = makeApi({
+      circles: [
+        { id: 'circle-family', name: 'Family', isPersonal: false },
+        { id: 'circle-dump', name: 'Dump', isPersonal: false },
+        { id: 'circle-explicit', name: 'Explicit', isPersonal: false },
+      ],
+    });
+    const { upload } = makeUpload();
+
+    // src-a is explicitly mapped (beats both --into-circle and its name match);
+    // src-b falls through to --into-circle (beats its own name match).
+    await runRestore(
+      {
+        root: tmpRoot,
+        intoCircle: 'circle-dump',
+        mapCircle: new Map([['src-a', 'circle-explicit']]),
+      },
+      { db, api, upload },
+    );
+
+    const byFile = new Map(
+      calls.mediaCreated.map((b) => [b['originalFilename'] as string, b['circleId']]),
+    );
+    expect(byFile.get('A.jpg')).toBe('circle-explicit');
+    expect(byFile.get('B.jpg')).toBe('circle-dump');
+    // Name matching never ran — nothing was created.
+    expect(calls.circlesCreated).toEqual([]);
+  });
+
+  it('creates a circle by sidecar name when nothing matches', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Brand New', fileName: 'A.jpg' });
+
+    const { api, calls } = makeApi({ circles: [] });
+    const { upload } = makeUpload();
+
+    const summary = await runRestore({ root: tmpRoot }, { db, api, upload });
+
+    expect(calls.circlesCreated).toEqual([{ name: 'Brand New' }]);
+    expect(summary.circlesCreated).toBe(1);
+    expect(calls.mediaCreated[0]!['circleId']).toBe('new-circle-1');
+  });
+
+  it('hard-errors on an unknown --map-circle target BEFORE any write', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+
+    const { api, calls } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+    });
+    const { upload, uploaded } = makeUpload();
+
+    await expect(
+      runRestore(
+        { root: tmpRoot, mapCircle: new Map([['src', 'circle-that-does-not-exist']]) },
+        { db, api, upload },
+      ),
+    ).rejects.toThrow(RestoreMappingError);
+
+    // Absolutely nothing was written.
+    expect(uploaded).toEqual([]);
+    expect(calls.mediaCreated).toEqual([]);
+    expect(calls.circlesCreated).toEqual([]);
+    expect(repo.getById('i1')?.restoredMediaItemId).toBeNull();
+  });
+
+  it('hard-errors on an unknown --into-circle target', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+    const { api } = makeApi({ circles: [] });
+    const { upload, uploaded } = makeUpload();
+
+    await expect(
+      runRestore({ root: tmpRoot, intoCircle: 'nope' }, { db, api, upload }),
+    ).rejects.toThrow(/--into-circle target nope/);
+    expect(uploaded).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope
+// ---------------------------------------------------------------------------
+
+describe('restore scope', () => {
+  it('never restores quarantined items, and restores trashed ones only with --include trashed', async () => {
+    seed({ id: 'present-1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+    seed({
+      id: 'trashed-1',
+      circleId: 'src',
+      circleName: 'Family',
+      fileName: 'T.jpg',
+      status: 'trashed',
+    });
+    seed({
+      id: 'quarantined-1',
+      circleId: 'src',
+      circleName: 'Family',
+      fileName: 'Q.jpg',
+      status: 'quarantined',
+    });
+    seed({
+      id: 'failed-1',
+      circleId: 'src',
+      circleName: 'Family',
+      fileName: 'F.jpg',
+      status: 'failed',
+    });
+
+    // Default scope: present only. The same server (shared knownMediaIds)
+    // serves both runs, so the second one skips what the first restored.
+    const known = new Set<string>();
+    const first = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+      knownMediaIds: known,
+    });
+    const firstUpload = makeUpload();
+    const defaultSummary = await runRestore(
+      { root: tmpRoot },
+      { db, api: first.api, upload: firstUpload.upload },
+    );
+    expect(firstUpload.uploaded).toEqual(['A.jpg']);
+    expect(defaultSummary.plan.totalItems).toBe(1);
+
+    // --include trashed: the trashed row is restored too, as an ACTIVE item —
+    // it must NOT be archived or otherwise hidden, since no public API can put
+    // an item back into the server's Trash.
+    const second = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+      knownMediaIds: known,
+    });
+    const secondUpload = makeUpload();
+    const summary = await runRestore(
+      { root: tmpRoot, includeTrashed: true },
+      { db, api: second.api, upload: secondUpload.upload },
+    );
+
+    expect(secondUpload.uploaded).toEqual(['T.jpg']);
+    expect(summary.plan.includeTrashed).toBe(true);
+    expect(summary.plan.totalItems).toBe(2);
+    expect(second.calls.archives).toEqual([]);
+    expect(repo.getById('trashed-1')?.restoredMediaItemId).toMatch(/^srv-/);
+
+    // Quarantined and failed rows were never touched, in either run.
+    expect(repo.getById('quarantined-1')?.restoredMediaItemId).toBeNull();
+    expect(repo.getById('failed-1')?.restoredMediaItemId).toBeNull();
+    expect([...firstUpload.uploaded, ...secondUpload.uploaded]).not.toContain('Q.jpg');
+    expect([...firstUpload.uploaded, ...secondUpload.uploaded]).not.toContain('F.jpg');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resume
+// ---------------------------------------------------------------------------
+
+describe('restore resume after a partial run', () => {
+  it('re-runs only the items that did not finish', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+    seed({ id: 'i2', circleId: 'src', circleName: 'Family', fileName: 'B.jpg' });
+    seed({ id: 'i3', circleId: 'src', circleName: 'Family', fileName: 'C.jpg' });
+
+    const known = new Set<string>();
+    const circles: Circle[] = [{ id: 'circle-family', name: 'Family', isPersonal: false }];
+
+    // First run dies on everything except A.jpg (concurrency 1 keeps it ordered).
+    const first = makeApi({ circles: circles.slice(), knownMediaIds: known });
+    const firstUpload = makeUpload((filePath) => !filePath.endsWith('A.jpg'));
+    const killed = await runRestore(
+      { root: tmpRoot, concurrency: 1 },
+      { db, api: first.api, upload: firstUpload.upload },
+    );
+
+    expect(firstUpload.uploaded).toEqual(['A.jpg']);
+    expect(killed.uploaded).toBe(1);
+    expect(killed.failed).toBe(2);
+    expect(resolveRestoreExitCode(killed)).toBe(1);
+    expect(repo.getById('i1')?.restoredMediaItemId).toMatch(/^srv-/);
+    expect(repo.getById('i2')?.restoredMediaItemId).toBeNull();
+    expect(repo.getById('i3')?.restoredMediaItemId).toBeNull();
+
+    // Second run: only the two unfinished items upload; A.jpg is verified+skipped.
+    const second = makeApi({ circles: circles.slice(), knownMediaIds: known });
+    const secondUpload = makeUpload();
+    const resumed = await runRestore(
+      { root: tmpRoot, concurrency: 1 },
+      { db, api: second.api, upload: secondUpload.upload },
+    );
+
+    expect(secondUpload.uploaded.sort()).toEqual(['B.jpg', 'C.jpg']);
+    expect(resumed.uploaded).toBe(2);
+    expect(resumed.skippedExisting).toBe(1);
+    expect(resumed.failed).toBe(0);
+    expect(resolveRestoreExitCode(resumed)).toBe(0);
+    for (const id of ['i1', 'i2', 'i3']) {
+      expect(repo.getById(id)?.restoredMediaItemId).toMatch(/^srv-/);
+    }
+  });
+
+  it('re-uploads when the recorded MediaItem no longer exists server-side', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+    repo.setRestoredMediaItemId('i1', 'stale-id');
+
+    // The server 404s the stale id (nothing is in knownMediaIds).
+    const { api, calls } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+    });
+    const { upload, uploaded } = makeUpload();
+
+    const summary = await runRestore({ root: tmpRoot }, { db, api, upload });
+
+    expect(calls.mediaGets).toEqual(['stale-id']);
+    expect(uploaded).toEqual(['A.jpg']);
+    expect(summary.uploaded).toBe(1);
+    expect(repo.getById('i1')?.restoredMediaItemId).toBe('srv-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+describe('restore events', () => {
+  it('emits a plan, one item-done per item, and a finished summary', async () => {
+    seed({ id: 'i1', circleId: 'src', circleName: 'Family', fileName: 'A.jpg' });
+    seed({ id: 'i2', circleId: 'src', circleName: 'Family', fileName: 'B.jpg' });
+
+    const { api } = makeApi({
+      circles: [{ id: 'circle-family', name: 'Family', isPersonal: false }],
+    });
+    const { upload } = makeUpload();
+
+    const emitter = new RestoreEmitter();
+    const events: string[] = [];
+    let finished: RestoreSummary | null = null;
+    emitter.on('restore-plan', () => events.push('plan'));
+    emitter.on('restore-item-started', () => events.push('started'));
+    emitter.on('restore-item-done', () => events.push('done'));
+    emitter.on('restore-finished', (p: { summary: RestoreSummary }) => {
+      events.push('finished');
+      finished = p.summary;
+    });
+
+    await runRestore({ root: tmpRoot, concurrency: 1 }, { db, api, upload }, emitter);
+
+    expect(events[0]).toBe('plan');
+    expect(events.at(-1)).toBe('finished');
+    expect(events.filter((e) => e === 'done')).toHaveLength(2);
+    expect(events.filter((e) => e === 'started')).toHaveLength(2);
+    expect(finished).not.toBeNull();
+    expect((finished as unknown as RestoreSummary).uploaded).toBe(2);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.2.23",
+      "version": "1.2.24",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary

Child 8 of Epic #308 — the capability that proves the backup. `memoriahub backup restore` points a backup root at a server and rebuilds the library: re-uploads every original through the existing resumable upload path and reapplies the human-meaningful metadata captured in the sidecars (description, favorite, capturedAt, manual location, tags, albums, people, archive state). Idempotent and resumable.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #321
Relates to #308

## Changes Made

- `backup/restore-engine.ts` — UI-free evented engine over `runPool` (default concurrency 2, `withRetry` + `CooldownGate`): upload → record `restored_media_item_id` → reapply sidecar metadata → flush archive last. Circle mapping precedence `--map-circle` > `--into-circle` > find-or-create by `circleName`, fully resolved and validated **before the first write** (unknown target → `RestoreMappingError` listing available circles). Scope is `present` rows (archived included, then re-archived); `--include trashed` restores trashed rows as active; quarantined never restored.
- Catalog **migration v2** — `ALTER TABLE items ADD COLUMN restored_media_item_id TEXT` via the existing `user_version` runner. `upsertItemWithDims` (an `INSERT OR REPLACE`) now carries the column forward via a correlated subselect, so a later `backup run` can't silently wipe restore markers.
- Two independent idempotence mechanisms: the recorded id (written before metadata, so a crash mid-metadata still resumes) is **verified** with `GET /api/media/:id` rather than trusted — a 404/403 clears the stale marker and re-uploads; server-side `(circle_id, content_hash)` dedup covers the rest and counts as `skipped-existing`, not an error.
- `nod_` credential rejected up front with the reason and fix (restore writes media/albums/tags, which node credentials structurally cannot reach).
- `api.ts` — `createCircle`, `getMediaItem`, `createMediaItem`, `bulkUpdateMedia`, `bulkTags`, `bulkArchiveMedia`, `listAlbums`, `createAlbum`, `addAlbumItems`, `addPersonToMedia`, plus a generic `patch<T>()`; signatures matched against the real controllers/DTOs.
- `--dry-run` prints the resolved mapping and per-circle totals with zero writes; `--json` NDJSON; non-zero exit on any failure; output notes that faces re-detect via enrichment and that enrichment will churn after a restore.
- CLI version 1.2.23 → 1.2.24 + lockfile sync.

## Testing

- [x] Unit tests pass (`npm test`) — CLI `test:ci`: 122 suites / 1559 tests, 0 failures (baseline 120/1535, zero regressions)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

23 new tests: write-free dry-run plan, fresh restore e2e (uploads, albums/tags/people, re-archive), second-run no-op, dedup capture, mapping precedence + pre-write hard error, `--include trashed`, quarantine exclusion, mid-run kill then resume, a genuine hand-built v1 catalog upgraded to v2 with data intact, and `nod_` rejection.

## Additional Notes

`description` rides along on `POST /api/media` because `PATCH /api/media/bulk`'s `set` covers only location/favorite/capturedAt. Tag batching groups by identical tag *set*, so items sharing tags collapse into one bulk call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU4LJhpU8pQut5fQMuBMPZ)_