### PR TITLE
feat(api): Memories settings namespace, feature flag, AI model selection &amp; generation job skeleton (#302)

### DIFF
--- a/apps/api/src/ai/ai-settings.controller.ts
+++ b/apps/api/src/ai/ai-settings.controller.ts
@@ -26,6 +26,7 @@ import {
   SetTaggingFeatureDto,
   SetEmbeddingFeatureDto,
   SetEnhanceFeatureDto,
+  SetMemoriesFeatureDto,
   TestEmbeddingDto,
 } from './dto/ai-credentials.dto';
 
@@ -176,5 +177,29 @@ export class AiSettingsController {
     @CurrentUser('id') userId: string,
   ) {
     return this.aiSettingsService.setEnhanceFeature(dto, userId);
+  }
+
+  @Put('features/memories')
+  @Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.AI_SETTINGS_WRITE] })
+  @ApiOperation({
+    summary:
+      'Set active provider and model for Memories title generation (Admin)',
+    description:
+      'Chat-capable provider/model used to write memory titles, subtitles and ' +
+      'narratives (epic #300). List candidates with GET /api/ai/models?capability=chat. ' +
+      'Passing a null provider or model clears the selection, in which case ' +
+      'memories fall back to deterministic template titles. Returns 400 when the ' +
+      'selected provider has no configured, enabled credential.',
+  })
+  @ApiResponse({ status: 200, description: 'Memories feature config updated' })
+  @ApiResponse({
+    status: 400,
+    description: 'Provider is not configured or is disabled',
+  })
+  async setMemoriesFeature(
+    @Body() dto: SetMemoriesFeatureDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.aiSettingsService.setMemoriesFeature(dto, userId);
   }
 }

--- a/apps/api/src/ai/ai-settings.service.spec.ts
+++ b/apps/api/src/ai/ai-settings.service.spec.ts
@@ -209,6 +209,7 @@ describe('AiSettingsService', () => {
         tagging: { provider: null, model: null },
         embedding: { provider: null, model: null },
         enhance: null,
+        memories: null,
       });
     });
 
@@ -351,6 +352,100 @@ describe('AiSettingsService', () => {
       );
 
       expect(result).toEqual({ provider: 'anthropic', model: 'embed-v1' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // setMemoriesFeature / resolveMemoriesConfig (epic #300, issue #302)
+  // ---------------------------------------------------------------------------
+  describe('setMemoriesFeature', () => {
+    it('persists the provider/model pair when the credential exists and is enabled', async () => {
+      mockPrisma.aiProviderCredential.findUnique.mockResolvedValue({
+        enabled: true,
+      } as any);
+      mockSystemSettings.patchSettings.mockResolvedValue(undefined);
+
+      const result = await service.setMemoriesFeature(
+        { provider: 'openai', model: 'gpt-4o-mini' },
+        'user-1',
+      );
+
+      expect(mockSystemSettings.patchSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ai: {
+            features: {
+              memories: { provider: 'openai', model: 'gpt-4o-mini' },
+            },
+          },
+        }),
+        'user-1',
+      );
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
+    });
+
+    it('rejects a provider with NO configured credential (400)', async () => {
+      mockPrisma.aiProviderCredential.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.setMemoriesFeature({ provider: 'openai', model: 'gpt-4o-mini' }, 'user-1'),
+      ).rejects.toThrow(BadRequestException);
+
+      // Nothing is written when validation fails.
+      expect(mockSystemSettings.patchSettings).not.toHaveBeenCalled();
+    });
+
+    it('rejects a provider whose credential is DISABLED (400)', async () => {
+      mockPrisma.aiProviderCredential.findUnique.mockResolvedValue({
+        enabled: false,
+      } as any);
+
+      await expect(
+        service.setMemoriesFeature({ provider: 'openai', model: 'gpt-4o-mini' }, 'user-1'),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockSystemSettings.patchSettings).not.toHaveBeenCalled();
+    });
+
+    it('clears the selection to null when either field is null — no credential check', async () => {
+      mockSystemSettings.patchSettings.mockResolvedValue(undefined);
+
+      const result = await service.setMemoriesFeature(
+        { provider: 'openai', model: null },
+        'user-1',
+      );
+
+      expect(result).toBeNull();
+      expect(mockPrisma.aiProviderCredential.findUnique).not.toHaveBeenCalled();
+      expect(mockSystemSettings.patchSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ ai: { features: { memories: null } } }),
+        'user-1',
+      );
+    });
+  });
+
+  describe('resolveMemoriesConfig', () => {
+    it('returns {provider, model} when configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({
+        ai: { features: { memories: { provider: 'openai', model: 'gpt-4o-mini' } } },
+      });
+
+      await expect(service.resolveMemoriesConfig()).resolves.toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      });
+    });
+
+    it('returns null when unset, so callers fall back to template titles', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({
+        ai: { features: { memories: null } },
+      });
+
+      await expect(service.resolveMemoriesConfig()).resolves.toBeNull();
+    });
+
+    it('returns null on a pre-#302 settings document with no memories key', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({ ai: { features: {} } });
+
+      await expect(service.resolveMemoriesConfig()).resolves.toBeNull();
     });
   });
 

--- a/apps/api/src/ai/ai-settings.service.ts
+++ b/apps/api/src/ai/ai-settings.service.ts
@@ -15,6 +15,7 @@ import {
   SetTaggingFeatureDto,
   SetEmbeddingFeatureDto,
   SetEnhanceFeatureDto,
+  SetMemoriesFeatureDto,
   TestEmbeddingDto,
 } from './dto/ai-credentials.dto';
 
@@ -69,6 +70,7 @@ export class AiSettingsService {
         tagging: { provider: null, model: null },
         embedding: { provider: null, model: null },
         enhance: null,
+        memories: null,
       },
     };
   }
@@ -326,6 +328,74 @@ export class AiSettingsService {
       userId,
     );
     return value;
+  }
+
+  /**
+   * Update the Memories title/subtitle/narrative feature config (epic #300).
+   *
+   * Same nullable-object shape as ai.features.enhance — a partial provider/model
+   * pair is not a valid selection, so clearing either field clears the whole
+   * setting and Memories falls back to deterministic template titles.
+   *
+   * Unlike the older search/tagging/embedding setters, a non-null selection is
+   * validated against the credential store up front: selecting a provider that
+   * has no enabled credential can only ever fail later, inside a background
+   * `memory_generation` job where the admin would never see the error.
+   */
+  async setMemoriesFeature(dto: SetMemoriesFeatureDto, userId: string) {
+    const value =
+      dto.provider && dto.model
+        ? { provider: dto.provider, model: dto.model }
+        : null;
+
+    if (value) {
+      await this.assertProviderUsable(value.provider);
+    }
+
+    await this.systemSettings.patchSettings(
+      {
+        ai: {
+          features: {
+            memories: value,
+          },
+        },
+      } as any,
+      userId,
+    );
+    return value;
+  }
+
+  /**
+   * Throw a 400 unless the provider has a configured AND enabled credential.
+   * Deliberately does not decrypt the key — existence and the enabled flag are
+   * all a feature-selection write needs to know.
+   */
+  private async assertProviderUsable(providerKey: string): Promise<void> {
+    const cred = await this.prisma.aiProviderCredential.findUnique({
+      where: { provider: providerKey },
+      select: { enabled: true },
+    });
+    if (!cred) {
+      throw new BadRequestException(
+        `Provider "${providerKey}" is not configured`,
+      );
+    }
+    if (!cred.enabled) {
+      throw new BadRequestException(`Provider "${providerKey}" is disabled`);
+    }
+  }
+
+  /**
+   * Resolve the active Memories provider + model from system settings.
+   * Returns null when unset — callers fall back to template titles (#306).
+   */
+  async resolveMemoriesConfig(): Promise<{ provider: string; model: string } | null> {
+    const sysSettings = await this.systemSettings.getSettings();
+    const memories = sysSettings.ai?.features?.memories;
+    if (!memories?.provider || !memories?.model) {
+      return null;
+    }
+    return { provider: memories.provider, model: memories.model };
   }
 
   /**

--- a/apps/api/src/ai/dto/ai-credentials.dto.ts
+++ b/apps/api/src/ai/dto/ai-credentials.dto.ts
@@ -38,6 +38,15 @@ export const setEnhanceFeatureSchema = z.object({
 });
 export class SetEnhanceFeatureDto extends createZodDto(setEnhanceFeatureSchema) {}
 
+// Memories title/subtitle/narrative generation (epic #300, issue #302).
+// Same nullable pair shape as `enhance`: clearing either field clears the
+// whole selection, since a half-filled provider/model pair is not usable.
+export const setMemoriesFeatureSchema = z.object({
+  provider: z.string().min(1).nullable(),
+  model: z.string().min(1).nullable(),
+});
+export class SetMemoriesFeatureDto extends createZodDto(setMemoriesFeatureSchema) {}
+
 // Both fields optional — an empty body tests the configured ai.features.embedding.
 // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
 export const testEmbeddingSchema = z.object({

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -39,6 +39,7 @@ import { NodesModule } from './nodes/nodes.module';
 import { WorkflowsModule } from './workflows/workflows.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { NotificationsReconcileModule } from './notifications/notifications-reconcile.module';
+import { MemoriesModule } from './memories/memories.module';
 import { DoctorModule } from './doctor/doctor.module';
 import { LoggerModule } from './common/logger/logger.module';
 import { TestAuthModule } from './test-auth/test-auth.module';
@@ -105,6 +106,7 @@ import configuration from './config/configuration';
     WorkflowsModule,
     NotificationsModule,
     NotificationsReconcileModule,
+    MemoriesModule,
 
     // Test modules (non-production only)
     ...(process.env.NODE_ENV !== 'production' ? [TestAuthModule] : []),

--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -207,6 +207,9 @@ export const systemSettingsSchema = z.object({
   //   - locationInference: interpolate/extrapolate missing GPS coords from timeline anchors
   //   - socialMediaDetection: social-media video detection (OCR-based)
   //   - faceAutoArchive: auto-archive faces matching a previously-archived face
+  //   - pictureEnhancement: AI picture enhancer
+  //   - workflows: media workflow automation
+  //   - memories: curated memory collections (On This Day, Trips, People, …)
   features: z.record(z.string(), z.boolean()),
   ai: z.object({
     features: z.object({
@@ -223,6 +226,14 @@ export const systemSettingsSchema = z.object({
         model: z.string().nullable(),
       }),
       enhance: z.object({
+        provider: z.string(),
+        model: z.string(),
+      }).nullable().default(null),
+      // Memories title/subtitle/narrative generation (epic #300, issue #302).
+      // Chat-capable provider+model, same nullable-object shape as `enhance`:
+      // a half-filled pair is not a valid selection, so the whole object is
+      // either present or null. Consumed by MemoryTitleService (#306).
+      memories: z.object({
         provider: z.string(),
         model: z.string(),
       }).nullable().default(null),
@@ -411,6 +422,67 @@ export const systemSettingsSchema = z.object({
     triggers: { onEnrichment: true, scheduled: true },
     scheduleMinIntervalMinutes: 60,
   }),
+  // Memories (epic #300, issue #302). The FULL namespace ships here alongside the
+  // generation job skeleton so every later issue in the epic (curators #303–#305,
+  // AI titles #306, API #307, digest #311, admin page #315) reads its parameters
+  // through the one cached getSettings() call with no further schema change.
+  // Issue #302 actively reads only generation.intervalHours (+ features.memories).
+  memories: z.object({
+    generation: z.object({
+      intervalHours: z.number().int().min(1).max(168).default(24),
+    }).default({ intervalHours: 24 }),
+    maxItemsPerMemory: z.number().int().min(5).max(100).default(30),
+    aiTitles: z.object({
+      enabled: z.boolean().default(true),
+    }).default({ enabled: true }),
+    onThisDay: z.object({
+      enabled: z.boolean().default(true),
+      lookbackYears: z.number().int().min(1).max(50).default(10),
+      minItems: z.number().int().min(1).max(20).default(3),
+    }).default({ enabled: true, lookbackYears: 10, minItems: 3 }),
+    trips: z.object({
+      enabled: z.boolean().default(true),
+      minDays: z.number().int().min(1).max(14).default(2),
+      minItems: z.number().int().min(3).max(100).default(10),
+      minDistanceKm: z.number().int().min(5).max(500).default(50),
+      lookbackMonths: z.number().int().min(1).max(240).default(18),
+    }).default({ enabled: true, minDays: 2, minItems: 10, minDistanceKm: 50, lookbackMonths: 18 }),
+    people: z.object({
+      enabled: z.boolean().default(true),
+      favoritesOnly: z.boolean().default(true),
+      minItems: z.number().int().min(3).max(50).default(8),
+    }).default({ enabled: true, favoritesOnly: true, minItems: 8 }),
+    themes: z.object({
+      enabled: z.boolean().default(true),
+      minItems: z.number().int().min(3).max(50).default(8),
+      maxPerPeriod: z.number().int().min(1).max(10).default(3),
+    }).default({ enabled: true, minItems: 8, maxPerPeriod: 3 }),
+    seasonal: z.object({
+      enabled: z.boolean().default(true),
+      minItems: z.number().int().min(5).max(100).default(12),
+    }).default({ enabled: true, minItems: 12 }),
+    yearInReview: z.object({
+      enabled: z.boolean().default(true),
+      minItems: z.number().int().min(5).max(100).default(15),
+    }).default({ enabled: true, minItems: 15 }),
+    digest: z.object({
+      enabled: z.boolean().default(true),
+      frequency: z.enum(['off', 'daily', 'weekly', 'monthly']).default('weekly'),
+      sendHourUtc: z.number().int().min(0).max(23).default(8),
+      imageTokenTtlDays: z.number().int().min(7).max(90).default(30),
+    }).default({ enabled: true, frequency: 'weekly', sendHourUtc: 8, imageTokenTtlDays: 30 }),
+  }).optional().default({
+    generation: { intervalHours: 24 },
+    maxItemsPerMemory: 30,
+    aiTitles: { enabled: true },
+    onThisDay: { enabled: true, lookbackYears: 10, minItems: 3 },
+    trips: { enabled: true, minDays: 2, minItems: 10, minDistanceKm: 50, lookbackMonths: 18 },
+    people: { enabled: true, favoritesOnly: true, minItems: 8 },
+    themes: { enabled: true, minItems: 8, maxPerPeriod: 3 },
+    seasonal: { enabled: true, minItems: 12 },
+    yearInReview: { enabled: true, minItems: 15 },
+    digest: { enabled: true, frequency: 'weekly', sendHourUtc: 8, imageTokenTtlDays: 30 },
+  }),
 });
 
 export type SystemSettingsDto = z.infer<typeof systemSettingsSchema>;
@@ -436,6 +508,10 @@ export const systemSettingsPatchSchema = z.object({
         model: z.string().nullable().optional(),
       }).optional(),
       enhance: z.object({
+        provider: z.string(),
+        model: z.string(),
+      }).nullable().optional(),
+      memories: z.object({
         provider: z.string(),
         model: z.string(),
       }).nullable().optional(),
@@ -554,5 +630,51 @@ export const systemSettingsPatchSchema = z.object({
       scheduled: z.boolean().optional(),
     }).optional(),
     scheduleMinIntervalMinutes: z.number().int().min(60).max(10080).optional(),
+  }).optional(),
+  // Memories (epic #300, issue #302) — all-optional twin of the namespace above.
+  memories: z.object({
+    generation: z.object({
+      intervalHours: z.number().int().min(1).max(168).optional(),
+    }).optional(),
+    maxItemsPerMemory: z.number().int().min(5).max(100).optional(),
+    aiTitles: z.object({
+      enabled: z.boolean().optional(),
+    }).optional(),
+    onThisDay: z.object({
+      enabled: z.boolean().optional(),
+      lookbackYears: z.number().int().min(1).max(50).optional(),
+      minItems: z.number().int().min(1).max(20).optional(),
+    }).optional(),
+    trips: z.object({
+      enabled: z.boolean().optional(),
+      minDays: z.number().int().min(1).max(14).optional(),
+      minItems: z.number().int().min(3).max(100).optional(),
+      minDistanceKm: z.number().int().min(5).max(500).optional(),
+      lookbackMonths: z.number().int().min(1).max(240).optional(),
+    }).optional(),
+    people: z.object({
+      enabled: z.boolean().optional(),
+      favoritesOnly: z.boolean().optional(),
+      minItems: z.number().int().min(3).max(50).optional(),
+    }).optional(),
+    themes: z.object({
+      enabled: z.boolean().optional(),
+      minItems: z.number().int().min(3).max(50).optional(),
+      maxPerPeriod: z.number().int().min(1).max(10).optional(),
+    }).optional(),
+    seasonal: z.object({
+      enabled: z.boolean().optional(),
+      minItems: z.number().int().min(5).max(100).optional(),
+    }).optional(),
+    yearInReview: z.object({
+      enabled: z.boolean().optional(),
+      minItems: z.number().int().min(5).max(100).optional(),
+    }).optional(),
+    digest: z.object({
+      enabled: z.boolean().optional(),
+      frequency: z.enum(['off', 'daily', 'weekly', 'monthly']).optional(),
+      sendHourUtc: z.number().int().min(0).max(23).optional(),
+      imageTokenTtlDays: z.number().int().min(7).max(90).optional(),
+    }).optional(),
   }).optional(),
 });

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -88,6 +88,9 @@ export interface SystemSettingsValue {
    *   - locationInference: interpolate/extrapolate missing GPS coords from timeline anchors
    *   - socialMediaDetection: social-media video detection (OCR-based)
    *   - faceAutoArchive: auto-archive faces matching a previously-archived face
+   *   - pictureEnhancement: AI picture enhancer
+   *   - workflows: media workflow automation
+   *   - memories: curated memory collections (On This Day, Trips, People, …)
    */
   features: {
     [key: string]: boolean;
@@ -108,6 +111,15 @@ export interface SystemSettingsValue {
       };
       /** Active provider+model for AI picture enhancement; null when unset. */
       enhance?: {
+        provider: string;
+        model: string;
+      } | null;
+      /**
+       * Active chat-capable provider+model for Memories title/subtitle/narrative
+       * generation (epic #300); null when unset, in which case memory titles fall
+       * back to deterministic templates. Consumed by MemoryTitleService (#306).
+       */
+      memories?: {
         provider: string;
         model: string;
       } | null;
@@ -298,6 +310,43 @@ export interface SystemSettingsValue {
     /** Minimum cron interval enforced for scheduled workflows (Phase 4). */
     scheduleMinIntervalMinutes: number;
   };
+  /**
+   * Memories (epic #300). The full namespace ships with the generation job
+   * skeleton (issue #302) so later issues read it through getSettings() with no
+   * further schema change. Issue #302 actively reads only
+   * `generation.intervalHours` (plus the `features.memories` flag).
+   */
+  memories?: MemoriesSettingsValue;
+}
+
+/** The `memories.*` system-settings namespace (epic #300, issue #302). */
+export interface MemoriesSettingsValue {
+  generation: {
+    /** Hours between scheduled per-circle `memory_generation` jobs. */
+    intervalHours: number;
+  };
+  /** Hard cap on `MemoryItem` rows a curator may attach to one memory. */
+  maxItemsPerMemory: number;
+  /** Master switch for AI-written titles; templates are used when off (#306). */
+  aiTitles: { enabled: boolean };
+  onThisDay: { enabled: boolean; lookbackYears: number; minItems: number };
+  trips: {
+    enabled: boolean;
+    minDays: number;
+    minItems: number;
+    minDistanceKm: number;
+    lookbackMonths: number;
+  };
+  people: { enabled: boolean; favoritesOnly: boolean; minItems: number };
+  themes: { enabled: boolean; minItems: number; maxPerPeriod: number };
+  seasonal: { enabled: boolean; minItems: number };
+  yearInReview: { enabled: boolean; minItems: number };
+  digest: {
+    enabled: boolean;
+    frequency: 'off' | 'daily' | 'weekly' | 'monthly';
+    sendHourUtc: number;
+    imageTokenTtlDays: number;
+  };
 }
 
 /**
@@ -330,6 +379,25 @@ export function isPictureEnhancementEnabled(settings: {
   return (
     settings.features?.[FEATURE_KEYS.PICTURE_ENHANCEMENT] === true &&
     process.env['PICTURE_ENHANCEMENT_ENABLED'] !== 'false'
+  );
+}
+
+/**
+ * Resolve whether the Memories feature is active: the `features.memories`
+ * system-setting toggle must be on AND the `MEMORIES_ENABLED` env kill-switch
+ * must not be explicitly set to 'false'.
+ *
+ * Single source of truth shared by the generation cron, the generation handler,
+ * and every later Memories surface in epic #300, so no caller can drift from
+ * the others on what "enabled" means. Mirrors isWorkflowsEnabled /
+ * isPictureEnhancementEnabled above.
+ */
+export function isMemoriesEnabled(settings: {
+  features?: Record<string, boolean>;
+}): boolean {
+  return (
+    settings.features?.[FEATURE_KEYS.MEMORIES] === true &&
+    process.env['MEMORIES_ENABLED'] !== 'false'
   );
 }
 
@@ -392,6 +460,7 @@ export const FEATURE_KEYS = {
   FACE_AUTO_ARCHIVE: 'faceAutoArchive',
   PICTURE_ENHANCEMENT: 'pictureEnhancement',
   WORKFLOWS: 'workflows',
+  MEMORIES: 'memories',
 } as const;
 
 /**
@@ -424,6 +493,7 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
     [FEATURE_KEYS.FACE_AUTO_ARCHIVE]: false,
     [FEATURE_KEYS.PICTURE_ENHANCEMENT]: false,
     [FEATURE_KEYS.WORKFLOWS]: false,
+    [FEATURE_KEYS.MEMORIES]: false,
   },
   ai: {
     features: {
@@ -431,6 +501,7 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
       tagging: { provider: null, model: null },
       embedding: { provider: null, model: null },
       enhance: null,
+      memories: null,
     },
   },
   face: {
@@ -526,5 +597,17 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
       scheduled: true,
     },
     scheduleMinIntervalMinutes: 60,
+  },
+  memories: {
+    generation: { intervalHours: 24 },
+    maxItemsPerMemory: 30,
+    aiTitles: { enabled: true },
+    onThisDay: { enabled: true, lookbackYears: 10, minItems: 3 },
+    trips: { enabled: true, minDays: 2, minItems: 10, minDistanceKm: 50, lookbackMonths: 18 },
+    people: { enabled: true, favoritesOnly: true, minItems: 8 },
+    themes: { enabled: true, minItems: 8, maxPerPeriod: 3 },
+    seasonal: { enabled: true, minItems: 12 },
+    yearInReview: { enabled: true, minItems: 15 },
+    digest: { enabled: true, frequency: 'weekly', sendHourUtc: 8, imageTokenTtlDays: 30 },
   },
 };

--- a/apps/api/src/enrichment/job-type-labels.ts
+++ b/apps/api/src/enrichment/job-type-labels.ts
@@ -50,6 +50,11 @@ export const JOB_TYPE_LABELS: Record<string, string> = {
   workflow_evaluate_item: 'Workflow evaluate (item)',
   workflow_execute_batch: 'Workflow execute batch',
   workflow_history_purge: 'Workflow history purge',
+  // Memories (epic #300). `memory_digest` has no handler yet — its label is
+  // declared here with `memory_generation` so #311 does not have to touch this
+  // file again; an unlabeled type would only render title-cased anyway.
+  memory_generation: 'Memory generation',
+  memory_digest: 'Memory email digest',
 };
 
 /**

--- a/apps/api/src/enrichment/server-only-types.spec.ts
+++ b/apps/api/src/enrichment/server-only-types.spec.ts
@@ -49,6 +49,7 @@ import { WorkflowEvaluateItemHandler } from '../workflows/runs/workflow-evaluate
 import { WorkflowEvaluateHandler } from '../workflows/runs/workflow-evaluate.handler';
 import { WorkflowExecuteBatchHandler } from '../workflows/runs/workflow-execute-batch.handler';
 import { WorkflowHistoryPurgeHandler } from '../workflows/runs/workflow-history-purge.handler';
+import { MemoryGenerationHandler } from '../memories/memory-generation.handler';
 
 /** Every registered enrichment handler class (keep in sync with the modules). */
 const ALL_HANDLER_CLASSES = [
@@ -82,6 +83,7 @@ const ALL_HANDLER_CLASSES = [
   WorkflowEvaluateHandler,
   WorkflowExecuteBatchHandler,
   WorkflowHistoryPurgeHandler,
+  MemoryGenerationHandler,
 ];
 
 /**
@@ -97,6 +99,7 @@ const DOCUMENTED_SERVER_ONLY_TYPES = [
   'location_inference',
   'location_suggestion_run_evaluate',
   'location_suggestion_run_execute_batch',
+  'memory_generation',
   'notification_purge',
   'review_run_evaluate',
   'review_run_execute_batch',
@@ -254,6 +257,22 @@ describe('server-only type derivation (drift guard)', () => {
     it('duplicate_confidence_backfill is server-only and system-mode eligible', () => {
       expect(registry.serverOnlyTypes()).toContain('duplicate_confidence_backfill');
       expect(systemModeEligibleTypes(registry, {})).toContain('duplicate_confidence_backfill');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Memories (epic #300, issue #302): memory_generation omits the node-result
+  // pair by design — curation is a whole-circle DB read/write pass with no
+  // per-item unit of work to hand a node, and (from #306) needs a server-held
+  // AI credential. It therefore falls out of serverOnlyTypes() naturally, with
+  // no explicit pinning needed (unlike thumbnail_repair /
+  // workflow_execute_batch above), the same inference as the
+  // location_inference sweep and face_auto_archive_sweep.
+  // -------------------------------------------------------------------------
+  describe('memory_generation (issue #302)', () => {
+    it('memory_generation is server-only and system-mode eligible', () => {
+      expect(registry.serverOnlyTypes()).toContain('memory_generation');
+      expect(systemModeEligibleTypes(registry, {})).toContain('memory_generation');
     });
   });
 });

--- a/apps/api/src/memories/memories-generation.task.spec.ts
+++ b/apps/api/src/memories/memories-generation.task.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for MemoriesGenerationTask (epic #300, issue #302).
+ *
+ * Covers the three gates in order — MEMORIES_ENABLED env kill-switch,
+ * features.memories, and the per-circle (in-flight + interval) gate — plus the
+ * `skipDedup: true` contract that keeps one job per circle rather than one job
+ * for the whole deployment.
+ *
+ * No database required: PrismaService, EnrichmentJobService and
+ * SystemSettingsService are fully mocked (same shape as
+ * InsightsRefreshTask's spec).
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobReason, JobStatus } from '@prisma/client';
+import {
+  MEMORY_GENERATION_JOB_TYPE,
+  MemoriesGenerationTask,
+} from './memories-generation.task';
+import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal resolved-settings stand-in with the two fields the task reads. */
+function settingsWith(options: {
+  enabled: boolean;
+  intervalHours?: number;
+}): any {
+  return {
+    features: { memories: options.enabled },
+    memories:
+      options.intervalHours === undefined
+        ? undefined
+        : { generation: { intervalHours: options.intervalHours } },
+  };
+}
+
+function hoursAgo(h: number): Date {
+  return new Date(Date.now() - h * 3_600_000);
+}
+
+describe('MemoriesGenerationTask', () => {
+  let task: MemoriesGenerationTask;
+  let prisma: {
+    circle: { findMany: jest.Mock };
+    enrichmentJob: { findMany: jest.Mock; groupBy: jest.Mock };
+  };
+  let enrichment: { enqueue: jest.Mock };
+  let settings: { getSettings: jest.Mock };
+
+  const originalEnv = process.env['MEMORIES_ENABLED'];
+
+  beforeEach(async () => {
+    prisma = {
+      circle: { findMany: jest.fn().mockResolvedValue([]) },
+      enrichmentJob: {
+        findMany: jest.fn().mockResolvedValue([]),
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+    };
+    enrichment = { enqueue: jest.fn().mockResolvedValue({ id: 'job-1' }) };
+    settings = {
+      getSettings: jest.fn().mockResolvedValue(settingsWith({ enabled: true })),
+    };
+
+    delete process.env['MEMORIES_ENABLED'];
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemoriesGenerationTask,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EnrichmentJobService, useValue: enrichment },
+        { provide: SystemSettingsService, useValue: settings },
+      ],
+    }).compile();
+
+    task = module.get(MemoriesGenerationTask);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['MEMORIES_ENABLED'];
+    else process.env['MEMORIES_ENABLED'] = originalEnv;
+  });
+
+  // -------------------------------------------------------------------------
+  // Gating — the "zero background cost when off" contract
+  // -------------------------------------------------------------------------
+
+  describe('gating', () => {
+    it('enqueues nothing and reads NOTHING when MEMORIES_ENABLED=false', async () => {
+      process.env['MEMORIES_ENABLED'] = 'false';
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+
+      await task.handleScheduledGeneration();
+
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+      // The env kill-switch short-circuits before even the cached settings read.
+      expect(settings.getSettings).not.toHaveBeenCalled();
+      expect(prisma.circle.findMany).not.toHaveBeenCalled();
+    });
+
+    it('enqueues nothing and never pages circles when features.memories is off (the default)', async () => {
+      settings.getSettings.mockResolvedValue(settingsWith({ enabled: false }));
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+
+      await task.handleScheduledGeneration();
+
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+      // One cached settings read is the entire cost of a disabled tick.
+      expect(settings.getSettings).toHaveBeenCalledTimes(1);
+      expect(prisma.circle.findMany).not.toHaveBeenCalled();
+    });
+
+    it('treats an absent features.memories key as off', async () => {
+      settings.getSettings.mockResolvedValue({ features: {} } as any);
+
+      const result = await task.sweep();
+
+      expect(result.enqueued).toBe(0);
+      expect(prisma.circle.findMany).not.toHaveBeenCalled();
+    });
+
+    it('MEMORIES_ENABLED=false overrides features.memories=true', async () => {
+      process.env['MEMORIES_ENABLED'] = 'false';
+      settings.getSettings.mockResolvedValue(settingsWith({ enabled: true }));
+
+      // sweep() re-checks via isMemoriesEnabled, so even the direct call is safe.
+      const result = await task.sweep();
+
+      expect(result.enqueued).toBe(0);
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-circle enqueue
+  // -------------------------------------------------------------------------
+
+  describe('per-circle enqueue', () => {
+    it('enqueues ONE job per circle, each with skipDedup: true', async () => {
+      prisma.circle.findMany.mockResolvedValue([
+        { id: 'circle-a' },
+        { id: 'circle-b' },
+      ]);
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ circles: 2, enqueued: 2, skipped: 0, errors: 0 });
+      expect(enrichment.enqueue).toHaveBeenCalledTimes(2);
+      for (const circleId of ['circle-a', 'circle-b']) {
+        expect(enrichment.enqueue).toHaveBeenCalledWith({
+          type: MEMORY_GENERATION_JOB_TYPE,
+          mediaItemId: null,
+          circleId,
+          reason: JobReason.backfill,
+          priority: 100,
+          // Without this, the (type, mediaItemId IS NULL) global dedup would
+          // collapse both circles into a single job.
+          skipDedup: true,
+        });
+      }
+    });
+
+    it('enqueues for a circle that has never generated (no succeeded job)', async () => {
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+      prisma.enrichmentJob.groupBy.mockResolvedValue([]);
+
+      const result = await task.sweep();
+
+      expect(result.enqueued).toBe(1);
+    });
+
+    it('skips a circle whose job is already pending or running', async () => {
+      prisma.circle.findMany.mockResolvedValue([
+        { id: 'circle-a' },
+        { id: 'circle-b' },
+      ]);
+      prisma.enrichmentJob.findMany.mockResolvedValue([{ circleId: 'circle-a' }]);
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ enqueued: 1, skipped: 1 });
+      expect(enrichment.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ circleId: 'circle-b' }),
+      );
+      // The in-flight lookup is scoped to pending+running only.
+      expect(prisma.enrichmentJob.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: { in: [JobStatus.pending, JobStatus.running] },
+          }),
+        }),
+      );
+    });
+
+    it('isolates a per-circle enqueue failure without aborting the sweep', async () => {
+      prisma.circle.findMany.mockResolvedValue([
+        { id: 'circle-a' },
+        { id: 'circle-b' },
+      ]);
+      enrichment.enqueue
+        .mockRejectedValueOnce(new Error('db down'))
+        .mockResolvedValueOnce({ id: 'job-2' });
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ circles: 2, enqueued: 1, errors: 1 });
+    });
+
+    it('never throws out of the cron even when the sweep blows up', async () => {
+      prisma.circle.findMany.mockRejectedValue(new Error('connection reset'));
+
+      await expect(task.handleScheduledGeneration()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Interval gate
+  // -------------------------------------------------------------------------
+
+  describe('interval gate', () => {
+    it('skips a circle whose last success is INSIDE the configured interval', async () => {
+      settings.getSettings.mockResolvedValue(
+        settingsWith({ enabled: true, intervalHours: 24 }),
+      );
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+      prisma.enrichmentJob.groupBy.mockResolvedValue([
+        { circleId: 'circle-a', _max: { finishedAt: hoursAgo(1) } },
+      ]);
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ enqueued: 0, skipped: 1 });
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('enqueues once the last success falls OUTSIDE the interval', async () => {
+      settings.getSettings.mockResolvedValue(
+        settingsWith({ enabled: true, intervalHours: 24 }),
+      );
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+      prisma.enrichmentJob.groupBy.mockResolvedValue([
+        { circleId: 'circle-a', _max: { finishedAt: hoursAgo(25) } },
+      ]);
+
+      const result = await task.sweep();
+
+      expect(result.enqueued).toBe(1);
+    });
+
+    it('honours a shortened intervalHours', async () => {
+      settings.getSettings.mockResolvedValue(
+        settingsWith({ enabled: true, intervalHours: 1 }),
+      );
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+      prisma.enrichmentJob.groupBy.mockResolvedValue([
+        { circleId: 'circle-a', _max: { finishedAt: hoursAgo(2) } },
+      ]);
+
+      // 2h since the last run > the 1h interval → eligible again.
+      expect((await task.sweep()).enqueued).toBe(1);
+    });
+
+    it('falls back to a 24h interval when the setting is absent', async () => {
+      settings.getSettings.mockResolvedValue(settingsWith({ enabled: true }));
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+      prisma.enrichmentJob.groupBy.mockResolvedValue([
+        { circleId: 'circle-a', _max: { finishedAt: hoursAgo(12) } },
+      ]);
+
+      expect((await task.sweep()).enqueued).toBe(0);
+    });
+
+    it('only counts SUCCEEDED jobs toward the interval gate', async () => {
+      prisma.circle.findMany.mockResolvedValue([{ id: 'circle-a' }]);
+
+      await task.sweep();
+
+      expect(prisma.enrichmentJob.groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: JobStatus.succeeded }),
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Circle paging
+  // -------------------------------------------------------------------------
+
+  describe('circle paging', () => {
+    it('keyset-pages circles 100 at a time until a short page', async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => ({
+        id: `circle-${String(i).padStart(3, '0')}`,
+      }));
+      const page2 = [{ id: 'circle-100' }];
+      prisma.circle.findMany
+        .mockResolvedValueOnce(page1)
+        .mockResolvedValueOnce(page2);
+
+      const result = await task.sweep();
+
+      expect(result.circles).toBe(101);
+      expect(result.enqueued).toBe(101);
+      expect(prisma.circle.findMany).toHaveBeenCalledTimes(2);
+      // Second page continues after the last id of the first, skipping it.
+      expect(prisma.circle.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          take: 100,
+          cursor: { id: 'circle-099' },
+          skip: 1,
+        }),
+      );
+    });
+
+    it('stops immediately when there are no circles at all (fresh install)', async () => {
+      prisma.circle.findMany.mockResolvedValue([]);
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ circles: 0, enqueued: 0 });
+      expect(prisma.circle.findMany).toHaveBeenCalledTimes(1);
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('batches the two job lookups per page, not per circle', async () => {
+      prisma.circle.findMany.mockResolvedValue([
+        { id: 'circle-a' },
+        { id: 'circle-b' },
+        { id: 'circle-c' },
+      ]);
+
+      await task.sweep();
+
+      expect(prisma.enrichmentJob.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.enrichmentJob.groupBy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/memories/memories-generation.task.ts
+++ b/apps/api/src/memories/memories-generation.task.ts
@@ -1,0 +1,213 @@
+// =============================================================================
+// Memories Generation Scheduled Task (epic #300, issue #302)
+// =============================================================================
+//
+// Hourly, interval-gated cron that enqueues ONE `memory_generation` enrichment
+// job per circle whose last successful generation is older than
+// `memories.generation.intervalHours`. Mirrors InsightsRefreshTask's
+// interval-gate shape (hourly tick, configurable interval, skip while a job is
+// already pending/running) and TrashPurgeTask/ThumbnailRepairTask's cron
+// contract (env kill-switch, try/catch that never throws).
+//
+// ZERO COST WHEN OFF. With `features.memories` absent/false — the default — the
+// tick costs exactly one CACHED settings read and returns: no circle paging, no
+// job rows, nothing for the worker to claim. `MEMORIES_ENABLED=false` short-
+// circuits even that.
+//
+// WHY `skipDedup: true` IS MANDATORY. EnrichmentJobService's default dedup finds
+// an existing pending/running job with the same `(type, mediaItemId)` — and for
+// a global job `mediaItemId` is NULL for every circle, so the FIRST circle's job
+// would swallow the enqueue for all the others, system-wide. The per-circle
+// pending/running check below is this task's own, correctly-scoped replacement
+// for that dedup. Precedent: `face_auto_archive_sweep` (FaceBackfillService).
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { JobReason, JobStatus } from '@prisma/client';
+import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { isMemoriesEnabled } from '../common/types/settings.types';
+
+/** The enrichment job type this task schedules. */
+export const MEMORY_GENERATION_JOB_TYPE = 'memory_generation';
+
+/** Circles fetched per keyset page — the sweep never loads them all at once. */
+const CIRCLE_PAGE_SIZE = 100;
+
+/** Background priority: never starve upload enrichment (rerun=0, upload=10). */
+const MEMORY_GENERATION_PRIORITY = 100;
+
+/** Fallback when `memories.generation.intervalHours` is absent (pre-#302 rows). */
+const DEFAULT_INTERVAL_HOURS = 24;
+
+/** Outcome tally for one sweep — logged, and returned for tests. */
+export interface MemoriesGenerationSweepResult {
+  circles: number;
+  enqueued: number;
+  skipped: number;
+  errors: number;
+}
+
+@Injectable()
+export class MemoriesGenerationTask {
+  private readonly logger = new Logger(MemoriesGenerationTask.name);
+
+  /**
+   * In-process overlap guard. A sweep over a large deployment can outlive its
+   * hourly slot and two concurrent sweeps would do identical work twice.
+   * Single-process only, and sufficient: the per-circle pending/running check
+   * makes a duplicated sweep idempotent, so the worst case across replicas is
+   * wasted effort, never a duplicated job row for the same circle.
+   */
+  private sweepInFlight = false;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly enrichmentJobService: EnrichmentJobService,
+    private readonly systemSettings: SystemSettingsService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async handleScheduledGeneration(): Promise<void> {
+    // Gate 1 — env kill-switch. Checked before anything else so a CI/test
+    // deployment pays not even a cached settings read.
+    if (process.env['MEMORIES_ENABLED'] === 'false') {
+      return;
+    }
+
+    if (this.sweepInFlight) {
+      this.logger.debug('Memories generation sweep already in flight; skipping tick');
+      return;
+    }
+    this.sweepInFlight = true;
+
+    try {
+      const result = await this.sweep();
+      if (result.enqueued > 0 || result.errors > 0) {
+        this.logger.log(
+          `Memories generation: ${result.enqueued} job(s) enqueued across ` +
+            `${result.circles} circle(s), ${result.skipped} skipped` +
+            (result.errors > 0 ? `, ${result.errors} circle(s) failed` : ''),
+        );
+      }
+    } catch (err) {
+      this.logger.error('Memories generation schedule check failed', err as Error);
+    } finally {
+      this.sweepInFlight = false;
+    }
+  }
+
+  /**
+   * Enqueue a `memory_generation` job for every eligible circle.
+   *
+   * Exposed (rather than inlined into the cron body) so the admin backfill in
+   * #315 and this task's tests can drive the same code path.
+   */
+  async sweep(): Promise<MemoriesGenerationSweepResult> {
+    const result: MemoriesGenerationSweepResult = {
+      circles: 0,
+      enqueued: 0,
+      skipped: 0,
+      errors: 0,
+    };
+
+    // Gate 2 — feature flag, read ONCE for the whole sweep through the cached
+    // getSettings(), so a 500-circle deployment costs one settings read.
+    const settings = await this.systemSettings.getSettings();
+    if (!isMemoriesEnabled(settings)) {
+      return result;
+    }
+
+    const intervalHours =
+      settings.memories?.generation?.intervalHours ?? DEFAULT_INTERVAL_HOURS;
+    const cutoff = new Date(Date.now() - intervalHours * 3_600_000);
+
+    let cursor: string | undefined;
+    for (;;) {
+      const circles = await this.prisma.circle.findMany({
+        select: { id: true },
+        orderBy: { id: 'asc' },
+        take: CIRCLE_PAGE_SIZE,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      });
+      if (circles.length === 0) break;
+
+      const circleIds = circles.map((c) => c.id);
+
+      // Two batched reads per page instead of two per circle.
+      const [inFlight, lastSucceeded] = await Promise.all([
+        this.prisma.enrichmentJob.findMany({
+          where: {
+            type: MEMORY_GENERATION_JOB_TYPE,
+            circleId: { in: circleIds },
+            status: { in: [JobStatus.pending, JobStatus.running] },
+          },
+          select: { circleId: true },
+        }),
+        this.prisma.enrichmentJob.groupBy({
+          by: ['circleId'],
+          where: {
+            type: MEMORY_GENERATION_JOB_TYPE,
+            circleId: { in: circleIds },
+            status: JobStatus.succeeded,
+          },
+          _max: { finishedAt: true },
+        }),
+      ]);
+
+      const busy = new Set(inFlight.map((j) => j.circleId).filter((id): id is string => !!id));
+      const lastSuccessAt = new Map<string, Date | null>();
+      for (const row of lastSucceeded) {
+        if (row.circleId) lastSuccessAt.set(row.circleId, row._max.finishedAt);
+      }
+
+      for (const circleId of circleIds) {
+        result.circles += 1;
+
+        // Gate 3a — a job for this circle is already queued or running.
+        if (busy.has(circleId)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        // Gate 3b — interval gate. A circle that has never generated (no
+        // succeeded row) has no `last` and is always eligible.
+        const last = lastSuccessAt.get(circleId);
+        if (last && last > cutoff) {
+          result.skipped += 1;
+          continue;
+        }
+
+        // A per-circle failure is logged and counted, never fatal — one bad
+        // circle must not stop the rest of the deployment from generating.
+        try {
+          await this.enrichmentJobService.enqueue({
+            type: MEMORY_GENERATION_JOB_TYPE,
+            mediaItemId: null,
+            circleId,
+            reason: JobReason.backfill,
+            priority: MEMORY_GENERATION_PRIORITY,
+            // MANDATORY — see the header. Without it, one circle's job would
+            // suppress every other circle's, since global-job dedup keys on
+            // (type, mediaItemId IS NULL) system-wide.
+            skipDedup: true,
+          });
+          result.enqueued += 1;
+        } catch (err) {
+          result.errors += 1;
+          this.logger.warn(
+            `memory_generation enqueue failed for circle ${circleId}: ` +
+              (err instanceof Error ? err.message : String(err)),
+          );
+        }
+      }
+
+      if (circles.length < CIRCLE_PAGE_SIZE) break;
+      cursor = circleIds[circleIds.length - 1]!;
+    }
+
+    return result;
+  }
+}

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -1,0 +1,27 @@
+// =============================================================================
+// Memories Module (epic #300, issue #302)
+// =============================================================================
+//
+// Owns the Memories generation plumbing: the hourly per-circle scheduling cron
+// and the (v1 no-op) `memory_generation` enrichment handler. Later issues in the
+// epic add curators (#303–#305), AI titles (#306), the read API (#307) and the
+// email digest (#311) here.
+//
+// Minimal-template module (mirrors InsightsModule): PrismaModule for DB access,
+// SettingsModule for the cached feature-flag/settings reads, EnrichmentModule
+// for the job service and the handler registry.
+// =============================================================================
+
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SettingsModule } from '../settings/settings.module';
+import { EnrichmentModule } from '../enrichment/enrichment.module';
+import { MemoriesGenerationTask } from './memories-generation.task';
+import { MemoryGenerationHandler } from './memory-generation.handler';
+
+@Module({
+  imports: [PrismaModule, SettingsModule, EnrichmentModule],
+  providers: [MemoriesGenerationTask, MemoryGenerationHandler],
+  exports: [MemoriesGenerationTask],
+})
+export class MemoriesModule {}

--- a/apps/api/src/memories/memory-generation.handler.spec.ts
+++ b/apps/api/src/memories/memory-generation.handler.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for MemoryGenerationHandler (epic #300, issue #302).
+ *
+ * The v1 handler is a deliberate no-op, so what is actually worth asserting is
+ * its CONTRACT with the queue: it self-registers under the right type, it is
+ * server-only (no node-result pair), and a job that reaches the worker while
+ * the feature is disabled SUCCEEDS as a no-op rather than throwing — throwing
+ * would burn retry attempts and light up the admin job dashboard for a
+ * deliberately-off feature.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { EnrichmentJob } from '@prisma/client';
+import { MemoryGenerationHandler } from './memory-generation.handler';
+import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
+import { EnrichmentHandler } from '../enrichment/enrichment-handler.interface';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+
+function makeJob(overrides: Partial<EnrichmentJob> = {}): EnrichmentJob {
+  return {
+    id: 'job-1',
+    type: 'memory_generation',
+    mediaItemId: null,
+    circleId: 'circle-a',
+    ...overrides,
+  } as EnrichmentJob;
+}
+
+describe('MemoryGenerationHandler', () => {
+  let handler: MemoryGenerationHandler;
+  let registry: EnrichmentHandlerRegistry;
+  let settings: { getSettings: jest.Mock };
+
+  const originalEnv = process.env['MEMORIES_ENABLED'];
+
+  beforeEach(async () => {
+    settings = {
+      getSettings: jest.fn().mockResolvedValue({ features: { memories: true } }),
+    };
+    delete process.env['MEMORIES_ENABLED'];
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemoryGenerationHandler,
+        EnrichmentHandlerRegistry,
+        { provide: SystemSettingsService, useValue: settings },
+      ],
+    }).compile();
+
+    handler = module.get(MemoryGenerationHandler);
+    registry = module.get(EnrichmentHandlerRegistry);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['MEMORIES_ENABLED'];
+    else process.env['MEMORIES_ENABLED'] = originalEnv;
+  });
+
+  it('self-registers under type "memory_generation" on module init', () => {
+    handler.onModuleInit();
+
+    expect(handler.type).toBe('memory_generation');
+    expect(registry.get('memory_generation')).toBe(handler);
+  });
+
+  it('is SERVER-ONLY: carries no node-result pair', () => {
+    handler.onModuleInit();
+
+    // Viewed through the interface, since the class deliberately declares
+    // neither optional member at all.
+    const asHandler: EnrichmentHandler = handler;
+    expect(asHandler.nodeResultSchema).toBeUndefined();
+    expect(asHandler.persistNodeResult).toBeUndefined();
+    expect(registry.serverOnlyTypes()).toContain('memory_generation');
+  });
+
+  it('succeeds as a no-op when the feature is enabled (no curators yet)', async () => {
+    await expect(handler.process(makeJob())).resolves.toBeUndefined();
+  });
+
+  it('succeeds as a no-op when features.memories is off', async () => {
+    settings.getSettings.mockResolvedValue({ features: { memories: false } });
+
+    await expect(handler.process(makeJob())).resolves.toBeUndefined();
+  });
+
+  it('succeeds as a no-op when MEMORIES_ENABLED=false overrides an enabled flag', async () => {
+    process.env['MEMORIES_ENABLED'] = 'false';
+
+    await expect(handler.process(makeJob())).resolves.toBeUndefined();
+    expect(settings.getSettings).toHaveBeenCalled();
+  });
+
+  it('does not throw on a circle-less job — every memory is circle-scoped', async () => {
+    await expect(handler.process(makeJob({ circleId: null }))).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/memories/memory-generation.handler.ts
+++ b/apps/api/src/memories/memory-generation.handler.ts
@@ -1,0 +1,76 @@
+// =============================================================================
+// Memory Generation Enrichment Handler (epic #300, issue #302)
+// =============================================================================
+//
+// Runs one circle's memory curation pass. Enqueued once per circle by
+// MemoriesGenerationTask (see memories-generation.task.ts).
+//
+// SERVER-ONLY by design: no `nodeResultSchema` / `persistNodeResult` pair, so
+// EnrichmentHandlerRegistry.serverOnlyTypes() picks it up automatically and it
+// becomes eligible for the ENRICHMENT_WORKER_MODE=system claim set with no
+// explicit pinning — the same no-node-pair inference that covers
+// `face_auto_archive_sweep` and the `location_inference` sweep. Curation is a
+// pure DB read + write pass over a whole circle with no per-item unit of work
+// to hand a node, and (from #306) needs a server-held AI credential.
+//
+// v1 SCOPE (this issue): the handler is a deliberate NO-OP. Shipping the
+// scheduling, dedup, gating and observability plumbing before any curation
+// logic exists is what lets #303–#305 add curators to a queue path that is
+// already proven end to end. Curators arrive in #303 (On This Day),
+// #304 (Trips) and #305 (People / Theme / Seasonal / Year in Review).
+// =============================================================================
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { EnrichmentJob } from '@prisma/client';
+import { EnrichmentHandler } from '../enrichment/enrichment-handler.interface';
+import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { isMemoriesEnabled } from '../common/types/settings.types';
+
+@Injectable()
+export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit {
+  readonly type = 'memory_generation';
+
+  private readonly logger = new Logger(MemoryGenerationHandler.name);
+
+  constructor(
+    private readonly registry: EnrichmentHandlerRegistry,
+    private readonly systemSettings: SystemSettingsService,
+  ) {}
+
+  onModuleInit(): void {
+    this.registry.register(this);
+  }
+
+  async process(job: EnrichmentJob): Promise<void> {
+    // Re-check the gate here as well as in the cron. A job can sit pending
+    // across a settings change, be retried by hand from /admin/settings/jobs,
+    // or be enqueued by the future admin backfill (#315) — none of which go
+    // through the cron's gate. Succeeding as a no-op (rather than throwing) is
+    // deliberate: a disabled feature is not a failure, and failing would burn
+    // retry attempts and light up the job dashboard for no reason.
+    const settings = await this.systemSettings.getSettings();
+    if (!isMemoriesEnabled(settings)) {
+      this.logger.debug(
+        `Memories disabled; memory_generation job ${job.id} is a no-op`,
+      );
+      return;
+    }
+
+    if (!job.circleId) {
+      // Every memory is circle-scoped, so a circle-less job has nothing to
+      // curate. Not an error — just nothing to do.
+      this.logger.warn(
+        `memory_generation job ${job.id} has no circleId; nothing to generate`,
+      );
+      return;
+    }
+
+    // v1: no curators registered yet (#303–#305). The log line is the
+    // observability hook that proves the scheduling path works end to end.
+    this.logger.log(
+      `memory_generation ran for circle ${job.circleId} (job ${job.id}): ` +
+        'no curators registered yet',
+    );
+  }
+}

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -72,6 +72,13 @@ export const patchSystemSettingsSchema = z.object({
             })
             .nullable()
             .optional(),
+          memories: z
+            .object({
+              provider: z.string(),
+              model: z.string(),
+            })
+            .nullable()
+            .optional(),
         })
         .optional(),
     })
@@ -191,6 +198,77 @@ export const patchSystemSettingsSchema = z.object({
       blockReplaceOnDownscale: z.boolean().optional(),
       maxInputMegapixels: z.number().min(1).max(100).optional(),
       retentionHours: z.number().int().min(1).max(720).optional(),
+    })
+    .optional(),
+  // Memories (epic #300, issue #302). NOTE: this is the THIRD hand-maintained
+  // copy of the namespace (systemSettingsSchema + systemSettingsPatchSchema in
+  // common/schemas/settings.schema.ts are the other two). This one is the wire
+  // DTO, so a key missing HERE is silently stripped from the request body
+  // before the service ever sees it — a namespace added only to the other two
+  // would appear to work while every PATCH quietly no-ops.
+  memories: z
+    .object({
+      generation: z
+        .object({
+          intervalHours: z.number().int().min(1).max(168).optional(),
+        })
+        .optional(),
+      maxItemsPerMemory: z.number().int().min(5).max(100).optional(),
+      aiTitles: z
+        .object({
+          enabled: z.boolean().optional(),
+        })
+        .optional(),
+      onThisDay: z
+        .object({
+          enabled: z.boolean().optional(),
+          lookbackYears: z.number().int().min(1).max(50).optional(),
+          minItems: z.number().int().min(1).max(20).optional(),
+        })
+        .optional(),
+      trips: z
+        .object({
+          enabled: z.boolean().optional(),
+          minDays: z.number().int().min(1).max(14).optional(),
+          minItems: z.number().int().min(3).max(100).optional(),
+          minDistanceKm: z.number().int().min(5).max(500).optional(),
+          lookbackMonths: z.number().int().min(1).max(240).optional(),
+        })
+        .optional(),
+      people: z
+        .object({
+          enabled: z.boolean().optional(),
+          favoritesOnly: z.boolean().optional(),
+          minItems: z.number().int().min(3).max(50).optional(),
+        })
+        .optional(),
+      themes: z
+        .object({
+          enabled: z.boolean().optional(),
+          minItems: z.number().int().min(3).max(50).optional(),
+          maxPerPeriod: z.number().int().min(1).max(10).optional(),
+        })
+        .optional(),
+      seasonal: z
+        .object({
+          enabled: z.boolean().optional(),
+          minItems: z.number().int().min(5).max(100).optional(),
+        })
+        .optional(),
+      yearInReview: z
+        .object({
+          enabled: z.boolean().optional(),
+          minItems: z.number().int().min(5).max(100).optional(),
+        })
+        .optional(),
+      digest: z
+        .object({
+          enabled: z.boolean().optional(),
+          frequency: z.enum(['off', 'daily', 'weekly', 'monthly']).optional(),
+          sendHourUtc: z.number().int().min(0).max(23).optional(),
+          imageTokenTtlDays: z.number().int().min(7).max(90).optional(),
+        })
+        .optional(),
     })
     .optional(),
 }).default({});

--- a/apps/api/src/settings/system-settings/system-settings.service.spec.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.spec.ts
@@ -121,12 +121,15 @@ describe('SystemSettingsService', () => {
       // fixture must mirror ALL of those defaults (face, storage, burst,
       // dedup, geo, jobs, pictureEnhancement, workflows) or the
       // toHaveBeenCalledWith assertion below drifts out of sync every time a
-      // new default branch is added to the schema. `ai.features.enhance` is
-      // also filled with its default (null) even though `ai.features` itself
-      // was supplied, since the DTO's `ai.features` omits the `enhance` key.
+      // new default branch is added to the schema. `ai.features.enhance` and
+      // `ai.features.memories` are also filled with their defaults (null) even
+      // though `ai.features` itself was supplied, since the DTO's `ai.features`
+      // omits both keys.
       const expectedParsed = {
         ...newSettings,
-        ai: { features: { ...newSettings.ai.features, enhance: null } },
+        ai: {
+          features: { ...newSettings.ai.features, enhance: null, memories: null },
+        },
         face: DEFAULT_SYSTEM_SETTINGS.face,
         storage: DEFAULT_SYSTEM_SETTINGS.storage,
         burst: DEFAULT_SYSTEM_SETTINGS.burst,
@@ -141,6 +144,7 @@ describe('SystemSettingsService', () => {
         backup: DEFAULT_SYSTEM_SETTINGS.backup,
         reviewRuns: DEFAULT_SYSTEM_SETTINGS.reviewRuns,
         notifications: DEFAULT_SYSTEM_SETTINGS.notifications,
+        memories: DEFAULT_SYSTEM_SETTINGS.memories,
       };
 
       mockPrisma.systemSettings.upsert.mockResolvedValue({
@@ -230,7 +234,9 @@ describe('SystemSettingsService', () => {
       // the "should replace entire settings" test above re: ai.features.enhance.
       const expectedValidated = {
         ...newSettings,
-        ai: { features: { ...newSettings.ai.features, enhance: null } },
+        ai: {
+          features: { ...newSettings.ai.features, enhance: null, memories: null },
+        },
         face: DEFAULT_SYSTEM_SETTINGS.face,
         storage: DEFAULT_SYSTEM_SETTINGS.storage,
         burst: DEFAULT_SYSTEM_SETTINGS.burst,
@@ -245,6 +251,7 @@ describe('SystemSettingsService', () => {
         backup: DEFAULT_SYSTEM_SETTINGS.backup,
         reviewRuns: DEFAULT_SYSTEM_SETTINGS.reviewRuns,
         notifications: DEFAULT_SYSTEM_SETTINGS.notifications,
+        memories: DEFAULT_SYSTEM_SETTINGS.memories,
       };
 
       mockPrisma.systemSettings.upsert.mockResolvedValue({

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -40,6 +40,7 @@ export interface ResolvedSettings {
   pictureEnhancement: SystemSettingsValue['pictureEnhancement'];
   backup: SystemSettingsValue['backup'];
   workflows: SystemSettingsValue['workflows'];
+  memories: SystemSettingsValue['memories'];
   updatedAt: Date;
   updatedBy: { id: string; email: string } | null;
   version: number;
@@ -240,6 +241,7 @@ export class SystemSettingsService {
       pictureEnhancement: value.pictureEnhancement,
       backup: value.backup,
       workflows: value.workflows,
+      memories: value.memories,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,
@@ -297,6 +299,11 @@ export class SystemSettingsService {
             (dto as any).ai?.features?.enhance !== undefined
               ? (dto as any).ai?.features?.enhance
               : ((current.ai?.features as any)?.enhance ?? null),
+          // Nullable object, same contract as `enhance` above (epic #300).
+          memories:
+            (dto as any).ai?.features?.memories !== undefined
+              ? (dto as any).ai?.features?.memories
+              : ((current.ai?.features as any)?.memories ?? null),
         },
       },
       face: {
@@ -590,6 +597,127 @@ export class SystemSettingsService {
           (current as any).workflows?.scheduleMinIntervalMinutes ??
           60,
       },
+      // Memories (epic #300, issue #302).
+      memories: {
+        generation: {
+          intervalHours:
+            (dto as any).memories?.generation?.intervalHours ??
+            (current as any).memories?.generation?.intervalHours ??
+            24,
+        },
+        maxItemsPerMemory:
+          (dto as any).memories?.maxItemsPerMemory ??
+          (current as any).memories?.maxItemsPerMemory ??
+          30,
+        aiTitles: {
+          enabled:
+            (dto as any).memories?.aiTitles?.enabled ??
+            (current as any).memories?.aiTitles?.enabled ??
+            true,
+        },
+        onThisDay: {
+          enabled:
+            (dto as any).memories?.onThisDay?.enabled ??
+            (current as any).memories?.onThisDay?.enabled ??
+            true,
+          lookbackYears:
+            (dto as any).memories?.onThisDay?.lookbackYears ??
+            (current as any).memories?.onThisDay?.lookbackYears ??
+            10,
+          minItems:
+            (dto as any).memories?.onThisDay?.minItems ??
+            (current as any).memories?.onThisDay?.minItems ??
+            3,
+        },
+        trips: {
+          enabled:
+            (dto as any).memories?.trips?.enabled ??
+            (current as any).memories?.trips?.enabled ??
+            true,
+          minDays:
+            (dto as any).memories?.trips?.minDays ??
+            (current as any).memories?.trips?.minDays ??
+            2,
+          minItems:
+            (dto as any).memories?.trips?.minItems ??
+            (current as any).memories?.trips?.minItems ??
+            10,
+          minDistanceKm:
+            (dto as any).memories?.trips?.minDistanceKm ??
+            (current as any).memories?.trips?.minDistanceKm ??
+            50,
+          lookbackMonths:
+            (dto as any).memories?.trips?.lookbackMonths ??
+            (current as any).memories?.trips?.lookbackMonths ??
+            18,
+        },
+        people: {
+          enabled:
+            (dto as any).memories?.people?.enabled ??
+            (current as any).memories?.people?.enabled ??
+            true,
+          favoritesOnly:
+            (dto as any).memories?.people?.favoritesOnly ??
+            (current as any).memories?.people?.favoritesOnly ??
+            true,
+          minItems:
+            (dto as any).memories?.people?.minItems ??
+            (current as any).memories?.people?.minItems ??
+            8,
+        },
+        themes: {
+          enabled:
+            (dto as any).memories?.themes?.enabled ??
+            (current as any).memories?.themes?.enabled ??
+            true,
+          minItems:
+            (dto as any).memories?.themes?.minItems ??
+            (current as any).memories?.themes?.minItems ??
+            8,
+          maxPerPeriod:
+            (dto as any).memories?.themes?.maxPerPeriod ??
+            (current as any).memories?.themes?.maxPerPeriod ??
+            3,
+        },
+        seasonal: {
+          enabled:
+            (dto as any).memories?.seasonal?.enabled ??
+            (current as any).memories?.seasonal?.enabled ??
+            true,
+          minItems:
+            (dto as any).memories?.seasonal?.minItems ??
+            (current as any).memories?.seasonal?.minItems ??
+            12,
+        },
+        yearInReview: {
+          enabled:
+            (dto as any).memories?.yearInReview?.enabled ??
+            (current as any).memories?.yearInReview?.enabled ??
+            true,
+          minItems:
+            (dto as any).memories?.yearInReview?.minItems ??
+            (current as any).memories?.yearInReview?.minItems ??
+            15,
+        },
+        digest: {
+          enabled:
+            (dto as any).memories?.digest?.enabled ??
+            (current as any).memories?.digest?.enabled ??
+            true,
+          frequency:
+            (dto as any).memories?.digest?.frequency ??
+            (current as any).memories?.digest?.frequency ??
+            'weekly',
+          sendHourUtc:
+            (dto as any).memories?.digest?.sendHourUtc ??
+            (current as any).memories?.digest?.sendHourUtc ??
+            8,
+          imageTokenTtlDays:
+            (dto as any).memories?.digest?.imageTokenTtlDays ??
+            (current as any).memories?.digest?.imageTokenTtlDays ??
+            30,
+        },
+      },
     };
 
     // Validate merged result
@@ -640,6 +768,7 @@ export class SystemSettingsService {
       pictureEnhancement: value.pictureEnhancement,
       backup: value.backup,
       workflows: value.workflows,
+      memories: value.memories,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -142,6 +142,7 @@ export class SystemSettingsService {
       pictureEnhancement: value.pictureEnhancement,
       backup: value.backup,
       workflows: value.workflows,
+      memories: value.memories,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,

--- a/apps/api/test/memories/memories-generation-scheduling.integration.spec.ts
+++ b/apps/api/test/memories/memories-generation-scheduling.integration.spec.ts
@@ -1,0 +1,281 @@
+// DB_GATED: requires a real PostgreSQL database with migrations applied.
+// Reachability is probed synchronously at module load via `describeMaybeDb`
+// (test/helpers/db-probe.helper.ts), so the suite reports SKIPPED — never
+// PASSED — where no database is available (e.g. CI, see
+// docs/ci-known-failing-tests.md).
+//
+// Purpose (issue #302): drive MemoriesGenerationTask against a REAL database,
+// which is the only way to validate the parts of the scheduler a mocked
+// PrismaService cannot:
+//
+//   1. The `skipDedup: true` contract PRODUCES REAL ROWS: with two circles and
+//      the flag on, exactly ONE pending `memory_generation` row exists per
+//      circle — the thing the (type, mediaItemId IS NULL) global dedup would
+//      otherwise collapse into a single row for the whole deployment.
+//   2. The `enrichmentJob.groupBy({ by: ['circleId'], _max: { finishedAt } })`
+//      interval gate is valid SQL and returns what the task expects, including
+//      for a nullable aggregate column.
+//   3. The three gates end to end against real rows: an in-flight job blocks a
+//      circle; a recent success blocks a circle; an old success does not.
+//   4. THE ZERO-COST CONTRACT: with `features.memories` off (the default) and
+//      with `MEMORIES_ENABLED=false`, a tick writes NO rows at all.
+
+import { PrismaClient, JobStatus } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { randomUUID } from 'crypto';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
+import {
+  MEMORY_GENERATION_JOB_TYPE,
+  MemoriesGenerationTask,
+} from '../../src/memories/memories-generation.task';
+import { EnrichmentJobService } from '../../src/enrichment/enrichment-job.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { SystemSettingsService } from '../../src/settings/system-settings/system-settings.service';
+
+function resolveDatabaseUrl(): string {
+  if (process.env['DATABASE_URL']) return process.env['DATABASE_URL'] as string;
+  const host = process.env['POSTGRES_HOST'] ?? 'localhost';
+  const port = process.env['POSTGRES_PORT'] ?? '5432';
+  const user = process.env['POSTGRES_USER'] ?? 'postgres';
+  const password = process.env['POSTGRES_PASSWORD'] ?? 'postgres';
+  const db = process.env['POSTGRES_DB'] ?? 'appdb';
+  return `postgresql://${user}:${encodeURIComponent(password)}@${host}:${port}/${db}`;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+
+describeMaybeDb(
+  'Memories generation scheduling (DB_GATED: real PostgreSQL)',
+  () => {
+    let prisma: PrismaClient;
+    let task: MemoriesGenerationTask;
+    let settings: { getSettings: jest.Mock };
+
+    const userId = randomUUID();
+    const circleAId = randomUUID();
+    const circleBId = randomUUID();
+
+    const originalEnv = process.env['MEMORIES_ENABLED'];
+
+    /**
+     * Only this suite's two circles exist as far as the assertions are
+     * concerned — a shared database may hold others, so every count is scoped
+     * to these ids.
+     */
+    const ourCircles = { in: [circleAId, circleBId] };
+
+    beforeAll(async () => {
+      const adapter = new PrismaPg({ connectionString: DATABASE_URL });
+      prisma = new PrismaClient({ adapter });
+      await prisma.$connect();
+
+      await prisma.user.create({
+        data: { id: userId, email: `memories-sched-${userId}@example.test` },
+      });
+      await prisma.circle.createMany({
+        data: [
+          { id: circleAId, name: 'Memories Sched A', ownerId: userId },
+          { id: circleBId, name: 'Memories Sched B', ownerId: userId },
+        ],
+      });
+    }, 30000);
+
+    afterAll(async () => {
+      if (!prisma) return;
+      await prisma.enrichmentJob
+        .deleteMany({ where: { circleId: ourCircles } })
+        .catch(() => undefined);
+      await prisma.circle.deleteMany({ where: { id: ourCircles } });
+      await prisma.user.deleteMany({ where: { id: userId } });
+      await prisma.$disconnect();
+
+      if (originalEnv === undefined) delete process.env['MEMORIES_ENABLED'];
+      else process.env['MEMORIES_ENABLED'] = originalEnv;
+    }, 30000);
+
+    beforeEach(async () => {
+      delete process.env['MEMORIES_ENABLED'];
+      await prisma.enrichmentJob.deleteMany({ where: { circleId: ourCircles } });
+
+      // Real PrismaService/EnrichmentJobService; only the settings read is
+      // stubbed, so every query in the path is genuine SQL.
+      settings = {
+        getSettings: jest.fn().mockResolvedValue({
+          features: { memories: true },
+          memories: { generation: { intervalHours: 24 } },
+        }),
+      };
+      task = new MemoriesGenerationTask(
+        prisma as unknown as PrismaService,
+        new EnrichmentJobService(prisma as unknown as PrismaService),
+        settings as unknown as SystemSettingsService,
+      );
+    });
+
+    /** memory_generation rows belonging to this suite's circles. */
+    async function ourJobs() {
+      return prisma.enrichmentJob.findMany({
+        where: { type: MEMORY_GENERATION_JOB_TYPE, circleId: ourCircles },
+        orderBy: { circleId: 'asc' },
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. skipDedup — one job PER CIRCLE, not one for the deployment
+    // -----------------------------------------------------------------------
+
+    it('creates exactly one pending job per circle (skipDedup verified against real rows)', async () => {
+      await task.sweep();
+
+      const jobs = await ourJobs();
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((j) => j.circleId).sort()).toEqual(
+        [circleAId, circleBId].sort(),
+      );
+      for (const job of jobs) {
+        expect(job.status).toBe(JobStatus.pending);
+        expect(job.mediaItemId).toBeNull();
+        // Background priority — never starves upload enrichment.
+        expect(job.priority).toBe(100);
+      }
+    });
+
+    it('a second tick adds nothing while the first tick\'s jobs are still pending', async () => {
+      await task.sweep();
+      const second = await task.sweep();
+
+      expect(second).toMatchObject({ enqueued: 0, skipped: 2 });
+      expect(await ourJobs()).toHaveLength(2);
+    });
+
+    // -----------------------------------------------------------------------
+    // 2/3. Interval gate against real rows (exercises groupBy + _max SQL)
+    // -----------------------------------------------------------------------
+
+    it('skips a circle whose last SUCCEEDED job is inside the interval, enqueues the other', async () => {
+      await prisma.enrichmentJob.create({
+        data: {
+          type: MEMORY_GENERATION_JOB_TYPE,
+          circleId: circleAId,
+          status: JobStatus.succeeded,
+          reason: 'backfill',
+          finishedAt: new Date(Date.now() - 60 * 60 * 1000), // 1h ago < 24h
+        },
+      });
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ circles: 2, enqueued: 1, skipped: 1 });
+      const pending = await prisma.enrichmentJob.findMany({
+        where: {
+          type: MEMORY_GENERATION_JOB_TYPE,
+          circleId: ourCircles,
+          status: JobStatus.pending,
+        },
+      });
+      expect(pending).toHaveLength(1);
+      expect(pending[0]!.circleId).toBe(circleBId);
+    });
+
+    it('enqueues again once the last success falls outside the interval', async () => {
+      await prisma.enrichmentJob.create({
+        data: {
+          type: MEMORY_GENERATION_JOB_TYPE,
+          circleId: circleAId,
+          status: JobStatus.succeeded,
+          reason: 'backfill',
+          finishedAt: new Date(Date.now() - 25 * 60 * 60 * 1000), // 25h ago
+        },
+      });
+
+      const result = await task.sweep();
+
+      expect(result.enqueued).toBe(2);
+    });
+
+    it('uses the MOST RECENT success when a circle has several (the _max aggregate)', async () => {
+      await prisma.enrichmentJob.createMany({
+        data: [
+          {
+            type: MEMORY_GENERATION_JOB_TYPE,
+            circleId: circleAId,
+            status: JobStatus.succeeded,
+            reason: 'backfill',
+            finishedAt: new Date(Date.now() - 100 * 60 * 60 * 1000),
+          },
+          {
+            type: MEMORY_GENERATION_JOB_TYPE,
+            circleId: circleAId,
+            status: JobStatus.succeeded,
+            reason: 'backfill',
+            finishedAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+          },
+        ],
+      });
+
+      const result = await task.sweep();
+
+      // The 2h-old success wins over the 100h-old one → circle A stays gated.
+      expect(result).toMatchObject({ enqueued: 1, skipped: 1 });
+    });
+
+    it('ignores FAILED history — only succeeded jobs gate the interval', async () => {
+      await prisma.enrichmentJob.create({
+        data: {
+          type: MEMORY_GENERATION_JOB_TYPE,
+          circleId: circleAId,
+          status: JobStatus.failed,
+          reason: 'backfill',
+          finishedAt: new Date(),
+        },
+      });
+
+      expect((await task.sweep()).enqueued).toBe(2);
+    });
+
+    it('skips a circle with a RUNNING job even when its last success is old', async () => {
+      await prisma.enrichmentJob.createMany({
+        data: [
+          {
+            type: MEMORY_GENERATION_JOB_TYPE,
+            circleId: circleAId,
+            status: JobStatus.succeeded,
+            reason: 'backfill',
+            finishedAt: new Date(Date.now() - 200 * 60 * 60 * 1000),
+          },
+          {
+            type: MEMORY_GENERATION_JOB_TYPE,
+            circleId: circleAId,
+            status: JobStatus.running,
+            reason: 'backfill',
+          },
+        ],
+      });
+
+      const result = await task.sweep();
+
+      expect(result).toMatchObject({ enqueued: 1, skipped: 1 });
+    });
+
+    // -----------------------------------------------------------------------
+    // 4. Zero background cost when off
+    // -----------------------------------------------------------------------
+
+    it('writes NOTHING when features.memories is off (the default)', async () => {
+      settings.getSettings.mockResolvedValue({ features: {} });
+
+      await task.handleScheduledGeneration();
+
+      expect(await ourJobs()).toHaveLength(0);
+    });
+
+    it('writes NOTHING when MEMORIES_ENABLED=false, even with the flag on', async () => {
+      process.env['MEMORIES_ENABLED'] = 'false';
+
+      await task.handleScheduledGeneration();
+
+      expect(await ourJobs()).toHaveLength(0);
+      expect(settings.getSettings).not.toHaveBeenCalled();
+    });
+  },
+);

--- a/apps/api/test/memories/memories-settings.integration.spec.ts
+++ b/apps/api/test/memories/memories-settings.integration.spec.ts
@@ -1,0 +1,427 @@
+/**
+ * Integration tests for the Memories configuration surface (epic #300, issue #302).
+ *
+ * Covers the three HTTP-visible pieces this issue ships:
+ *   1. PATCH /api/system-settings round-trips every `memories.*` key, and
+ *      rejects out-of-bounds values with a 400.
+ *   2. GET /api/features exposes `memories` to any authenticated user (it is the
+ *      least-privilege path non-admin clients read gated affordances from).
+ *   3. PUT /api/ai/features/memories persists the provider/model pair, refuses a
+ *      provider with no enabled credential, and is Admin + ai_settings:write.
+ *
+ * Runs against the mocked Prisma client, so the assertion for a persisted value
+ * is made against the argument handed to `systemSettings.update` — that is the
+ * document the service actually wrote, after its deep merge and schema parse.
+ */
+
+import request from 'supertest';
+import {
+  TestContext,
+  createTestApp,
+  closeTestApp,
+} from '../helpers/test-app.helper';
+import { resetPrismaMock } from '../mocks/prisma.mock';
+import { setupBaseMocks } from '../fixtures/mock-setup.helper';
+import {
+  createMockAdminUser,
+  createMockViewerUser,
+  authHeader,
+} from '../helpers/auth-mock.helper';
+import { DEFAULT_SYSTEM_SETTINGS } from '../../src/common/types/settings.types';
+import { SystemSettingsService } from '../../src/settings/system-settings/system-settings.service';
+
+describe('Memories settings integration (issue #302)', () => {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    context = await createTestApp({ useMockDatabase: true });
+  });
+
+  afterAll(async () => {
+    await closeTestApp(context);
+  });
+
+  beforeEach(async () => {
+    resetPrismaMock();
+    setupBaseMocks();
+    // SystemSettingsService caches for 5 s in process, and the app instance is
+    // shared across the whole file — without this, one test's settings row is
+    // still being served to the next.
+    (context.module.get(SystemSettingsService) as any).settingsCache = null;
+  });
+
+  /**
+   * Layers `ai_settings:read` + `ai_settings:write` onto the JWT-resolved user
+   * row. The shared `mockPermissions` fixture has no ai_settings entries, so an
+   * admin created by `createMockAdminUser` cannot reach /api/ai/*; this grants
+   * them per-test without mutating the shared fixture. Same technique as
+   * `grantNodePermissions` in workflow-node-execution.integration.spec.ts.
+   */
+  function grantAiSettingsPermissions(userId: string): void {
+    const base = (context.prismaMock.user.findUnique as jest.Mock).getMockImplementation();
+    (context.prismaMock.user.findUnique as jest.Mock).mockImplementation(async (args: any) => {
+      const result = base ? await base(args) : null;
+      if (!result || result.id !== userId) return result;
+      return {
+        ...result,
+        userRoles: result.userRoles.map((ur: any) => ({
+          ...ur,
+          role: {
+            ...ur.role,
+            rolePermissions: [
+              ...ur.role.rolePermissions,
+              { permission: { id: 'perm-ai-read', name: 'ai_settings:read' } },
+              { permission: { id: 'perm-ai-write', name: 'ai_settings:write' } },
+            ],
+          },
+        })),
+      };
+    });
+  }
+
+  /** Seed the mocked settings row and capture whatever the service writes. */
+  function stubSettingsRow(value: unknown = DEFAULT_SYSTEM_SETTINGS) {
+    context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+      id: 'settings-1',
+      key: 'global',
+      value: value as any,
+      version: 1,
+      updatedAt: new Date(),
+      updatedByUserId: null,
+      updatedByUser: null,
+    });
+    context.prismaMock.systemSettings.update.mockImplementation((args: any) =>
+      Promise.resolve({
+        id: 'settings-1',
+        key: 'global',
+        value: args.data.value,
+        version: 2,
+        updatedAt: new Date(),
+        updatedByUserId: null,
+        updatedByUser: null,
+      }),
+    );
+    context.prismaMock.auditEvent.create.mockResolvedValue({} as any);
+  }
+
+  /** The `memories` block the service actually persisted. */
+  function persistedMemories(): any {
+    const call = context.prismaMock.systemSettings.update.mock.calls.at(-1);
+    return (call?.[0] as any).data.value.memories;
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. memories.* namespace
+  // -------------------------------------------------------------------------
+
+  describe('PATCH /api/system-settings — memories.*', () => {
+    beforeEach(() => stubSettingsRow());
+
+    it('ships the documented defaults', async () => {
+      const admin = await createMockAdminUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .expect(200);
+
+      expect(response.body.data.memories).toEqual({
+        generation: { intervalHours: 24 },
+        maxItemsPerMemory: 30,
+        aiTitles: { enabled: true },
+        onThisDay: { enabled: true, lookbackYears: 10, minItems: 3 },
+        trips: {
+          enabled: true,
+          minDays: 2,
+          minItems: 10,
+          minDistanceKm: 50,
+          lookbackMonths: 18,
+        },
+        people: { enabled: true, favoritesOnly: true, minItems: 8 },
+        themes: { enabled: true, minItems: 8, maxPerPeriod: 3 },
+        seasonal: { enabled: true, minItems: 12 },
+        yearInReview: { enabled: true, minItems: 15 },
+        digest: {
+          enabled: true,
+          frequency: 'weekly',
+          sendHourUtc: 8,
+          imageTokenTtlDays: 30,
+        },
+      });
+    });
+
+    it('round-trips every memories.* key', async () => {
+      const admin = await createMockAdminUser(context);
+
+      const update = {
+        memories: {
+          generation: { intervalHours: 6 },
+          maxItemsPerMemory: 50,
+          aiTitles: { enabled: false },
+          onThisDay: { enabled: false, lookbackYears: 25, minItems: 5 },
+          trips: {
+            enabled: false,
+            minDays: 3,
+            minItems: 20,
+            minDistanceKm: 120,
+            lookbackMonths: 36,
+          },
+          people: { enabled: false, favoritesOnly: false, minItems: 12 },
+          themes: { enabled: false, minItems: 15, maxPerPeriod: 7 },
+          seasonal: { enabled: false, minItems: 40 },
+          yearInReview: { enabled: false, minItems: 60 },
+          digest: {
+            enabled: false,
+            frequency: 'monthly',
+            sendHourUtc: 0,
+            imageTokenTtlDays: 90,
+          },
+        },
+      };
+
+      const response = await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send(update)
+        .expect(200);
+
+      expect(response.body.data.memories).toEqual(update.memories);
+      expect(persistedMemories()).toEqual(update.memories);
+    });
+
+    it('merges a single nested key without disturbing its siblings', async () => {
+      const admin = await createMockAdminUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ memories: { onThisDay: { minItems: 5 } } })
+        .expect(200);
+
+      const memories = persistedMemories();
+      expect(memories.onThisDay).toEqual({
+        enabled: true,
+        lookbackYears: 10,
+        minItems: 5,
+      });
+      expect(memories.trips.minDistanceKm).toBe(50);
+      expect(memories.generation.intervalHours).toBe(24);
+    });
+
+    it.each([
+      ['generation.intervalHours below min', { generation: { intervalHours: 0 } }],
+      ['generation.intervalHours above max', { generation: { intervalHours: 169 } }],
+      ['generation.intervalHours non-integer', { generation: { intervalHours: 1.5 } }],
+      ['maxItemsPerMemory below min', { maxItemsPerMemory: 4 }],
+      ['maxItemsPerMemory above max', { maxItemsPerMemory: 101 }],
+      ['onThisDay.lookbackYears above max', { onThisDay: { lookbackYears: 51 } }],
+      ['onThisDay.minItems above max', { onThisDay: { minItems: 21 } }],
+      ['trips.minDays above max', { trips: { minDays: 15 } }],
+      ['trips.minDistanceKm below min', { trips: { minDistanceKm: 4 } }],
+      ['trips.lookbackMonths above max', { trips: { lookbackMonths: 241 } }],
+      ['people.minItems below min', { people: { minItems: 2 } }],
+      ['themes.maxPerPeriod above max', { themes: { maxPerPeriod: 11 } }],
+      ['seasonal.minItems below min', { seasonal: { minItems: 4 } }],
+      ['yearInReview.minItems above max', { yearInReview: { minItems: 101 } }],
+      ['digest.frequency not in the enum', { digest: { frequency: 'hourly' } }],
+      ['digest.sendHourUtc above max', { digest: { sendHourUtc: 24 } }],
+      ['digest.imageTokenTtlDays below min', { digest: { imageTokenTtlDays: 6 } }],
+      ['aiTitles.enabled wrong type', { aiTitles: { enabled: 'yes' } }],
+    ])('rejects %s with 400', async (_label, memories) => {
+      const admin = await createMockAdminUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ memories })
+        .expect(400);
+    });
+
+    it('accepts the inclusive bounds at both ends', async () => {
+      const admin = await createMockAdminUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({
+          memories: {
+            generation: { intervalHours: 1 },
+            maxItemsPerMemory: 100,
+            digest: { sendHourUtc: 23, imageTokenTtlDays: 7 },
+          },
+        })
+        .expect(200);
+
+      const memories = persistedMemories();
+      expect(memories.generation.intervalHours).toBe(1);
+      expect(memories.maxItemsPerMemory).toBe(100);
+      expect(memories.digest.sendHourUtc).toBe(23);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. features.memories via GET /api/features
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/features — features.memories', () => {
+    it('reports memories: false by default', async () => {
+      stubSettingsRow();
+      const viewer = await createMockViewerUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/features')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.features.memories).toBe(false);
+    });
+
+    it('reports memories: true once the flag is enabled', async () => {
+      stubSettingsRow({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        features: { ...DEFAULT_SYSTEM_SETTINGS.features, memories: true },
+      });
+      // Deliberately a NON-admin: /api/features exists precisely so ordinary
+      // circle members can resolve gated affordances without system_settings:read.
+      const viewer = await createMockViewerUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/features')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.features.memories).toBe(true);
+    });
+
+    it('toggles through PATCH /api/system-settings', async () => {
+      stubSettingsRow();
+      const admin = await createMockAdminUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ features: { memories: true } })
+        .expect(200);
+
+      expect(response.body.data.features.memories).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. PUT /api/ai/features/memories
+  // -------------------------------------------------------------------------
+
+  describe('PUT /api/ai/features/memories', () => {
+    beforeEach(() => stubSettingsRow());
+
+    it('returns 401 without auth', async () => {
+      await request(context.app.getHttpServer())
+        .put('/api/ai/features/memories')
+        .send({ provider: 'openai', model: 'gpt-4o-mini' })
+        .expect(401);
+    });
+
+    it('returns 403 without ai_settings:write', async () => {
+      const viewer = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .put('/api/ai/features/memories')
+        .set(authHeader(viewer.accessToken))
+        .send({ provider: 'openai', model: 'gpt-4o-mini' })
+        .expect(403);
+    });
+
+    it('persists the provider/model pair for an admin', async () => {
+      const admin = await createMockAdminUser(context);
+      grantAiSettingsPermissions(admin.id);
+      context.prismaMock.aiProviderCredential.findUnique.mockResolvedValue({
+        enabled: true,
+      } as any);
+
+      const response = await request(context.app.getHttpServer())
+        .put('/api/ai/features/memories')
+        .set(authHeader(admin.accessToken))
+        .send({ provider: 'openai', model: 'gpt-4o-mini' })
+        .expect(200);
+
+      expect(response.body.data).toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      });
+
+      const call = context.prismaMock.systemSettings.update.mock.calls.at(-1);
+      expect((call?.[0] as any).data.value.ai.features.memories).toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      });
+    });
+
+    it('returns 400 when the provider has no configured credential', async () => {
+      const admin = await createMockAdminUser(context);
+      grantAiSettingsPermissions(admin.id);
+      context.prismaMock.aiProviderCredential.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .put('/api/ai/features/memories')
+        .set(authHeader(admin.accessToken))
+        .send({ provider: 'openai', model: 'gpt-4o-mini' })
+        .expect(400);
+
+      expect(context.prismaMock.systemSettings.update).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the provider credential is disabled', async () => {
+      const admin = await createMockAdminUser(context);
+      grantAiSettingsPermissions(admin.id);
+      context.prismaMock.aiProviderCredential.findUnique.mockResolvedValue({
+        enabled: false,
+      } as any);
+
+      await request(context.app.getHttpServer())
+        .put('/api/ai/features/memories')
+        .set(authHeader(admin.accessToken))
+        .send({ provider: 'openai', model: 'gpt-4o-mini' })
+        .expect(400);
+    });
+
+    it('clears the selection when a field is null (fall back to template titles)', async () => {
+      const admin = await createMockAdminUser(context);
+      grantAiSettingsPermissions(admin.id);
+
+      const response = await request(context.app.getHttpServer())
+        .put('/api/ai/features/memories')
+        .set(authHeader(admin.accessToken))
+        .send({ provider: null, model: null })
+        .expect(200);
+
+      expect(response.body.data).toBeNull();
+      const call = context.prismaMock.systemSettings.update.mock.calls.at(-1);
+      expect((call?.[0] as any).data.value.ai.features.memories).toBeNull();
+    });
+
+    it('surfaces the configured pair in GET /api/ai/settings', async () => {
+      stubSettingsRow({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        ai: {
+          features: {
+            ...DEFAULT_SYSTEM_SETTINGS.ai.features,
+            memories: { provider: 'openai', model: 'gpt-4o-mini' },
+          },
+        },
+      });
+      const admin = await createMockAdminUser(context);
+      grantAiSettingsPermissions(admin.id);
+      context.prismaMock.aiProviderCredential.findMany.mockResolvedValue([]);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/ai/settings')
+        .set(authHeader(admin.accessToken))
+        .expect(200);
+
+      expect(response.body.data.features.memories).toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      });
+    });
+  });
+});

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.1 (data model only) |
+| **Version** | 0.2 (data model + generation plumbing) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model Implemented (issue #301); all other sections are placeholders for later issues in epic #300 |
+| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302); §4–§8 and §10 are placeholders for later issues in epic #300 |
 
 ---
 
@@ -32,7 +32,9 @@ Following the Immich precedent, memories are **persisted and pre-generated**, no
 
 Seven memory types ship across the epic (see [§2.1](#21-memorytype-enum)): `on_this_day`, `trip`, `person_highlights`, `person_over_years`, `theme`, `seasonal`, `year_in_review`. Each is produced by its own curator, gated by its own `memories.<type>.enabled` setting, and degrades independently — e.g. no geo data means no trips, but every other type is unaffected.
 
-This issue (#301) lays only the database foundation: the `MemoryType` enum and the `Memory` / `MemoryItem` / `MemoryUserState` models, with no generation, curation, AI, API, or UI code yet. Every later issue in the epic builds on this schema without altering it. Sections 3–10 below are placeholders that name the issue expected to fill them in; do not treat their absence as an oversight.
+The epic is delivered incrementally, and this document grows with it. Implemented so far: the database foundation — the `MemoryType` enum and the `Memory` / `MemoryItem` / `MemoryUserState` models ([#301](https://github.com/marinoscar/MemoriaHub/issues/301), §2) — and the configuration surface plus generation plumbing: the `features.memories` flag, the `memories.*` namespace, `ai.features.memories`, and an hourly per-circle `memory_generation` job whose handler is still a deliberate **no-op** ([#302](https://github.com/marinoscar/MemoriaHub/issues/302), §3 and §9). Every later issue builds on the #301 schema without altering it.
+
+Sections 4–8 and 10 are placeholders that name the issue expected to fill them in; do not treat their absence as an oversight. Until curators land in #303–#305, an enabled deployment schedules jobs and creates **zero** memory rows — which is the intended, tested intermediate state.
 
 ## 2. Data Model
 
@@ -181,7 +183,51 @@ Note that `Memory.deletedAt` (the tombstone, §2.5) is an **application-level** 
 
 ## 3. Generation
 
-Placeholder. Covered by issue [#302](https://github.com/marinoscar/MemoriaHub/issues/302) (settings namespace, feature flag, AI model selection, and the generation job skeleton) and issue [#303](https://github.com/marinoscar/MemoriaHub/issues/303) (curation engine, On This Day curator, template titles). Expected shape per the epic's architecture summary: an hourly `MemoriesGenerationTask` cron enqueuing one `memory_generation` `enrichment_jobs` row per circle (`skipDedup: true`, background priority), whose handler runs each enabled type-specific curator with per-curator error isolation, server-only (no `nodeResultSchema`).
+Introduced by issue [#302](https://github.com/marinoscar/MemoriaHub/issues/302). The scheduling, gating, dedup and observability plumbing ships here with a **no-op handler** — zero curators — so the whole queue path is proven end to end before any curation logic lands in [#303](https://github.com/marinoscar/MemoriaHub/issues/303)–[#305](https://github.com/marinoscar/MemoriaHub/issues/305).
+
+Everything lives in `apps/api/src/memories/` (`MemoriesModule`, registered in `AppModule`), a minimal-template module mirroring `InsightsModule`: `imports: [PrismaModule, SettingsModule, EnrichmentModule]`.
+
+### 3.1 `MemoriesGenerationTask` — the hourly interval-gated cron
+
+`memories-generation.task.ts`. `@Cron(CronExpression.EVERY_HOUR)`, wrapped in a try/catch that never throws (the contract every cron task in this repo follows), plus an in-process `sweepInFlight` overlap guard so a sweep that outlives its hourly slot is not run twice concurrently.
+
+Three gates, **in this order**:
+
+| # | Gate | Effect |
+|---|---|---|
+| 1 | `MEMORIES_ENABLED=false` (env) | Return immediately — before even the cached settings read |
+| 2 | `isMemoriesEnabled(settings)` — i.e. `features.memories === true` | Return before paging circles |
+| 3 | Per circle: no `pending`/`running` `memory_generation` job for that circle, **and** its last `succeeded` job is older than `memories.generation.intervalHours` | Enqueue, else skip |
+
+Gate ordering is what delivers the epic's **zero-cost-when-off** requirement (see the new-install matrix in [#300](https://github.com/marinoscar/MemoriaHub/issues/300)): with the flag absent — the default — a tick costs exactly one *cached* `SystemSettingsService.getSettings()` call and writes nothing; with the env kill-switch set it costs nothing at all. A circle that has never generated has no `succeeded` row, so it has no `last` and is always eligible. Only `succeeded` jobs gate the interval — a `failed` run does not push the next attempt out by a day.
+
+Circles are keyset-paged 100 at a time (`orderBy: { id: 'asc' }`, `cursor` + `skip: 1`), and each page issues exactly **two** batched job reads — one `findMany` for in-flight jobs and one `groupBy(['circleId'], { _max: { finishedAt } })` for the last success — rather than two reads per circle. A per-circle enqueue failure is logged and counted, never fatal: one bad circle must not stop the rest of the deployment from generating.
+
+The sweep body is exposed as `sweep()` (returning `{ circles, enqueued, skipped, errors }`) rather than inlined into the cron handler, so the admin backfill in [#315](https://github.com/marinoscar/MemoriaHub/issues/315) can drive the identical code path.
+
+### 3.2 Why `skipDedup: true` is mandatory
+
+Jobs are enqueued through `EnrichmentJobService.enqueue({ type: 'memory_generation', mediaItemId: null, circleId, reason: JobReason.backfill, priority: 100, skipDedup: true })`.
+
+`skipDedup: true` is **not optional**. The service's default idempotency check looks for an existing pending/running job with the same `(type, mediaItemId)` — and for a global job `mediaItemId` is `NULL` for *every* circle, so the first circle's job would swallow the enqueue for all the others, system-wide. This task's per-circle pending/running check (gate 3) is the correctly-scoped replacement for that dedup. Same reasoning, same flag, as `face_auto_archive_sweep`.
+
+`priority: 100` is the repo's background tier (`rerun=0`, `upload=10`, `backfill=100`), so memory generation can never starve upload enrichment.
+
+> **Deviation from the issue text.** Issue #302 specifies `reason: 'scheduled'`, but the `JobReason` enum is `upload | rerun | backfill` and adding a value is a schema change owned by [#301](https://github.com/marinoscar/MemoriaHub/issues/301). `JobReason.backfill` is used instead — this repo's established reason for cron-enqueued background work at priority 100 (`trash_purge`, `thumbnail_repair`, `storage_insights` all do the same).
+
+### 3.3 `MemoryGenerationHandler` — server-only, v1 no-op
+
+`memory-generation.handler.ts`. Implements `EnrichmentHandler` with `readonly type = 'memory_generation'` and self-registers via `onModuleInit() { this.registry.register(this) }` — the mandatory registration pattern (see [Enrichment Queue §6](enrichment-queue.md)), never multi-provider DI.
+
+**Server-only**: it deliberately omits both `nodeResultSchema` and `persistNodeResult`. Curation is a whole-circle DB read/write pass with no per-item unit of work to hand a distributed node, and from [#306](https://github.com/marinoscar/MemoriaHub/issues/306) it needs a server-held AI credential. Because the pair is absent, `EnrichmentHandlerRegistry.serverOnlyTypes()` picks the type up automatically and it becomes eligible for the `ENRICHMENT_WORKER_MODE=system` claim set **with no explicit pinning** — the same no-node-pair inference that already covers `face_auto_archive_sweep` and the `location_inference` sweep, and unlike `thumbnail_repair` / `workflow_execute_batch`, which carry the pair and must be pinned by hand. The drift guard in `apps/api/src/enrichment/server-only-types.spec.ts` asserts this. `memory_generation` is correspondingly absent from the CLI's `NODE_JOB_TYPES`.
+
+The handler **re-checks the feature gate itself** rather than trusting the cron's. A job can sit pending across a settings change, be retried by hand from `/admin/settings/jobs`, or be enqueued by the future admin backfill — none of which pass through the cron's gate. When the feature is off it **succeeds as a no-op rather than throwing**: a disabled feature is not a failure, and failing would burn retry attempts and light up the admin job dashboard for no reason. A job with a null `circleId` is likewise a logged no-op, since every memory is circle-scoped.
+
+v1's body is a log line and a return. That log line is the observability hook proving the scheduling path works end to end.
+
+### 3.4 Job-type labels
+
+`JOB_TYPE_LABELS` (`apps/api/src/enrichment/job-type-labels.ts`) gains `memory_generation: 'Memory generation'` so the type renders with a friendly name in `/admin/settings/jobs`. `memory_digest: 'Memory email digest'` is declared alongside it now, ahead of its handler, so [#311](https://github.com/marinoscar/MemoriaHub/issues/311) does not have to touch the file again.
 
 ## 4. Curation Engine
 
@@ -205,7 +251,74 @@ Placeholder. Covered by issue [#309](https://github.com/marinoscar/MemoriaHub/is
 
 ## 9. Settings
 
-Placeholder. Covered by issue [#302](https://github.com/marinoscar/MemoriaHub/issues/302) (feature flag and settings namespace skeleton) and issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315) (admin settings page `/admin/settings/memories` and library backfill). Expected namespace per the epic's architecture summary: `features.memories` (global flag, default off) and a `memories.*` namespace covering `generation.intervalHours`, `maxItemsPerMemory`, `aiTitles.enabled`, and per-type sub-namespaces (`onThisDay`, `trips`, `people`, `themes`, `seasonal`, `yearInReview`, `digest`) — see epic [#300](https://github.com/marinoscar/MemoriaHub/issues/300) for the full parameter table and bounds/defaults.
+Introduced by issue [#302](https://github.com/marinoscar/MemoriaHub/issues/302). The admin page that edits these (`/admin/settings/memories`) arrives with issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315); until then every key below is reachable through the generic `PUT`/`PATCH /api/system-settings` (Admin + `system_settings:write`).
+
+The **full** namespace ships now, not just the keys #302 reads, so every later issue in the epic consumes its parameters through the one cached `SystemSettingsService.getSettings()` call with no further schema change. Issue #302 itself actively reads only `memories.generation.intervalHours` (plus the feature flag).
+
+### 9.1 `features.memories` — the global flag
+
+A boolean in the open `features` record (`z.record(z.string(), z.boolean())`), so it needs no schema change of its own; it is added to `FEATURE_KEYS` and to `DEFAULT_SYSTEM_SETTINGS.features` as `false`. **Default off.** It flows to clients automatically via `GET /api/features`, whose `getPublicFeatures()` spreads `settings.features` — which matters because that endpoint requires authentication only, so a non-admin circle member can resolve the gated affordance without a 403 on the Admin-only `GET /api/system-settings`.
+
+`MEMORIES_ENABLED` (env, default `true`) is the hard kill-switch, with the same semantics as `THUMBNAIL_REPAIR_ENABLED` / `BURST_DETECTION_ENABLED`: when `'false'`, the cron enqueues nothing and the handler no-ops **regardless** of the system setting. The two are folded together by `isMemoriesEnabled(settings)` in `apps/api/src/common/types/settings.types.ts` — a single source of truth shared by the cron, the handler and every future Memories surface, mirroring `isWorkflowsEnabled` / `isPictureEnhancementEnabled` so no caller can drift on what "enabled" means. Documented in `infra/compose/.env.example`.
+
+### 9.2 The `memories.*` namespace
+
+| Key | Type / bounds | Default | Read by |
+|---|---|---|---|
+| `generation.intervalHours` | int 1–168 | `24` | #302 (the cron's interval gate) |
+| `maxItemsPerMemory` | int 5–100 | `30` | #303 |
+| `aiTitles.enabled` | bool | `true` | #306 |
+| `onThisDay.enabled` | bool | `true` | #303 |
+| `onThisDay.lookbackYears` | int 1–50 | `10` | #303 |
+| `onThisDay.minItems` | int 1–20 | `3` | #303 |
+| `trips.enabled` | bool | `true` | #304 |
+| `trips.minDays` | int 1–14 | `2` | #304 |
+| `trips.minItems` | int 3–100 | `10` | #304 |
+| `trips.minDistanceKm` | int 5–500 | `50` | #304 |
+| `trips.lookbackMonths` | int 1–240 | `18` | #304 |
+| `people.enabled` | bool | `true` | #305 |
+| `people.favoritesOnly` | bool | `true` | #305 |
+| `people.minItems` | int 3–50 | `8` | #305 |
+| `themes.enabled` | bool | `true` | #305 |
+| `themes.minItems` | int 3–50 | `8` | #305 |
+| `themes.maxPerPeriod` | int 1–10 | `3` | #305 |
+| `seasonal.enabled` | bool | `true` | #305 |
+| `seasonal.minItems` | int 5–100 | `12` | #305 |
+| `yearInReview.enabled` | bool | `true` | #305 |
+| `yearInReview.minItems` | int 5–100 | `15` | #305 |
+| `digest.enabled` | bool | `true` | #311 |
+| `digest.frequency` | enum `off`\|`daily`\|`weekly`\|`monthly` | `weekly` | #311 |
+| `digest.sendHourUtc` | int 0–23 | `8` | #311 |
+| `digest.imageTokenTtlDays` | int 7–90 | `30` | #311 |
+
+Note the per-type `enabled` flags all default to **`true`** while `features.memories` defaults to **`false`**. That is intentional: the master flag is the only off switch that matters for a fresh install, and once an admin turns Memories on they should get all seven memory types without having to enable each one individually.
+
+### 9.3 Three hand-maintained copies — a real pitfall
+
+This repo duplicates every settings namespace by hand across **three** files, and all three must be edited together:
+
+| File | Symbol | Role |
+|---|---|---|
+| `common/schemas/settings.schema.ts` | `systemSettingsSchema` | Validation + defaults for `PUT`, and for the merged document `patchSettings` re-parses |
+| `common/schemas/settings.schema.ts` | `systemSettingsPatchSchema` | All-optional twin |
+| `settings/dto/update-system-settings.dto.ts` | `patchSystemSettingsSchema` | **The wire DTO** |
+
+The third one is the trap. It is what `nestjs-zod` validates the request body against, and it **strips unknown keys**, so a namespace added only to the first two validates and merges perfectly in unit tests while every real `PATCH` silently no-ops — the key never survives the DTO. (`workflows.*` and `backup.*` are, as of this writing, in exactly that state: schema-complete but absent from the wire DTO, hence not PATCH-able over HTTP.) `memories` is present in all three, and `test/memories/memories-settings.integration.spec.ts` round-trips every key through the real HTTP endpoint precisely to keep it that way.
+
+`SystemSettingsService.patchSettings` also merges each key by hand (there is no generic deep merge), and `getSettings()`/`replaceSettings()` project the resolved document field by field — so a new namespace must be added there too or it will never be *returned*, only stored.
+
+### 9.4 `ai.features.memories`
+
+Lives under `ai.features.*`, not `features.*`. Shape is `{ provider, model } | null`, default `null` — the same nullable-object contract as `ai.features.enhance`, chosen because a half-filled provider/model pair is not a usable selection, so clearing either field clears the whole thing.
+
+- `PUT /api/ai/features/memories` — body `{ provider, model }`, Admin + `ai_settings:write`. Mirrors `PUT /api/ai/features/tagging`.
+- Surfaced (masked, like its siblings) by `GET /api/ai/settings`.
+- Model candidates come from the existing `GET /api/ai/models?provider=&capability=chat` — memories generate titles/subtitles/narratives, which is a **chat** capability. No new capability value was added.
+- `AiSettingsService.resolveMemoriesConfig()` returns the pair or `null`; `null` means memory titles fall back to deterministic templates (#306), never an error.
+
+One deliberate divergence from the older `search`/`tagging`/`embedding` setters: a non-null selection is **validated against the credential store up front** and rejected with a `400` when the provider has no configured, *enabled* credential. Those older setters accept anything, which is tolerable for a feature whose next call is an interactive request the admin will see fail — but a bad Memories selection would only ever surface inside a background `memory_generation` job, where nobody is watching.
+
+Consumed by `MemoryTitleService` in [#306](https://github.com/marinoscar/MemoriaHub/issues/306); #302 ships only the config, the endpoint and their tests.
 
 ## 10. RBAC
 
@@ -229,3 +342,4 @@ Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/is
 | Version | Date | Author | Changes |
 |---|---|---|---|
 | 0.1 | August 2026 | AI Assistant | Initial specification for issue #301: the `MemoryType` enum, the `Memory`/`MemoryItem`/`MemoryUserState` data model, the `periodKey`/`subjectKey` semantics, the tombstone contract, cascade summary, and alternatives considered. Sections 3–10 are placeholders for later issues in epic #300. |
+| 0.2 | August 2026 | AI Assistant | Issue #302: filled in §3 (Generation — `MemoriesGenerationTask`'s three gates and zero-cost-when-off contract, the mandatory `skipDedup: true` rationale, the server-only `MemoryGenerationHandler` and its no-node-pair system-mode inference, job labels, and the `JobReason.backfill` deviation from the issue text) and §9 (Settings — `features.memories` + the `MEMORIES_ENABLED` kill-switch and their shared `isMemoriesEnabled()` gate, the full `memories.*` bounds/defaults table, the three-hand-maintained-copies pitfall, and `ai.features.memories` with its up-front credential validation). §4–§8 and §10 remain placeholders. |

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -302,6 +302,16 @@ AUTO_TAG_ENABLED=true          # Set to false to disable auto-tagging on upload 
 # Default: 2000. Set higher for better accuracy on small faces in wide shots.
 FACE_MAX_IMAGE_DIM=2000
 
+# Memories (epic #300) — curated memory collections (On This Day, Trips, People,
+# Themes, Seasonal, Year in Review).
+# Hard kill-switch for CI/test: when 'false', the hourly MemoriesGenerationTask
+# cron enqueues nothing and the memory_generation handler is a no-op, REGARDLESS
+# of the features.memories system setting. Mirrors AUTO_TAG_ENABLED /
+# FACE_AUTO_DETECT semantics. The runtime toggle is the features.memories system
+# setting (default OFF); all memories.* parameters are system settings too.
+# Default: true
+# MEMORIES_ENABLED=true
+
 # Enrichment Job Queue (generic worker — replaces face-specific FaceJobWorker)
 # Worker mode (issue #108): all | system | off
 #   all    — claim every registered job type (classic single-box posture; default)


### PR DESCRIPTION
## Summary

The configuration and scheduling layer for Memories: the full `memories.*` settings namespace, the `features.memories` global flag (**default off**) with its `MEMORIES_ENABLED` env kill-switch, user-selectable `ai.features.memories` provider/model, and the server-only `memory_generation` job type driven by an interval-gated hourly cron.

No curators exist yet (#303–#305), so the handler is a no-op skeleton — this PR is inert at runtime with the flag off, which is the default.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #300
Fixes #302

## Changes Made

**Settings & feature flag**
- `memories` namespace in `settings.schema.ts` (+ its all-optional patch twin), `MemoriesSettingsValue` / `FEATURE_KEYS.MEMORIES` / `isMemoriesEnabled()` in `settings.types.ts`, and both projections + `patchSettings` merge blocks in `system-settings.service.ts`.

**AI feature config** — `PUT /api/ai/features/memories` (`ai_settings:write`) + `resolveMemoriesConfig()`, mirroring the existing `ai.features.tagging` / `embedding` / `enhance` pattern.

**Job skeleton** — `apps/api/src/memories/` (`memories.module.ts`, `memory-generation.handler.ts`, `memories-generation.task.ts`), registered in `app.module.ts`, plus the job-type label and server-only drift-guard entry.

### Settings keys

`memories.*`: `generation.intervalHours` 1–168=24 · `maxItemsPerMemory` 5–100=30 · `aiTitles.enabled`=true · `onThisDay.{enabled, lookbackYears 1–50=10, minItems 1–20=3}` · `trips.{enabled, minDays 1–14=2, minItems 3–100=10, minDistanceKm 5–500=50, lookbackMonths 1–240=18}` · `people.{enabled, favoritesOnly=true, minItems 3–50=8}` · `themes.{enabled, minItems 3–50=8, maxPerPeriod 1–10=3}` · `seasonal.{enabled, minItems 5–100=12}` · `yearInReview.{enabled, minItems 5–100=15}` · `digest.{enabled=true, frequency off|daily|weekly|monthly=weekly, sendHourUtc 0–23=8, imageTokenTtlDays 7–90=30}`. Plus `ai.features.memories: {provider, model} | null` = null.

### Job + cron wiring

`memory_generation` is **server-only** — it declares no `nodeResultSchema`/`persistNodeResult`, so `serverOnlyTypes()` infers it automatically (verified by the existing drift guard); no explicit system-mode pinning needed. `MemoriesGenerationTask` is an hourly cron gating env → `features.memories` → per-circle eligibility (no pending/running job **and** last *succeeded* older than `intervalHours`), keyset-paging circles 100 at a time with two batched job reads per page, enqueuing at `priority: 100` with `skipDedup: true` (the `face_auto_archive_sweep` precedent — global-job dedup keys on `(type, mediaItemId=null)` system-wide and would otherwise collapse every circle into one job).

**Zero cost when off** is covered by tests: flag off ⇒ cron enqueues nothing, handler no-ops.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
Test Suites: 28 passed, 28 total     (memories + settings suites)
Tests:       13 skipped, 738 passed, 751 total
```

The DB-gated `memories-generation-scheduling.integration.spec.ts` was run against a **live PostgreSQL 16 + pgvector** instance rather than skipped (9 passed), which is what actually proves the `groupBy`/`_max` interval query is valid SQL and that `skipDedup` yields one real row per circle.

<details>
<summary>Two unrelated suites fail locally — pre-existing, with evidence</summary>

`circles/migration-backfill` and `notifications/notification-dedup` fail (23 tests) both here and on `origin/main`. Root cause is in their own fixture helper, which generates malformed UUIDs:

```
Invalid `prisma.user.createMany()` invocation
Invalid input value: invalid input syntax for type uuid: "usr1-bd04c69300000000000000000000000"
```

They fail before reaching any assertion, and they never run in CI because no database is present there — which is why this went unnoticed. Untouched by this PR; worth its own bug issue.
</details>

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Two deviations/findings reviewers should weigh in on:

**1. `reason: 'scheduled'` was not implementable as the issue specified.** `JobReason` is a Postgres enum of `upload|rerun|backfill`; adding a value needs a migration that belongs to #301's schema scope. Used `JobReason.backfill`, which is this repo's established reason for cron-enqueued priority-100 work (`trash_purge`, `thumbnail_repair`, `storage_insights`). Documented in spec §3.2.

**2. A latent bug worth its own issue.** The settings schema is hand-duplicated in **three** places, not the two the issue names. The third — `patchSystemSettingsSchema` in `settings/dto/update-system-settings.dto.ts` — is the nestjs-zod wire DTO, and it *strips unknown keys*. Registering `memories` in only the first two made every `PATCH /api/system-settings` silently no-op while unit tests still passed; the round-trip integration test caught it. **`workflows.*` and `backup.*` are currently in exactly that broken state** — schema-complete but absent from the wire DTO, therefore not PATCH-able over HTTP. Left alone as out of scope, trap documented in spec §9.3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_