### PR TITLE
feat(api): Memories curation engine, On This Day curator &amp; template titles (#303)

### DIFF
--- a/apps/api/prisma/migrations/20260809140000_memories_on_this_day_index/migration.sql
+++ b/apps/api/prisma/migrations/20260809140000_memories_on_this_day_index/migration.sql
@@ -1,0 +1,64 @@
+-- Widened functional index serving the Memories "On This Day" curator
+-- (epic #300, issue #303).
+--
+-- INTENT: OnThisDayCurator asks, per anchor day and per circle, "which items in
+-- THIS circle were captured on month M / day D of any past year?" — and the
+-- admin backfill (#315) additionally asks "which (month, day) pairs does this
+-- circle have any candidate on at all?" (a DISTINCT scan). Both are
+-- circle-scoped and both exclude archived items, neither of which the existing
+-- "media_items_captured_md_idx" covers:
+--
+--   media_items_captured_md_idx  (20260615000000_media_oncethisday_index)
+--     ON media_items (EXTRACT(MONTH …), EXTRACT(DAY …)) WHERE deleted_at IS NULL
+--
+-- That index has no leading circle_id, so a circle-scoped query has to scan
+-- every circle's rows for the matching calendar day and then filter — fine for
+-- the single-circle dashboard it was built for, wasteful for a per-circle
+-- generation job that runs this twice per circle per pass. It also cannot serve
+-- the backfill's DISTINCT (month, day) scan at all, since that needs circle_id
+-- as the leading key to bound the scan to one circle.
+--
+-- This index leads with circle_id and folds the two remaining curation base
+-- filter predicates (archived_at IS NULL, captured_at IS NOT NULL) into the
+-- partial predicate, so the whole On This Day candidate query — and the
+-- backfill's anchor-discovery scan — is served directly.
+--
+-- WHY THE EXISTING INDEX IS KEPT: MediaService.getDashboard still issues the
+-- un-scoped-by-archive variant, and dropping it would regress that path. The
+-- two coexist; the planner picks per query.
+--
+-- WHY AT TIME ZONE 'UTC' IS REQUIRED:
+--   captured_at is timestamptz, and PostgreSQL marks EXTRACT(field FROM
+--   timestamptz) only STABLE (its result depends on the session TimeZone), while
+--   index expressions must be IMMUTABLE. Casting to a plain timestamp with
+--   AT TIME ZONE 'UTC' first makes EXTRACT immutable. This matches the UTC
+--   semantics the curator itself uses (it derives anchors via getUTCFullYear /
+--   getUTCMonth / getUTCDate), so the index expression and the query agree
+--   exactly — a mismatch here would silently produce a full sequential scan.
+--
+-- WHY A HAND-AUTHORED MIGRATION (not schema.prisma):
+--   Prisma's schema DSL has no syntax for functional/expression indexes; an
+--   @@index() directive accepts only plain column names and would produce a
+--   plain B-tree on the timestamp column, useless for this access pattern.
+--
+-- SCHEMA DRIFT NOTE:
+--   Intentionally not represented in schema.prisma — the same documented drift
+--   as media_items_captured_md_idx, media_items_gallery_idx,
+--   media_items_map_locations_idx, people_circle_id_hidden_at_idx and the
+--   review_run_items partial uniques. The project runs `prisma migrate deploy`
+--   (never `migrate dev`) outside local development, so no drift-detection step
+--   runs against it.
+--
+-- DOWN DIRECTION:
+--   DROP INDEX "media_items_circle_captured_md_idx";
+
+-- CreateIndex (functional, partial, circle-scoped)
+CREATE INDEX IF NOT EXISTS "media_items_circle_captured_md_idx"
+  ON "media_items" (
+    "circle_id",
+    EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC')),
+    EXTRACT(DAY   FROM ("captured_at" AT TIME ZONE 'UTC'))
+  )
+  WHERE "deleted_at" IS NULL
+    AND "archived_at" IS NULL
+    AND "captured_at" IS NOT NULL;

--- a/apps/api/src/memories/curation/memory-curation.pure.spec.ts
+++ b/apps/api/src/memories/curation/memory-curation.pure.spec.ts
@@ -1,0 +1,333 @@
+/**
+ * Unit tests for the PURE half of the curation engine (issue #303): scoring,
+ * near-duplicate collapse, diversity selection, finalization and the membership
+ * distance that drives title preservation.
+ *
+ * These are exported as free functions precisely so they can be asserted with
+ * plain object literals — no Nest module graph, no Prisma. The DB-dependent
+ * half (base filter, keyset streaming, tombstone upsert) is covered against a
+ * real PostgreSQL in test/memories/memories-curation.integration.spec.ts, where
+ * mocking would prove nothing.
+ */
+
+import { MediaType } from '@prisma/client';
+import {
+  AI_CONTENT_BONUS,
+  FAVORITE_BONUS,
+  FAVORITE_PERSON_BONUS,
+  LONG_VIDEO_PENALTY,
+  MATERIAL_CHANGE_THRESHOLD,
+  MAX_VIDEOS_PER_MEMORY,
+  NEUTRAL_SHARPNESS,
+  collapseGroups,
+  collapseKey,
+  finalizeSelection,
+  isLongVideo,
+  membershipDistance,
+  memoryCandidateBaseWhere,
+  scoreCandidate,
+  scoreCandidates,
+  selectDiverse,
+} from './memory-curation.service';
+import { MemoryCandidate } from './memory-curation.types';
+
+const DAY = 86_400_000;
+const BASE_TIME = Date.UTC(2019, 2, 12, 8, 0, 0);
+
+function candidate(over: Partial<MemoryCandidate> & { id: string }): MemoryCandidate {
+  return {
+    capturedAt: new Date(BASE_TIME),
+    type: MediaType.photo,
+    durationMs: null,
+    favorite: false,
+    sharpnessScore: null,
+    burstGroupId: null,
+    duplicateGroupId: null,
+    hasAiContent: false,
+    hasFavoritePersonFace: false,
+    ...over,
+  };
+}
+
+describe('memoryCandidateBaseWhere', () => {
+  it('encodes all four non-negotiable base predicates plus the circle scope', () => {
+    // Asserted structurally because this object IS the contract: a curator can
+    // never opt out of it, so a regression here silently leaks archived or
+    // trashed photos into every memory type at once.
+    expect(memoryCandidateBaseWhere('circle-1')).toEqual({
+      circleId: 'circle-1',
+      capturedAt: { not: null },
+      deletedAt: null,
+      archivedAt: null,
+      socialMediaSource: null,
+    });
+  });
+});
+
+describe('scoreCandidate', () => {
+  it('scores a bare candidate at the neutral sharpness only', () => {
+    expect(scoreCandidate(candidate({ id: 'a' }))).toBeCloseTo(NEUTRAL_SHARPNESS);
+  });
+
+  it('adds the favorite bonus', () => {
+    expect(scoreCandidate(candidate({ id: 'a', favorite: true }))).toBeCloseTo(
+      FAVORITE_BONUS + NEUTRAL_SHARPNESS,
+    );
+  });
+
+  it('normalizes sharpness into [0,1] and clamps a runaway value', () => {
+    expect(scoreCandidate(candidate({ id: 'a', sharpnessScore: 500 }))).toBeCloseTo(0.5);
+    expect(scoreCandidate(candidate({ id: 'a', sharpnessScore: 99_999 }))).toBeCloseTo(1);
+    expect(scoreCandidate(candidate({ id: 'a', sharpnessScore: -5 }))).toBeCloseTo(0);
+  });
+
+  it('treats a NULL sharpness as neutral, not as blurry', () => {
+    // The distinction matters: scoring "unmeasured" as 0 would push every
+    // pre-feature import and every video out of every memory.
+    expect(scoreCandidate(candidate({ id: 'a', sharpnessScore: null }))).toBeGreaterThan(
+      scoreCandidate(candidate({ id: 'b', sharpnessScore: 0 })),
+    );
+  });
+
+  it('adds the favorite-person and AI-content bonuses', () => {
+    const score = scoreCandidate(
+      candidate({ id: 'a', hasFavoritePersonFace: true, hasAiContent: true, sharpnessScore: 0 }),
+    );
+    expect(score).toBeCloseTo(FAVORITE_PERSON_BONUS + AI_CONTENT_BONUS);
+  });
+});
+
+describe('video preference', () => {
+  it('flags long and unknown-duration videos, never photos', () => {
+    expect(isLongVideo(candidate({ id: 'a', type: MediaType.video, durationMs: 120_000 }))).toBe(
+      true,
+    );
+    expect(isLongVideo(candidate({ id: 'b', type: MediaType.video, durationMs: null }))).toBe(true);
+    expect(isLongVideo(candidate({ id: 'c', type: MediaType.video, durationMs: 30_000 }))).toBe(
+      false,
+    );
+    expect(isLongVideo(candidate({ id: 'd', durationMs: 999_999 }))).toBe(false);
+  });
+
+  it('penalizes selectionScore only, leaving the persisted score pure', () => {
+    const [short, long] = scoreCandidates([
+      candidate({ id: 'short', type: MediaType.video, durationMs: 10_000 }),
+      candidate({ id: 'long', type: MediaType.video, durationMs: 600_000 }),
+    ]);
+    expect(long!.score).toBeCloseTo(short!.score);
+    expect(long!.selectionScore).toBeCloseTo(long!.score - LONG_VIDEO_PENALTY);
+    expect(short!.selectionScore).toBeCloseTo(short!.score);
+  });
+});
+
+describe('collapse', () => {
+  it('prefers the burst group when an item carries both group ids', () => {
+    // Mirrors the app-wide rule that a burst-grouped item should not be in a
+    // duplicate group at all (DuplicateDetectionService.evictFromDuplicateGroups).
+    expect(collapseKey(candidate({ id: 'a', burstGroupId: 'B', duplicateGroupId: 'D' }))).toBe(
+      'b:B',
+    );
+    expect(collapseKey(candidate({ id: 'a', duplicateGroupId: 'D' }))).toBe('d:D');
+    expect(collapseKey(candidate({ id: 'a' }))).toBe('i:a');
+  });
+
+  it('keeps the group suggestedBestItemId when it is among the candidates', () => {
+    const scored = scoreCandidates([
+      candidate({ id: 'best', burstGroupId: 'B' }),
+      // Higher-scored, but the group already has an opinion about which shot won.
+      candidate({ id: 'sharp', burstGroupId: 'B', favorite: true }),
+    ]);
+
+    const kept = collapseGroups(scored, new Map([['b:B', 'best']]));
+
+    expect(kept.map((c) => c.id)).toEqual(['best']);
+  });
+
+  it('falls back to the highest-scored member when the suggested best is filtered out', () => {
+    // e.g. the suggested best was archived or trashed since the group formed —
+    // it never reached the candidate set, so the group must still contribute.
+    const scored = scoreCandidates([
+      candidate({ id: 'plain', burstGroupId: 'B' }),
+      candidate({ id: 'fav', burstGroupId: 'B', favorite: true }),
+    ]);
+
+    const kept = collapseGroups(scored, new Map([['b:B', 'archived-item']]));
+
+    expect(kept.map((c) => c.id)).toEqual(['fav']);
+  });
+
+  it('contributes at most one item per group and leaves ungrouped items alone', () => {
+    const scored = scoreCandidates([
+      candidate({ id: 'b1', burstGroupId: 'B' }),
+      candidate({ id: 'b2', burstGroupId: 'B' }),
+      candidate({ id: 'b3', burstGroupId: 'B' }),
+      candidate({ id: 'd1', duplicateGroupId: 'D' }),
+      candidate({ id: 'd2', duplicateGroupId: 'D' }),
+      candidate({ id: 'solo' }),
+    ]);
+
+    const kept = collapseGroups(scored, new Map());
+
+    expect(kept).toHaveLength(3);
+    expect(kept.filter((c) => c.burstGroupId === 'B')).toHaveLength(1);
+    expect(kept.filter((c) => c.duplicateGroupId === 'D')).toHaveLength(1);
+    expect(kept.some((c) => c.id === 'solo')).toBe(true);
+  });
+});
+
+describe('selectDiverse', () => {
+  /** n candidates one hour apart, scored so index order == quality order. */
+  function spread(n: number, over: (i: number) => Partial<MemoryCandidate> = () => ({})) {
+    return scoreCandidates(
+      Array.from({ length: n }, (_, i) =>
+        candidate({
+          id: `i${String(i).padStart(3, '0')}`,
+          capturedAt: new Date(BASE_TIME + i * 3_600_000),
+          sharpnessScore: 100,
+          ...over(i),
+        }),
+      ),
+    );
+  }
+
+  it('returns everything when there is less material than the cap', () => {
+    expect(selectDiverse(spread(4), 30)).toHaveLength(4);
+  });
+
+  it('is empty for an empty candidate set or a zero cap', () => {
+    expect(selectDiverse([], 30)).toEqual([]);
+    expect(selectDiverse(spread(5), 0)).toEqual([]);
+  });
+
+  it('spreads across the time span instead of taking one clustered moment', () => {
+    // 30 shots inside one minute, plus 3 lone shots hours apart. A pure
+    // top-N-by-score pick would return 30 near-identical frames of one moment.
+    const cluster = scoreCandidates(
+      Array.from({ length: 30 }, (_, i) =>
+        candidate({
+          id: `c${String(i).padStart(2, '0')}`,
+          capturedAt: new Date(BASE_TIME + i * 1_000),
+          favorite: true,
+        }),
+      ),
+    );
+    const spaced = scoreCandidates([
+      candidate({ id: 'far1', capturedAt: new Date(BASE_TIME + 4 * 3_600_000) }),
+      candidate({ id: 'far2', capturedAt: new Date(BASE_TIME + 8 * 3_600_000) }),
+      candidate({ id: 'far3', capturedAt: new Date(BASE_TIME + 11 * 3_600_000) }),
+    ]);
+
+    const picked = selectDiverse([...cluster, ...spaced], 5);
+
+    expect(picked).toHaveLength(5);
+    // Every lower-scored but temporally distinct shot earns a slot.
+    expect(picked.map((c) => c.id)).toEqual(expect.arrayContaining(['far1', 'far2', 'far3']));
+  });
+
+  it('still fills the cap when the whole set shares one timestamp', () => {
+    const same = scoreCandidates(
+      Array.from({ length: 10 }, (_, i) => candidate({ id: `s${i}` })),
+    );
+    expect(selectDiverse(same, 4)).toHaveLength(4);
+  });
+
+  it('caps videos and backfills the freed slots with photos', () => {
+    const videos = spread(8, (i) => ({
+      type: MediaType.video,
+      durationMs: 10_000,
+      favorite: true,
+      id: `v${i}`,
+    }));
+    const photos = spread(8, (i) => ({ id: `p${i}` }));
+
+    const picked = selectDiverse([...videos, ...photos], 10);
+
+    expect(picked).toHaveLength(10);
+    expect(picked.filter((c) => c.type === MediaType.video)).toHaveLength(MAX_VIDEOS_PER_MEMORY);
+  });
+
+  it('returns fewer than the cap when the video cap is the binding constraint', () => {
+    const videos = spread(8, (i) => ({ type: MediaType.video, durationMs: 5_000, id: `v${i}` }));
+    expect(selectDiverse(videos, 30)).toHaveLength(MAX_VIDEOS_PER_MEMORY);
+  });
+
+  it('is deterministic: the same input yields the same selection', () => {
+    const input = spread(50, (i) => ({ favorite: i % 3 === 0 }));
+    const a = selectDiverse(input, 12).map((c) => c.id);
+    const b = selectDiverse([...input].reverse(), 12).map((c) => c.id);
+    expect(new Set(a)).toEqual(new Set(b));
+  });
+});
+
+describe('finalizeSelection', () => {
+  const chosen = scoreCandidates([
+    candidate({ id: 'late', capturedAt: new Date(BASE_TIME + 2 * DAY), sharpnessScore: 200 }),
+    candidate({ id: 'early', capturedAt: new Date(BASE_TIME), sharpnessScore: 100 }),
+    candidate({ id: 'mid', capturedAt: new Date(BASE_TIME + DAY), favorite: true }),
+  ]);
+
+  it('orders chronologically ascending with contiguous positions', () => {
+    const selection = finalizeSelection(chosen, 3, false);
+    expect(selection.items.map((i) => i.mediaItemId)).toEqual(['early', 'mid', 'late']);
+    expect(selection.items.map((i) => i.position)).toEqual([0, 1, 2]);
+  });
+
+  it('persists the pure score on each item and reports the period bounds', () => {
+    const selection = finalizeSelection(chosen, 3, false);
+    expect(selection.items[1]!.score).toBeGreaterThan(selection.items[0]!.score);
+    expect(selection.periodStart).toEqual(new Date(BASE_TIME));
+    expect(selection.periodEnd).toEqual(new Date(BASE_TIME + 2 * DAY));
+  });
+
+  it('picks the highest-scored item as cover', () => {
+    expect(finalizeSelection(chosen, 3, false).coverMediaItemId).toBe('mid');
+  });
+
+  it('never picks a video as cover, even when it is the best item', () => {
+    const withVideo = scoreCandidates([
+      candidate({ id: 'clip', type: MediaType.video, durationMs: 5_000, favorite: true }),
+      candidate({ id: 'photo', capturedAt: new Date(BASE_TIME + DAY) }),
+    ]);
+    expect(finalizeSelection(withVideo, 2, false).coverMediaItemId).toBe('photo');
+  });
+
+  it('has no cover at all when the selection is entirely video', () => {
+    const allVideo = scoreCandidates([
+      candidate({ id: 'clip', type: MediaType.video, durationMs: 5_000 }),
+    ]);
+    expect(finalizeSelection(allVideo, 1, false).coverMediaItemId).toBeNull();
+  });
+
+  it('degrades cleanly on an empty selection', () => {
+    const selection = finalizeSelection([], 0, false);
+    expect(selection.items).toEqual([]);
+    expect(selection.coverMediaItemId).toBeNull();
+    expect(selection.periodStart).toBeNull();
+    expect(selection.periodEnd).toBeNull();
+  });
+});
+
+describe('membershipDistance', () => {
+  it('is 0 for identical sets and for two empty sets', () => {
+    expect(membershipDistance(['a', 'b'], ['b', 'a'])).toBe(0);
+    expect(membershipDistance([], [])).toBe(0);
+  });
+
+  it('is 1 for disjoint sets', () => {
+    expect(membershipDistance(['a'], ['b'])).toBe(1);
+  });
+
+  it('stays below the material threshold when one item joins a large set', () => {
+    // 10 -> 11 items: the very churn the threshold exists to absorb, so an AI
+    // title is not discarded and re-paid for because one photo arrived.
+    const before = Array.from({ length: 10 }, (_, i) => `m${i}`);
+    const after = [...before, 'new'];
+    expect(membershipDistance(before, after)).toBeLessThan(MATERIAL_CHANGE_THRESHOLD);
+  });
+
+  it('crosses the material threshold on a substantial reshuffle', () => {
+    const before = ['a', 'b', 'c', 'd', 'e'];
+    const after = ['a', 'b', 'c', 'x', 'y'];
+    expect(membershipDistance(before, after)).toBeGreaterThanOrEqual(MATERIAL_CHANGE_THRESHOLD);
+  });
+});

--- a/apps/api/src/memories/curation/memory-curation.service.ts
+++ b/apps/api/src/memories/curation/memory-curation.service.ts
@@ -1,0 +1,789 @@
+// =============================================================================
+// Memories — shared curation engine (epic #300, issue #303)
+// =============================================================================
+//
+// The one place that answers "given a slice of a circle's library, which items
+// belong in a memory, in what order, and how do I write that down without
+// creating duplicates or resurrecting something the user deleted?"
+//
+// Every curator — On This Day here, Trips (#304), People/Theme/Seasonal/
+// Year-in-Review (#305) — funnels through `curate()` and `upsertMemory()`.
+// Nothing type-specific lives in this file; a curator contributes only the
+// Prisma `where` that selects its slice and the identity/title it wants written.
+//
+// FOUR PROPERTIES THIS FILE IS RESPONSIBLE FOR
+// --------------------------------------------
+//
+// 1. THE BASE FILTER IS NOT OPTIONAL. `memoryCandidateBaseWhere()` is applied by
+//    `loadCandidates()` itself, not by callers, so a curator physically cannot
+//    forget it. Archived, trashed, social-media and NULL-`capturedAt` items are
+//    excluded structurally rather than by convention. (`capturedAt` is nullable
+//    in this schema — an import with no EXIF date is common — and every memory
+//    is time-anchored, so a NULL date is not "unknown time", it is "not a
+//    candidate".)
+//
+// 2. MEMORY SAFETY AT LIBRARY SCALE. The target deployment is ~70k photos /
+//    ~8k videos in one circle. Candidates are streamed with constant-memory
+//    keyset pagination (the `workflow_evaluate` precedent) and enriched in
+//    per-page batches — never one query per item, never the whole library
+//    resident. A hard `maxCandidates` cap bounds the resident array even if a
+//    future curator hands us a pathologically wide slice.
+//
+// 3. THE TOMBSTONE CONTRACT IS ABSOLUTE. `upsertMemory()` reads the existing row
+//    FIRST and returns untouched if `deletedAt` is set. A user-deleted memory is
+//    never recreated, never refreshed, never re-titled — the `@@unique` key
+//    spans live and tombstoned rows precisely so the slot stays occupied
+//    forever. See docs/specs/memories.md §2.5.
+//
+// 4. REFRESH DOES NOT CHURN. A memory whose membership barely moved keeps its
+//    title/subtitle/narrative — including an AI-written one from #306. Only a
+//    material change (Jaccard distance >= 30% on the media-item id set) resets
+//    titling. Without this, every generation run would discard and re-pay for
+//    AI titles because one photo joined.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MediaTagSource, MediaType, MemoryType, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  CuratedItem,
+  CuratedSelection,
+  MemoryCandidate,
+  ScoredCandidate,
+  UpsertMemoryInput,
+  UpsertMemoryResult,
+} from './memory-curation.types';
+
+// --- Scoring weights (epic #300 / issue #303) --------------------------------
+
+/** A user-marked favorite is the strongest signal the library has. */
+export const FAVORITE_BONUS = 3.0;
+/** A face belonging to a Person the user marked favorite. */
+export const FAVORITE_PERSON_BONUS = 1.0;
+/** Evidence auto-tagging actually found content (description or >= 1 AI tag). */
+export const AI_CONTENT_BONUS = 0.25;
+/** Variance-of-Laplacian value that maps to a full 1.0 sharpness contribution. */
+export const SHARPNESS_FULL_SCALE = 1000;
+/**
+ * Sharpness stand-in for an item that was never scored (video, pre-feature
+ * import, failed processing). Neutral 0.5 rather than 0: a missing measurement
+ * is not evidence of a blurry photo, and scoring it as one would push every
+ * un-analyzed item out of every memory.
+ */
+export const NEUTRAL_SHARPNESS = 0.5;
+
+// --- Video policy ------------------------------------------------------------
+
+/** Hard cap on videos in one memory — a memory is a photo story with punctuation. */
+export const MAX_VIDEOS_PER_MEMORY = 3;
+/** Videos at or under this length are preferred; longer ones are penalized. */
+export const PREFERRED_VIDEO_MAX_MS = 60_000;
+/**
+ * Selection-time penalty for a long (or unknown-duration) video. Applied to
+ * `selectionScore` only — the persisted `MemoryItem.score` stays the pure
+ * quality score, so the penalty never masquerades as "this clip is bad".
+ */
+export const LONG_VIDEO_PENALTY = 0.5;
+
+// --- Streaming / batching ----------------------------------------------------
+
+/** Rows per keyset page while streaming candidates. */
+export const CANDIDATE_PAGE_SIZE = 500;
+/**
+ * Hard ceiling on resident candidates for one curation pass. At ~200 bytes per
+ * `MemoryCandidate` this is a few megabytes — deliberately generous, because a
+ * cap that bites introduces selection bias (we would silently curate only the
+ * chronologically earliest slice). It exists as a crash guard, not a tuning
+ * knob; a curator that routinely hits it is asking the wrong question.
+ */
+export const DEFAULT_MAX_CANDIDATES = 20_000;
+/** Chunk size for `id IN (...)` lookups so a wide page never builds a huge query. */
+const IN_CHUNK = 1_000;
+
+// --- Refresh policy ----------------------------------------------------------
+
+/**
+ * Jaccard DISTANCE at or above which a refresh counts as material: the titles
+ * are reset to templates and `materiallyChanged` is reported to callers.
+ */
+export const MATERIAL_CHANGE_THRESHOLD = 0.3;
+
+/**
+ * Stamped into every memory's `meta.generatorVersion`. Bump when the scoring or
+ * selection algorithm changes in a way that would produce a different item set
+ * from identical inputs — it is the only way to tell, after the fact, which
+ * algorithm produced a given memory.
+ */
+export const MEMORY_GENERATOR_VERSION = 1;
+
+/** Exactly the columns `loadCandidates` selects while streaming candidates. */
+interface CandidateRow {
+  id: string;
+  capturedAt: Date | null;
+  type: MediaType;
+  durationMs: number | null;
+  favorite: boolean;
+  sharpnessScore: number | null;
+  burstGroupId: string | null;
+  duplicateGroupId: string | null;
+  description: string | null;
+}
+
+/** Options accepted by `loadCandidates` / `curate`. */
+export interface CurateOptions {
+  /** Hard cap on items in the produced memory (`memories.maxItemsPerMemory`). */
+  maxItems: number;
+  /** Override the resident-candidate ceiling. Defaults to DEFAULT_MAX_CANDIDATES. */
+  maxCandidates?: number;
+}
+
+/**
+ * THE curation base filter, in one expression. Applied by `loadCandidates` to
+ * every curator's slice — see this file's header, property 1.
+ */
+export function memoryCandidateBaseWhere(circleId: string): Prisma.MediaItemWhereInput {
+  return {
+    circleId,
+    capturedAt: { not: null },
+    deletedAt: null,
+    archivedAt: null,
+    socialMediaSource: null,
+  };
+}
+
+/** The epic's quality formula. Pure — exported for direct unit testing. */
+export function scoreCandidate(candidate: MemoryCandidate): number {
+  let score = 0;
+  if (candidate.favorite) score += FAVORITE_BONUS;
+
+  // Clamp into [0,1]: sharpness is an unbounded variance, and an unusually
+  // crisp macro shot must not out-vote a favorite.
+  const sharpness =
+    candidate.sharpnessScore == null
+      ? NEUTRAL_SHARPNESS
+      : Math.min(Math.max(candidate.sharpnessScore / SHARPNESS_FULL_SCALE, 0), 1);
+  score += sharpness;
+
+  if (candidate.hasFavoritePersonFace) score += FAVORITE_PERSON_BONUS;
+  if (candidate.hasAiContent) score += AI_CONTENT_BONUS;
+  return score;
+}
+
+/** True for a video that is long, or whose duration we simply do not know. */
+export function isLongVideo(candidate: MemoryCandidate): boolean {
+  return (
+    candidate.type === MediaType.video &&
+    (candidate.durationMs == null || candidate.durationMs > PREFERRED_VIDEO_MAX_MS)
+  );
+}
+
+/** Attach `score` and `selectionScore`. Pure — exported for unit testing. */
+export function scoreCandidates(candidates: MemoryCandidate[]): ScoredCandidate[] {
+  return candidates.map((c) => {
+    const score = scoreCandidate(c);
+    return {
+      ...c,
+      score,
+      selectionScore: isLongVideo(c) ? score - LONG_VIDEO_PENALTY : score,
+    };
+  });
+}
+
+/**
+ * Ranking order for selection: best first, ties broken deterministically so two
+ * runs over an unchanged library produce byte-identical memories (which is what
+ * makes "re-running changes nothing" testable rather than approximately true).
+ */
+function compareForSelection(a: ScoredCandidate, b: ScoredCandidate): number {
+  if (b.selectionScore !== a.selectionScore) return b.selectionScore - a.selectionScore;
+  const at = a.capturedAt.getTime();
+  const bt = b.capturedAt.getTime();
+  if (at !== bt) return at - bt;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * The collapse bucket an item belongs to.
+ *
+ * BURST WINS OVER DUPLICATE when an item somehow carries both group ids. That
+ * is not an arbitrary tie-break: it mirrors the app-wide rule already enforced
+ * by `DuplicateDetectionService.evictFromDuplicateGroups` (see CLAUDE.md's
+ * duplicate-detection section) — an item in a burst group is not supposed to be
+ * in a duplicate group at all, and if a race left it in both, the burst grouping
+ * is the authoritative one.
+ */
+export function collapseKey(candidate: MemoryCandidate): string {
+  if (candidate.burstGroupId) return `b:${candidate.burstGroupId}`;
+  if (candidate.duplicateGroupId) return `d:${candidate.duplicateGroupId}`;
+  return `i:${candidate.id}`;
+}
+
+/**
+ * Collapse burst/duplicate groups down to one representative each, preferring
+ * the group's own `suggestedBestItemId` when it survived the base filter.
+ *
+ * Pure (the suggested-best map is resolved by the caller) so the interesting
+ * behavior is unit-testable without a database.
+ */
+export function collapseGroups(
+  scored: ScoredCandidate[],
+  suggestedBestByKey: Map<string, string | null>,
+): ScoredCandidate[] {
+  const groups = new Map<string, ScoredCandidate[]>();
+  for (const c of scored) {
+    const key = collapseKey(c);
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(c);
+    else groups.set(key, [c]);
+  }
+
+  const kept: ScoredCandidate[] = [];
+  for (const [key, members] of groups) {
+    if (members.length === 1) {
+      kept.push(members[0]!);
+      continue;
+    }
+    const suggested = suggestedBestByKey.get(key) ?? null;
+    // The suggested best only wins if it is itself a candidate — it may have
+    // been archived, trashed or flagged since the group was formed.
+    const winner =
+      (suggested ? members.find((m) => m.id === suggested) : undefined) ??
+      [...members].sort(compareForSelection)[0]!;
+    kept.push(winner);
+  }
+  return kept;
+}
+
+/**
+ * Pick up to `maxItems` items that span the memory's time range instead of
+ * clustering on whichever moment happened to be photographed hardest.
+ *
+ * Two passes: divide the span into equal buckets and take each bucket's best,
+ * then fill any remaining slots with the next-best overall. The video cap is
+ * enforced throughout, so a rejected video simply leaves its slot to the fill
+ * pass rather than shrinking the memory.
+ *
+ * Pure — exported for unit testing.
+ */
+export function selectDiverse(scored: ScoredCandidate[], maxItems: number): ScoredCandidate[] {
+  if (scored.length === 0 || maxItems <= 0) return [];
+
+  const ranked = [...scored].sort(compareForSelection);
+
+  const selected = new Map<string, ScoredCandidate>();
+  let videoCount = 0;
+
+  const tryAdd = (c: ScoredCandidate | undefined): void => {
+    if (!c || selected.has(c.id) || selected.size >= maxItems) return;
+    if (c.type === MediaType.video) {
+      if (videoCount >= MAX_VIDEOS_PER_MEMORY) return;
+      videoCount += 1;
+    }
+    selected.set(c.id, c);
+  };
+
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  for (const c of ranked) {
+    const t = c.capturedAt.getTime();
+    if (t < minTime) minTime = t;
+    if (t > maxTime) maxTime = t;
+  }
+  const span = maxTime - minTime;
+
+  if (span > 0) {
+    const bucketCount = Math.max(1, Math.min(maxItems, ranked.length));
+    const bucketBest = new Map<number, ScoredCandidate>();
+    // `ranked` is best-first, so the first arrival in a bucket IS its best.
+    for (const c of ranked) {
+      const idx = Math.min(
+        bucketCount - 1,
+        Math.floor(((c.capturedAt.getTime() - minTime) / span) * bucketCount),
+      );
+      if (!bucketBest.has(idx)) bucketBest.set(idx, c);
+    }
+    for (let i = 0; i < bucketCount; i += 1) tryAdd(bucketBest.get(i));
+  }
+
+  // Fill pass — covers a zero-span set, buckets skipped by the video cap, and
+  // any slots left when there are fewer buckets than maxItems.
+  for (const c of ranked) {
+    if (selected.size >= maxItems) break;
+    tryAdd(c);
+  }
+
+  return [...selected.values()];
+}
+
+/**
+ * Turn a chosen set into the final, ordered `CuratedSelection`: chronological
+ * ascending positions, and a cover that is never a video.
+ *
+ * Pure — exported for unit testing.
+ */
+export function finalizeSelection(
+  chosen: ScoredCandidate[],
+  candidateCount: number,
+  truncated: boolean,
+): CuratedSelection {
+  const ordered = [...chosen].sort((a, b) => {
+    const at = a.capturedAt.getTime();
+    const bt = b.capturedAt.getTime();
+    if (at !== bt) return at - bt;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  const items: CuratedItem[] = ordered.map((c, index) => ({
+    mediaItemId: c.id,
+    position: index,
+    score: c.score,
+  }));
+
+  // A video never becomes the cover: cover art is rendered as a still, and a
+  // video's poster frame is a different (and often worse) image than any photo
+  // in the set. An all-video memory simply has no cover.
+  let cover: ScoredCandidate | null = null;
+  for (const c of ordered) {
+    if (c.type === MediaType.video) continue;
+    if (!cover || c.score > cover.score || (c.score === cover.score && c.id < cover.id)) {
+      cover = c;
+    }
+  }
+
+  return {
+    items,
+    coverMediaItemId: cover?.id ?? null,
+    periodStart: ordered.length > 0 ? ordered[0]!.capturedAt : null,
+    periodEnd: ordered.length > 0 ? ordered[ordered.length - 1]!.capturedAt : null,
+    candidateCount,
+    truncated,
+  };
+}
+
+/**
+ * Jaccard DISTANCE between two media-item id sets: `1 - |A∩B| / |A∪B|`.
+ *
+ * Two empty sets are defined as distance 0 (nothing changed), which keeps a
+ * degenerate refresh from being reported as material.
+ */
+export function membershipDistance(before: Iterable<string>, after: Iterable<string>): number {
+  const a = new Set(before);
+  const b = new Set(after);
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const id of a) if (b.has(id)) intersection += 1;
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : 1 - intersection / union;
+}
+
+/** Split an array into fixed-size chunks (for bounded `IN (...)` predicates). */
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+@Injectable()
+export class MemoryCurationService {
+  private readonly logger = new Logger(MemoryCurationService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Stream every candidate matching the base filter AND the curator's `where`,
+   * hydrated with the scoring signals.
+   *
+   * Constant memory in the number of PAGES: one page of rows plus two batched
+   * signal lookups are live at a time; only the (capped) candidate array grows.
+   * Ordering is `(capturedAt ASC, id ASC)` — a total order, since `capturedAt`
+   * is non-null under the base filter — which makes the keyset cursor exact with
+   * no NULLS-handling and no rows skipped or repeated across pages.
+   */
+  async loadCandidates(
+    circleId: string,
+    where: Prisma.MediaItemWhereInput,
+    options: { maxCandidates?: number } = {},
+  ): Promise<{ candidates: MemoryCandidate[]; truncated: boolean }> {
+    const maxCandidates = options.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+    const base = memoryCandidateBaseWhere(circleId);
+
+    const candidates: MemoryCandidate[] = [];
+    let truncated = false;
+    let cursor: { capturedAt: Date; id: string } | null = null;
+
+    for (;;) {
+      const cursorPredicate: Prisma.MediaItemWhereInput | null = cursor
+        ? {
+            OR: [
+              { capturedAt: { gt: cursor.capturedAt } },
+              { capturedAt: cursor.capturedAt, id: { gt: cursor.id } },
+            ],
+          }
+        : null;
+
+      // Explicitly annotated: without it TypeScript reports TS7022, because the
+      // page's `where` is built from `cursor`, which is in turn assigned from
+      // this very result — a self-reference the inferencer cannot break.
+      const rows: CandidateRow[] = await this.prisma.mediaItem.findMany({
+        where: cursorPredicate ? { AND: [base, where, cursorPredicate] } : { AND: [base, where] },
+        orderBy: [{ capturedAt: 'asc' }, { id: 'asc' }],
+        take: CANDIDATE_PAGE_SIZE,
+        select: {
+          id: true,
+          capturedAt: true,
+          type: true,
+          durationMs: true,
+          favorite: true,
+          sharpnessScore: true,
+          burstGroupId: true,
+          duplicateGroupId: true,
+          description: true,
+        },
+      });
+      if (rows.length === 0) break;
+
+      const last = rows[rows.length - 1]!;
+      // `capturedAt` cannot be null here (base filter), but the generated type
+      // still says it can — assert once, at the cursor, rather than per row.
+      cursor = { capturedAt: last.capturedAt as Date, id: last.id };
+
+      const pageIds = rows.map((r) => r.id);
+      const [favoritePersonIds, aiTaggedIds] = await Promise.all([
+        this.mediaItemsWithFavoritePersonFace(pageIds),
+        this.mediaItemsWithAiTags(pageIds),
+      ]);
+
+      for (const row of rows) {
+        if (candidates.length >= maxCandidates) {
+          truncated = true;
+          break;
+        }
+        candidates.push({
+          id: row.id,
+          capturedAt: row.capturedAt as Date,
+          type: row.type,
+          durationMs: row.durationMs,
+          favorite: row.favorite,
+          sharpnessScore: row.sharpnessScore,
+          burstGroupId: row.burstGroupId,
+          duplicateGroupId: row.duplicateGroupId,
+          hasAiContent:
+            (row.description != null && row.description.trim().length > 0) ||
+            aiTaggedIds.has(row.id),
+          hasFavoritePersonFace: favoritePersonIds.has(row.id),
+        });
+      }
+
+      if (truncated) {
+        this.logger.warn(
+          `Memory candidate scan for circle ${circleId} hit the ${maxCandidates}-item cap; ` +
+            'the tail of the slice was not considered',
+        );
+        break;
+      }
+      if (rows.length < CANDIDATE_PAGE_SIZE) break;
+    }
+
+    return { candidates, truncated };
+  }
+
+  /** Which of these items carry a face assigned to a live, favorite Person. */
+  private async mediaItemsWithFavoritePersonFace(ids: string[]): Promise<Set<string>> {
+    const found = new Set<string>();
+    if (ids.length === 0) return found;
+    for (const part of chunk(ids, IN_CHUNK)) {
+      const rows = await this.prisma.face.findMany({
+        where: {
+          mediaItemId: { in: part },
+          personId: { not: null },
+          // A hidden or soft-deleted person is not a signal the user wants
+          // surfaced — hiding a person is an explicit "stop showing me this".
+          person: { favorite: true, hiddenAt: null, deletedAt: null },
+        },
+        select: { mediaItemId: true },
+        distinct: ['mediaItemId'],
+      });
+      for (const r of rows) found.add(r.mediaItemId);
+    }
+    return found;
+  }
+
+  /** Which of these items carry at least one AI-applied tag. */
+  private async mediaItemsWithAiTags(ids: string[]): Promise<Set<string>> {
+    const found = new Set<string>();
+    if (ids.length === 0) return found;
+    for (const part of chunk(ids, IN_CHUNK)) {
+      const rows = await this.prisma.mediaTag.findMany({
+        where: { mediaItemId: { in: part }, source: MediaTagSource.ai },
+        select: { mediaItemId: true },
+        distinct: ['mediaItemId'],
+      });
+      for (const r of rows) found.add(r.mediaItemId);
+    }
+    return found;
+  }
+
+  /**
+   * Resolve `suggestedBestItemId` for every burst/duplicate group present in the
+   * candidate set, keyed by the same `collapseKey()` the collapse pass uses.
+   */
+  private async resolveSuggestedBest(
+    candidates: MemoryCandidate[],
+  ): Promise<Map<string, string | null>> {
+    const burstIds = new Set<string>();
+    const duplicateIds = new Set<string>();
+    for (const c of candidates) {
+      if (c.burstGroupId) burstIds.add(c.burstGroupId);
+      // Only groups that can actually win a bucket are worth resolving — an
+      // item with a burst group never collapses on its duplicate group.
+      else if (c.duplicateGroupId) duplicateIds.add(c.duplicateGroupId);
+    }
+
+    const map = new Map<string, string | null>();
+    for (const part of chunk([...burstIds], IN_CHUNK)) {
+      const rows = await this.prisma.burstGroup.findMany({
+        where: { id: { in: part } },
+        select: { id: true, suggestedBestItemId: true },
+      });
+      for (const r of rows) map.set(`b:${r.id}`, r.suggestedBestItemId);
+    }
+    for (const part of chunk([...duplicateIds], IN_CHUNK)) {
+      const rows = await this.prisma.duplicateGroup.findMany({
+        where: { id: { in: part } },
+        select: { id: true, suggestedBestItemId: true },
+      });
+      for (const r of rows) map.set(`d:${r.id}`, r.suggestedBestItemId);
+    }
+    return map;
+  }
+
+  /**
+   * The full pipeline for one memory's slice:
+   * load (base filter + curator `where`) → score → collapse near-duplicates →
+   * diversity-select → order chronologically and pick a cover.
+   */
+  async curate(
+    circleId: string,
+    where: Prisma.MediaItemWhereInput,
+    options: CurateOptions,
+  ): Promise<CuratedSelection> {
+    const { candidates, truncated } = await this.loadCandidates(circleId, where, {
+      maxCandidates: options.maxCandidates,
+    });
+    if (candidates.length === 0) {
+      return finalizeSelection([], 0, truncated);
+    }
+
+    const scored = scoreCandidates(candidates);
+    const suggestedBest = await this.resolveSuggestedBest(candidates);
+    const collapsed = collapseGroups(scored, suggestedBest);
+    const chosen = selectDiverse(collapsed, options.maxItems);
+    return finalizeSelection(chosen, candidates.length, truncated);
+  }
+
+  /**
+   * Write a curated selection under its `(circleId, type, periodKey,
+   * subjectKey)` identity — creating it, or refreshing it in place.
+   *
+   * THE TOMBSTONE CHECK COMES FIRST, before any write and before any title
+   * computation, because "the user deleted this" outranks everything else this
+   * method could do.
+   *
+   * `MemoryUserState` is untouched by design: it lives in its own table keyed by
+   * memory id, so a refresh that replaces every item still preserves seen /
+   * hidden / favorited state for every user. That is the whole reason per-user
+   * state was not modeled as columns on `Memory`.
+   */
+  async upsertMemory(input: UpsertMemoryInput): Promise<UpsertMemoryResult> {
+    const subjectKey = input.subjectKey ?? '';
+    const identity = {
+      circleId_type_periodKey_subjectKey: {
+        circleId: input.circleId,
+        type: input.type,
+        periodKey: input.periodKey,
+        subjectKey,
+      },
+    };
+
+    const existing = await this.prisma.memory.findUnique({
+      where: identity,
+      select: { id: true, deletedAt: true, items: { select: { mediaItemId: true } } },
+    });
+
+    if (existing?.deletedAt) {
+      this.logger.debug(
+        `Memory ${input.type}/${input.periodKey}/${subjectKey} in circle ${input.circleId} ` +
+          'is tombstoned; upsert refused',
+      );
+      return { memoryId: null, created: false, materiallyChanged: false, skippedTombstone: true };
+    }
+
+    if (!existing) {
+      try {
+        const memoryId = await this.createMemory(input, subjectKey);
+        return { memoryId, created: true, materiallyChanged: true, skippedTombstone: false };
+      } catch (err) {
+        // A concurrent generation pass won the race on the unique key. Re-read
+        // and fall through to the refresh path — including its tombstone check,
+        // since the winner could in principle already have been deleted.
+        if (
+          !(err instanceof Prisma.PrismaClientKnownRequestError) ||
+          err.code !== 'P2002'
+        ) {
+          throw err;
+        }
+        const raced = await this.prisma.memory.findUnique({
+          where: identity,
+          select: { id: true, deletedAt: true, items: { select: { mediaItemId: true } } },
+        });
+        if (!raced || raced.deletedAt) {
+          return {
+            memoryId: null,
+            created: false,
+            materiallyChanged: false,
+            skippedTombstone: raced != null,
+          };
+        }
+        return this.refreshMemory(input, raced);
+      }
+    }
+
+    return this.refreshMemory(input, existing);
+  }
+
+  private buildMeta(input: UpsertMemoryInput): Prisma.InputJsonValue {
+    return {
+      ...(input.meta ?? {}),
+      generatorVersion: MEMORY_GENERATOR_VERSION,
+    } as Prisma.InputJsonValue;
+  }
+
+  private async createMemory(input: UpsertMemoryInput, subjectKey: string): Promise<string> {
+    const now = new Date();
+    const { periodStart, periodEnd } = this.resolvePeriod(input, now);
+
+    return this.prisma.$transaction(async (tx) => {
+      const memory = await tx.memory.create({
+        data: {
+          circleId: input.circleId,
+          type: input.type,
+          periodKey: input.periodKey,
+          subjectKey,
+          personId: input.personId ?? null,
+          title: input.title,
+          subtitle: input.subtitle ?? null,
+          // Narrative is an AI-only field (#306); a template-titled memory has
+          // none, and writing an empty string instead of NULL would make
+          // "has a narrative" untestable downstream.
+          narrative: null,
+          titleSource: 'template',
+          titleModel: null,
+          coverMediaItemId: input.selection.coverMediaItemId,
+          periodStart,
+          periodEnd,
+          itemCount: input.selection.items.length,
+          meta: this.buildMeta(input),
+          generatedAt: now,
+          refreshedAt: now,
+          expiresAt: input.expiresAt ?? null,
+        },
+        select: { id: true },
+      });
+
+      if (input.selection.items.length > 0) {
+        await tx.memoryItem.createMany({
+          data: input.selection.items.map((item) => ({
+            memoryId: memory.id,
+            mediaItemId: item.mediaItemId,
+            position: item.position,
+            score: item.score,
+          })),
+        });
+      }
+
+      return memory.id;
+    });
+  }
+
+  private async refreshMemory(
+    input: UpsertMemoryInput,
+    existing: { id: string; items: Array<{ mediaItemId: string }> },
+  ): Promise<UpsertMemoryResult> {
+    const now = new Date();
+    const { periodStart, periodEnd } = this.resolvePeriod(input, now);
+
+    const distance = membershipDistance(
+      existing.items.map((i) => i.mediaItemId),
+      input.selection.items.map((i) => i.mediaItemId),
+    );
+    const materiallyChanged = distance >= MATERIAL_CHANGE_THRESHOLD;
+
+    await this.prisma.$transaction(async (tx) => {
+      // Replace rather than diff: MemoryItem carries no per-item user state, so
+      // a wholesale replacement is both simpler and cheaper than computing an
+      // add/remove/reposition delta, and `position` shifts on almost every
+      // refresh anyway.
+      await tx.memoryItem.deleteMany({ where: { memoryId: existing.id } });
+      if (input.selection.items.length > 0) {
+        await tx.memoryItem.createMany({
+          data: input.selection.items.map((item) => ({
+            memoryId: existing.id,
+            mediaItemId: item.mediaItemId,
+            position: item.position,
+            score: item.score,
+          })),
+        });
+      }
+
+      await tx.memory.update({
+        where: { id: existing.id },
+        data: {
+          coverMediaItemId: input.selection.coverMediaItemId,
+          periodStart,
+          periodEnd,
+          itemCount: input.selection.items.length,
+          meta: this.buildMeta(input),
+          refreshedAt: now,
+          expiresAt: input.expiresAt ?? null,
+          personId: input.personId ?? null,
+          // Titling is preserved on a minor refresh — including an AI title and
+          // narrative from #306. On a MATERIAL change the old title may now
+          // describe a set that no longer exists, so it is reset to the
+          // template and handed back to AI re-titling on a later pass.
+          ...(materiallyChanged
+            ? {
+                title: input.title,
+                subtitle: input.subtitle ?? null,
+                narrative: null,
+                titleSource: 'template',
+                titleModel: null,
+              }
+            : {}),
+        },
+      });
+    });
+
+    return {
+      memoryId: existing.id,
+      created: false,
+      materiallyChanged,
+      skippedTombstone: false,
+    };
+  }
+
+  /**
+   * `periodStart`/`periodEnd` are NOT NULL in the schema, but a selection can
+   * legitimately be empty (a curator upserting a now-empty period). Fall back to
+   * "now" for both so the row stays writable and self-consistent rather than
+   * blowing up a whole generation run over a degenerate edge.
+   */
+  private resolvePeriod(
+    input: UpsertMemoryInput,
+    fallback: Date,
+  ): { periodStart: Date; periodEnd: Date } {
+    return {
+      periodStart: input.selection.periodStart ?? fallback,
+      periodEnd: input.selection.periodEnd ?? fallback,
+    };
+  }
+}

--- a/apps/api/src/memories/curation/memory-curation.service.ts
+++ b/apps/api/src/memories/curation/memory-curation.service.ts
@@ -43,7 +43,7 @@
 // =============================================================================
 
 import { Injectable, Logger } from '@nestjs/common';
-import { MediaTagSource, MediaType, MemoryType, Prisma } from '@prisma/client';
+import { MediaTagSource, MediaType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import {
   CuratedItem,

--- a/apps/api/src/memories/curation/memory-curation.types.ts
+++ b/apps/api/src/memories/curation/memory-curation.types.ts
@@ -1,0 +1,110 @@
+// =============================================================================
+// Memories — shared curation types (epic #300, issue #303)
+// =============================================================================
+//
+// The vocabulary every curator speaks. Kept in its own module (rather than
+// inside MemoryCurationService) so a curator can import the shapes without
+// importing the service, and so the pure scoring/selection helpers stay unit
+// testable with plain object literals and no Nest module graph.
+// =============================================================================
+
+import { MediaType, MemoryType } from '@prisma/client';
+
+/**
+ * One media item considered for inclusion in a memory, hydrated with exactly
+ * the signals the scorer needs and nothing else.
+ *
+ * Deliberately flat and tiny: a curation pass over a large circle holds up to
+ * `maxCandidates` of these at once, so every field here is paid for per
+ * candidate. `capturedAt` is non-nullable because the curation base filter
+ * (`capturedAt IS NOT NULL`) makes it so — a candidate can never reach this
+ * type with a null capture date.
+ */
+export interface MemoryCandidate {
+  id: string;
+  capturedAt: Date;
+  type: MediaType;
+  durationMs: number | null;
+  favorite: boolean;
+  sharpnessScore: number | null;
+  burstGroupId: string | null;
+  duplicateGroupId: string | null;
+  /** Has an AI description or at least one AI-applied tag. */
+  hasAiContent: boolean;
+  /** Carries a face assigned to a live, non-hidden Person marked `favorite`. */
+  hasFavoritePersonFace: boolean;
+}
+
+/** A candidate plus its computed scores. */
+export interface ScoredCandidate extends MemoryCandidate {
+  /**
+   * The pure quality score from the epic's formula. This is what gets
+   * persisted to `MemoryItem.score` — an audit of why the item was picked,
+   * independent of any selection-time preference.
+   */
+  score: number;
+  /**
+   * The score actually used for ranking during selection. Equal to `score`
+   * except for long/unknown-duration videos, which carry a preference penalty
+   * (see LONG_VIDEO_PENALTY). Never persisted: it is an ordering device, not a
+   * property of the item.
+   */
+  selectionScore: number;
+}
+
+/** One chosen item, in final chronological order. */
+export interface CuratedItem {
+  mediaItemId: string;
+  position: number;
+  score: number;
+}
+
+/** The full output of a curation pass over one candidate set. */
+export interface CuratedSelection {
+  /** Chronologically ascending, `position` 0..n-1. */
+  items: CuratedItem[];
+  /** Highest-scored NON-video item, or null when the selection is all video. */
+  coverMediaItemId: string | null;
+  /** Earliest / latest `capturedAt` across `items`; null when empty. */
+  periodStart: Date | null;
+  periodEnd: Date | null;
+  /** Candidates seen before collapse/selection — useful for logging. */
+  candidateCount: number;
+  /** True when the candidate scan hit its hard cap and stopped early. */
+  truncated: boolean;
+}
+
+/** Input to the idempotent `upsertMemory` helper every curator funnels through. */
+export interface UpsertMemoryInput {
+  circleId: string;
+  type: MemoryType;
+  /** Per-type period identity — see the MemoryType enum comment in schema.prisma. */
+  periodKey: string;
+  /** Per-type subject identity. NEVER null — `''` when the type does not use it. */
+  subjectKey?: string;
+  personId?: string | null;
+  /** Template-derived title/subtitle. Used verbatim on create, and on a material refresh. */
+  title: string;
+  subtitle?: string | null;
+  selection: CuratedSelection;
+  meta?: Record<string, unknown> | null;
+  expiresAt?: Date | null;
+}
+
+/** Outcome of one `upsertMemory` call. */
+export interface UpsertMemoryResult {
+  /** The live row, or null when the upsert was refused by the tombstone. */
+  memoryId: string | null;
+  created: boolean;
+  /**
+   * True when this call materially changed what the memory contains: a fresh
+   * create, or a refresh whose membership moved by at least
+   * MATERIAL_CHANGE_THRESHOLD (Jaccard distance on media-item id sets).
+   *
+   * Consumed by #311's notification/digest producers to answer "is there
+   * anything new worth telling the circle about?" without re-diffing.
+   */
+  materiallyChanged: boolean;
+  /** True when an existing tombstoned (user-deleted) row refused the upsert. */
+  skippedTombstone: boolean;
+}

--- a/apps/api/src/memories/curation/memory-title-templates.spec.ts
+++ b/apps/api/src/memories/curation/memory-title-templates.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the deterministic memory title templates (issue #303).
+ *
+ * These are the permanent floor of the feature — on a deployment with no AI
+ * provider configured they are the ONLY titles that ever render — so all seven
+ * types are covered here, including the two edges the issue calls out
+ * explicitly: pluralization, and a Person row with a NULL name.
+ */
+
+import {
+  SEASON_LABELS,
+  formatLongDate,
+  formatMonthYear,
+  onThisDayTitle,
+  personHighlightsTitle,
+  personOverYearsTitle,
+  pluralize,
+  seasonForMonth,
+  seasonalTitle,
+  themeTitle,
+  titleCaseTag,
+  tripTitle,
+  yearInReviewTitle,
+} from './memory-title-templates';
+
+describe('memory title templates', () => {
+  describe('helpers', () => {
+    it('pluralizes on 1 vs. n', () => {
+      expect(pluralize(1, 'year')).toBe('1 year');
+      expect(pluralize(6, 'year')).toBe('6 years');
+      expect(pluralize(0, 'year')).toBe('0 years');
+    });
+
+    it('formats dates in UTC regardless of the host zone', () => {
+      // 2019-03-12T23:30Z is still March 12 in UTC but March 13 in, say,
+      // Asia/Tokyo — the explicit timeZone pin is what keeps a title stable
+      // across deployments.
+      expect(formatLongDate(new Date('2019-03-12T23:30:00Z'))).toBe('March 12, 2019');
+      expect(formatMonthYear(new Date('2023-03-01T00:00:00Z'))).toBe('March 2023');
+    });
+
+    it('title-cases multi-word tags without touching inner characters', () => {
+      expect(titleCaseTag('golden sunsets')).toBe('Golden Sunsets');
+      expect(titleCaseTag('beach')).toBe('Beach');
+      expect(titleCaseTag('  spaced   out ')).toBe('Spaced Out');
+    });
+
+    it('maps months to northern-hemisphere meteorological seasons', () => {
+      expect(seasonForMonth(12)).toBe('winter');
+      expect(seasonForMonth(1)).toBe('winter');
+      expect(seasonForMonth(2)).toBe('winter');
+      expect(seasonForMonth(3)).toBe('spring');
+      expect(seasonForMonth(5)).toBe('spring');
+      expect(seasonForMonth(6)).toBe('summer');
+      expect(seasonForMonth(8)).toBe('summer');
+      expect(seasonForMonth(9)).toBe('fall');
+      expect(seasonForMonth(11)).toBe('fall');
+      expect(Object.keys(SEASON_LABELS)).toHaveLength(4);
+    });
+  });
+
+  it('on_this_day', () => {
+    expect(onThisDayTitle(6, new Date('2019-03-12T10:00:00Z'))).toEqual({
+      title: 'On this day — 6 years ago',
+      subtitle: 'March 12, 2019',
+    });
+    // The singular case is the one a naive `${n} years ago` gets wrong.
+    expect(onThisDayTitle(1, new Date('2024-12-25T00:00:00Z'))).toEqual({
+      title: 'On this day — 1 year ago',
+      subtitle: 'December 25, 2024',
+    });
+  });
+
+  describe('trip', () => {
+    it('uses a single month when the trip does not span one', () => {
+      expect(
+        tripTitle('Guanacaste', new Date('2023-03-12T00:00:00Z'), new Date('2023-03-19T00:00:00Z')),
+      ).toEqual({ title: 'Trip to Guanacaste', subtitle: 'March 2023' });
+    });
+
+    it('uses a month range within one year', () => {
+      expect(
+        tripTitle('Kyoto', new Date('2023-03-28T00:00:00Z'), new Date('2023-04-04T00:00:00Z')),
+      ).toEqual({ title: 'Trip to Kyoto', subtitle: 'March–April 2023' });
+    });
+
+    it('repeats the year for a trip spanning New Year', () => {
+      expect(
+        tripTitle('Bariloche', new Date('2023-12-28T00:00:00Z'), new Date('2024-01-04T00:00:00Z')),
+      ).toEqual({ title: 'Trip to Bariloche', subtitle: 'December 2023–January 2024' });
+    });
+  });
+
+  describe('person_highlights', () => {
+    it('names the person and the year', () => {
+      expect(personHighlightsTitle('Abuela', 2025)).toEqual({
+        title: 'Best of Abuela',
+        subtitle: '2025',
+      });
+    });
+
+    it('falls back for a NULL-named person rather than rendering an empty name', () => {
+      expect(personHighlightsTitle(null, 2025).title).toBe('Best moments together');
+      expect(personHighlightsTitle(undefined, 2025).title).toBe('Best moments together');
+      expect(personHighlightsTitle('   ', 2025).title).toBe('Best moments together');
+    });
+
+    it('omits the subtitle for an all-time collection', () => {
+      expect(personHighlightsTitle('Abuela', null).subtitle).toBeNull();
+    });
+  });
+
+  describe('person_over_years', () => {
+    it('renders the year span', () => {
+      expect(personOverYearsTitle('Camila', 2016, 2025)).toEqual({
+        title: 'Camila through the years',
+        subtitle: '2016–2025',
+      });
+    });
+
+    it('collapses a single-year span', () => {
+      expect(personOverYearsTitle('Camila', 2025, 2025).subtitle).toBe('2025');
+    });
+
+    it('falls back for a NULL-named person', () => {
+      expect(personOverYearsTitle(null, 2016, 2025).title).toBe('Through the years');
+    });
+  });
+
+  it('theme', () => {
+    expect(themeTitle('golden sunsets', 14)).toEqual({
+      title: 'Golden Sunsets',
+      subtitle: '14 favorite moments',
+    });
+    expect(themeTitle('pets', 1).subtitle).toBe('1 favorite moment');
+  });
+
+  it('seasonal', () => {
+    expect(seasonalTitle('summer', 2025)).toEqual({ title: 'Summer 2025', subtitle: null });
+    expect(seasonalTitle('winter', 2024).title).toBe('Winter 2024');
+  });
+
+  it('year_in_review', () => {
+    expect(yearInReviewTitle(2025, 42)).toEqual({
+      title: 'Your 2025 in review',
+      subtitle: '42 highlights from the year',
+    });
+    expect(yearInReviewTitle(2025, 1).subtitle).toBe('1 highlight from the year');
+  });
+});

--- a/apps/api/src/memories/curation/memory-title-templates.ts
+++ b/apps/api/src/memories/curation/memory-title-templates.ts
@@ -1,0 +1,211 @@
+// =============================================================================
+// Memories — deterministic title templates (epic #300, issue #303)
+// =============================================================================
+//
+// Pure functions, zero I/O, no Nest wiring: given the facts a curator already
+// knows, produce the `title` / `subtitle` pair that goes on the Memory row with
+// `titleSource = 'template'`.
+//
+// WHY THESE EXIST EVEN THOUGH #306 ADDS AI TITLES. Templates are not a
+// placeholder — they are the permanent floor of the feature. AI titling is
+// gated on `memories.aiTitles.enabled` AND a configured `ai.features.memories`
+// provider AND a successful, time-bounded model call; ANY of those three
+// missing falls back here. On a deployment with no AI provider configured
+// (a supported, documented configuration) these are the only titles that ever
+// render, so they have to read well on their own rather than look like debug
+// output.
+//
+// LOCALE. English, formatted through `Intl.DateTimeFormat('en', …)` with an
+// explicit `timeZone: 'UTC'`. The UTC pin is load-bearing, not decorative: a
+// memory's `periodStart` is a `timestamptz`, and formatting it in the server's
+// local zone would render "December 31, 2024" or "January 1, 2025" for the same
+// instant depending on where the container happens to run — i.e. a title that
+// changes when you redeploy. Every curator computes its period boundaries in
+// UTC, so formatting must agree.
+// =============================================================================
+
+/** A rendered template result. `subtitle` is null when the type has none. */
+export interface MemoryTitleParts {
+  title: string;
+  subtitle: string | null;
+}
+
+/**
+ * Season labels, and the month→season mapping, in ONE place.
+ *
+ * Northern-hemisphere meteorological seasons (Dec–Feb Winter, Mar–May Spring,
+ * Jun–Aug Summer, Sep–Nov Fall), per the epic. Centralized deliberately: a
+ * future hemisphere/locale configuration only has to replace this table, not
+ * hunt for month arithmetic scattered through the seasonal curator (#305).
+ */
+export const SEASON_LABELS = {
+  winter: 'Winter',
+  spring: 'Spring',
+  summer: 'Summer',
+  fall: 'Fall',
+} as const;
+
+export type SeasonKey = keyof typeof SEASON_LABELS;
+
+/**
+ * Northern-hemisphere season for a 1-based month.
+ *
+ * December belongs to the winter that *starts* in that calendar year, which is
+ * why the seasonal curator's `periodKey` (`"2025-winter"`) and the label year
+ * can legitimately disagree with a naive `getUTCFullYear()` of a January photo.
+ * That reconciliation belongs to the curator (#305); this function answers only
+ * "which season is month N".
+ */
+export function seasonForMonth(month1Based: number): SeasonKey {
+  if (month1Based === 12 || month1Based <= 2) return 'winter';
+  if (month1Based <= 5) return 'spring';
+  if (month1Based <= 8) return 'summer';
+  return 'fall';
+}
+
+/** `1 → "1 year"`, `6 → "6 years"`. */
+export function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+const monthDayYear = new Intl.DateTimeFormat('en', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+const monthYear = new Intl.DateTimeFormat('en', {
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+const monthOnly = new Intl.DateTimeFormat('en', {
+  month: 'long',
+  timeZone: 'UTC',
+});
+
+/** `"March 12, 2023"` — always UTC. */
+export function formatLongDate(date: Date): string {
+  return monthDayYear.format(date);
+}
+
+/** `"March 2023"` — always UTC. */
+export function formatMonthYear(date: Date): string {
+  return monthYear.format(date);
+}
+
+/**
+ * Title-case a free-form tag name: `"golden sunsets" → "Golden Sunsets"`.
+ *
+ * Word-wise rather than sentence-case because tags are labels, not prose, and
+ * the vocabulary is admin-curated so an all-lowercase entry is the norm. An
+ * already-capitalized or acronym-ish tag is left alone beyond its first letter.
+ */
+export function titleCaseTag(tag: string): string {
+  return tag
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * `on_this_day` — "On this day — 6 years ago" / "March 12, 2019".
+ *
+ * @param yearsAgo  how far back the source photos are (>= 1)
+ * @param sourceDate any instant within the source day; formatted in UTC
+ */
+export function onThisDayTitle(yearsAgo: number, sourceDate: Date): MemoryTitleParts {
+  return {
+    title: `On this day — ${pluralize(yearsAgo, 'year')} ago`,
+    subtitle: formatLongDate(sourceDate),
+  };
+}
+
+/**
+ * `trip` — "Trip to Guanacaste" / "March 2023" (or "March–April 2023").
+ *
+ * The place is whatever the trip curator (#304) resolved as dominant, already
+ * narrowed to locality → admin1 → country by the caller; this function does not
+ * re-derive it.
+ */
+export function tripTitle(place: string, start: Date, end: Date): MemoryTitleParts {
+  const sameMonth =
+    start.getUTCFullYear() === end.getUTCFullYear() && start.getUTCMonth() === end.getUTCMonth();
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
+
+  let subtitle: string;
+  if (sameMonth) {
+    subtitle = formatMonthYear(start);
+  } else if (sameYear) {
+    // "March–April 2023" — one year suffix, en dash.
+    subtitle = `${monthOnly.format(start)}–${formatMonthYear(end)}`;
+  } else {
+    // A trip spanning New Year needs both years to be unambiguous.
+    subtitle = `${formatMonthYear(start)}–${formatMonthYear(end)}`;
+  }
+
+  return { title: `Trip to ${place}`, subtitle };
+}
+
+/**
+ * `person_highlights` — "Best of Abuela" / "2025".
+ *
+ * A Person row may legitimately have a NULL `name` (an unlabeled cluster the
+ * user has favorited but not yet named). Rendering "Best of null" or "Best of "
+ * would be worse than a generic-but-warm fallback, so an unnamed person gets
+ * "Best moments together" with no name at all.
+ *
+ * @param year the highlight year, or null for an all-time collection
+ */
+export function personHighlightsTitle(
+  name: string | null | undefined,
+  year: number | null,
+): MemoryTitleParts {
+  const trimmed = name?.trim();
+  return {
+    title: trimmed ? `Best of ${trimmed}` : 'Best moments together',
+    subtitle: year === null ? null : String(year),
+  };
+}
+
+/**
+ * `person_over_years` — "Camila through the years" / "2016–2025".
+ *
+ * The unnamed-person fallback mirrors personHighlightsTitle's rationale.
+ */
+export function personOverYearsTitle(
+  name: string | null | undefined,
+  firstYear: number,
+  lastYear: number,
+): MemoryTitleParts {
+  const trimmed = name?.trim();
+  return {
+    title: trimmed ? `${trimmed} through the years` : 'Through the years',
+    // A single-year span reads "2025", not "2025–2025".
+    subtitle: firstYear === lastYear ? String(firstYear) : `${firstYear}–${lastYear}`,
+  };
+}
+
+/** `theme` — "Golden Sunsets" / "14 favorite moments". */
+export function themeTitle(tag: string, count: number): MemoryTitleParts {
+  return {
+    title: titleCaseTag(tag),
+    subtitle: `${pluralize(count, 'favorite moment')}`,
+  };
+}
+
+/** `seasonal` — "Summer 2025". No subtitle: the title already says everything. */
+export function seasonalTitle(season: SeasonKey, year: number): MemoryTitleParts {
+  return { title: `${SEASON_LABELS[season]} ${year}`, subtitle: null };
+}
+
+/** `year_in_review` — "Your 2025 in review" / "42 highlights from the year". */
+export function yearInReviewTitle(year: number, count: number): MemoryTitleParts {
+  return {
+    title: `Your ${year} in review`,
+    subtitle: `${pluralize(count, 'highlight')} from the year`,
+  };
+}

--- a/apps/api/src/memories/curators/memory-curator.interface.ts
+++ b/apps/api/src/memories/curators/memory-curator.interface.ts
@@ -1,0 +1,83 @@
+// =============================================================================
+// Memories — curator contract (epic #300, issue #303)
+// =============================================================================
+//
+// A curator answers one question: "which memories of MY type should exist in
+// this circle right now?" It owns its slice selection, its identity keys
+// (`periodKey`/`subjectKey`), its template titles and its own expiry/retention
+// tail; it does NOT own scoring, near-duplicate collapse, diversity, or the
+// idempotent write — those are MemoryCurationService's, shared by every type.
+//
+// The registry is an injected ARRAY rather than a hard-coded list inside the
+// handler, so #304 (Trips) and #305 (People / Theme / Seasonal / Year in
+// Review) add a provider and nothing else. The handler runs each entry inside
+// its own try/catch — see MemoryGenerationHandler for why per-curator isolation
+// is a correctness requirement, not politeness.
+// =============================================================================
+
+import { MemoriesSettingsValue } from '../../common/types/settings.types';
+
+/** DI token for the ordered curator registry. */
+export const MEMORY_CURATORS = Symbol('MEMORY_CURATORS');
+
+/** Everything a curator needs for one circle's generation pass. */
+export interface MemoryCuratorContext {
+  circleId: string;
+  /**
+   * The `memories.*` namespace with every default resolved, so a curator never
+   * writes `?? 10` for a value the settings schema already defaults.
+   */
+  settings: MemoriesSettingsValue;
+  /**
+   * Wall clock for the whole run, captured ONCE by the handler and shared by
+   * every curator. A run that straddles midnight must not have one curator
+   * anchoring on today and the next on tomorrow.
+   */
+  now: Date;
+  /**
+   * Admin backfill (#315): widen from "what is relevant today" to "everything
+   * this circle's library supports". Scheduled runs are always `false`.
+   */
+  backfill: boolean;
+}
+
+/** What one curator did, for logging and the handler's run summary. */
+export interface MemoryCuratorResult {
+  created: number;
+  refreshed: number;
+  /** Periods that produced no memory (below `minItems`, or nothing to curate). */
+  skipped: number;
+  /** Upserts refused because the memory carries a user-delete tombstone. */
+  tombstoned: number;
+}
+
+export function emptyCuratorResult(): MemoryCuratorResult {
+  return { created: 0, refreshed: 0, skipped: 0, tombstoned: 0 };
+}
+
+export interface MemoryCurator {
+  /** Stable identifier used in logs and error messages. */
+  readonly name: string;
+
+  /**
+   * Per-type settings gate (`memories.<type>.enabled`). Kept on the curator
+   * rather than as a settings key string on the registry entry so the mapping
+   * from curator to setting is type-checked instead of stringly-typed.
+   */
+  isEnabled(settings: MemoriesSettingsValue): boolean;
+
+  /** Generate/refresh this curator's memories for one circle. */
+  run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult>;
+
+  /**
+   * Optional retention tail, run after `run()` on every generation job.
+   *
+   * Lives on the curator because retention is type-specific: only
+   * `on_this_day` memories expire at all. Implemented as a hook rather than a
+   * separate cron so it costs nothing on a deployment with the feature off, and
+   * so a type's creation and cleanup rules stay in one file.
+   *
+   * @returns number of rows removed
+   */
+  purge?(ctx: MemoryCuratorContext): Promise<number>;
+}

--- a/apps/api/src/memories/curators/on-this-day.curator.ts
+++ b/apps/api/src/memories/curators/on-this-day.curator.ts
@@ -31,7 +31,7 @@
 // scheduled run, not 2 × lookbackYears.
 // =============================================================================
 
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { MemoryType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { MemoryCurationService } from '../curation/memory-curation.service';

--- a/apps/api/src/memories/curators/on-this-day.curator.ts
+++ b/apps/api/src/memories/curators/on-this-day.curator.ts
@@ -1,0 +1,326 @@
+// =============================================================================
+// Memories — On This Day curator (epic #300, issue #303)
+// =============================================================================
+//
+// Resurfaces, for a given calendar day, one memory PER PAST YEAR that has
+// enough photos on that day: "On this day — 6 years ago".
+//
+// WHY TODAY *AND* TOMORROW. Generation is a background job on an interval
+// (default 24h); notifications and the email digest (#311) fire in the morning.
+// If a circle only ever generated for "today", a digest sent at 08:00 UTC would
+// race the generation job that produces the content it is supposed to announce.
+// Pre-generating tomorrow means the content for any given morning already
+// exists the evening before, whatever order the two jobs happen to run in.
+//
+// WHY A MEMORY PER YEAR, NOT ONE PER DAY. "On this day" across ten years is ten
+// separate stories, not one 300-photo pile. Per-year memories also give each
+// year its own stable identity (`subjectKey`), which is what makes per-user
+// seen/hidden/favorite state and the tombstone meaningful — you can delete
+// 2014's awkward party without losing 2019's beach trip.
+//
+// THE DAY MATCH IS A FUNCTIONAL-INDEX QUERY. Matching "same month and day, any
+// year" cannot be expressed as a range, so it goes through raw SQL against
+// `EXTRACT(MONTH/DAY FROM (captured_at AT TIME ZONE 'UTC'))` — the same
+// expression as `MediaService.getDashboard`'s On This Day query, and the same
+// UTC pin (the cast makes EXTRACT IMMUTABLE, which is what allows an index on
+// it at all; see 20260615000000_media_oncethisday_index). This curator is
+// circle-scoped and excludes archived items, which that original index does not
+// cover, so migration 20260809140000_memories_on_this_day_index adds a widened
+// `(circle_id, month, day)` partial functional index for it. ONE query per
+// anchor date covers every lookback year at once — 2 queries per circle per
+// scheduled run, not 2 × lookbackYears.
+// =============================================================================
+
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { MemoryType, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { onThisDayTitle } from '../curation/memory-title-templates';
+import {
+  MEMORY_CURATORS,
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * How long an `on_this_day` memory survives past its anchor day before the
+ * generation job's purge tail hard-deletes it — TOMBSTONED OR NOT.
+ *
+ * Ignoring the tombstone here is deliberate and safe: the tombstone's job is
+ * "do not recreate this memory", and once the anchor day is a month gone the
+ * curator has no reason to generate that periodKey again until the date comes
+ * back around a year later — by which point the underlying library has changed
+ * and the memory is legitimately a new one. Keeping tombstones forever would
+ * mean an unbounded row per (day × year) accumulating for the life of the
+ * deployment, for content nobody can ever see again.
+ */
+export const ON_THIS_DAY_RETENTION_DAYS = 30;
+
+/** Rows deleted per statement in the purge tail (lock-safe batching). */
+const PURGE_BATCH_SIZE = 5_000;
+
+/**
+ * Defensive ceiling on ids pulled for one anchor across ALL lookback years.
+ * Ordered `captured_at ASC` so the cut is deterministic; a circle dense enough
+ * to hit this has far more than enough material for a good memory anyway.
+ */
+const MAX_ANCHOR_ROWS = 20_000;
+
+/** Farthest ahead `nextAnchorOccurrence` will look — covers Feb 29's 8-year gap. */
+const MAX_ANCHOR_LOOKAHEAD_YEARS = 8;
+
+/** UTC midnight of the day containing `date`. */
+export function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+/** `2026-08-09` — the `periodKey` form for an anchor day. */
+export function toIsoDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * The next occurrence of (month, day) at or after `now`, at UTC midnight.
+ *
+ * Feb 29 is the whole reason this is a loop rather than arithmetic:
+ * `Date.UTC(2027, 1, 29)` silently rolls over to March 1, so a naive
+ * implementation would generate a "February 29" memory keyed to March 1 in
+ * three years out of four. The round-trip check rejects the rollover and the
+ * loop walks forward to the next leap year.
+ */
+export function nextAnchorOccurrence(now: Date, month: number, day: number): Date | null {
+  const today = startOfUtcDay(now).getTime();
+  const startYear = now.getUTCFullYear();
+  for (let year = startYear; year <= startYear + MAX_ANCHOR_LOOKAHEAD_YEARS; year += 1) {
+    const candidate = new Date(Date.UTC(year, month - 1, day));
+    if (candidate.getUTCMonth() !== month - 1 || candidate.getUTCDate() !== day) continue;
+    if (candidate.getTime() >= today) return candidate;
+  }
+  return null;
+}
+
+@Injectable()
+export class OnThisDayCurator implements MemoryCurator {
+  readonly name = 'on_this_day';
+
+  private readonly logger = new Logger(OnThisDayCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.onThisDay.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const anchors = await this.resolveAnchors(ctx);
+
+    for (const anchor of anchors) {
+      const anchorResult = await this.curateAnchor(ctx, anchor);
+      result.created += anchorResult.created;
+      result.refreshed += anchorResult.refreshed;
+      result.skipped += anchorResult.skipped;
+      result.tombstoned += anchorResult.tombstoned;
+    }
+
+    return result;
+  }
+
+  /**
+   * Which calendar days to generate for.
+   *
+   * Scheduled: today + tomorrow (UTC). Backfill (#315): every (month, day) the
+   * circle actually has photos on, each mapped to its NEXT occurrence — so a
+   * backfilled memory's `periodKey` and `expiresAt` describe a day that is still
+   * ahead, rather than a day that has already passed (which would make the row
+   * born expired and immediately purge-eligible).
+   */
+  private async resolveAnchors(ctx: MemoryCuratorContext): Promise<Date[]> {
+    if (!ctx.backfill) {
+      const today = startOfUtcDay(ctx.now);
+      return [today, new Date(today.getTime() + MS_PER_DAY)];
+    }
+
+    // At most 366 rows — one per calendar day the circle has any candidate on.
+    const pairs = await this.prisma.$queryRaw<Array<{ month: number; day: number }>>(Prisma.sql`
+      SELECT DISTINCT
+        EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC'))::int AS month,
+        EXTRACT(DAY   FROM ("captured_at" AT TIME ZONE 'UTC'))::int AS day
+      FROM "media_items"
+      WHERE "circle_id" = ${ctx.circleId}::uuid
+        AND "deleted_at" IS NULL
+        AND "archived_at" IS NULL
+        AND "captured_at" IS NOT NULL
+        AND "social_media_source" IS NULL
+    `);
+
+    const byKey = new Map<string, Date>();
+    for (const { month, day } of pairs) {
+      const anchor = nextAnchorOccurrence(ctx.now, month, day);
+      if (anchor) byKey.set(toIsoDateKey(anchor), anchor);
+    }
+    return [...byKey.values()].sort((a, b) => a.getTime() - b.getTime());
+  }
+
+  /** Generate/refresh every qualifying past year for one anchor day. */
+  private async curateAnchor(
+    ctx: MemoryCuratorContext,
+    anchor: Date,
+  ): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { lookbackYears, minItems } = ctx.settings.onThisDay;
+    const maxItems = ctx.settings.maxItemsPerMemory;
+
+    const anchorYear = anchor.getUTCFullYear();
+    const month = anchor.getUTCMonth() + 1;
+    const day = anchor.getUTCDate();
+
+    // Half-open [floor, ceil): every year strictly BEFORE the anchor year, back
+    // `lookbackYears`. Excluding the anchor year itself is what makes every
+    // memory "N years ago" with N >= 1 — today's own photos are not a memory yet.
+    const floor = new Date(Date.UTC(anchorYear - lookbackYears, 0, 1));
+    const ceil = new Date(Date.UTC(anchorYear, 0, 1));
+
+    const rows = await this.prisma.$queryRaw<Array<{ id: string; year: number }>>(Prisma.sql`
+      SELECT "id",
+             EXTRACT(YEAR FROM ("captured_at" AT TIME ZONE 'UTC'))::int AS year
+      FROM "media_items"
+      WHERE "circle_id" = ${ctx.circleId}::uuid
+        AND "deleted_at" IS NULL
+        AND "archived_at" IS NULL
+        AND "captured_at" IS NOT NULL
+        AND "social_media_source" IS NULL
+        AND "captured_at" >= ${floor}
+        AND "captured_at" < ${ceil}
+        AND EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC')) = ${month}
+        AND EXTRACT(DAY   FROM ("captured_at" AT TIME ZONE 'UTC')) = ${day}
+      ORDER BY "captured_at" ASC, "id" ASC
+      LIMIT ${MAX_ANCHOR_ROWS}
+    `);
+
+    if (rows.length === 0) return result;
+
+    const idsByYear = new Map<number, string[]>();
+    for (const row of rows) {
+      const bucket = idsByYear.get(row.year);
+      if (bucket) bucket.push(row.id);
+      else idsByYear.set(row.year, [row.id]);
+    }
+
+    const periodKey = toIsoDateKey(anchor);
+    // Active until the anchor day is over. `Memory.expiresAt` is compared with
+    // `expiresAt > now()`, so start-of-next-day is the correct exclusive bound.
+    const expiresAt = new Date(anchor.getTime() + MS_PER_DAY);
+
+    // Descending: most recent year first, so a run that is cut short by a job
+    // timeout has produced the years users are most likely to care about.
+    const years = [...idsByYear.keys()].sort((a, b) => b - a);
+
+    for (const sourceYear of years) {
+      const ids = idsByYear.get(sourceYear)!;
+      // A year that cannot possibly clear `minItems` even before collapse and
+      // the video cap is not worth a curation pass.
+      if (ids.length < minItems) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const selection = await this.curation.curate(
+        ctx.circleId,
+        { id: { in: ids } },
+        { maxItems },
+      );
+      if (selection.items.length < minItems) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const yearsAgo = anchorYear - sourceYear;
+      // The exact source day, constructed rather than taken from the first
+      // item's timestamp: both name the same UTC calendar day (the EXTRACT
+      // filter guarantees it) and the constructed one cannot drift.
+      const sourceDate = new Date(Date.UTC(sourceYear, month - 1, day));
+      const { title, subtitle } = onThisDayTitle(yearsAgo, sourceDate);
+
+      const upsert = await this.curation.upsertMemory({
+        circleId: ctx.circleId,
+        type: MemoryType.on_this_day,
+        periodKey,
+        subjectKey: String(sourceYear),
+        title,
+        subtitle,
+        selection,
+        expiresAt,
+        meta: { yearsAgo, sourceYear, anchorMonth: month, anchorDay: day },
+      });
+
+      if (upsert.skippedTombstone) result.tombstoned += 1;
+      else if (upsert.created) result.created += 1;
+      else result.refreshed += 1;
+    }
+
+    return result;
+  }
+
+  /**
+   * Retention tail: hard-delete this circle's `on_this_day` memories whose
+   * anchor day is more than ON_THIS_DAY_RETENTION_DAYS past.
+   *
+   * Runs at the end of every generation job rather than on its own cron: the
+   * work is proportional to what generation just produced, it must not run on a
+   * deployment with the feature off, and a separate cron would be a second
+   * schedule to reason about for a single `deleteMany`.
+   *
+   * Batched despite the small expected cardinality because a backfilled circle
+   * can hold up to `366 × lookbackYears` rows of this type, and a single
+   * unbounded delete over that set is a needlessly long-held lock.
+   */
+  async purge(ctx: MemoryCuratorContext): Promise<number> {
+    const cutoff = new Date(ctx.now.getTime() - ON_THIS_DAY_RETENTION_DAYS * MS_PER_DAY);
+    let deleted = 0;
+
+    for (;;) {
+      const batch = await this.prisma.memory.findMany({
+        where: {
+          circleId: ctx.circleId,
+          type: MemoryType.on_this_day,
+          expiresAt: { not: null, lt: cutoff },
+        },
+        select: { id: true },
+        take: PURGE_BATCH_SIZE,
+      });
+      if (batch.length === 0) break;
+
+      const removed = await this.prisma.memory.deleteMany({
+        where: { id: { in: batch.map((m) => m.id) } },
+      });
+      deleted += removed.count;
+      if (batch.length < PURGE_BATCH_SIZE) break;
+    }
+
+    if (deleted > 0) {
+      this.logger.debug(
+        `Purged ${deleted} expired on_this_day memor${deleted === 1 ? 'y' : 'ies'} ` +
+          `from circle ${ctx.circleId}`,
+      );
+    }
+    return deleted;
+  }
+}
+
+/**
+ * Registry factory for the curator array. Later issues append their curators
+ * here; ordering is the execution order inside a generation job.
+ */
+export const memoryCuratorsProvider = {
+  provide: MEMORY_CURATORS,
+  useFactory: (onThisDay: OnThisDayCurator): MemoryCurator[] => [onThisDay],
+  inject: [OnThisDayCurator],
+};

--- a/apps/api/src/memories/memories-settings.util.ts
+++ b/apps/api/src/memories/memories-settings.util.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// Memories — settings resolution (epic #300, issue #303)
+// =============================================================================
+//
+// `SystemSettingsService.getSettings()` returns `memories` as OPTIONAL, and it
+// genuinely can be absent: the row is JSONB written before this namespace
+// existed, and nothing back-fills it (that is exactly what makes the namespace
+// migration-free). Curators must not each carry `?? 10` fallbacks for values the
+// settings schema already defines a default for — that is three copies of the
+// same number drifting apart, the pitfall docs/specs/memories.md §9.3 already
+// documents for this namespace.
+//
+// This resolves the namespace ONCE per generation job, deep-merging over
+// DEFAULT_SYSTEM_SETTINGS.memories, so every curator receives a fully-populated
+// MemoriesSettingsValue and can read `settings.onThisDay.minItems` directly.
+// =============================================================================
+
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  MemoriesSettingsValue,
+} from '../common/types/settings.types';
+
+const DEFAULTS = DEFAULT_SYSTEM_SETTINGS.memories as MemoriesSettingsValue;
+
+/** Merge one nested settings group over its defaults, ignoring undefined keys. */
+function mergeGroup<T extends object>(defaults: T, partial: Partial<T> | undefined): T {
+  if (!partial) return { ...defaults };
+  const out = { ...defaults };
+  for (const [key, value] of Object.entries(partial)) {
+    if (value !== undefined) (out as Record<string, unknown>)[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Fill every `memories.*` value from defaults where the stored settings are
+ * silent. Never mutates the input, and never returns a partially-populated
+ * group — a caller can dereference any documented key unconditionally.
+ */
+export function resolveMemoriesSettings(
+  stored: Partial<MemoriesSettingsValue> | undefined | null,
+): MemoriesSettingsValue {
+  return {
+    generation: mergeGroup(DEFAULTS.generation, stored?.generation),
+    maxItemsPerMemory: stored?.maxItemsPerMemory ?? DEFAULTS.maxItemsPerMemory,
+    aiTitles: mergeGroup(DEFAULTS.aiTitles, stored?.aiTitles),
+    onThisDay: mergeGroup(DEFAULTS.onThisDay, stored?.onThisDay),
+    trips: mergeGroup(DEFAULTS.trips, stored?.trips),
+    people: mergeGroup(DEFAULTS.people, stored?.people),
+    themes: mergeGroup(DEFAULTS.themes, stored?.themes),
+    seasonal: mergeGroup(DEFAULTS.seasonal, stored?.seasonal),
+    yearInReview: mergeGroup(DEFAULTS.yearInReview, stored?.yearInReview),
+    digest: mergeGroup(DEFAULTS.digest, stored?.digest),
+  };
+}

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -2,14 +2,19 @@
 // Memories Module (epic #300, issue #302)
 // =============================================================================
 //
-// Owns the Memories generation plumbing: the hourly per-circle scheduling cron
-// and the (v1 no-op) `memory_generation` enrichment handler. Later issues in the
-// epic add curators (#303–#305), AI titles (#306), the read API (#307) and the
-// email digest (#311) here.
+// Owns the Memories generation plumbing: the hourly per-circle scheduling cron,
+// the `memory_generation` enrichment handler, the shared curation engine and the
+// curator registry. Later issues in the epic add more curators (#304–#305), AI
+// titles (#306), the read API (#307) and the email digest (#311) here.
 //
 // Minimal-template module (mirrors InsightsModule): PrismaModule for DB access,
 // SettingsModule for the cached feature-flag/settings reads, EnrichmentModule
 // for the job service and the handler registry.
+//
+// THE CURATOR REGISTRY is provided as an injected array under the
+// MEMORY_CURATORS token (see memoryCuratorsProvider) rather than hard-coded in
+// the handler, so a new curator is a provider + one entry in that factory and
+// nothing else changes.
 // =============================================================================
 
 import { Module } from '@nestjs/common';
@@ -18,10 +23,18 @@ import { SettingsModule } from '../settings/settings.module';
 import { EnrichmentModule } from '../enrichment/enrichment.module';
 import { MemoriesGenerationTask } from './memories-generation.task';
 import { MemoryGenerationHandler } from './memory-generation.handler';
+import { MemoryCurationService } from './curation/memory-curation.service';
+import { OnThisDayCurator, memoryCuratorsProvider } from './curators/on-this-day.curator';
 
 @Module({
   imports: [PrismaModule, SettingsModule, EnrichmentModule],
-  providers: [MemoriesGenerationTask, MemoryGenerationHandler],
-  exports: [MemoriesGenerationTask],
+  providers: [
+    MemoriesGenerationTask,
+    MemoryGenerationHandler,
+    MemoryCurationService,
+    OnThisDayCurator,
+    memoryCuratorsProvider,
+  ],
+  exports: [MemoriesGenerationTask, MemoryCurationService],
 })
 export class MemoriesModule {}

--- a/apps/api/src/memories/memory-generation.handler.spec.ts
+++ b/apps/api/src/memories/memory-generation.handler.spec.ts
@@ -1,12 +1,20 @@
 /**
- * Unit tests for MemoryGenerationHandler (epic #300, issue #302).
+ * Unit tests for MemoryGenerationHandler (epic #300, issues #302 + #303).
  *
- * The v1 handler is a deliberate no-op, so what is actually worth asserting is
- * its CONTRACT with the queue: it self-registers under the right type, it is
- * server-only (no node-result pair), and a job that reaches the worker while
- * the feature is disabled SUCCEEDS as a no-op rather than throwing — throwing
- * would burn retry attempts and light up the admin job dashboard for a
- * deliberately-off feature.
+ * Two things are worth asserting here, and both are contracts rather than
+ * behavior of any single curator:
+ *
+ *  1. The QUEUE contract (#302): it self-registers under the right type, it is
+ *     server-only (no node-result pair), and a job that reaches the worker while
+ *     the feature is disabled SUCCEEDS as a no-op rather than throwing —
+ *     throwing would burn retry attempts and light up the admin job dashboard
+ *     for a deliberately-off feature.
+ *
+ *  2. The CURATOR-ISOLATION contract (#303): curators are gated individually by
+ *     their own settings toggle, a curator that throws does not abort the run or
+ *     fail the job, and its retention tail still runs. This is a stated
+ *     acceptance criterion of #303, not defensive programming — a circle with
+ *     bad geo data must still get its On This Day memories.
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
@@ -15,6 +23,11 @@ import { MemoryGenerationHandler } from './memory-generation.handler';
 import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
 import { EnrichmentHandler } from '../enrichment/enrichment-handler.interface';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import {
+  MEMORY_CURATORS,
+  MemoryCurator,
+  MemoryCuratorResult,
+} from './curators/memory-curator.interface';
 
 function makeJob(overrides: Partial<EnrichmentJob> = {}): EnrichmentJob {
   return {
@@ -22,33 +35,55 @@ function makeJob(overrides: Partial<EnrichmentJob> = {}): EnrichmentJob {
     type: 'memory_generation',
     mediaItemId: null,
     circleId: 'circle-a',
+    payload: null,
     ...overrides,
   } as EnrichmentJob;
+}
+
+function result(over: Partial<MemoryCuratorResult> = {}): MemoryCuratorResult {
+  return { created: 0, refreshed: 0, skipped: 0, tombstoned: 0, ...over };
+}
+
+/** A curator test double whose gate, run and purge are all controllable. */
+function fakeCurator(name: string, over: Partial<MemoryCurator> = {}): jest.Mocked<MemoryCurator> {
+  return {
+    name,
+    isEnabled: jest.fn().mockReturnValue(true),
+    run: jest.fn().mockResolvedValue(result()),
+    purge: jest.fn().mockResolvedValue(0),
+    ...over,
+  } as unknown as jest.Mocked<MemoryCurator>;
 }
 
 describe('MemoryGenerationHandler', () => {
   let handler: MemoryGenerationHandler;
   let registry: EnrichmentHandlerRegistry;
   let settings: { getSettings: jest.Mock };
+  let curators: MemoryCurator[];
 
   const originalEnv = process.env['MEMORIES_ENABLED'];
+
+  async function build(withCurators: MemoryCurator[] = []): Promise<void> {
+    curators = withCurators;
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemoryGenerationHandler,
+        EnrichmentHandlerRegistry,
+        { provide: SystemSettingsService, useValue: settings },
+        { provide: MEMORY_CURATORS, useValue: curators },
+      ],
+    }).compile();
+
+    handler = module.get(MemoryGenerationHandler);
+    registry = module.get(EnrichmentHandlerRegistry);
+  }
 
   beforeEach(async () => {
     settings = {
       getSettings: jest.fn().mockResolvedValue({ features: { memories: true } }),
     };
     delete process.env['MEMORIES_ENABLED'];
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        MemoryGenerationHandler,
-        EnrichmentHandlerRegistry,
-        { provide: SystemSettingsService, useValue: settings },
-      ],
-    }).compile();
-
-    handler = module.get(MemoryGenerationHandler);
-    registry = module.get(EnrichmentHandlerRegistry);
+    await build();
   });
 
   afterEach(() => {
@@ -74,24 +109,111 @@ describe('MemoryGenerationHandler', () => {
     expect(registry.serverOnlyTypes()).toContain('memory_generation');
   });
 
-  it('succeeds as a no-op when the feature is enabled (no curators yet)', async () => {
+  it('succeeds as a no-op when no curators are registered', async () => {
     await expect(handler.process(makeJob())).resolves.toBeUndefined();
   });
 
   it('succeeds as a no-op when features.memories is off', async () => {
     settings.getSettings.mockResolvedValue({ features: { memories: false } });
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
 
     await expect(handler.process(makeJob())).resolves.toBeUndefined();
+    // The gate must short-circuit BEFORE any curator work, not merely discard
+    // its output — a disabled feature costs one cached settings read.
+    expect(curator.run).not.toHaveBeenCalled();
   });
 
   it('succeeds as a no-op when MEMORIES_ENABLED=false overrides an enabled flag', async () => {
     process.env['MEMORIES_ENABLED'] = 'false';
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
 
     await expect(handler.process(makeJob())).resolves.toBeUndefined();
     expect(settings.getSettings).toHaveBeenCalled();
+    expect(curator.run).not.toHaveBeenCalled();
   });
 
   it('does not throw on a circle-less job — every memory is circle-scoped', async () => {
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
+
     await expect(handler.process(makeJob({ circleId: null }))).resolves.toBeUndefined();
+    expect(curator.run).not.toHaveBeenCalled();
+  });
+
+  it('runs every enabled curator and passes one shared context', async () => {
+    const a = fakeCurator('a');
+    const b = fakeCurator('b');
+    await build([a, b]);
+
+    await handler.process(makeJob());
+
+    expect(a.run).toHaveBeenCalledTimes(1);
+    expect(b.run).toHaveBeenCalledTimes(1);
+    const ctxA = a.run.mock.calls[0]![0];
+    const ctxB = b.run.mock.calls[0]![0];
+    expect(ctxA.circleId).toBe('circle-a');
+    expect(ctxA.backfill).toBe(false);
+    // One wall clock for the whole run: a pass straddling midnight must not
+    // have curator A anchoring on today and curator B on tomorrow.
+    expect(ctxB.now).toBe(ctxA.now);
+    // Defaults are resolved for the curators, not left undefined.
+    expect(ctxA.settings.onThisDay.lookbackYears).toBe(10);
+    expect(ctxA.settings.maxItemsPerMemory).toBe(30);
+  });
+
+  it('skips a curator whose per-type toggle is off, but still runs the others', async () => {
+    const off = fakeCurator('off', { isEnabled: jest.fn().mockReturnValue(false) });
+    const on = fakeCurator('on');
+    await build([off, on]);
+
+    await handler.process(makeJob());
+
+    expect(off.run).not.toHaveBeenCalled();
+    expect(off.purge).not.toHaveBeenCalled();
+    expect(on.run).toHaveBeenCalled();
+  });
+
+  it('ISOLATION: a throwing curator does not abort the run or fail the job', async () => {
+    const boom = fakeCurator('boom', {
+      run: jest.fn().mockRejectedValue(new Error('curator exploded')),
+    });
+    const healthy = fakeCurator('healthy');
+    await build([boom, healthy]);
+
+    await expect(handler.process(makeJob())).resolves.toBeUndefined();
+
+    expect(healthy.run).toHaveBeenCalledTimes(1);
+    // The retention tail still runs for the failed curator: its rows are stale
+    // regardless of whether this pass produced new ones.
+    expect(boom.purge).toHaveBeenCalledTimes(1);
+  });
+
+  it('ISOLATION: a throwing purge does not fail the job either', async () => {
+    const curator = fakeCurator('leaky', {
+      purge: jest.fn().mockRejectedValue(new Error('purge exploded')),
+    });
+    await build([curator]);
+
+    await expect(handler.process(makeJob())).resolves.toBeUndefined();
+    expect(curator.run).toHaveBeenCalled();
+  });
+
+  it('tolerates a curator with no purge hook', async () => {
+    const curator = fakeCurator('no-tail');
+    delete (curator as Partial<MemoryCurator>).purge;
+    await build([curator]);
+
+    await expect(handler.process(makeJob())).resolves.toBeUndefined();
+  });
+
+  it('propagates payload.backfill into the curator context', async () => {
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
+
+    await handler.process(makeJob({ payload: { backfill: true } as never }));
+
+    expect(curator.run.mock.calls[0]![0].backfill).toBe(true);
   });
 });

--- a/apps/api/src/memories/memory-generation.handler.ts
+++ b/apps/api/src/memories/memory-generation.handler.ts
@@ -1,5 +1,5 @@
 // =============================================================================
-// Memory Generation Enrichment Handler (epic #300, issue #302)
+// Memory Generation Enrichment Handler (epic #300, issues #302 + #303)
 // =============================================================================
 //
 // Runs one circle's memory curation pass. Enqueued once per circle by
@@ -13,19 +13,35 @@
 // pure DB read + write pass over a whole circle with no per-item unit of work
 // to hand a node, and (from #306) needs a server-held AI credential.
 //
-// v1 SCOPE (this issue): the handler is a deliberate NO-OP. Shipping the
-// scheduling, dedup, gating and observability plumbing before any curation
-// logic exists is what lets #303–#305 add curators to a queue path that is
-// already proven end to end. Curators arrive in #303 (On This Day),
-// #304 (Trips) and #305 (People / Theme / Seasonal / Year in Review).
+// PER-CURATOR ERROR ISOLATION IS A CORRECTNESS REQUIREMENT (#303), not
+// politeness. The curators are independent producers of independent content: a
+// circle with malformed geo data must still get its On This Day memories, and a
+// single curator throwing must not cost the job its retry budget or leave the
+// other six types un-generated until a human notices. Each curator therefore
+// runs inside its own try/catch and the job SUCCEEDS as long as the plumbing
+// worked — mirroring the best-effort philosophy of the notification producers.
+// A curator that fails every run shows up in the logs, not as a red job that
+// blocks the rest of the feature.
 // =============================================================================
 
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { EnrichmentJob } from '@prisma/client';
 import { EnrichmentHandler } from '../enrichment/enrichment-handler.interface';
 import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { isMemoriesEnabled } from '../common/types/settings.types';
+import { resolveMemoriesSettings } from './memories-settings.util';
+import {
+  MEMORY_CURATORS,
+  MemoryCurator,
+  MemoryCuratorContext,
+} from './curators/memory-curator.interface';
+
+/** Payload shape for a `memory_generation` job. */
+interface MemoryGenerationPayload {
+  /** Admin library backfill (#315): widen curators past "what matters today". */
+  backfill?: boolean;
+}
 
 @Injectable()
 export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit {
@@ -36,6 +52,7 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
   constructor(
     private readonly registry: EnrichmentHandlerRegistry,
     private readonly systemSettings: SystemSettingsService,
+    @Inject(MEMORY_CURATORS) private readonly curators: MemoryCurator[],
   ) {}
 
   onModuleInit(): void {
@@ -66,11 +83,66 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
       return;
     }
 
-    // v1: no curators registered yet (#303–#305). The log line is the
-    // observability hook that proves the scheduling path works end to end.
-    this.logger.log(
-      `memory_generation ran for circle ${job.circleId} (job ${job.id}): ` +
-        'no curators registered yet',
-    );
+    const payload = (job.payload as unknown as MemoryGenerationPayload | null) ?? {};
+    const ctx: MemoryCuratorContext = {
+      circleId: job.circleId,
+      settings: resolveMemoriesSettings(settings.memories),
+      // ONE wall clock for the whole run: a pass that straddles midnight must
+      // not have curator A anchoring on today and curator B on tomorrow.
+      now: new Date(),
+      backfill: payload.backfill === true,
+    };
+
+    let created = 0;
+    let refreshed = 0;
+    let tombstoned = 0;
+    let purged = 0;
+    let failed = 0;
+
+    for (const curator of this.curators) {
+      if (!curator.isEnabled(ctx.settings)) continue;
+
+      try {
+        const result = await curator.run(ctx);
+        created += result.created;
+        refreshed += result.refreshed;
+        tombstoned += result.tombstoned;
+      } catch (err) {
+        failed += 1;
+        this.logger.error(
+          `Memory curator "${curator.name}" failed for circle ${ctx.circleId} ` +
+            `(job ${job.id}): ${err instanceof Error ? err.message : String(err)}`,
+          err instanceof Error ? err.stack : undefined,
+        );
+      }
+
+      // The retention tail runs even when run() threw: expired rows are stale
+      // regardless of whether this pass managed to produce new ones, and a
+      // curator whose generation is broken is exactly the one whose old rows
+      // would otherwise accumulate.
+      if (curator.purge) {
+        try {
+          purged += await curator.purge(ctx);
+        } catch (err) {
+          failed += 1;
+          this.logger.error(
+            `Memory curator "${curator.name}" purge failed for circle ${ctx.circleId}: ` +
+              (err instanceof Error ? err.message : String(err)),
+          );
+        }
+      }
+    }
+
+    this.logger.log({
+      event: 'memory_generation.completed',
+      jobId: job.id,
+      circleId: ctx.circleId,
+      backfill: ctx.backfill,
+      created,
+      refreshed,
+      tombstoned,
+      purged,
+      failedCurators: failed,
+    });
   }
 }

--- a/apps/api/test/memories/memories-curation.integration.spec.ts
+++ b/apps/api/test/memories/memories-curation.integration.spec.ts
@@ -1,0 +1,767 @@
+// DB_GATED: requires a real PostgreSQL with migrations applied (through
+// 20260809140000_memories_on_this_day_index). Reachability is probed
+// synchronously at module load via `describeMaybeDb`, so with no database the
+// whole suite is registered as `describe.skip` and reports SKIPPED — never a
+// green PASS that asserted nothing. See test/helpers/db-probe.helper.ts.
+//
+// WHY THIS SUITE IS DB-BACKED AND NOT MOCKED
+// ------------------------------------------
+// Issue #303's acceptance criteria are almost entirely statements about SQL and
+// about rows: "items violating the base filter never appear", "re-running
+// changes nothing", "MemoryUserState survives a refresh", "a tombstoned memory
+// is NEVER recreated". Against a mocked PrismaService each of those tests would
+// assert that the code calls the mock the way the test author expected — which
+// is a restatement of the implementation, not evidence the filter actually
+// excludes an archived photo or that the unique index actually holds. The pure
+// scoring/selection/collapse algebra IS unit tested, with no database, in
+// src/memories/curation/memory-curation.pure.spec.ts; everything here is
+// specifically the part that only a real database can prove.
+//
+// Time is pinned: the curator's anchors derive from `ctx.now`, which this suite
+// supplies as a fixed instant, so "today" and "tomorrow" are deterministic and
+// the fixtures can be seeded on exact past anniversaries.
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { randomUUID } from 'crypto';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import {
+  ON_THIS_DAY_RETENTION_DAYS,
+  OnThisDayCurator,
+} from '../../src/memories/curators/on-this-day.curator';
+import { MemoryCuratorContext } from '../../src/memories/curators/memory-curator.interface';
+import { resolveMemoriesSettings } from '../../src/memories/memories-settings.util';
+
+function resolveDatabaseUrl(): string {
+  if (process.env['DATABASE_URL']) return process.env['DATABASE_URL'] as string;
+  const host = process.env['POSTGRES_HOST'] ?? 'localhost';
+  const port = process.env['POSTGRES_PORT'] ?? '5432';
+  const user = process.env['POSTGRES_USER'] ?? 'postgres';
+  const password = process.env['POSTGRES_PASSWORD'] ?? 'postgres';
+  const db = process.env['POSTGRES_DB'] ?? 'appdb';
+  return `postgresql://${user}:${encodeURIComponent(password)}@${host}:${port}/${db}`;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+const MS_PER_DAY = 86_400_000;
+
+/** Fixed clock: anchors are 2026-08-09 (today) and 2026-08-10 (tomorrow) UTC. */
+const NOW = new Date(Date.UTC(2026, 7, 9, 12, 0, 0));
+const ANCHOR_MONTH = 8;
+const ANCHOR_DAY = 9;
+
+describeMaybeDb('Memories — curation engine & On This Day (DB_GATED: real PostgreSQL)', () => {
+  let prisma: PrismaClient;
+  let curation: MemoryCurationService;
+  let curator: OnThisDayCurator;
+
+  const userId = randomUUID();
+  const circleId = randomUUID();
+  /** A second, deliberately empty circle — the new-install / empty-library case. */
+  const emptyCircleId = randomUUID();
+  const createdStorageObjectIds: string[] = [];
+
+  function ctx(over: Partial<MemoryCuratorContext> = {}): MemoryCuratorContext {
+    return {
+      circleId,
+      settings: resolveMemoriesSettings(undefined),
+      now: NOW,
+      backfill: false,
+      ...over,
+    };
+  }
+
+  /**
+   * Seed one media item. Returns its id.
+   *
+   * `capturedAt` accepts null so the base filter's NULL-date exclusion can be
+   * exercised for real rather than trusted.
+   */
+  async function seedItem(options: {
+    capturedAt: Date | null;
+    circle?: string;
+    favorite?: boolean;
+    sharpnessScore?: number | null;
+    type?: 'photo' | 'video';
+    durationMs?: number | null;
+    archivedAt?: Date | null;
+    deletedAt?: Date | null;
+    socialMediaSource?: string | null;
+    burstGroupId?: string | null;
+    duplicateGroupId?: string | null;
+  }): Promise<string> {
+    const storageObjectId = randomUUID();
+    createdStorageObjectIds.push(storageObjectId);
+    await prisma.storageObject.create({
+      data: {
+        id: storageObjectId,
+        name: `${storageObjectId}.jpg`,
+        size: BigInt(2048),
+        mimeType: 'image/jpeg',
+        storageKey: `memories-curation/${storageObjectId}`,
+        status: 'ready',
+        uploadedById: userId,
+      },
+    });
+    const item = await prisma.mediaItem.create({
+      data: {
+        storageObjectId,
+        circleId: options.circle ?? circleId,
+        addedById: userId,
+        type: options.type ?? 'photo',
+        source: 'web',
+        originalFilename: `${storageObjectId}.jpg`,
+        capturedAt: options.capturedAt,
+        favorite: options.favorite ?? false,
+        sharpnessScore: options.sharpnessScore ?? null,
+        durationMs: options.durationMs ?? null,
+        archivedAt: options.archivedAt ?? null,
+        deletedAt: options.deletedAt ?? null,
+        socialMediaSource: options.socialMediaSource ?? null,
+        burstGroupId: options.burstGroupId ?? null,
+        duplicateGroupId: options.duplicateGroupId ?? null,
+      },
+      select: { id: true },
+    });
+    return item.id;
+  }
+
+  /** An instant on the anchor month/day of `year`, `hour` hours in. */
+  function anniversary(year: number, hour: number): Date {
+    return new Date(Date.UTC(year, ANCHOR_MONTH - 1, ANCHOR_DAY, hour, 0, 0));
+  }
+
+  /** Wipe every memory in the fixture circles between tests. */
+  async function clearMemories(): Promise<void> {
+    await prisma.memory.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+  }
+
+  /** Wipe every media item in the fixture circles between tests. */
+  async function clearMedia(): Promise<void> {
+    await prisma.mediaItem.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    if (createdStorageObjectIds.length > 0) {
+      await prisma.storageObject.deleteMany({ where: { id: { in: createdStorageObjectIds } } });
+      createdStorageObjectIds.length = 0;
+    }
+  }
+
+  beforeAll(async () => {
+    const adapter = new PrismaPg({ connectionString: DATABASE_URL });
+    prisma = new PrismaClient({ adapter });
+    await prisma.$connect();
+
+    // The services take a PrismaService (a Nest-lifecycle subclass of
+    // PrismaClient); a raw client satisfies every method they actually call.
+    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    curator = new OnThisDayCurator(prisma as unknown as PrismaService, curation);
+
+    await prisma.user.create({
+      data: { id: userId, email: `memories-curation-${userId}@example.test` },
+    });
+    await prisma.circle.create({
+      data: { id: circleId, name: 'Memories Curation Circle', ownerId: userId },
+    });
+    await prisma.circle.create({
+      data: { id: emptyCircleId, name: 'Memories Empty Circle', ownerId: userId },
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await clearMemories().catch(() => undefined);
+    await clearMedia().catch(() => undefined);
+    await prisma.burstGroup.deleteMany({ where: { circleId } }).catch(() => undefined);
+    await prisma.duplicateGroup.deleteMany({ where: { circleId } }).catch(() => undefined);
+    await prisma.circle.deleteMany({ where: { id: { in: [circleId, emptyCircleId] } } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.$disconnect();
+  }, 30000);
+
+  afterEach(async () => {
+    await clearMemories();
+    await clearMedia();
+    await prisma.burstGroup.deleteMany({ where: { circleId } });
+    await prisma.duplicateGroup.deleteMany({ where: { circleId } });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty library / new install
+  // ---------------------------------------------------------------------------
+
+  it('produces zero rows and does not throw on an empty circle', async () => {
+    const result = await curator.run(ctx({ circleId: emptyCircleId }));
+
+    expect(result).toEqual({ created: 0, refreshed: 0, skipped: 0, tombstoned: 0 });
+    expect(await prisma.memory.count({ where: { circleId: emptyCircleId } })).toBe(0);
+  });
+
+  it('does not choke on items with a NULL capturedAt', async () => {
+    // The whole reason the base filter names capturedAt explicitly: an import
+    // with no EXIF date is common, and every memory is time-anchored.
+    await seedItem({ capturedAt: null });
+    await seedItem({ capturedAt: null });
+    await seedItem({ capturedAt: null });
+
+    const result = await curator.run(ctx());
+
+    expect(result.created).toBe(0);
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Base filter
+  // ---------------------------------------------------------------------------
+
+  it('excludes archived, trashed, social-media and NULL-date items from a memory', async () => {
+    const keep = [
+      await seedItem({ capturedAt: anniversary(2019, 9) }),
+      await seedItem({ capturedAt: anniversary(2019, 11) }),
+      await seedItem({ capturedAt: anniversary(2019, 13) }),
+    ];
+    // Each of these violates exactly one base-filter predicate.
+    await seedItem({ capturedAt: anniversary(2019, 10), archivedAt: new Date() });
+    await seedItem({ capturedAt: anniversary(2019, 12), deletedAt: new Date() });
+    await seedItem({ capturedAt: anniversary(2019, 14), socialMediaSource: 'tiktok' });
+    await seedItem({ capturedAt: null });
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'on_this_day' },
+      include: { items: true },
+    });
+    expect(memory.items.map((i) => i.mediaItemId).sort()).toEqual([...keep].sort());
+    expect(memory.itemCount).toBe(3);
+  });
+
+  it('ignores items from other circles', async () => {
+    await seedItem({ capturedAt: anniversary(2019, 9) });
+    await seedItem({ capturedAt: anniversary(2019, 10) });
+    await seedItem({ capturedAt: anniversary(2019, 11) });
+    // Same day, different circle: must not leak in.
+    await seedItem({ capturedAt: anniversary(2019, 12), circle: emptyCircleId });
+    await seedItem({ capturedAt: anniversary(2019, 13), circle: emptyCircleId });
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'on_this_day' },
+    });
+    expect(memory.itemCount).toBe(3);
+  });
+
+  // ---------------------------------------------------------------------------
+  // On This Day shape
+  // ---------------------------------------------------------------------------
+
+  it('creates one memory per qualifying past year, keyed by anchor date and source year', async () => {
+    for (const year of [2019, 2023]) {
+      for (const hour of [8, 10, 12]) {
+        await seedItem({ capturedAt: anniversary(year, hour) });
+      }
+    }
+    // 2024 has too few items to clear onThisDay.minItems (3).
+    await seedItem({ capturedAt: anniversary(2024, 9) });
+
+    const result = await curator.run(ctx());
+
+    const memories = await prisma.memory.findMany({
+      where: { circleId, type: 'on_this_day' },
+      orderBy: { subjectKey: 'asc' },
+    });
+    expect(memories).toHaveLength(2);
+    expect(result.created).toBe(2);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    expect(memories.map((m) => m.subjectKey)).toEqual(['2019', '2023']);
+    expect(new Set(memories.map((m) => m.periodKey))).toEqual(new Set(['2026-08-09']));
+    expect(memories[0]!.title).toBe('On this day — 7 years ago');
+    expect(memories[1]!.title).toBe('On this day — 3 years ago');
+    expect(memories[0]!.subtitle).toBe('August 9, 2019');
+    expect(memories[0]!.titleSource).toBe('template');
+    expect(memories[0]!.titleModel).toBeNull();
+    expect((memories[0]!.meta as Record<string, unknown>)['yearsAgo']).toBe(7);
+  });
+
+  it('orders items chronologically, picks the highest-scored photo as cover, and expires at end of the anchor day', async () => {
+    const early = await seedItem({ capturedAt: anniversary(2019, 6), sharpnessScore: 100 });
+    const best = await seedItem({ capturedAt: anniversary(2019, 12), favorite: true });
+    const late = await seedItem({ capturedAt: anniversary(2019, 20), sharpnessScore: 200 });
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'on_this_day', subjectKey: '2019' },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+
+    expect(memory.items.map((i) => i.mediaItemId)).toEqual([early, best, late]);
+    expect(memory.items.map((i) => i.position)).toEqual([0, 1, 2]);
+    expect(memory.coverMediaItemId).toBe(best);
+    expect(memory.periodStart).toEqual(anniversary(2019, 6));
+    expect(memory.periodEnd).toEqual(anniversary(2019, 20));
+    // Exclusive end-of-day bound: `Active = expiresAt IS NULL OR expiresAt > now()`.
+    expect(memory.expiresAt).toEqual(new Date(Date.UTC(2026, 7, 10)));
+  });
+
+  it('also pre-generates tomorrow, so a morning digest cannot race generation', async () => {
+    for (const hour of [8, 10, 12]) {
+      await seedItem({ capturedAt: new Date(Date.UTC(2019, 7, 10, hour)) });
+    }
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({ where: { circleId } });
+    expect(memory.periodKey).toBe('2026-08-10');
+  });
+
+  it('never generates a memory for the anchor year itself', async () => {
+    // Today's own photos are not a memory yet — yearsAgo is always >= 1.
+    for (const hour of [8, 10, 12]) {
+      await seedItem({ capturedAt: anniversary(2026, hour) });
+    }
+
+    await curator.run(ctx());
+
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(0);
+  });
+
+  it('honours onThisDay.lookbackYears', async () => {
+    for (const hour of [8, 10, 12]) {
+      await seedItem({ capturedAt: anniversary(2010, hour) }); // 16 years ago
+      await seedItem({ capturedAt: anniversary(2022, hour) }); // 4 years ago
+    }
+    const settings = resolveMemoriesSettings({ onThisDay: { lookbackYears: 5 } } as never);
+
+    await curator.run(ctx({ settings }));
+
+    const memories = await prisma.memory.findMany({ where: { circleId } });
+    expect(memories.map((m) => m.subjectKey)).toEqual(['2022']);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Near-duplicate collapse
+  // ---------------------------------------------------------------------------
+
+  it('contributes at most one item per burst group, preferring suggestedBestItemId', async () => {
+    const solo = await seedItem({ capturedAt: anniversary(2019, 6) });
+    const soloB = await seedItem({ capturedAt: anniversary(2019, 7) });
+
+    const burstGroup = await prisma.burstGroup.create({
+      data: { circleId, status: 'pending', mediaCount: 3 },
+      select: { id: true },
+    });
+    const members: string[] = [];
+    for (const hour of [12, 13, 14]) {
+      members.push(
+        await seedItem({
+          capturedAt: anniversary(2019, hour),
+          burstGroupId: burstGroup.id,
+          // The LAST member is deliberately the favorite, so a naive
+          // "highest score wins" would pick a different item than the group's
+          // own suggestion — proving the suggestion is what actually decides.
+          favorite: hour === 14,
+        }),
+      );
+    }
+    await prisma.burstGroup.update({
+      where: { id: burstGroup.id },
+      data: { suggestedBestItemId: members[0] },
+    });
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, subjectKey: '2019' },
+      include: { items: true },
+    });
+    const ids = memory.items.map((i) => i.mediaItemId).sort();
+    expect(ids).toEqual([solo, soloB, members[0]!].sort());
+    expect(memory.itemCount).toBe(3);
+  });
+
+  it('falls back to the best-scored member when the suggested best was filtered out', async () => {
+    await seedItem({ capturedAt: anniversary(2019, 6) });
+    await seedItem({ capturedAt: anniversary(2019, 7) });
+
+    const group = await prisma.duplicateGroup.create({
+      data: { circleId, status: 'pending', mediaCount: 3 },
+      select: { id: true },
+    });
+    const plain = await seedItem({ capturedAt: anniversary(2019, 12), duplicateGroupId: group.id });
+    const favorite = await seedItem({
+      capturedAt: anniversary(2019, 13),
+      duplicateGroupId: group.id,
+      favorite: true,
+    });
+    // The group's suggestion has since been archived, so it is not a candidate.
+    const archived = await seedItem({
+      capturedAt: anniversary(2019, 14),
+      duplicateGroupId: group.id,
+      archivedAt: new Date(),
+    });
+    await prisma.duplicateGroup.update({
+      where: { id: group.id },
+      data: { suggestedBestItemId: archived },
+    });
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, subjectKey: '2019' },
+      include: { items: true },
+    });
+    const ids = memory.items.map((i) => i.mediaItemId);
+    expect(ids).toContain(favorite);
+    expect(ids).not.toContain(plain);
+    expect(ids).not.toContain(archived);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotent regeneration
+  // ---------------------------------------------------------------------------
+
+  it('re-running against an unchanged library changes nothing', async () => {
+    for (const hour of [8, 10, 12]) await seedItem({ capturedAt: anniversary(2019, hour) });
+
+    const first = await curator.run(ctx());
+    const before = await prisma.memory.findFirstOrThrow({
+      where: { circleId },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+
+    const second = await curator.run(ctx());
+    const after = await prisma.memory.findFirstOrThrow({
+      where: { circleId },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+
+    expect(first.created).toBe(1);
+    expect(second.created).toBe(0);
+    expect(second.refreshed).toBe(1);
+    // Exactly one row, same identity, same content, same generatedAt.
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(1);
+    expect(after.id).toBe(before.id);
+    expect(after.generatedAt).toEqual(before.generatedAt);
+    expect(after.itemCount).toBe(before.itemCount);
+    expect(after.items.map((i) => i.mediaItemId)).toEqual(before.items.map((i) => i.mediaItemId));
+    expect(after.title).toBe(before.title);
+  });
+
+  it('refreshes the item set in place when the library grows', async () => {
+    for (const hour of [8, 10, 12]) await seedItem({ capturedAt: anniversary(2019, hour) });
+    await curator.run(ctx());
+    const before = await prisma.memory.findFirstOrThrow({ where: { circleId } });
+
+    const added = await seedItem({ capturedAt: anniversary(2019, 16) });
+    await curator.run(ctx());
+
+    const after = await prisma.memory.findFirstOrThrow({
+      where: { circleId },
+      include: { items: true },
+    });
+    expect(after.id).toBe(before.id);
+    expect(after.itemCount).toBe(4);
+    expect(after.items.map((i) => i.mediaItemId)).toContain(added);
+    expect(after.refreshedAt.getTime()).toBeGreaterThanOrEqual(before.refreshedAt.getTime());
+  });
+
+  it('preserves MemoryUserState across a refresh', async () => {
+    for (const hour of [8, 10, 12]) await seedItem({ capturedAt: anniversary(2019, hour) });
+    await curator.run(ctx());
+    const memory = await prisma.memory.findFirstOrThrow({ where: { circleId } });
+
+    const seenAt = new Date(Date.UTC(2026, 7, 9, 6));
+    await prisma.memoryUserState.create({
+      data: { memoryId: memory.id, userId, seenAt, favoritedAt: seenAt },
+    });
+
+    await seedItem({ capturedAt: anniversary(2019, 18) });
+    await curator.run(ctx());
+
+    // Per-user state lives in its own table keyed by memory id — which is
+    // exactly why a refresh that replaces every MemoryItem row cannot touch it.
+    const state = await prisma.memoryUserState.findFirstOrThrow({
+      where: { memoryId: memory.id, userId },
+    });
+    expect(state.seenAt).toEqual(seenAt);
+    expect(state.favoritedAt).toEqual(seenAt);
+  });
+
+  it('preserves the title on a minor refresh and resets it on a material one', async () => {
+    const original = [];
+    for (const hour of [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]) {
+      original.push(await seedItem({ capturedAt: anniversary(2019, hour) }));
+    }
+    await curator.run(ctx());
+    const memory = await prisma.memory.findFirstOrThrow({ where: { circleId } });
+
+    // Simulate #306 having written an AI title over the template.
+    await prisma.memory.update({
+      where: { id: memory.id },
+      data: {
+        title: 'A summer afternoon',
+        subtitle: 'AI subtitle',
+        narrative: 'AI narrative',
+        titleSource: 'ai',
+        titleModel: 'gpt-test',
+      },
+    });
+
+    // One photo joins a 10-item set: ~9% membership change, below the 30%
+    // material threshold, so the AI title must survive.
+    await seedItem({ capturedAt: anniversary(2019, 21) });
+    await curator.run(ctx());
+
+    let after = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+    expect(after.title).toBe('A summer afternoon');
+    expect(after.titleSource).toBe('ai');
+    expect(after.narrative).toBe('AI narrative');
+    expect(after.itemCount).toBe(11);
+
+    // Now trash most of the original set: the memory is materially a different
+    // collection, so the stale AI title is reset to the template.
+    await prisma.mediaItem.updateMany({
+      where: { id: { in: original.slice(0, 8) } },
+      data: { deletedAt: new Date() },
+    });
+    await curator.run(ctx());
+
+    after = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+    expect(after.titleSource).toBe('template');
+    expect(after.title).toBe('On this day — 7 years ago');
+    expect(after.titleModel).toBeNull();
+    expect(after.narrative).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // The tombstone contract (stated epic success criterion)
+  // ---------------------------------------------------------------------------
+
+  it('NEVER recreates or modifies a user-deleted (tombstoned) memory', async () => {
+    for (const hour of [8, 10, 12]) await seedItem({ capturedAt: anniversary(2019, hour) });
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({ where: { circleId } });
+    const deletedAt = new Date();
+    await prisma.memory.update({ where: { id: memory.id }, data: { deletedAt } });
+    const tombstoned = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+
+    // Change the library so a regeneration would definitely want to refresh it.
+    await seedItem({ capturedAt: anniversary(2019, 16) });
+    await seedItem({ capturedAt: anniversary(2019, 18) });
+    const result = await curator.run(ctx());
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.refreshed).toBe(0);
+
+    // Still exactly one row — no second memory slipped in under the same key.
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(1);
+
+    const after = await prisma.memory.findUniqueOrThrow({
+      where: { id: memory.id },
+      include: { items: true },
+    });
+    expect(after.deletedAt).toEqual(deletedAt);
+    expect(after.itemCount).toBe(tombstoned.itemCount);
+    expect(after.items).toHaveLength(3);
+    expect(after.refreshedAt).toEqual(tombstoned.refreshedAt);
+    expect(after.updatedAt).toEqual(tombstoned.updatedAt);
+  });
+
+  it('the tombstone does not block OTHER years of the same anchor day', async () => {
+    for (const year of [2019, 2023]) {
+      for (const hour of [8, 10, 12]) await seedItem({ capturedAt: anniversary(year, hour) });
+    }
+    await curator.run(ctx());
+    await prisma.memory.updateMany({
+      where: { circleId, subjectKey: '2019' },
+      data: { deletedAt: new Date() },
+    });
+
+    await seedItem({ capturedAt: anniversary(2023, 16) });
+    const result = await curator.run(ctx());
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.refreshed).toBe(1);
+    const live = await prisma.memory.findFirstOrThrow({
+      where: { circleId, subjectKey: '2023' },
+    });
+    expect(live.itemCount).toBe(4);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retention tail
+  // ---------------------------------------------------------------------------
+
+  it('purges on_this_day memories past the retention window, tombstoned or not', async () => {
+    for (const hour of [8, 10, 12]) await seedItem({ capturedAt: anniversary(2019, hour) });
+    await curator.run(ctx());
+
+    const stale = new Date(NOW.getTime() - (ON_THIS_DAY_RETENTION_DAYS + 5) * MS_PER_DAY);
+    const fresh = new Date(NOW.getTime() - 1 * MS_PER_DAY);
+
+    const [old1, old2, recent] = await Promise.all([
+      prisma.memory.create({
+        data: {
+          circleId,
+          type: 'on_this_day',
+          periodKey: '2026-05-01',
+          subjectKey: '2015',
+          title: 'old',
+          titleSource: 'template',
+          periodStart: stale,
+          periodEnd: stale,
+          itemCount: 0,
+          generatedAt: stale,
+          refreshedAt: stale,
+          expiresAt: stale,
+        },
+      }),
+      prisma.memory.create({
+        data: {
+          circleId,
+          type: 'on_this_day',
+          periodKey: '2026-05-02',
+          subjectKey: '2016',
+          title: 'old tombstoned',
+          titleSource: 'template',
+          periodStart: stale,
+          periodEnd: stale,
+          itemCount: 0,
+          generatedAt: stale,
+          refreshedAt: stale,
+          expiresAt: stale,
+          // Deliberately tombstoned: past the retention window the tombstone has
+          // done its job and the row is reaped like any other.
+          deletedAt: stale,
+        },
+      }),
+      prisma.memory.create({
+        data: {
+          circleId,
+          type: 'on_this_day',
+          periodKey: '2026-08-08',
+          subjectKey: '2017',
+          title: 'recent',
+          titleSource: 'template',
+          periodStart: fresh,
+          periodEnd: fresh,
+          itemCount: 0,
+          generatedAt: fresh,
+          refreshedAt: fresh,
+          expiresAt: fresh,
+        },
+      }),
+    ]);
+
+    const purged = await curator.purge(ctx());
+
+    expect(purged).toBe(2);
+    expect(await prisma.memory.findUnique({ where: { id: old1.id } })).toBeNull();
+    expect(await prisma.memory.findUnique({ where: { id: old2.id } })).toBeNull();
+    expect(await prisma.memory.findUnique({ where: { id: recent.id } })).not.toBeNull();
+    // The freshly generated memory for today is untouched.
+    expect(
+      await prisma.memory.count({ where: { circleId, periodKey: '2026-08-09' } }),
+    ).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Backfill mode
+  // ---------------------------------------------------------------------------
+
+  it('backfill widens to every (month, day) the circle has data on', async () => {
+    // Two distinct calendar days, neither of them today or tomorrow.
+    for (const hour of [8, 10, 12]) {
+      await seedItem({ capturedAt: new Date(Date.UTC(2019, 0, 15, hour)) });
+      await seedItem({ capturedAt: new Date(Date.UTC(2020, 5, 30, hour)) });
+    }
+
+    const scheduled = await curator.run(ctx());
+    expect(scheduled.created).toBe(0);
+
+    const backfilled = await curator.run(ctx({ backfill: true }));
+
+    expect(backfilled.created).toBe(2);
+    const memories = await prisma.memory.findMany({
+      where: { circleId },
+      orderBy: { periodKey: 'asc' },
+    });
+    // Anchors map to their NEXT occurrence, so a backfilled row is never born
+    // already expired: Jan 15 has passed in 2026, June 30 has passed too.
+    expect(memories.map((m) => m.periodKey)).toEqual(['2027-01-15', '2027-06-30']);
+    for (const m of memories) {
+      expect(m.expiresAt!.getTime()).toBeGreaterThan(NOW.getTime());
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Engine internals against real SQL
+  // ---------------------------------------------------------------------------
+
+  it('loadCandidates pages through more rows than one page holds, without duplicates', async () => {
+    // CANDIDATE_PAGE_SIZE is 500; 520 rows forces a second keyset page and
+    // proves the cursor neither skips nor repeats at the boundary.
+    const total = 520;
+    const rows = Array.from({ length: total }, (_, i) => ({
+      capturedAt: new Date(Date.UTC(2019, 7, 9, 0, 0, 0) + i * 60_000),
+    }));
+    for (const row of rows) await seedItem(row);
+
+    const { candidates, truncated } = await curation.loadCandidates(circleId, {});
+
+    expect(truncated).toBe(false);
+    expect(candidates).toHaveLength(total);
+    expect(new Set(candidates.map((c) => c.id)).size).toBe(total);
+    // Keyset order is (capturedAt ASC, id ASC).
+    for (let i = 1; i < candidates.length; i += 1) {
+      expect(candidates[i]!.capturedAt.getTime()).toBeGreaterThanOrEqual(
+        candidates[i - 1]!.capturedAt.getTime(),
+      );
+    }
+  }, 60000);
+
+  it('loadCandidates stops at maxCandidates and reports truncation', async () => {
+    for (let i = 0; i < 12; i += 1) {
+      await seedItem({ capturedAt: new Date(Date.UTC(2019, 7, 9, 0, i)) });
+    }
+
+    const { candidates, truncated } = await curation.loadCandidates(
+      circleId,
+      {},
+      { maxCandidates: 5 },
+    );
+
+    expect(candidates).toHaveLength(5);
+    expect(truncated).toBe(true);
+  });
+
+  it('caps videos at three and never uses one as cover', async () => {
+    for (let i = 0; i < 6; i += 1) {
+      await seedItem({
+        capturedAt: anniversary(2019, 4 + i),
+        type: 'video',
+        durationMs: 15_000,
+        favorite: true,
+      });
+    }
+    const photo = await seedItem({ capturedAt: anniversary(2019, 20) });
+
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId },
+      include: { items: true },
+    });
+    const items = await prisma.mediaItem.findMany({
+      where: { id: { in: memory.items.map((i) => i.mediaItemId) } },
+      select: { id: true, type: true },
+    });
+    expect(items.filter((i) => i.type === 'video')).toHaveLength(3);
+    expect(memory.coverMediaItemId).toBe(photo);
+  });
+});

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.2 (data model + generation plumbing) |
+| **Version** | 0.3 (data model + generation plumbing + curation engine & On This Day) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302); §4–§8 and §10 are placeholders for later issues in epic #300 |
+| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303); §5–§8 and §10 are placeholders for later issues in epic #300 |
 
 ---
 
@@ -34,7 +34,7 @@ Seven memory types ship across the epic (see [§2.1](#21-memorytype-enum)): `on_
 
 The epic is delivered incrementally, and this document grows with it. Implemented so far: the database foundation — the `MemoryType` enum and the `Memory` / `MemoryItem` / `MemoryUserState` models ([#301](https://github.com/marinoscar/MemoriaHub/issues/301), §2) — and the configuration surface plus generation plumbing: the `features.memories` flag, the `memories.*` namespace, `ai.features.memories`, and an hourly per-circle `memory_generation` job whose handler is still a deliberate **no-op** ([#302](https://github.com/marinoscar/MemoriaHub/issues/302), §3 and §9). Every later issue builds on the #301 schema without altering it.
 
-Sections 4–8 and 10 are placeholders that name the issue expected to fill them in; do not treat their absence as an oversight. Until curators land in #303–#305, an enabled deployment schedules jobs and creates **zero** memory rows — which is the intended, tested intermediate state.
+Sections 5–8 and 10 are placeholders that name the issue expected to fill them in; do not treat their absence as an oversight. With #303 landed, an enabled deployment generates real `on_this_day` memories; the remaining six types arrive with #304–#305 and plug into the §4 engine unchanged.
 
 ## 2. Data Model
 
@@ -231,7 +231,174 @@ v1's body is a log line and a return. That log line is the observability hook pr
 
 ## 4. Curation Engine
 
-Placeholder. Covered by issue [#303](https://github.com/marinoscar/MemoriaHub/issues/303) (curation engine, On This Day curator), issue [#304](https://github.com/marinoscar/MemoriaHub/issues/304) (Trips curator), and issue [#305](https://github.com/marinoscar/MemoriaHub/issues/305) (People, Theme, Seasonal & Year-in-Review curators). Expected to define: the shared base filter (`capturedAt IS NOT NULL AND deletedAt IS NULL AND archivedAt IS NULL AND socialMediaSource IS NULL`), quality scoring (favorites, sharpness, favorite-person faces), burst/duplicate best-shot collapse via `suggestedBestItemId`, time-bucket diversity, and per-type minimum item counts.
+Introduced by issue [#303](https://github.com/marinoscar/MemoriaHub/issues/303), which ships the shared engine, the curator registry, deterministic titles for all seven types, and the first real curator (On This Day). The remaining curators — Trips ([#304](https://github.com/marinoscar/MemoriaHub/issues/304)) and People / Theme / Seasonal / Year-in-Review ([#305](https://github.com/marinoscar/MemoriaHub/issues/305)) — plug into this engine and add no new machinery.
+
+The split is deliberate: **a curator owns only what is type-specific** — which slice of the library it is interested in, its `periodKey`/`subjectKey` identity, its template title, and its own retention tail. Everything else (scoring, collapse, diversity, ordering, cover choice, the idempotent write, the tombstone) belongs to `MemoryCurationService` and is therefore identical across all seven types by construction rather than by convention.
+
+| File | Role |
+|---|---|
+| `apps/api/src/memories/curation/memory-curation.types.ts` | The shared vocabulary (`MemoryCandidate`, `CuratedSelection`, `UpsertMemoryInput`/`Result`) |
+| `apps/api/src/memories/curation/memory-curation.service.ts` | The engine: candidate streaming, scoring, collapse, diversity, `upsertMemory()` |
+| `apps/api/src/memories/curation/memory-title-templates.ts` | Deterministic titles for all seven types (§4.6) |
+| `apps/api/src/memories/curators/memory-curator.interface.ts` | The `MemoryCurator` contract + the `MEMORY_CURATORS` DI token |
+| `apps/api/src/memories/curators/on-this-day.curator.ts` | The On This Day curator and the registry factory (§4.7) |
+| `apps/api/src/memories/memories-settings.util.ts` | `resolveMemoriesSettings()` — defaults filled once per job (§4.8) |
+
+### 4.1 The base filter is structural, not a convention
+
+```
+capturedAt IS NOT NULL AND deletedAt IS NULL AND archivedAt IS NULL AND socialMediaSource IS NULL
+```
+
+`memoryCandidateBaseWhere(circleId)` is applied by `loadCandidates()` **itself**, and every curator reaches the database only through `curate()`. A curator therefore cannot forget the filter, cannot partially apply it, and cannot be reviewed into forgetting it later — the only way to bypass it would be to write a second query path, which is a visible change rather than an omission.
+
+`capturedAt IS NOT NULL` deserves its own note because it is the one predicate that looks like defensive noise and is not. `MediaItem.capturedAt` is genuinely nullable — an import with no EXIF `DateTimeOriginal` is common — and **every** memory type is time-anchored (`periodStart`/`periodEnd` are `NOT NULL`, `periodKey` is a date or a year). A NULL capture date does not mean "unknown time", it means "not a candidate".
+
+The other three exclusions each encode a user intent that outranks curation: archived means "hide this from browse surfaces", trashed means "I deleted this", and a non-null `social_media_source` means "this is a re-shared TikTok, not a family memory".
+
+### 4.2 Candidate streaming — constant memory at 70k items
+
+`loadCandidates()` walks the slice with keyset pagination over `(capturedAt ASC, id ASC)`, 500 rows per page, following the `workflow_evaluate` precedent (`apps/api/src/workflows/runs/workflow-evaluate.handler.ts`). That ordering is a **total order** under the base filter — `capturedAt` is non-null there — so the cursor is exact with no `NULLS LAST` handling and no row skipped or repeated at a page boundary.
+
+Two signals cannot come from the `media_items` row itself and are resolved **per page, batched** rather than per item:
+
+| Signal | Query |
+|---|---|
+| `hasFavoritePersonFace` | one `face.findMany` per page: `mediaItemId IN (page)` joined to a `Person` with `favorite = true AND hiddenAt IS NULL AND deletedAt IS NULL` |
+| `hasAiContent` | one `mediaTag.findMany` per page: `mediaItemId IN (page) AND source = 'ai'` (OR'd in memory with a non-empty `MediaItem.description`) |
+
+So a page of 500 candidates costs three queries, not 1 001. Hidden and soft-deleted people are excluded from the favorite-person signal because hiding a person is an explicit "stop surfacing this to me" — honouring it in curation is the same reasoning that keeps them out of the People UI.
+
+`DEFAULT_MAX_CANDIDATES` (20 000) bounds the resident array. It is a **crash guard, not a tuning knob**: a cap that actually bites introduces selection bias (the scan is chronological, so truncation silently curates only the earliest slice), which is why hitting it logs a warning and sets `CuratedSelection.truncated`. A curator that routinely truncates is asking the wrong question and should narrow its slice.
+
+### 4.3 Scoring
+
+Per candidate, higher is better:
+
+| Signal | Contribution |
+|---|---|
+| `favorite = true` | `+3.0` |
+| Sharpness | `+ clamp(sharpnessScore / 1000, 0, 1)`; **NULL ⇒ 0.5 (neutral)** |
+| A face assigned to a live, non-hidden, `favorite` Person | `+1.0` |
+| A non-empty AI description **or** ≥ 1 `source='ai'` tag | `+0.25` |
+
+The NULL-sharpness rule is the load-bearing one. `sharpnessScore` is only written by the burst-detection pipeline, so videos and every pre-feature import carry NULL. Scoring "unmeasured" as `0` would read as "measured, and blurry", and would systematically push every un-analyzed item out of every memory on a library that predates the feature. Neutral `0.5` says what is actually true: we do not know.
+
+Sharpness is clamped rather than raw so an unusually crisp macro shot cannot out-vote an explicit user favorite — variance-of-Laplacian is unbounded, and an unbounded term makes every other weight decorative.
+
+**Videos carry a second, separate score.** `MemoryItem.score` persists the pure quality score above; ranking uses `selectionScore`, which subtracts `LONG_VIDEO_PENALTY` (0.5) from videos longer than 60 s or of unknown duration. Keeping them apart matters: the penalty is a *presentation preference* ("a two-minute clip is a bad thing to open a story with"), not a claim about the clip's quality, and persisting it would make the stored score lie about why an item was chosen.
+
+### 4.4 Near-duplicate collapse
+
+Candidates are bucketed by a `collapseKey()`: `b:<burstGroupId>` if set, else `d:<duplicateGroupId>` if set, else the item's own id. Each bucket contributes **exactly one** item:
+
+1. the group's `suggestedBestItemId`, **if that item is itself in the candidate set** — it may have been archived, trashed or flagged since the group formed, in which case the group must still contribute rather than vanish;
+2. otherwise the highest-`selectionScore` member, ties broken by `(capturedAt, id)`.
+
+**Burst wins over duplicate** when an item somehow carries both group ids. That is not an arbitrary tie-break — it mirrors the app-wide rule already enforced by `DuplicateDetectionService.evictFromDuplicateGroups`: a burst-grouped item is not supposed to be in a duplicate group at all, and if an upload-time race left it in both, the burst grouping is authoritative.
+
+This is also why the engine reuses these groups instead of computing its own visual cohesion: burst and duplicate groups are already CLIP/dHash-derived and already have a human-reviewable best-shot opinion. Direct embedding scoring can be added later with no schema change (`MemoryItem.score` is persisted for exactly that reason) — see §11.
+
+### 4.5 Diversity selection, ordering and cover
+
+Naive top-N-by-score returns thirty frames of whichever moment was photographed hardest. `selectDiverse()` instead:
+
+1. divides the candidate span into `min(maxItemsPerMemory, candidateCount)` equal time buckets and takes each bucket's best-ranked item;
+2. fills any remaining slots with the next-best overall.
+
+A zero-length span (every candidate at one instant) skips straight to step 2. The **3-video cap** is enforced throughout both passes, so a rejected video leaves its slot to the fill pass rather than shrinking the memory — but when videos are all that exists, the memory is legitimately shorter than the cap.
+
+Selection is **deterministic**: ties break on `(selectionScore, capturedAt, id)`, so two runs over an unchanged library produce byte-identical memories. That is what makes "re-running changes nothing" a testable claim rather than an approximate one.
+
+Final items are ordered **chronologically ascending** with contiguous `position` values. The cover is the highest-scored **non-video** item; a video is never a cover (cover art renders as a still, and a poster frame is a different — usually worse — image than any photo in the set). An all-video memory simply has `coverMediaItemId = NULL`.
+
+### 4.6 Template titles
+
+`memory-title-templates.ts` is pure, I/O-free, and covers all seven types:
+
+| Type | Title | Subtitle |
+|---|---|---|
+| `on_this_day` | `On this day — {N} year(s) ago` | `{Month D, YYYY}` |
+| `trip` | `Trip to {place}` | `{Month YYYY}`, `{Month}–{Month YYYY}`, or `{Month YYYY}–{Month YYYY}` across a year boundary |
+| `person_highlights` | `Best of {name}` (NULL name ⇒ `Best moments together`) | `{YYYY}`, or none for an all-time collection |
+| `person_over_years` | `{name} through the years` (NULL name ⇒ `Through the years`) | `{firstYear}–{lastYear}`, collapsed to one year when equal |
+| `theme` | `{Tag, title-cased}` | `{N} favorite moment(s)` |
+| `seasonal` | `{Season} {YYYY}` | — |
+| `year_in_review` | `Your {YYYY} in review` | `{N} highlight(s) from the year` |
+
+These are **not a placeholder for AI titling** — they are the permanent floor. A deployment with no `ai.features.memories` provider configured is a supported configuration (§5, and the new-install matrix in #300), so these titles render forever there and have to read like product copy.
+
+Two details are deliberate. Every formatter is pinned to `Intl.DateTimeFormat('en', { timeZone: 'UTC' })`: `periodStart` is a `timestamptz`, and formatting in the container's local zone would render "December 31, 2024" or "January 1, 2025" for the same instant depending on where the process happens to run — a title that changes on redeploy. And season labels plus the month→season mapping live in one exported table (`SEASON_LABELS` / `seasonForMonth`) so a future southern-hemisphere or locale configuration replaces one table rather than hunting month arithmetic through the seasonal curator.
+
+### 4.7 The On This Day curator
+
+**One memory per past year, not one per day.** Ten years of "on this day" are ten stories, not one 300-photo pile — and per-year identity (`subjectKey = "2019"`) is what makes per-user seen/hidden/favorite state and the tombstone meaningful: you can delete 2014's awkward party without losing 2019's beach trip.
+
+| Field | Value |
+|---|---|
+| `periodKey` | the anchor day, ISO `YYYY-MM-DD` |
+| `subjectKey` | the source year, e.g. `"2019"` |
+| `expiresAt` | start of the day **after** the anchor (exclusive bound, matching `expiresAt > now()`) |
+| `meta` | `{ yearsAgo, sourceYear, anchorMonth, anchorDay, generatorVersion }` |
+
+**Anchors are today AND tomorrow (UTC).** Generation runs on an interval (default 24 h) while notifications and the digest fire in the morning; if a circle only ever generated for "today", an 08:00 digest would race the job producing the content it announces. Pre-generating tomorrow means the morning's content already exists the evening before, whatever order the two jobs run in.
+
+**One query per anchor covers every lookback year.** Matching "same month and day, any year" is not a range, so it goes through raw SQL over `EXTRACT(MONTH/DAY FROM (captured_at AT TIME ZONE 'UTC'))` — the same expression and the same UTC pin as `MediaService.getDashboard`'s dashboard query (the cast is what makes `EXTRACT` `IMMUTABLE` and therefore indexable at all). Results are grouped by year in memory and each year's ids are handed back to `curate()` as an `id IN (…)` slice. That is **2 queries per circle per scheduled run**, not 2 × `lookbackYears`.
+
+Migration `20260809140000_memories_on_this_day_index` adds a circle-scoped partial functional index for it:
+
+```sql
+CREATE INDEX "media_items_circle_captured_md_idx"
+  ON "media_items" ("circle_id",
+                    EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC')),
+                    EXTRACT(DAY   FROM ("captured_at" AT TIME ZONE 'UTC')))
+  WHERE "deleted_at" IS NULL AND "archived_at" IS NULL AND "captured_at" IS NOT NULL;
+```
+
+The pre-existing `media_items_captured_md_idx` (migration `20260615000000_media_oncethisday_index`) has no leading `circle_id` and does not exclude archived rows, so a per-circle generation job would scan every circle's rows for the calendar day — and it cannot serve the backfill's `DISTINCT (month, day)` anchor scan at all, which needs `circle_id` as the leading key. Both indexes are kept: the dashboard still issues the un-scoped variant. Like `media_items_gallery_idx` and `media_items_map_locations_idx`, this index is hand-authored, **not** representable in Prisma's schema DSL, and is documented schema drift.
+
+**Backfill mode** (`job.payload.backfill === true`, which [#315](https://github.com/marinoscar/MemoriaHub/issues/315) sets) widens the anchor set from today+tomorrow to every `(month, day)` the circle has a candidate on — at most 366 rows from one `DISTINCT` scan. Each pair is mapped to its **next** occurrence at or after today, so a backfilled memory's `periodKey`/`expiresAt` describe a day that is still ahead rather than one already past (which would make the row born expired and immediately purge-eligible). February 29 is handled by a round-trip check rather than date arithmetic: `Date.UTC(2027, 1, 29)` silently rolls over to March 1, so a naive implementation would key three out of four "February 29" memories to March 1.
+
+**Retention tail.** `OnThisDayCurator.purge()` hard-deletes this circle's `on_this_day` rows whose `expiresAt` is more than 30 days past — **tombstoned or not**. Ignoring the tombstone here is safe rather than a contradiction of §2.5: the tombstone's job is "do not recreate this memory", and once the anchor day is a month gone the curator has no reason to generate that `periodKey` again until the date comes back around a year later, by which point the underlying library has changed and the memory is legitimately a new one. Keeping the tombstones forever would accumulate one unreadable row per (day × year) for the life of the deployment. The tail runs at the end of every generation job rather than on its own cron: the work is proportional to what generation just produced, it must not run when the feature is off, and a separate schedule would be a second thing to reason about for one batched `deleteMany`.
+
+### 4.8 Idempotent regeneration — `upsertMemory()`
+
+Every curator writes through this one method, keyed on `@@unique([circleId, type, periodKey, subjectKey])`.
+
+1. **Read the existing row first.** If `deletedAt` is set, return immediately with `skippedTombstone: true` — no write, no title computation, nothing. §2.5's contract is enforced here, and it outranks every other rule in this section.
+2. **Create** (row absent): `Memory` + `MemoryItem[]` in one transaction, `generatedAt = refreshedAt = now()`, `titleSource = 'template'`. A `P2002` from a concurrent pass falls through to the refresh path (re-reading, and re-checking the tombstone).
+3. **Refresh** (row present and live): items are **replaced** (`deleteMany` + `createMany` in one transaction) rather than diffed — `MemoryItem` carries no per-item user state and `position` shifts on nearly every refresh, so a delta computation would be strictly more code for the same result. `itemCount`, `periodStart`/`periodEnd`, cover, `meta` and `refreshedAt` are recomputed.
+
+**`MemoryUserState` is untouched by design.** It lives in its own table keyed by memory id, so a refresh that replaces every item preserves seen/hidden/favorited for every user. That is precisely why per-user state was not modeled as columns on `Memory` (§2.4).
+
+**Titles survive a minor refresh.** Membership change is measured as Jaccard **distance** on the media-item id sets; below `MATERIAL_CHANGE_THRESHOLD` (30%) the `title`/`subtitle`/`narrative`/`titleSource`/`titleModel` are all left alone. Without this, one new photo joining a ten-item memory would discard an AI title (#306) and re-pay for it on every generation run forever. At or above 30% the old title may now describe a collection that no longer exists, so it is reset to the template with `titleSource = 'template'`, `titleModel = NULL` and `narrative = NULL`, and handed back to AI re-titling on a later pass.
+
+`UpsertMemoryResult` returns `{ memoryId, created, materiallyChanged, skippedTombstone }`. `materiallyChanged` exists for [#311](https://github.com/marinoscar/MemoriaHub/issues/311)'s notification and digest producers, which need "is there anything genuinely new to tell the circle about?" without re-diffing the item set themselves.
+
+`meta.generatorVersion` (currently `1`) is stamped centrally on every write. Bump it when scoring or selection changes in a way that would produce a different item set from identical inputs — it is the only way to tell, after the fact, which algorithm produced a given memory.
+
+### 4.9 Registry and per-curator error isolation
+
+Curators are injected as an array under the `MEMORY_CURATORS` token (`memoryCuratorsProvider` in `on-this-day.curator.ts`), so #304 and #305 add a provider plus one entry in that factory and touch nothing else. `MemoryGenerationHandler` iterates it:
+
+- each curator is gated by **its own** `memories.<type>.enabled` toggle, checked via `MemoryCurator.isEnabled(settings)` rather than a stringly-typed settings key on the registry entry;
+- each `run()` is **individually try/caught**, and so is each `purge()`;
+- the retention tail runs **even when `run()` threw** — expired rows are stale regardless of whether this pass produced new ones, and a curator whose generation is broken is exactly the one whose old rows would otherwise accumulate;
+- the job **succeeds** as long as the plumbing worked, logging a structured `memory_generation.completed` summary with `created`/`refreshed`/`tombstoned`/`purged`/`failedCurators`.
+
+This is a correctness requirement, not politeness. The seven types are independent producers of independent content: a circle with malformed geo data must still get its On This Day memories, and a single throwing curator must not burn the job's retry budget or leave six other types un-generated until a human notices a red row in `/admin/settings/jobs`.
+
+One wall clock (`ctx.now`) is captured once by the handler and shared by every curator, so a run that straddles midnight cannot have one curator anchoring on today and the next on tomorrow.
+
+### 4.10 Settings resolution
+
+`resolveMemoriesSettings()` deep-merges the stored `memories.*` namespace over `DEFAULT_SYSTEM_SETTINGS.memories` **once per generation job**, so curators read `settings.onThisDay.minItems` unconditionally and never carry their own `?? 10` fallbacks. The namespace is genuinely optional on an older JSONB row — that is what makes it migration-free (§9.2) — and per-curator fallbacks would be a fourth hand-maintained copy of every default, on top of the three §9.3 already warns about.
+
+### 4.11 Known gaps
+
+- **A period that falls below `minItems` after items are removed keeps its existing memory.** Curators only upsert periods that still qualify; they do not delete a memory whose material has since been trashed. Its `MemoryItem` rows for hard-deleted media cascade away and `itemCount` is corrected on the next refresh, but a memory whose items were all *soft*-deleted lingers until read-time filtering ([#307](https://github.com/marinoscar/MemoriaHub/issues/307)) hides it. Deleting it automatically was rejected for v1: a curator silently destroying a memory a user may have favorited is a worse failure than a stale one.
+- **Backfill is unchunked.** A full On This Day backfill for a dense circle is up to 366 anchors × `lookbackYears` curations in one job, which can approach `ENRICHMENT_JOB_TIMEOUT_MS`. It is memory-safe (nothing accumulates across anchors) and restartable (every write is idempotent), but chunking the admin backfill into multiple jobs belongs to #315.
+- **Truncation is chronologically biased.** When `DEFAULT_MAX_CANDIDATES` is hit the scan keeps the earliest candidates. See §4.2 for why that is accepted as a crash guard rather than solved.
 
 ## 5. AI Titles, Subtitles & Narratives
 
@@ -342,4 +509,5 @@ Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/is
 | Version | Date | Author | Changes |
 |---|---|---|---|
 | 0.1 | August 2026 | AI Assistant | Initial specification for issue #301: the `MemoryType` enum, the `Memory`/`MemoryItem`/`MemoryUserState` data model, the `periodKey`/`subjectKey` semantics, the tombstone contract, cascade summary, and alternatives considered. Sections 3–10 are placeholders for later issues in epic #300. |
+| 0.3 | August 2026 | AI Assistant | Issue #303: filled in §4 (Curation Engine — the structural base filter, constant-memory keyset candidate streaming with per-page batched signal lookups, the scoring weights and the neutral-NULL-sharpness rule, the pure-score-vs-selectionScore split for the long-video preference, burst/duplicate collapse and its burst-wins precedence, time-bucket diversity with the 3-video cap, deterministic ordering and the never-a-video cover rule, template titles for all seven types, the On This Day curator with its today+tomorrow anchors / one-query-per-anchor design / new circle-scoped functional index / backfill anchor widening / retention tail, the `upsertMemory()` idempotency and tombstone contract with its Jaccard title-preservation rule, the curator registry and per-curator error isolation, settings resolution, and known gaps). §5–§8 and §10 remain placeholders. |
 | 0.2 | August 2026 | AI Assistant | Issue #302: filled in §3 (Generation — `MemoriesGenerationTask`'s three gates and zero-cost-when-off contract, the mandatory `skipDedup: true` rationale, the server-only `MemoryGenerationHandler` and its no-node-pair system-mode inference, job labels, and the `JobReason.backfill` deviation from the issue text) and §9 (Settings — `features.memories` + the `MEMORIES_ENABLED` kill-switch and their shared `isMemoriesEnabled()` gate, the full `memories.*` bounds/defaults table, the three-hand-maintained-copies pitfall, and `ai.features.memories` with its up-front credential validation). §4–§8 and §10 remain placeholders. |


### PR DESCRIPTION
## Summary

The curation engine at the heart of the epic, plus the first curator (On This Day) and deterministic template titles for all seven memory types. This turns #302's no-op `memory_generation` handler into a working generator.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #300
Fixes #303

## Changes Made

**Engine** — `apps/api/src/memories/curation/`: `memory-curation.service.ts` (candidate streaming, scoring, burst/duplicate collapse, time-bucket diversity, `upsertMemory()`), `memory-curation.types.ts`, `memory-title-templates.ts` (all 7 types).

**Curator contract** — `curators/memory-curator.interface.ts` (`MemoryCurator` + `MEMORY_CURATORS` DI token) so #304/#305 plug in without touching the handler, and `curators/on-this-day.curator.ts`.

**Wiring** — `memory-generation.handler.ts` runs the curator loop with per-curator try/catch isolation; `memories.module.ts`; `memories-settings.util.ts`.

**Migration** — `20260809140000_memories_on_this_day_index`: one `CREATE INDEX IF NOT EXISTS`, no destructive statements.

### Scale and memory safety

Pagination follows the `workflow_evaluate` precedent: keyset over `(capturedAt ASC, id ASC)` — a *total* order under the base filter since `capturedAt` is non-null there, so no `NULLS LAST` handling and no boundary gaps. 500-row pages, with the two off-row signals resolved **per page, batched** (one `face.findMany` + one `mediaTag.findMany` per page, not per item — 3 queries per 500 candidates). `DEFAULT_MAX_CANDIDATES = 20_000` bounds the resident array as a crash guard, logging a warning and setting `truncated` when it bites.

On This Day issues **one** functional-index query per anchor covering all lookback years at once — 2 queries per circle per scheduled run, not 2 × `lookbackYears`.

### Scoring

`+3.0` favorite · `+ clamp(sharpness/1000, 0, 1)` with NULL → 0.5 neutral · `+1.0` favorite-person face · `+0.25` AI content. The long-video preference lives in a **separate** `selectionScore` so the persisted `MemoryItem.score` stays the pure quality score. Then collapse (suggested-best preferred, burst beats duplicate), time-bucket diversity with a 3-video cap, chronological ordering, non-video cover.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
memories suites:  Test Suites: 9 passed, 9 total
                  Tests:     177 passed, 177 total

full test:ci:     Test Suites: 2 failed, 1 skipped, 285 passed, 287 of 288
                  Tests:      23 failed, 71 skipped, 6817 passed, 6911 total
```

The 2 failing suites are the pre-existing malformed-UUID fixtures documented in #333 — untouched here, and invisible in CI (no database).

**22 DB-gated tests genuinely ran** against live PostgreSQL 16 + pgvector rather than skipping. They prove the base filter really excludes archived/trashed/social-media/NULL-date rows; keyset paging across a 520-row set with no gaps or repeats; collapse against real `burst_groups`/`duplicate_groups`; idempotent re-run (same id, stable `generatedAt`); `MemoryUserState` surviving a refresh; title preserved at ~9% item churn and reset past 30%; the retention purge; and backfill anchor widening.

**The tombstone contract is proven, not asserted:** after a regeneration attempt against a user-deleted memory, `refreshedAt`/`updatedAt` are byte-identical — the curator did not touch the row.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Judgement calls made where the issue was silent — all documented in spec §4.11, all worth a reviewer's opinion:

- **Backfill anchor year.** The issue doesn't say which year a backfilled `(month, day)` anchor belongs to. Mapped to its **next** occurrence, so a backfilled row isn't born already-expired and immediately purge-eligible. Feb 29 needed a round-trip check — `Date.UTC(2027, 1, 29)` silently rolls to March 1.
- **A new index rather than reusing the existing one.** `media_items_captured_md_idx` has no leading `circle_id`, doesn't exclude archived rows, and structurally cannot serve the backfill's `DISTINCT (month, day)` scan. Both indexes are kept — the dashboard still uses the old one.
- **`narrative` is nulled on a material refresh.** The issue says reset `titleSource='template'` but is silent on `narrative`; leaving a stale AI narrative describing a set that no longer exists seemed worse.
- **Below-`minItems` periods keep their existing memory.** Nothing deletes a memory whose material was since trashed (read-filtering is #307's). Auto-deleting a memory a user may have favorited is the worse failure mode.
- **Backfill is unchunked** — up to 366 anchors × `lookbackYears` in one job, which can approach `ENRICHMENT_JOB_TIMEOUT_MS`. Memory-safe and restartable (every write idempotent); chunking belongs to #315.

CLAUDE.md is deliberately untouched — #317 owns it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_