### PR TITLE
feat(api): Memories Trips curator — home inference &amp; away-day clustering (#304)

### DIFF
--- a/apps/api/src/common/geo/haversine.util.ts
+++ b/apps/api/src/common/geo/haversine.util.ts
@@ -1,0 +1,35 @@
+// =============================================================================
+// Great-circle distance — the ONE implementation (epic #300, issue #304)
+// =============================================================================
+//
+// Extracted from LocationInferenceService, which owned the only copy until the
+// Memories Trips curator (#304) needed the same computation for "how far is
+// this day from home?". Issue #304 explicitly calls for moving it to a shared
+// util rather than growing a second copy: two haversines that drift apart by an
+// earth-radius constant would make a location suggestion and a trip boundary
+// disagree about the same pair of coordinates, which is exactly the class of bug
+// nobody goes looking for.
+//
+// `location-inference.service.ts` re-exports `haversineKm` from here, so its
+// existing importers (and its golden-value spec) are unaffected.
+// =============================================================================
+
+/** Mean Earth radius, kilometers — the spherical approximation's one constant. */
+export const EARTH_RADIUS_KM = 6371;
+
+/**
+ * Great-circle distance between two lat/lng points, in kilometers.
+ *
+ * Spherical (haversine), not ellipsoidal: the ~0.5% worst-case error against
+ * WGS-84 is far below the resolution any caller here cares about — a 50 km trip
+ * threshold and a multi-kilometer anchor-agreement radius.
+ */
+export function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}

--- a/apps/api/src/location-inference/location-inference.service.ts
+++ b/apps/api/src/location-inference/location-inference.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { DEFAULT_SYSTEM_SETTINGS, SystemSettingsValue } from '../common/types/settings.types';
+import { haversineKm } from '../common/geo/haversine.util';
 
 export type LocationInferenceConfig = NonNullable<SystemSettingsValue['locationInference']>;
 
@@ -34,17 +35,15 @@ export interface ComputedLocationSuggestion {
   autoApplyEligible: boolean;
 }
 
-/** Great-circle distance between two lat/lng points, in kilometers. */
-export function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLng = ((lng2 - lng1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return R * c;
-}
+/**
+ * Great-circle distance between two lat/lng points, in kilometers.
+ *
+ * The implementation moved to `common/geo/haversine.util` when the Memories
+ * Trips curator (#304) needed the same computation; it is re-exported here so
+ * this module's existing importers and its golden-value spec keep working, and
+ * so there is exactly one earth-radius constant in the codebase.
+ */
+export { haversineKm } from '../common/geo/haversine.util';
 
 /**
  * Antimeridian-safe time-weighted longitude interpolation.

--- a/apps/api/src/memories/curation/memory-curation.service.ts
+++ b/apps/api/src/memories/curation/memory-curation.service.ts
@@ -717,6 +717,11 @@ export class MemoryCurationService {
       input.selection.items.map((i) => i.mediaItemId),
     );
     const materiallyChanged = distance >= MATERIAL_CHANGE_THRESHOLD;
+    // A caller may also declare the title stale for a reason membership cannot
+    // show — see UpsertMemoryInput.retitle. This resets titling without claiming
+    // the item set materially changed, which is a separate fact the caller (and
+    // #311's digest) reads independently.
+    const resetTitle = materiallyChanged || input.retitle === true;
 
     await this.prisma.$transaction(async (tx) => {
       // Replace rather than diff: MemoryItem carries no per-item user state, so
@@ -747,10 +752,11 @@ export class MemoryCurationService {
           expiresAt: input.expiresAt ?? null,
           personId: input.personId ?? null,
           // Titling is preserved on a minor refresh — including an AI title and
-          // narrative from #306. On a MATERIAL change the old title may now
-          // describe a set that no longer exists, so it is reset to the
-          // template and handed back to AI re-titling on a later pass.
-          ...(materiallyChanged
+          // narrative from #306. On a MATERIAL change (or an explicit `retitle`)
+          // the old title may now describe a set, or a place, that no longer
+          // exists, so it is reset to the template and handed back to AI
+          // re-titling on a later pass.
+          ...(resetTitle
             ? {
                 title: input.title,
                 subtitle: input.subtitle ?? null,

--- a/apps/api/src/memories/curation/memory-curation.types.ts
+++ b/apps/api/src/memories/curation/memory-curation.types.ts
@@ -89,6 +89,19 @@ export interface UpsertMemoryInput {
   selection: CuratedSelection;
   meta?: Record<string, unknown> | null;
   expiresAt?: Date | null;
+  /**
+   * Force `title`/`subtitle` back to the supplied template on a refresh that
+   * `membershipDistance` would otherwise call minor.
+   *
+   * Defaults to false, so the anti-churn rule (a memory whose membership barely
+   * moved keeps its title, including an AI one from #306) is unchanged for every
+   * existing caller. It exists for the case where the memory's SUBJECT changed
+   * rather than its contents: the Trips curator (#304) re-keys a memory whose
+   * dominant locality drifted after a better reverse-geocode, and a title still
+   * naming the old town would be wrong forever — the anti-churn rule is meant to
+   * protect a title that is still accurate, not one that has been falsified.
+   */
+  retitle?: boolean;
 }
 
 /** Outcome of one `upsertMemory` call. */

--- a/apps/api/src/memories/curators/memory-curators.provider.ts
+++ b/apps/api/src/memories/curators/memory-curators.provider.ts
@@ -1,0 +1,32 @@
+// =============================================================================
+// Memories — the curator registry (epic #300, issues #303 + #304)
+// =============================================================================
+//
+// The ordered array injected under MEMORY_CURATORS. Adding a memory type is a
+// provider plus one entry here; MemoryGenerationHandler iterates whatever this
+// factory returns and needs no edit.
+//
+// It lives in its own file (rather than beside the first curator, where #303
+// put it) now that there is more than one curator: the registry importing every
+// curator means a file that also DEFINES a curator ends up importing its
+// siblings, which is a needless coupling and an easy way to introduce an import
+// cycle as the list grows.
+//
+// ORDER IS EXECUTION ORDER, and it is cheapest-first: On This Day runs two
+// bounded functional-index queries, while Trips streams the circle's whole geo
+// history. A generation job cut short by a timeout has then produced the daily
+// content users actually see on Home.
+// =============================================================================
+
+import { MEMORY_CURATORS, MemoryCurator } from './memory-curator.interface';
+import { OnThisDayCurator } from './on-this-day.curator';
+import { TripCurator } from './trip.curator';
+
+export const memoryCuratorsProvider = {
+  provide: MEMORY_CURATORS,
+  useFactory: (onThisDay: OnThisDayCurator, trip: TripCurator): MemoryCurator[] => [
+    onThisDay,
+    trip,
+  ],
+  inject: [OnThisDayCurator, TripCurator],
+};

--- a/apps/api/src/memories/curators/on-this-day.curator.ts
+++ b/apps/api/src/memories/curators/on-this-day.curator.ts
@@ -37,7 +37,6 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { MemoryCurationService } from '../curation/memory-curation.service';
 import { onThisDayTitle } from '../curation/memory-title-templates';
 import {
-  MEMORY_CURATORS,
   MemoryCurator,
   MemoryCuratorContext,
   MemoryCuratorResult,
@@ -314,13 +313,3 @@ export class OnThisDayCurator implements MemoryCurator {
     return deleted;
   }
 }
-
-/**
- * Registry factory for the curator array. Later issues append their curators
- * here; ordering is the execution order inside a generation job.
- */
-export const memoryCuratorsProvider = {
-  provide: MEMORY_CURATORS,
-  useFactory: (onThisDay: OnThisDayCurator): MemoryCurator[] => [onThisDay],
-  inject: [OnThisDayCurator],
-};

--- a/apps/api/src/memories/curators/trip-clustering.spec.ts
+++ b/apps/api/src/memories/curators/trip-clustering.spec.ts
@@ -1,0 +1,499 @@
+// =============================================================================
+// Memories — Trips clustering algebra (epic #300, issue #304)
+// =============================================================================
+//
+// Pure unit tests: no database, no Nest, no clock. Everything here is a
+// statement about the ALGORITHM — the 30% home-share floor, median-based day
+// classification, gap tolerance, and the overlap denominator that keeps a
+// boundary-shifted trip from becoming a duplicate memory.
+//
+// The DB-backed half (does a seeded away cluster actually become one `trip` row,
+// does the tombstone hold when boundaries shift) lives in
+// test/memories/memories-trips.integration.spec.ts, because those are statements
+// about rows and SQL that a mock could only restate.
+// =============================================================================
+
+import {
+  ClassifiedDay,
+  DayAggregate,
+  HOME_MIN_SHARE,
+  MS_PER_DAY,
+  accumulateHomeSample,
+  classifyDay,
+  createDayAggregate,
+  createHomeStats,
+  dayIndexToKey,
+  dayRangeOverlapRatio,
+  dominantPlace,
+  inferHome,
+  matchRunsToExisting,
+  median,
+  mergeAwayRuns,
+  modalKey,
+  slugifyPlace,
+  tally,
+  toDayIndex,
+} from './trip-clustering';
+
+/** San José, Costa Rica — "home" for every fixture below. */
+const HOME = { lat: 9.9281, lng: -84.0907 };
+/** Tamarindo, Guanacaste — ~180 km away, comfortably past the 50 km default. */
+const AWAY = { lat: 10.2993, lng: -85.8371 };
+
+const DAY0 = toDayIndex(new Date(Date.UTC(2023, 2, 12)));
+
+function day(
+  offset: number,
+  options: {
+    coords?: Array<{ lat: number; lng: number }>;
+    photoCount?: number;
+    locality?: string;
+    admin1?: string;
+    country?: string;
+  } = {},
+): DayAggregate {
+  const agg = createDayAggregate(DAY0 + offset);
+  const coords = options.coords ?? [];
+  for (const c of coords) {
+    agg.lats.push(c.lat);
+    agg.lngs.push(c.lng);
+  }
+  agg.photoCount = options.photoCount ?? Math.max(coords.length, 0);
+  for (let i = 0; i < Math.max(agg.photoCount, 1); i += 1) {
+    tally(agg.localityCounts, options.locality);
+    tally(agg.admin1Counts, options.admin1);
+    tally(agg.countryCounts, options.country);
+  }
+  return agg;
+}
+
+/** N photos at one place, enough to clear MIN_DAY_PHOTOS. */
+function at(point: { lat: number; lng: number }, count = 4): Array<{ lat: number; lng: number }> {
+  return Array.from({ length: count }, () => ({ ...point }));
+}
+
+function classifyAll(days: DayAggregate[], minDistanceKm = 50): ClassifiedDay[] {
+  const home = { level: 'locality' as const, label: 'San José', admin1: 'San José', ...HOME, share: 1, sampleCount: 100 };
+  return days.map((d) => classifyDay(d, home, minDistanceKm));
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+describe('day index helpers', () => {
+  it('maps an instant to its UTC calendar day and back', () => {
+    expect(dayIndexToKey(toDayIndex(new Date(Date.UTC(2023, 2, 12, 23, 59, 59))))).toBe('2023-03-12');
+    expect(dayIndexToKey(toDayIndex(new Date(Date.UTC(2023, 2, 13, 0, 0, 0))))).toBe('2023-03-13');
+  });
+
+  it('is exactly one index per calendar day', () => {
+    const a = toDayIndex(new Date(Date.UTC(2023, 2, 12, 5)));
+    const b = toDayIndex(new Date(Date.UTC(2023, 2, 15, 5)));
+    expect(b - a).toBe(3);
+    expect(b * MS_PER_DAY - a * MS_PER_DAY).toBe(3 * MS_PER_DAY);
+  });
+});
+
+describe('median', () => {
+  it('returns null for an empty sample', () => {
+    expect(median([])).toBeNull();
+  });
+
+  it('takes the middle value of an odd sample', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it('takes the LOWER middle of an even sample rather than the mean', () => {
+    // A value an item actually reported beats an average that may sit in the
+    // sea between two islands.
+    expect(median([10, 20])).toBe(10);
+  });
+
+  it('ignores a single wild outlier', () => {
+    expect(median([9.9, 9.9, 9.9, 9.9, -70])).toBe(9.9);
+  });
+});
+
+describe('modalKey', () => {
+  it('returns null for an empty tally', () => {
+    expect(modalKey(new Map())).toBeNull();
+  });
+
+  it('breaks ties alphabetically so a run is reproducible', () => {
+    expect(modalKey(new Map([['Zurich', 2], ['Aarau', 2]]))).toBe('Aarau');
+  });
+});
+
+describe('slugifyPlace', () => {
+  it('ASCII-folds accents so a re-geocode cannot mint a duplicate identity', () => {
+    expect(slugifyPlace('San José')).toBe('san-jose');
+    expect(slugifyPlace('Zürich')).toBe('zurich');
+  });
+
+  it('collapses punctuation and trims dashes', () => {
+    expect(slugifyPlace('  Playa   Tamarindo, CR ')).toBe('playa-tamarindo-cr');
+  });
+
+  it('maps an absent place to the empty subjectKey', () => {
+    expect(slugifyPlace(null)).toBe('');
+    expect(slugifyPlace('   ')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Home inference
+// ---------------------------------------------------------------------------
+
+describe('inferHome', () => {
+  function stats(samples: Array<{ lat: number; lng: number; locality: string | null; admin1: string | null }>) {
+    const s = createHomeStats();
+    for (const sample of samples) {
+      accumulateHomeSample(s, {
+        lat: sample.lat,
+        lng: sample.lng,
+        geoLocality: sample.locality,
+        geoAdmin1: sample.admin1,
+      });
+    }
+    return s;
+  }
+
+  it('returns null when the circle has no geocoded items at all', () => {
+    expect(inferHome(createHomeStats())).toBeNull();
+  });
+
+  it('picks the modal locality and its centroid', () => {
+    const s = stats([
+      ...Array.from({ length: 7 }, () => ({ ...HOME, locality: 'San José', admin1: 'San José' })),
+      ...Array.from({ length: 3 }, () => ({ ...AWAY, locality: 'Tamarindo', admin1: 'Guanacaste' })),
+    ]);
+
+    const home = inferHome(s);
+
+    expect(home).not.toBeNull();
+    expect(home!.level).toBe('locality');
+    expect(home!.label).toBe('San José');
+    expect(home!.admin1).toBe('San José');
+    expect(home!.share).toBeCloseTo(0.7, 5);
+    expect(home!.lat).toBeCloseTo(HOME.lat, 5);
+    expect(home!.lng).toBeCloseTo(HOME.lng, 5);
+  });
+
+  it('refuses to name a home when the modal locality is below the 30% share floor', () => {
+    // A travel-only archive: nowhere is a center of gravity, and calling the
+    // biggest minority "home" would report every other day as a trip.
+    const s = stats([
+      ...Array.from({ length: 3 }, () => ({ ...HOME, locality: 'A', admin1: 'RA' })),
+      ...Array.from({ length: 3 }, () => ({ ...AWAY, locality: 'B', admin1: 'RB' })),
+      ...Array.from({ length: 3 }, () => ({ ...AWAY, locality: 'C', admin1: 'RC' })),
+      ...Array.from({ length: 2 }, () => ({ ...AWAY, locality: 'D', admin1: 'RD' })),
+    ]);
+
+    expect(inferHome(s)).toBeNull();
+  });
+
+  it('falls back to admin1 when localities are sparse but the region is obvious', () => {
+    // Offline reverse geocoding often resolves a region and not a town: home is
+    // unmistakable one level up, so reporting "unknown" would be wrong.
+    const s = stats([
+      ...Array.from({ length: 8 }, () => ({ ...HOME, locality: null, admin1: 'San José' })),
+      ...Array.from({ length: 2 }, () => ({ ...AWAY, locality: null, admin1: 'Guanacaste' })),
+    ]);
+
+    const home = inferHome(s);
+
+    expect(home!.level).toBe('admin1');
+    expect(home!.label).toBe('San José');
+    expect(home!.admin1).toBe('San José');
+  });
+
+  it('applies the SAME floor to the admin1 fallback', () => {
+    const s = stats([
+      ...Array.from({ length: 2 }, () => ({ ...HOME, locality: null, admin1: 'A' })),
+      ...Array.from({ length: 2 }, () => ({ ...AWAY, locality: null, admin1: 'B' })),
+      ...Array.from({ length: 2 }, () => ({ ...AWAY, locality: null, admin1: 'C' })),
+      ...Array.from({ length: 2 }, () => ({ ...AWAY, locality: null, admin1: 'D' })),
+      ...Array.from({ length: 1 }, () => ({ ...AWAY, locality: null, admin1: 'E' })),
+    ]);
+
+    expect(inferHome(s, HOME_MIN_SHARE)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Day classification
+// ---------------------------------------------------------------------------
+
+describe('classifyDay', () => {
+  it('classifies a far-away day with enough photos as away', () => {
+    const [d] = classifyAll([day(0, { coords: at(AWAY) })]);
+    expect(d!.dayClass).toBe('away');
+    expect(d!.distanceKm).toBeGreaterThan(150);
+  });
+
+  it('classifies a nearby day with enough photos as home', () => {
+    const [d] = classifyAll([day(0, { coords: at(HOME) })]);
+    expect(d!.dayClass).toBe('home');
+    expect(d!.distanceKm).toBeLessThan(1);
+  });
+
+  it('leaves a thin day neutral even when it is far away', () => {
+    // One airport-layover photo must not open a trip.
+    const [d] = classifyAll([day(0, { coords: at(AWAY, 1) })]);
+    expect(d!.dayClass).toBe('neutral');
+    expect(d!.distanceKm).toBeGreaterThan(150);
+  });
+
+  it('leaves a thin day neutral even when it is at home, so it cannot close a trip', () => {
+    const [d] = classifyAll([day(0, { coords: at(HOME, 2) })]);
+    expect(d!.dayClass).toBe('neutral');
+  });
+
+  it('honours minDistanceKm', () => {
+    const days = [day(0, { coords: at(AWAY) })];
+    expect(classifyAll(days, 50)[0]!.dayClass).toBe('away');
+    // Raise the threshold past the actual distance and the same day is home.
+    expect(classifyAll(days, 500)[0]!.dayClass).toBe('home');
+  });
+
+  it('uses the metadata fallback when a day has no coordinates but a differing admin1', () => {
+    const [d] = classifyAll([day(0, { photoCount: 5, admin1: 'Guanacaste' })]);
+    expect(d!.dayClass).toBe('away');
+    expect(d!.distanceKm).toBeNull();
+  });
+
+  it('never classifies a coordinate-less day as home — only away or neutral', () => {
+    // A matching region is weak evidence (adjacent regions are minutes apart),
+    // so the fallback can only ever ADD an away day.
+    const [same] = classifyAll([day(0, { photoCount: 5, admin1: 'San José' })]);
+    expect(same!.dayClass).toBe('neutral');
+
+    const [none] = classifyAll([day(0, { photoCount: 5 })]);
+    expect(none!.dayClass).toBe('neutral');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Run assembly
+// ---------------------------------------------------------------------------
+
+describe('mergeAwayRuns', () => {
+  it('merges consecutive away days into one run', () => {
+    const runs = mergeAwayRuns(
+      classifyAll([0, 1, 2, 3, 4].map((i) => day(i, { coords: at(AWAY) }))),
+    );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.startDayIndex).toBe(DAY0);
+    expect(runs[0]!.endDayIndex).toBe(DAY0 + 4);
+    expect(runs[0]!.spanDays).toBe(5);
+    expect(runs[0]!.photoCount).toBe(20);
+    expect(runs[0]!.maxDistanceKm).toBeGreaterThan(150);
+  });
+
+  it('a one-day photo gap mid-trip does NOT split the trip', () => {
+    // Day 2 simply has no photos — a day you did not take pictures, not the end.
+    const runs = mergeAwayRuns(
+      classifyAll([0, 1, 3, 4].map((i) => day(i, { coords: at(AWAY) }))),
+    );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.spanDays).toBe(5);
+  });
+
+  it('a two-day gap DOES split the trip', () => {
+    const runs = mergeAwayRuns(
+      classifyAll([0, 1, 4, 5].map((i) => day(i, { coords: at(AWAY) }))),
+    );
+
+    expect(runs).toHaveLength(2);
+    expect(runs.map((r) => r.spanDays)).toEqual([2, 2]);
+  });
+
+  it('a neutral day inside the tolerance bridges, a home day terminates', () => {
+    const bridged = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY) }),
+        day(1, { coords: at(AWAY, 1) }), // thin ⇒ neutral
+        day(2, { coords: at(AWAY) }),
+      ]),
+    );
+    expect(bridged).toHaveLength(1);
+
+    const split = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY) }),
+        day(1, { coords: at(HOME) }), // positive evidence the trip ended
+        day(2, { coords: at(AWAY) }),
+      ]),
+    );
+    expect(split).toHaveLength(2);
+  });
+
+  it('trims neutral edges: a run starts and ends on an away day', () => {
+    const runs = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY, 1) }), // neutral
+        day(1, { coords: at(AWAY) }),
+        day(2, { coords: at(AWAY) }),
+        day(3, { coords: at(AWAY, 1) }), // neutral
+      ]),
+    );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.startDayIndex).toBe(DAY0 + 1);
+    expect(runs[0]!.endDayIndex).toBe(DAY0 + 2);
+  });
+
+  it('keeps two trips three weeks apart separate', () => {
+    const runs = mergeAwayRuns(
+      classifyAll([0, 1, 2, 21, 22, 23].map((i) => day(i, { coords: at(AWAY) }))),
+    );
+
+    expect(runs).toHaveLength(2);
+    expect(runs[0]!.startDayIndex).toBe(DAY0);
+    expect(runs[1]!.startDayIndex).toBe(DAY0 + 21);
+  });
+
+  it('produces nothing when the circle never left home', () => {
+    expect(mergeAwayRuns(classifyAll([0, 1, 2, 3].map((i) => day(i, { coords: at(HOME) }))))).toEqual(
+      [],
+    );
+  });
+
+  it("includes a bridged gap day's own photos in the run's counts", () => {
+    const runs = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY) }),
+        day(1, { coords: at(AWAY, 1) }), // neutral, but still 1 candidate
+        day(2, { coords: at(AWAY) }),
+      ]),
+    );
+
+    expect(runs[0]!.days).toHaveLength(3);
+    expect(runs[0]!.photoCount).toBe(9);
+  });
+});
+
+describe('dominantPlace', () => {
+  it('prefers locality, then admin1, then country', () => {
+    const withLocality = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY), locality: 'Tamarindo', admin1: 'Guanacaste', country: 'Costa Rica' }),
+        day(1, { coords: at(AWAY), locality: 'Nosara', admin1: 'Guanacaste', country: 'Costa Rica' }),
+        day(2, { coords: at(AWAY), locality: 'Tamarindo', admin1: 'Guanacaste', country: 'Costa Rica' }),
+      ]),
+    )[0]!;
+    expect(dominantPlace(withLocality).place).toBe('Tamarindo');
+
+    const admin1Only = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY), admin1: 'Guanacaste', country: 'Costa Rica' }),
+        day(1, { coords: at(AWAY), admin1: 'Guanacaste', country: 'Costa Rica' }),
+      ]),
+    )[0]!;
+    expect(dominantPlace(admin1Only).place).toBe('Guanacaste');
+
+    const countryOnly = mergeAwayRuns(
+      classifyAll([
+        day(0, { coords: at(AWAY), country: 'Costa Rica' }),
+        day(1, { coords: at(AWAY), country: 'Costa Rica' }),
+      ]),
+    )[0]!;
+    expect(dominantPlace(countryOnly).place).toBe('Costa Rica');
+  });
+
+  it('reports a null place when nothing was reverse-geocoded', () => {
+    const run = mergeAwayRuns(classifyAll([day(0, { coords: at(AWAY) }), day(1, { coords: at(AWAY) })]))[0]!;
+    expect(dominantPlace(run).place).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh matching
+// ---------------------------------------------------------------------------
+
+describe('dayRangeOverlapRatio', () => {
+  const range = (start: number, end: number) => ({ startDayIndex: start, endDayIndex: end });
+
+  it('is 0 for disjoint ranges', () => {
+    expect(dayRangeOverlapRatio(range(0, 2), range(10, 12))).toBe(0);
+  });
+
+  it('is 0 for adjacent-but-not-overlapping ranges', () => {
+    expect(dayRangeOverlapRatio(range(0, 2), range(3, 5))).toBe(0);
+  });
+
+  it('is 1 for identical ranges', () => {
+    expect(dayRangeOverlapRatio(range(0, 4), range(0, 4))).toBe(1);
+  });
+
+  it('scores a boundary EXTENSION as a full match — the whole point of the denominator', () => {
+    // Late uploads grow a 3-day trip into a 10-day one. Jaccard would score this
+    // 3/10 = 0.3 and mint a duplicate memory; min-span scores 1.0 and refreshes.
+    expect(dayRangeOverlapRatio(range(0, 2), range(0, 9))).toBe(1);
+  });
+
+  it('scores a half-shifted window at exactly the match threshold', () => {
+    // [0..3] vs [2..5]: overlap 2 days, shorter span 4 ⇒ 0.5.
+    expect(dayRangeOverlapRatio(range(0, 3), range(2, 5))).toBe(0.5);
+  });
+
+  it('falls below the threshold when only one day of four lines up', () => {
+    expect(dayRangeOverlapRatio(range(0, 3), range(3, 6))).toBeCloseTo(0.25, 5);
+  });
+});
+
+describe('matchRunsToExisting', () => {
+  const run = (start: number, end: number) => ({ startDayIndex: start, endDayIndex: end });
+  const trip = (id: string, start: number, end: number, tombstoned = false) => ({
+    id,
+    periodKey: dayIndexToKey(start),
+    subjectKey: 'somewhere',
+    startDayIndex: start,
+    endDayIndex: end,
+    tombstoned,
+  });
+
+  it('matches a shifted run to its existing memory', () => {
+    const r = run(100, 106);
+    const existing = trip('m1', 102, 108);
+
+    expect(matchRunsToExisting([r], [existing]).get(r)).toBe(existing);
+  });
+
+  it('leaves a genuinely new trip unmatched', () => {
+    const r = run(200, 204);
+    expect(matchRunsToExisting([r], [trip('m1', 100, 104)]).size).toBe(0);
+  });
+
+  it('matches a TOMBSTONED memory too, so a deleted trip stays deleted when boundaries shift', () => {
+    const r = run(100, 106);
+    const dead = trip('m1', 101, 105, true);
+
+    expect(matchRunsToExisting([r], [dead]).get(r)).toBe(dead);
+  });
+
+  it('never pairs one memory with two runs, or one run with two memories', () => {
+    const near = run(100, 109);
+    const far = run(104, 113);
+    const existing = trip('m1', 100, 109);
+
+    const matched = matchRunsToExisting([near, far], [existing]);
+
+    expect(matched.size).toBe(1);
+    // The better fit (a perfect overlap) wins over chronological order.
+    expect(matched.get(near)).toBe(existing);
+    expect(matched.has(far)).toBe(false);
+  });
+
+  it('is deterministic when two memories fit a run equally well', () => {
+    const r = run(100, 103);
+    const a = trip('aaaa', 100, 103);
+    const b = trip('bbbb', 100, 103);
+
+    expect(matchRunsToExisting([r], [a, b]).get(r)).toBe(a);
+    expect(matchRunsToExisting([r], [b, a]).get(r)).toBe(a);
+  });
+});

--- a/apps/api/src/memories/curators/trip-clustering.ts
+++ b/apps/api/src/memories/curators/trip-clustering.ts
@@ -1,0 +1,585 @@
+// =============================================================================
+// Memories — Trips: home inference and away-day clustering (epic #300, #304)
+// =============================================================================
+//
+// Every decision the Trips curator makes, as pure functions over plain data:
+// no Prisma, no Nest, no clock. The curator (trip.curator.ts) does the I/O —
+// streams rows into `DayAggregate`s, then hands them here and writes whatever
+// comes back. That split is what makes the interesting behavior (gap tolerance,
+// the 30% home-share floor, overlap-based refresh matching) testable with object
+// literals instead of a seeded database.
+//
+// WHY DAY RUNS AND NOT GEO-CLUSTERING. A DBSCAN/HDBSCAN pass over coordinates
+// would be the textbook answer and is the wrong one here: it clusters *places*,
+// while a trip is a contiguous stretch of *time* spent away — two separate
+// visits to the same beach a year apart are two trips, and one road trip across
+// four towns is one. Day-run merging models that directly, is explainable to a
+// user ("you were away from March 12 to March 17"), matches how Apple's Trips
+// behave, and adds no dependency. See docs/specs/memories.md §4.12.
+// =============================================================================
+
+import { haversineKm } from '../../common/geo/haversine.util';
+
+export const MS_PER_DAY = 86_400_000;
+
+/**
+ * Fixed 24-month window for home inference, deliberately NOT a setting.
+ *
+ * Home is a slow-moving fact about a family, and `memories.trips.lookbackMonths`
+ * (default 18) answers a different question — "how far back do we look for
+ * trips?". Tying home to it would mean an admin narrowing the trip window to 3
+ * months silently re-infers home from one quarter's photos, which is exactly
+ * when a long vacation can outvote the house. Two years is long enough that no
+ * single trip can be modal and short enough to follow a real relocation.
+ */
+export const HOME_WINDOW_MONTHS = 24;
+
+/**
+ * Minimum share of geocoded items the modal place must hold to count as home.
+ *
+ * Below this the library has no center of gravity (a travel-only archive, a
+ * shared circle spanning three countries), and *every* day would read as "away
+ * from" a place that is not home — producing a wall of bogus trips. Skipping
+ * the circle entirely is the correct answer, and it is the epic's stated
+ * failure-mode behavior for "no geo data".
+ */
+export const HOME_MIN_SHARE = 0.3;
+
+/** Minimum candidate photos on a day before it can be classified at all. */
+export const MIN_DAY_PHOTOS = 3;
+
+/**
+ * Gap days tolerated inside one trip. A single photo-less (or unclassifiable)
+ * day in the middle of a week away is a day you did not take pictures, not the
+ * end of the trip.
+ */
+export const MAX_GAP_DAYS = 1;
+
+/**
+ * Day-range overlap at or above which a re-detected trip is considered THE SAME
+ * trip as an existing memory. See `dayRangeOverlapRatio` for the denominator
+ * choice, which is the load-bearing part.
+ */
+export const TRIP_OVERLAP_MATCH_RATIO = 0.5;
+
+/** Title place-name of last resort, when a trip has coordinates but no geocode. */
+export const UNKNOWN_TRIP_PLACE = 'a new place';
+
+// ---------------------------------------------------------------------------
+// Day aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything one calendar day contributes, accumulated as rows stream past.
+ *
+ * Media-item IDs are deliberately NOT retained: the curator re-selects a trip's
+ * items through `MemoryCurationService.curate()` with a date-range `where` once
+ * the run has qualified, so holding tens of thousands of ids through the scan
+ * would be memory spent on a set that is thrown away for every day that turns
+ * out to be at home.
+ */
+export interface DayAggregate {
+  /** `YYYY-MM-DD`, UTC. */
+  dayKey: string;
+  /** Whole days since the epoch — the integer the run merger actually walks. */
+  dayIndex: number;
+  /** Candidate photos/videos captured on this day (with or without coordinates). */
+  photoCount: number;
+  /** Latitudes of this day's coordinate-bearing items. */
+  lats: number[];
+  /** Longitudes, index-aligned with `lats`. */
+  lngs: number[];
+  localityCounts: Map<string, number>;
+  admin1Counts: Map<string, number>;
+  countryCounts: Map<string, number>;
+}
+
+/** UTC midnight day index (days since epoch) for an instant. */
+export function toDayIndex(date: Date): number {
+  return Math.floor(date.getTime() / MS_PER_DAY);
+}
+
+/** `YYYY-MM-DD` for a day index. */
+export function dayIndexToKey(dayIndex: number): string {
+  return new Date(dayIndex * MS_PER_DAY).toISOString().slice(0, 10);
+}
+
+/** UTC midnight `Date` for a day index. */
+export function dayIndexToDate(dayIndex: number): Date {
+  return new Date(dayIndex * MS_PER_DAY);
+}
+
+export function createDayAggregate(dayIndex: number): DayAggregate {
+  return {
+    dayKey: dayIndexToKey(dayIndex),
+    dayIndex,
+    photoCount: 0,
+    lats: [],
+    lngs: [],
+    localityCounts: new Map(),
+    admin1Counts: new Map(),
+    countryCounts: new Map(),
+  };
+}
+
+/** Increment a string tally, ignoring null/blank values. */
+export function tally(counts: Map<string, number>, value: string | null | undefined): void {
+  const trimmed = value?.trim();
+  if (!trimmed) return;
+  counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
+}
+
+/** The most frequent key, ties broken alphabetically so runs are reproducible. */
+export function modalKey(counts: Map<string, number>): string | null {
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [key, count] of counts) {
+    if (count > bestCount || (count === bestCount && best !== null && key < best)) {
+      best = key;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** Sum several tallies into one (used to fold a run's days together). */
+export function mergeCounts(sources: Iterable<Map<string, number>>): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const source of sources) {
+    for (const [key, count] of source) out.set(key, (out.get(key) ?? 0) + count);
+  }
+  return out;
+}
+
+/**
+ * Median of a numeric sample. Even-length samples take the lower of the two
+ * middle values rather than their mean — a coordinate that an item actually
+ * reported is a better representative than an average of two, which can land in
+ * the sea between two islands.
+ */
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor((sorted.length - 1) / 2)]!;
+}
+
+// ---------------------------------------------------------------------------
+// Home inference
+// ---------------------------------------------------------------------------
+
+/** Running totals for one candidate home place. */
+export interface HomePlaceStats {
+  count: number;
+  latSum: number;
+  lngSum: number;
+}
+
+/** Everything the 24-month scan accumulates for home inference. */
+export interface HomeStats {
+  /** Geocoded (coordinate-bearing) items seen in the window. */
+  geocodedCount: number;
+  byLocality: Map<string, HomePlaceStats>;
+  byAdmin1: Map<string, HomePlaceStats>;
+  /** Modal admin1 observed for each locality — the home admin1 for the fallback. */
+  admin1ByLocality: Map<string, Map<string, number>>;
+}
+
+export function createHomeStats(): HomeStats {
+  return {
+    geocodedCount: 0,
+    byLocality: new Map(),
+    byAdmin1: new Map(),
+    admin1ByLocality: new Map(),
+  };
+}
+
+function accumulatePlace(
+  map: Map<string, HomePlaceStats>,
+  key: string | null | undefined,
+  lat: number,
+  lng: number,
+): void {
+  const trimmed = key?.trim();
+  if (!trimmed) return;
+  const stats = map.get(trimmed) ?? { count: 0, latSum: 0, lngSum: 0 };
+  stats.count += 1;
+  stats.latSum += lat;
+  stats.lngSum += lng;
+  map.set(trimmed, stats);
+}
+
+/** Fold one coordinate-bearing item into the home statistics. */
+export function accumulateHomeSample(
+  stats: HomeStats,
+  sample: {
+    lat: number;
+    lng: number;
+    geoLocality: string | null;
+    geoAdmin1: string | null;
+  },
+): void {
+  stats.geocodedCount += 1;
+  accumulatePlace(stats.byLocality, sample.geoLocality, sample.lat, sample.lng);
+  accumulatePlace(stats.byAdmin1, sample.geoAdmin1, sample.lat, sample.lng);
+
+  const locality = sample.geoLocality?.trim();
+  if (locality) {
+    const admin1s = stats.admin1ByLocality.get(locality) ?? new Map<string, number>();
+    tally(admin1s, sample.geoAdmin1);
+    stats.admin1ByLocality.set(locality, admin1s);
+  }
+}
+
+/** The inferred home of a circle. */
+export interface HomeLocation {
+  /** Which column the inference landed on. */
+  level: 'locality' | 'admin1';
+  /** The place name itself (`geoLocality` or `geoAdmin1` value). */
+  label: string;
+  /** Home's admin1, used by the no-coordinate metadata fallback. Null when unknown. */
+  admin1: string | null;
+  /** Centroid — mean lat/lng of the items in the modal place. */
+  lat: number;
+  lng: number;
+  /** Share of geocoded items the modal place holds, in [0,1]. */
+  share: number;
+  /** Items backing the centroid. */
+  sampleCount: number;
+}
+
+/**
+ * Infer a circle's home, or return null when the library has no center of
+ * gravity.
+ *
+ * Locality first, admin1 as the fallback: `geoLocality` is the level a person
+ * would name ("Escazú"), but it is also the level most likely to be sparse —
+ * offline reverse geocoding can resolve a region and not a town, and a rural
+ * library may have `geoAdmin1` on nearly everything and `geoLocality` on almost
+ * nothing. Trying locality alone would then report "home unknown" for a circle
+ * whose home is perfectly obvious one level up.
+ *
+ * The admin1 fallback intentionally reuses the SAME share floor rather than a
+ * looser one: a coarser geography is easier to be modal in, so if it cannot even
+ * clear 30% there is genuinely no home here.
+ */
+export function inferHome(stats: HomeStats, minShare = HOME_MIN_SHARE): HomeLocation | null {
+  if (stats.geocodedCount === 0) return null;
+
+  const pick = (
+    map: Map<string, HomePlaceStats>,
+    level: 'locality' | 'admin1',
+  ): HomeLocation | null => {
+    let bestKey: string | null = null;
+    let best: HomePlaceStats | null = null;
+    for (const [key, place] of map) {
+      if (
+        best === null ||
+        place.count > best.count ||
+        (place.count === best.count && bestKey !== null && key < bestKey)
+      ) {
+        bestKey = key;
+        best = place;
+      }
+    }
+    if (!bestKey || !best) return null;
+
+    const share = best.count / stats.geocodedCount;
+    if (share < minShare) return null;
+
+    return {
+      level,
+      label: bestKey,
+      admin1:
+        level === 'admin1'
+          ? bestKey
+          : modalKey(stats.admin1ByLocality.get(bestKey) ?? new Map<string, number>()),
+      lat: best.latSum / best.count,
+      lng: best.lngSum / best.count,
+      share,
+      sampleCount: best.count,
+    };
+  };
+
+  return pick(stats.byLocality, 'locality') ?? pick(stats.byAdmin1, 'admin1');
+}
+
+// ---------------------------------------------------------------------------
+// Away-day classification
+// ---------------------------------------------------------------------------
+
+/**
+ * - `away`    — evidence the circle was away from home this day.
+ * - `home`    — evidence it was at home. TERMINATES a run outright; it is not a
+ *               gap, it is a contradiction.
+ * - `neutral` — not enough evidence either way. Consumes gap budget but never
+ *               splits a trip on its own.
+ */
+export type DayClass = 'away' | 'home' | 'neutral';
+
+export interface ClassifiedDay extends DayAggregate {
+  dayClass: DayClass;
+  /** Distance from home to this day's median coordinate; null with no coordinates. */
+  distanceKm: number | null;
+}
+
+/**
+ * Classify one day against the inferred home.
+ *
+ * The median (not the mean) of the day's coordinates is the representative
+ * point: a single mis-geotagged frame — an iPhone that cached a stale fix, a
+ * scanned photo with a manual coordinate — would drag a mean hundreds of
+ * kilometers and invent a trip. The median ignores it.
+ *
+ * Latitude and longitude are taken independently (a "marginal median"), which is
+ * not the geometric median but is O(n log n), dependency-free, and identical for
+ * the compact same-day clusters this actually sees.
+ *
+ * KNOWN GAP: a day whose photos straddle the ±180° antimeridian gets a
+ * meaningless median longitude. Documented rather than solved — see
+ * docs/specs/memories.md §4.12.
+ */
+export function classifyDay(
+  day: DayAggregate,
+  home: HomeLocation,
+  minDistanceKm: number,
+): ClassifiedDay {
+  const lat = median(day.lats);
+  const lng = median(day.lngs);
+
+  if (lat !== null && lng !== null) {
+    const distanceKm = haversineKm(home.lat, home.lng, lat, lng);
+    // A day too thin to be evidence stays neutral even when it is far away: one
+    // photo from an airport layover should not open a trip, and one photo taken
+    // at home mid-vacation should not close one.
+    if (day.photoCount < MIN_DAY_PHOTOS) {
+      return { ...day, dayClass: 'neutral', distanceKm };
+    }
+    return {
+      ...day,
+      dayClass: distanceKm > minDistanceKm ? 'away' : 'home',
+      distanceKm,
+    };
+  }
+
+  // METADATA FALLBACK — no coordinates at all today. The only signal left is the
+  // reverse-geocoded region, and it can only ever ADD an away day: a matching
+  // admin1 is weak evidence of home (adjacent regions are minutes apart) while a
+  // differing one is strong evidence of away. So a mismatch classifies `away`
+  // and everything else stays neutral, never `home`.
+  if (day.photoCount >= MIN_DAY_PHOTOS && home.admin1) {
+    const admin1 = modalKey(day.admin1Counts);
+    if (admin1 && admin1 !== home.admin1) {
+      return { ...day, dayClass: 'away', distanceKm: null };
+    }
+  }
+  return { ...day, dayClass: 'neutral', distanceKm: null };
+}
+
+// ---------------------------------------------------------------------------
+// Run assembly
+// ---------------------------------------------------------------------------
+
+/** One contiguous stretch away from home, before it is checked against minDays. */
+export interface AwayRun {
+  startDayIndex: number;
+  endDayIndex: number;
+  /** Calendar days spanned, inclusive of both ends. */
+  spanDays: number;
+  /** Every day in `[start, end]` that produced candidates, away or not. */
+  days: ClassifiedDay[];
+  /** Largest per-day distance from home across the run. Null if none had coordinates. */
+  maxDistanceKm: number | null;
+  /** Candidates captured across the run's days — the pre-curation floor check. */
+  photoCount: number;
+}
+
+/**
+ * Merge away days into runs, tolerating `maxGapDays` consecutive non-away days.
+ *
+ * A run is anchored on away days at BOTH ends: neutral days at the edges are
+ * trimmed, so a trip never reports a start date on which nothing said "away".
+ * A `home` day inside the tolerance window still terminates the run — it is
+ * positive evidence that the trip ended, not merely an absence of evidence, and
+ * treating it as a gap would fuse a weekend away, a week at home with one quiet
+ * day, and the next weekend away into one eleven-day "trip".
+ */
+export function mergeAwayRuns(
+  classified: ClassifiedDay[],
+  maxGapDays = MAX_GAP_DAYS,
+): AwayRun[] {
+  const byIndex = new Map<number, ClassifiedDay>();
+  for (const day of classified) byIndex.set(day.dayIndex, day);
+
+  const awayIndices = classified
+    .filter((d) => d.dayClass === 'away')
+    .map((d) => d.dayIndex)
+    .sort((a, b) => a - b);
+
+  const runs: AwayRun[] = [];
+  let start: number | null = null;
+  let previous: number | null = null;
+
+  const flush = (): void => {
+    if (start === null || previous === null) return;
+    const days: ClassifiedDay[] = [];
+    for (let i = start; i <= previous; i += 1) {
+      const day = byIndex.get(i);
+      if (day) days.push(day);
+    }
+    const distances = days
+      .map((d) => d.distanceKm)
+      .filter((d): d is number => d !== null && Number.isFinite(d));
+    runs.push({
+      startDayIndex: start,
+      endDayIndex: previous,
+      spanDays: previous - start + 1,
+      days,
+      maxDistanceKm: distances.length > 0 ? Math.max(...distances) : null,
+      photoCount: days.reduce((sum, d) => sum + d.photoCount, 0),
+    });
+    start = null;
+    previous = null;
+  };
+
+  /** True when nothing between two away days contradicts them being one trip. */
+  const bridgeable = (from: number, to: number): boolean => {
+    const gap = to - from - 1;
+    if (gap > maxGapDays) return false;
+    for (let i = from + 1; i < to; i += 1) {
+      if (byIndex.get(i)?.dayClass === 'home') return false;
+    }
+    return true;
+  };
+
+  for (const index of awayIndices) {
+    if (start === null) {
+      start = index;
+      previous = index;
+      continue;
+    }
+    if (bridgeable(previous!, index)) {
+      previous = index;
+      continue;
+    }
+    flush();
+    start = index;
+    previous = index;
+  }
+  flush();
+
+  return runs;
+}
+
+/** Resolve a run's display place: locality → admin1 → country, else null. */
+export function dominantPlace(run: AwayRun): {
+  locality: string | null;
+  admin1: string | null;
+  country: string | null;
+  place: string | null;
+} {
+  const locality = modalKey(mergeCounts(run.days.map((d) => d.localityCounts)));
+  const admin1 = modalKey(mergeCounts(run.days.map((d) => d.admin1Counts)));
+  const country = modalKey(mergeCounts(run.days.map((d) => d.countryCounts)));
+  return { locality, admin1, country, place: locality ?? admin1 ?? country };
+}
+
+/**
+ * ASCII-folded, dash-separated slug for `subjectKey`.
+ *
+ * NFD-decompose then strip combining marks, so "Guanacaste"/"Cartago"/"Zürich"
+ * all land on stable ASCII — a subjectKey is an identity, and one that changes
+ * when a reverse-geocoding provider starts returning a differently-accented
+ * spelling of the same town would silently create a duplicate memory.
+ */
+export function slugifyPlace(value: string | null | undefined): string {
+  if (!value) return '';
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+// ---------------------------------------------------------------------------
+// Refresh matching
+// ---------------------------------------------------------------------------
+
+/** An inclusive day-index range. */
+export interface DayRange {
+  startDayIndex: number;
+  endDayIndex: number;
+}
+
+/**
+ * Overlap between two day ranges as a fraction of the SHORTER range.
+ *
+ * The denominator is the whole point. New uploads legitimately extend a trip's
+ * detected boundaries — a 3-day trip becomes a 10-day one once the second
+ * camera's photos are imported — and that is the same trip, refreshed, not a new
+ * one. Jaccard (`overlap / union`) scores that case 3/10 = 0.30 and would create
+ * a duplicate; `overlap / min(span)` scores it 1.0 and refreshes in place.
+ *
+ * The trade is that a short range fully contained in a much longer one always
+ * matches. That is accepted: a 2-day run inside an existing 30-day trip really
+ * is part of that trip.
+ */
+export function dayRangeOverlapRatio(a: DayRange, b: DayRange): number {
+  const start = Math.max(a.startDayIndex, b.startDayIndex);
+  const end = Math.min(a.endDayIndex, b.endDayIndex);
+  const overlap = end - start + 1;
+  if (overlap <= 0) return 0;
+  const spanA = a.endDayIndex - a.startDayIndex + 1;
+  const spanB = b.endDayIndex - b.startDayIndex + 1;
+  const shorter = Math.min(spanA, spanB);
+  return shorter <= 0 ? 0 : overlap / shorter;
+}
+
+/** An existing `trip` memory, reduced to what overlap matching needs. */
+export interface ExistingTrip extends DayRange {
+  id: string;
+  periodKey: string;
+  subjectKey: string;
+  tombstoned: boolean;
+}
+
+/**
+ * Greedily pair detected runs with existing trip memories by best overlap.
+ *
+ * Both sides are matched at most once. Pairs are considered in descending
+ * overlap order rather than run order, so when boundary drift makes two runs
+ * both plausible matches for one memory, the better fit wins instead of whoever
+ * happened to be chronologically first.
+ */
+export function matchRunsToExisting<T extends DayRange>(
+  runs: T[],
+  existing: ExistingTrip[],
+  minRatio = TRIP_OVERLAP_MATCH_RATIO,
+): Map<T, ExistingTrip> {
+  const pairs: Array<{ run: T; trip: ExistingTrip; ratio: number }> = [];
+  for (const run of runs) {
+    for (const trip of existing) {
+      const ratio = dayRangeOverlapRatio(run, trip);
+      if (ratio >= minRatio) pairs.push({ run, trip, ratio });
+    }
+  }
+  // Deterministic: ratio desc, then earliest run, then memory id.
+  pairs.sort(
+    (x, y) =>
+      y.ratio - x.ratio ||
+      x.run.startDayIndex - y.run.startDayIndex ||
+      (x.trip.id < y.trip.id ? -1 : x.trip.id > y.trip.id ? 1 : 0),
+  );
+
+  const matched = new Map<T, ExistingTrip>();
+  const claimedRuns = new Set<T>();
+  const claimedTrips = new Set<string>();
+  for (const pair of pairs) {
+    if (claimedRuns.has(pair.run) || claimedTrips.has(pair.trip.id)) continue;
+    claimedRuns.add(pair.run);
+    claimedTrips.add(pair.trip.id);
+    matched.set(pair.run, pair.trip);
+  }
+  return matched;
+}

--- a/apps/api/src/memories/curators/trip-clustering.ts
+++ b/apps/api/src/memories/curators/trip-clustering.ts
@@ -15,7 +15,7 @@
 // visits to the same beach a year apart are two trips, and one road trip across
 // four towns is one. Day-run merging models that directly, is explainable to a
 // user ("you were away from March 12 to March 17"), matches how Apple's Trips
-// behave, and adds no dependency. See docs/specs/memories.md §4.12.
+// behave, and adds no dependency. See docs/specs/memories.md §4.8.
 // =============================================================================
 
 import { haversineKm } from '../../common/geo/haversine.util';
@@ -336,7 +336,7 @@ export interface ClassifiedDay extends DayAggregate {
  *
  * KNOWN GAP: a day whose photos straddle the ±180° antimeridian gets a
  * meaningless median longitude. Documented rather than solved — see
- * docs/specs/memories.md §4.12.
+ * docs/specs/memories.md §4.8.
  */
 export function classifyDay(
   day: DayAggregate,

--- a/apps/api/src/memories/curators/trip.curator.ts
+++ b/apps/api/src/memories/curators/trip.curator.ts
@@ -475,6 +475,11 @@ export class TripCurator implements MemoryCurator {
       selection,
       // Trips never expire — unlike on_this_day, a trip stays interesting.
       expiresAt: null,
+      // The trip is still the same trip, but it is no longer named after the
+      // same town, so the stored title has been falsified rather than merely
+      // aged. See UpsertMemoryInput.retitle for why that is distinct from a
+      // material membership change.
+      retitle: identity.subjectChanged,
       meta: {
         locality: place.locality,
         admin1: place.admin1,
@@ -516,13 +521,13 @@ export class TripCurator implements MemoryCurator {
     subjectKey: string;
     match: ExistingTrip | null;
     existing: ExistingTrip[];
-  }): Promise<{ periodKey: string; subjectKey: string }> {
+  }): Promise<{ periodKey: string; subjectKey: string; subjectChanged: boolean }> {
     const { circleId, run, subjectKey, match, existing } = args;
     const periodKey = dayIndexToKey(run.startDayIndex);
 
-    if (!match) return { periodKey, subjectKey };
+    if (!match) return { periodKey, subjectKey, subjectChanged: false };
     if (match.periodKey === periodKey && match.subjectKey === subjectKey) {
-      return { periodKey, subjectKey };
+      return { periodKey, subjectKey, subjectChanged: false };
     }
 
     // Another memory already occupies the slot we would move into. Rather than
@@ -539,9 +544,10 @@ export class TripCurator implements MemoryCurator {
           `${periodKey}/${subjectKey}, which memory ${conflict.id} already holds; ` +
           'refreshing under its existing keys instead',
       );
-      return { periodKey: match.periodKey, subjectKey: match.subjectKey };
+      return { periodKey: match.periodKey, subjectKey: match.subjectKey, subjectChanged: false };
     }
 
+    const subjectChanged = match.subjectKey !== subjectKey;
     await this.prisma.memory.update({
       where: { id: match.id },
       data: { periodKey, subjectKey },
@@ -550,6 +556,6 @@ export class TripCurator implements MemoryCurator {
     match.periodKey = periodKey;
     match.subjectKey = subjectKey;
 
-    return { periodKey, subjectKey };
+    return { periodKey, subjectKey, subjectChanged };
   }
 }

--- a/apps/api/src/memories/curators/trip.curator.ts
+++ b/apps/api/src/memories/curators/trip.curator.ts
@@ -235,6 +235,18 @@ export class TripCurator implements MemoryCurator {
    *
    * Ordering is `(capturedAt ASC, id ASC)`, a total order under the base filter
    * (`capturedAt IS NOT NULL`), so the cursor never skips or repeats a row.
+   *
+   * NO NEW INDEX IS NEEDED, verified with EXPLAIN ANALYZE over a seeded 30k-item
+   * circle: the existing `media_items_gallery_idx` — `(circle_id, captured_at
+   * DESC, id DESC) WHERE deleted_at IS NULL AND archived_at IS NULL` — serves
+   * this as an `Index Scan Backward` with NO sort node (a btree scans either
+   * direction, so its DESC declaration costs nothing here), leaving only
+   * `social_media_source IS NULL` as a cheap filter. See docs/specs/memories.md
+   * §4.8 for the plan and for the one known cost: Prisma's OR-form keyset
+   * predicate lands as a Filter rather than an Index Cond, so page N re-walks
+   * the pages before it. That is inherited from `loadCandidates`, is bounded
+   * (~2.5M index-entry visits over a 70k-item circle, low seconds in a daily
+   * background job), and is not worth diverging into raw SQL to avoid.
    */
   private async scan(
     circleId: string,

--- a/apps/api/src/memories/curators/trip.curator.ts
+++ b/apps/api/src/memories/curators/trip.curator.ts
@@ -1,0 +1,555 @@
+// =============================================================================
+// Memories — Trips curator (epic #300, issue #304)
+// =============================================================================
+//
+// "Trip to Guanacaste, March 2023" — the only memory type that requires real
+// clustering, and the one users care about most.
+//
+// The library already knows where every photo was taken; what it has never had
+// is a notion of HOME. Everything here follows from inferring that one fact and
+// then asking, day by day, "were we away?". The decision algebra —
+// home inference, median-based day classification, gap-tolerant run merging,
+// overlap-based refresh matching — is pure and lives in `trip-clustering.ts`;
+// this file is the I/O half: one streaming scan in, curated memories out.
+//
+// THREE THINGS THIS FILE IS RESPONSIBLE FOR
+// -----------------------------------------
+//
+// 1. ONE SCAN, AGGREGATED AS IT STREAMS. A circle's whole geo history is read
+//    once via keyset pagination and folded immediately into per-day aggregates
+//    and home tallies. Media-item IDs are never retained: a trip's items are
+//    re-selected through `MemoryCurationService.curate()` with a date-range
+//    `where` only AFTER the run qualifies, so the 95% of days spent at home cost
+//    two floats each instead of a resident id list. This is what keeps backfill
+//    over a 70k-item library flat in memory (epic requirement).
+//
+// 2. GRACEFUL DEGRADATION IS THE DEFAULT PATH, NOT AN ERROR PATH. A circle with
+//    no coordinates, or no place holding a >=30% share, produces zero trips and
+//    returns normally — it does not throw, and it does not disturb the other six
+//    curators. The epic's failure-mode matrix requires exactly this.
+//
+// 3. REFRESH MATCHES BY OVERLAP, NOT BY KEY. A trip's detected boundaries move
+//    when new uploads land — the identity keys (`periodKey` = start date,
+//    `subjectKey` = locality slug) move with them. Matching on key equality
+//    would therefore mint a duplicate memory every time a late import extended a
+//    trip by a day. A re-detected run is paired with the existing memory it
+//    overlaps by >=50% (of the SHORTER span) and that row is re-keyed in place.
+//    Tombstoned trips take part in matching too, which is what keeps a deleted
+//    trip deleted when its boundaries shift.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MemoryType, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  MemoryCurationService,
+  memoryCandidateBaseWhere,
+} from '../curation/memory-curation.service';
+import { tripTitle } from '../curation/memory-title-templates';
+import {
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+import {
+  AwayRun,
+  ClassifiedDay,
+  DayAggregate,
+  ExistingTrip,
+  HOME_WINDOW_MONTHS,
+  HomeLocation,
+  HomeStats,
+  UNKNOWN_TRIP_PLACE,
+  accumulateHomeSample,
+  classifyDay,
+  createDayAggregate,
+  createHomeStats,
+  dayIndexToDate,
+  dayIndexToKey,
+  dominantPlace,
+  inferHome,
+  matchRunsToExisting,
+  mergeAwayRuns,
+  slugifyPlace,
+  tally,
+  toDayIndex,
+} from './trip-clustering';
+
+/** Rows per keyset page while streaming the geo scan. */
+const SCAN_PAGE_SIZE = 1_000;
+
+/**
+ * Defensive ceiling on rows folded into one circle's scan.
+ *
+ * The aggregates themselves are bounded by the number of distinct days, but the
+ * per-day coordinate samples that back each median are not — so the total row
+ * count is the honest bound to cap. At two floats plus a handful of tallies per
+ * row this is single-digit megabytes; a circle dense enough to hit it has
+ * decades of history and its oldest days simply fall outside the scan.
+ */
+const MAX_SCAN_ROWS = 500_000;
+
+/**
+ * Ceiling on existing `trip` memories loaded for overlap matching. A circle
+ * accumulates roughly one row per trip ever taken — hundreds, not thousands —
+ * so this is a crash guard, and hitting it is worth a warning because matching
+ * would silently degrade to "create a duplicate" for the rows left out.
+ */
+const MAX_EXISTING_TRIPS = 10_000;
+
+/** Exactly the columns the scan selects. */
+interface ScanRow {
+  capturedAt: Date | null;
+  takenLat: number | null;
+  takenLng: number | null;
+  geoLocality: string | null;
+  geoAdmin1: string | null;
+  geoCountry: string | null;
+  id: string;
+}
+
+/** What one streaming scan produced. */
+interface ScanResult {
+  home: HomeStats;
+  /** Per-calendar-day aggregates inside the TRIP window (may be wider than home's). */
+  days: DayAggregate[];
+  truncated: boolean;
+}
+
+/** UTC instant `months` before `from`. */
+export function subtractMonthsUtc(from: Date, months: number): Date {
+  return new Date(
+    Date.UTC(
+      from.getUTCFullYear(),
+      from.getUTCMonth() - months,
+      from.getUTCDate(),
+      from.getUTCHours(),
+      from.getUTCMinutes(),
+      from.getUTCSeconds(),
+      from.getUTCMilliseconds(),
+    ),
+  );
+}
+
+@Injectable()
+export class TripCurator implements MemoryCurator {
+  readonly name = 'trip';
+
+  private readonly logger = new Logger(TripCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.trips.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { minDays, minItems, minDistanceKm, lookbackMonths } = ctx.settings.trips;
+
+    // Home is always inferred over a fixed 24 months (see HOME_WINDOW_MONTHS),
+    // independent of the trip lookback. In BACKFILL mode the trip window opens
+    // to all of history, so the scan starts at the earlier of the two.
+    const homeWindowStart = subtractMonthsUtc(ctx.now, HOME_WINDOW_MONTHS);
+    const tripWindowStart = ctx.backfill ? null : subtractMonthsUtc(ctx.now, lookbackMonths);
+    const scanStart = ctx.backfill
+      ? null
+      : new Date(Math.min(homeWindowStart.getTime(), tripWindowStart!.getTime()));
+
+    const scan = await this.scan(ctx.circleId, scanStart, homeWindowStart, tripWindowStart);
+
+    const home = inferHome(scan.home);
+    if (!home) {
+      // THE GRACEFUL-DEGRADATION PATH. No coordinates at all, or no place with a
+      // >=30% share — a travel-only archive, a circle spanning three countries,
+      // or simply a library that was never reverse-geocoded. Every day would
+      // read as "away from" a place that is not home, so the honest answer is
+      // no trips. Debug, not warn: this is a supported configuration.
+      this.logger.debug(
+        `No home could be inferred for circle ${ctx.circleId} ` +
+          `(${scan.home.geocodedCount} geocoded item(s) in the last ${HOME_WINDOW_MONTHS} months); ` +
+          'skipping trips',
+      );
+      return result;
+    }
+
+    const classified: ClassifiedDay[] = scan.days.map((day) =>
+      classifyDay(day, home, minDistanceKm),
+    );
+    const runs = mergeAwayRuns(classified);
+    if (runs.length === 0) return result;
+
+    const existing = await this.loadExistingTrips(ctx.circleId);
+    const matches = matchRunsToExisting(runs, existing);
+
+    // Chronological, so a run cut short by a job timeout has produced the oldest
+    // trips consistently rather than an arbitrary subset.
+    for (const run of runs) {
+      // Two cheap floors before any query: a run that cannot span enough days,
+      // or does not have enough raw candidates to clear `minItems` even before
+      // near-duplicate collapse, is not worth curating.
+      if (run.spanDays < minDays || run.photoCount < minItems) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const outcome = await this.curateRun({
+        ctx,
+        run,
+        home,
+        match: matches.get(run) ?? null,
+        existing,
+      });
+      result.created += outcome.created;
+      result.refreshed += outcome.refreshed;
+      result.skipped += outcome.skipped;
+      result.tombstoned += outcome.tombstoned;
+    }
+
+    this.logger.debug(
+      `Trips for circle ${ctx.circleId}: home=${home.label} (${home.level}, ` +
+        `${(home.share * 100).toFixed(0)}%), ${runs.length} away run(s), ` +
+        `${result.created} created / ${result.refreshed} refreshed / ` +
+        `${result.skipped} skipped / ${result.tombstoned} tombstoned`,
+    );
+
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Scan
+  // -------------------------------------------------------------------------
+
+  /**
+   * One keyset-paginated pass over the circle's candidates, folded as it goes
+   * into home tallies (coordinate-bearing rows in the home window) and per-day
+   * aggregates (every row in the trip window).
+   *
+   * Both windows are served by the SAME scan because they overlap almost
+   * entirely — 24 months of home against a default 18 months of trips — and two
+   * passes would double the I/O to compute two projections of the same rows.
+   *
+   * Ordering is `(capturedAt ASC, id ASC)`, a total order under the base filter
+   * (`capturedAt IS NOT NULL`), so the cursor never skips or repeats a row.
+   */
+  private async scan(
+    circleId: string,
+    scanStart: Date | null,
+    homeWindowStart: Date,
+    tripWindowStart: Date | null,
+  ): Promise<ScanResult> {
+    const base = memoryCandidateBaseWhere(circleId);
+    const window: Prisma.MediaItemWhereInput = scanStart
+      ? { capturedAt: { gte: scanStart } }
+      : {};
+
+    const home = createHomeStats();
+    const byDay = new Map<number, DayAggregate>();
+
+    let scanned = 0;
+    let truncated = false;
+    let cursor: { capturedAt: Date; id: string } | null = null;
+
+    for (;;) {
+      const cursorPredicate: Prisma.MediaItemWhereInput | null = cursor
+        ? {
+            OR: [
+              { capturedAt: { gt: cursor.capturedAt } },
+              { capturedAt: cursor.capturedAt, id: { gt: cursor.id } },
+            ],
+          }
+        : null;
+
+      // Explicitly annotated for the same reason loadCandidates is: the page
+      // `where` is built from `cursor`, which is assigned from this result — a
+      // self-reference the inferencer reports as TS7022.
+      const rows: ScanRow[] = await this.prisma.mediaItem.findMany({
+        where: cursorPredicate
+          ? { AND: [base, window, cursorPredicate] }
+          : { AND: [base, window] },
+        orderBy: [{ capturedAt: 'asc' }, { id: 'asc' }],
+        take: SCAN_PAGE_SIZE,
+        select: {
+          id: true,
+          capturedAt: true,
+          takenLat: true,
+          takenLng: true,
+          geoLocality: true,
+          geoAdmin1: true,
+          geoCountry: true,
+        },
+      });
+      if (rows.length === 0) break;
+
+      const last = rows[rows.length - 1]!;
+      cursor = { capturedAt: last.capturedAt as Date, id: last.id };
+
+      for (const row of rows) {
+        if (scanned >= MAX_SCAN_ROWS) {
+          truncated = true;
+          break;
+        }
+        scanned += 1;
+
+        const capturedAt = row.capturedAt as Date;
+        const hasCoords = row.takenLat != null && row.takenLng != null;
+
+        if (hasCoords && capturedAt >= homeWindowStart) {
+          accumulateHomeSample(home, {
+            lat: row.takenLat!,
+            lng: row.takenLng!,
+            geoLocality: row.geoLocality,
+            geoAdmin1: row.geoAdmin1,
+          });
+        }
+
+        if (tripWindowStart && capturedAt < tripWindowStart) continue;
+
+        const dayIndex = toDayIndex(capturedAt);
+        let day = byDay.get(dayIndex);
+        if (!day) {
+          day = createDayAggregate(dayIndex);
+          byDay.set(dayIndex, day);
+        }
+        day.photoCount += 1;
+        if (hasCoords) {
+          day.lats.push(row.takenLat!);
+          day.lngs.push(row.takenLng!);
+        }
+        tally(day.localityCounts, row.geoLocality);
+        tally(day.admin1Counts, row.geoAdmin1);
+        tally(day.countryCounts, row.geoCountry);
+      }
+
+      if (truncated) {
+        this.logger.warn(
+          `Trip scan for circle ${circleId} hit the ${MAX_SCAN_ROWS}-row cap; ` +
+            'the tail of the history was not considered',
+        );
+        break;
+      }
+      if (rows.length < SCAN_PAGE_SIZE) break;
+    }
+
+    const days = [...byDay.values()].sort((a, b) => a.dayIndex - b.dayIndex);
+    return { home, days, truncated };
+  }
+
+  // -------------------------------------------------------------------------
+  // Refresh matching
+  // -------------------------------------------------------------------------
+
+  /**
+   * Every `trip` memory in the circle — LIVE AND TOMBSTONED — reduced to the day
+   * range overlap matching needs.
+   *
+   * Tombstoned rows are loaded deliberately: a user-deleted trip must keep
+   * refusing regeneration even after new uploads shift its detected boundaries
+   * (and therefore its would-be `periodKey`), which key-based tombstone checking
+   * alone cannot guarantee.
+   *
+   * The day range is read from `meta.startDate`/`meta.endDate` — the DETECTED
+   * range — rather than `periodStart`/`periodEnd`, which describe the curated
+   * item set and can be narrower (the first and last day of a trip are often the
+   * ones that lose their photos to the diversity cap). Rows written before those
+   * meta keys existed fall back to the period columns.
+   */
+  private async loadExistingTrips(circleId: string): Promise<ExistingTrip[]> {
+    const rows = await this.prisma.memory.findMany({
+      where: { circleId, type: MemoryType.trip },
+      select: {
+        id: true,
+        periodKey: true,
+        subjectKey: true,
+        deletedAt: true,
+        periodStart: true,
+        periodEnd: true,
+        meta: true,
+      },
+      orderBy: [{ periodKey: 'desc' }, { id: 'asc' }],
+      take: MAX_EXISTING_TRIPS,
+    });
+
+    if (rows.length === MAX_EXISTING_TRIPS) {
+      this.logger.warn(
+        `Circle ${circleId} has at least ${MAX_EXISTING_TRIPS} trip memories; ` +
+          'overlap matching considered only the most recent ones',
+      );
+    }
+
+    return rows.map((row) => {
+      const meta = (row.meta ?? {}) as Record<string, unknown>;
+      const startDate = typeof meta['startDate'] === 'string' ? meta['startDate'] : null;
+      const endDate = typeof meta['endDate'] === 'string' ? meta['endDate'] : null;
+      const start = startDate ? Date.parse(`${startDate}T00:00:00.000Z`) : NaN;
+      const end = endDate ? Date.parse(`${endDate}T00:00:00.000Z`) : NaN;
+
+      const startDayIndex = Number.isNaN(start)
+        ? toDayIndex(row.periodStart)
+        : toDayIndex(new Date(start));
+      const endDayIndex = Number.isNaN(end) ? toDayIndex(row.periodEnd) : toDayIndex(new Date(end));
+
+      return {
+        id: row.id,
+        periodKey: row.periodKey,
+        subjectKey: row.subjectKey,
+        tombstoned: row.deletedAt !== null,
+        startDayIndex,
+        // Defensive: a hand-edited or legacy row with end < start would make
+        // every overlap ratio zero, silently duplicating instead of refreshing.
+        endDayIndex: Math.max(startDayIndex, endDayIndex),
+      };
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // One run
+  // -------------------------------------------------------------------------
+
+  private async curateRun(args: {
+    ctx: MemoryCuratorContext;
+    run: AwayRun;
+    home: HomeLocation;
+    match: ExistingTrip | null;
+    existing: ExistingTrip[];
+  }): Promise<MemoryCuratorResult> {
+    const { ctx, run, home, match, existing } = args;
+    const result = emptyCuratorResult();
+
+    // A tombstoned match ends it here: the user deleted this trip, and a shifted
+    // boundary does not make it a different one. Note this is checked BEFORE any
+    // curation work, and independently of upsertMemory's own key-based tombstone
+    // check — that one would not fire, because the shifted run carries new keys.
+    if (match?.tombstoned) {
+      this.logger.debug(
+        `Trip ${dayIndexToKey(run.startDayIndex)}..${dayIndexToKey(run.endDayIndex)} in circle ` +
+          `${ctx.circleId} overlaps tombstoned memory ${match.id}; not regenerated`,
+      );
+      result.tombstoned += 1;
+      return result;
+    }
+
+    const rangeStart = dayIndexToDate(run.startDayIndex);
+    const rangeEndExclusive = dayIndexToDate(run.endDayIndex + 1);
+
+    const selection = await this.curation.curate(
+      ctx.circleId,
+      { capturedAt: { gte: rangeStart, lt: rangeEndExclusive } },
+      { maxItems: ctx.settings.maxItemsPerMemory },
+    );
+    if (selection.items.length < ctx.settings.trips.minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const place = dominantPlace(run);
+    // The place is resolved from the run's DAY AGGREGATES (every candidate in
+    // range) rather than from the curated items: a 30-item selection is a
+    // quality sample, not a geographic one, and naming the trip after whichever
+    // town happened to contribute the sharpest photos would be arbitrary.
+    const { title, subtitle } = tripTitle(
+      place.place ?? UNKNOWN_TRIP_PLACE,
+      rangeStart,
+      dayIndexToDate(run.endDayIndex),
+    );
+
+    const identity = await this.resolveIdentity({
+      circleId: ctx.circleId,
+      run,
+      subjectKey: slugifyPlace(place.place),
+      match,
+      existing,
+    });
+
+    const upsert = await this.curation.upsertMemory({
+      circleId: ctx.circleId,
+      type: MemoryType.trip,
+      periodKey: identity.periodKey,
+      subjectKey: identity.subjectKey,
+      title,
+      subtitle,
+      selection,
+      // Trips never expire — unlike on_this_day, a trip stays interesting.
+      expiresAt: null,
+      meta: {
+        locality: place.locality,
+        admin1: place.admin1,
+        country: place.country,
+        distanceKm: run.maxDistanceKm,
+        dayCount: run.spanDays,
+        // The DETECTED day range, which is what overlap matching reads back on
+        // the next run — see loadExistingTrips.
+        startDate: dayIndexToKey(run.startDayIndex),
+        endDate: dayIndexToKey(run.endDayIndex),
+        homePlace: home.label,
+        homeLevel: home.level,
+      },
+    });
+
+    if (upsert.skippedTombstone) result.tombstoned += 1;
+    else if (upsert.created) result.created += 1;
+    else result.refreshed += 1;
+
+    return result;
+  }
+
+  /**
+   * Decide which `(periodKey, subjectKey)` this run should be written under.
+   *
+   * With no overlap match, the run's own keys are used and `upsertMemory` does
+   * the rest (including its key-based tombstone check).
+   *
+   * With a match whose keys have DRIFTED — a boundary shift moved the start
+   * date, or a better reverse-geocode changed the dominant locality — the
+   * existing row is re-keyed in place first, so the subsequent upsert finds it
+   * by its new identity and refreshes rather than inserting a second row. The
+   * unique index permits this: it is an UPDATE of the row that already owns the
+   * old slot, not a competing insert.
+   */
+  private async resolveIdentity(args: {
+    circleId: string;
+    run: AwayRun;
+    subjectKey: string;
+    match: ExistingTrip | null;
+    existing: ExistingTrip[];
+  }): Promise<{ periodKey: string; subjectKey: string }> {
+    const { circleId, run, subjectKey, match, existing } = args;
+    const periodKey = dayIndexToKey(run.startDayIndex);
+
+    if (!match) return { periodKey, subjectKey };
+    if (match.periodKey === periodKey && match.subjectKey === subjectKey) {
+      return { periodKey, subjectKey };
+    }
+
+    // Another memory already occupies the slot we would move into. Rather than
+    // fight over it (the update would fail the unique index, and deleting the
+    // squatter could destroy a memory a user favorited), keep this row's current
+    // identity and refresh it there. The keys are an identity, not data — a
+    // stale-but-stable one beats a duplicate row.
+    const conflict = existing.find(
+      (t) => t.id !== match.id && t.periodKey === periodKey && t.subjectKey === subjectKey,
+    );
+    if (conflict) {
+      this.logger.debug(
+        `Trip memory ${match.id} in circle ${circleId} would re-key to ` +
+          `${periodKey}/${subjectKey}, which memory ${conflict.id} already holds; ` +
+          'refreshing under its existing keys instead',
+      );
+      return { periodKey: match.periodKey, subjectKey: match.subjectKey };
+    }
+
+    await this.prisma.memory.update({
+      where: { id: match.id },
+      data: { periodKey, subjectKey },
+    });
+    // Keep the in-memory view honest for the remaining runs' conflict checks.
+    match.periodKey = periodKey;
+    match.subjectKey = subjectKey;
+
+    return { periodKey, subjectKey };
+  }
+}

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -12,9 +12,9 @@
 // for the job service and the handler registry.
 //
 // THE CURATOR REGISTRY is provided as an injected array under the
-// MEMORY_CURATORS token (see memoryCuratorsProvider) rather than hard-coded in
-// the handler, so a new curator is a provider + one entry in that factory and
-// nothing else changes.
+// MEMORY_CURATORS token (see curators/memory-curators.provider.ts) rather than
+// hard-coded in the handler, so a new curator is a provider + one entry in that
+// factory and nothing else changes.
 // =============================================================================
 
 import { Module } from '@nestjs/common';
@@ -24,7 +24,9 @@ import { EnrichmentModule } from '../enrichment/enrichment.module';
 import { MemoriesGenerationTask } from './memories-generation.task';
 import { MemoryGenerationHandler } from './memory-generation.handler';
 import { MemoryCurationService } from './curation/memory-curation.service';
-import { OnThisDayCurator, memoryCuratorsProvider } from './curators/on-this-day.curator';
+import { OnThisDayCurator } from './curators/on-this-day.curator';
+import { TripCurator } from './curators/trip.curator';
+import { memoryCuratorsProvider } from './curators/memory-curators.provider';
 
 @Module({
   imports: [PrismaModule, SettingsModule, EnrichmentModule],
@@ -33,6 +35,7 @@ import { OnThisDayCurator, memoryCuratorsProvider } from './curators/on-this-day
     MemoryGenerationHandler,
     MemoryCurationService,
     OnThisDayCurator,
+    TripCurator,
     memoryCuratorsProvider,
   ],
   exports: [MemoriesGenerationTask, MemoryCurationService],

--- a/apps/api/test/memories/memories-generation-scheduling.integration.spec.ts
+++ b/apps/api/test/memories/memories-generation-scheduling.integration.spec.ts
@@ -120,6 +120,29 @@ describeMaybeDb(
       });
     }
 
+    /**
+     * Which of THIS SUITE'S circles came out of a tick with a pending job.
+     *
+     * Assertions go through this rather than through `sweep()`'s `enqueued` /
+     * `skipped` counters, which are necessarily DEPLOYMENT-WIDE: the task sweeps
+     * every circle in the database, so a circle belonging to another suite
+     * running in a parallel Jest worker (the Trips curator suite creates two)
+     * lands in those totals and makes an absolute count flaky. The rows are the
+     * real assertion anyway — "circle A was gated" is better evidenced by
+     * A having no pending job than by a global counter having incremented once.
+     */
+    async function ourPendingCircleIds(): Promise<string[]> {
+      const rows = await prisma.enrichmentJob.findMany({
+        where: {
+          type: MEMORY_GENERATION_JOB_TYPE,
+          circleId: ourCircles,
+          status: JobStatus.pending,
+        },
+        select: { circleId: true },
+      });
+      return rows.map((r) => r.circleId!).sort();
+    }
+
     // -----------------------------------------------------------------------
     // 1. skipDedup — one job PER CIRCLE, not one for the deployment
     // -----------------------------------------------------------------------
@@ -142,10 +165,12 @@ describeMaybeDb(
 
     it('a second tick adds nothing while the first tick\'s jobs are still pending', async () => {
       await task.sweep();
-      const second = await task.sweep();
+      await task.sweep();
 
-      expect(second).toMatchObject({ enqueued: 0, skipped: 2 });
+      // Still exactly one row per circle: the second tick's gate saw the first
+      // tick's pending jobs and enqueued nothing more.
       expect(await ourJobs()).toHaveLength(2);
+      expect(await ourPendingCircleIds()).toEqual([circleAId, circleBId].sort());
     });
 
     // -----------------------------------------------------------------------
@@ -165,16 +190,10 @@ describeMaybeDb(
 
       const result = await task.sweep();
 
-      expect(result).toMatchObject({ circles: 2, enqueued: 1, skipped: 1 });
-      const pending = await prisma.enrichmentJob.findMany({
-        where: {
-          type: MEMORY_GENERATION_JOB_TYPE,
-          circleId: ourCircles,
-          status: JobStatus.pending,
-        },
-      });
-      expect(pending).toHaveLength(1);
-      expect(pending[0]!.circleId).toBe(circleBId);
+      // The sweep covers every circle in the database, so this is a floor.
+      expect(result.circles).toBeGreaterThanOrEqual(2);
+      // Circle A is gated by its 1h-old success; circle B is not.
+      expect(await ourPendingCircleIds()).toEqual([circleBId]);
     });
 
     it('enqueues again once the last success falls outside the interval', async () => {
@@ -188,9 +207,9 @@ describeMaybeDb(
         },
       });
 
-      const result = await task.sweep();
+      await task.sweep();
 
-      expect(result.enqueued).toBe(2);
+      expect(await ourPendingCircleIds()).toEqual([circleAId, circleBId].sort());
     });
 
     it('uses the MOST RECENT success when a circle has several (the _max aggregate)', async () => {
@@ -213,10 +232,10 @@ describeMaybeDb(
         ],
       });
 
-      const result = await task.sweep();
+      await task.sweep();
 
       // The 2h-old success wins over the 100h-old one → circle A stays gated.
-      expect(result).toMatchObject({ enqueued: 1, skipped: 1 });
+      expect(await ourPendingCircleIds()).toEqual([circleBId]);
     });
 
     it('ignores FAILED history — only succeeded jobs gate the interval', async () => {
@@ -230,7 +249,9 @@ describeMaybeDb(
         },
       });
 
-      expect((await task.sweep()).enqueued).toBe(2);
+      await task.sweep();
+
+      expect(await ourPendingCircleIds()).toEqual([circleAId, circleBId].sort());
     });
 
     it('skips a circle with a RUNNING job even when its last success is old', async () => {
@@ -252,9 +273,10 @@ describeMaybeDb(
         ],
       });
 
-      const result = await task.sweep();
+      await task.sweep();
 
-      expect(result).toMatchObject({ enqueued: 1, skipped: 1 });
+      // Circle A's in-flight job blocks it despite the 200h-old success.
+      expect(await ourPendingCircleIds()).toEqual([circleBId]);
     });
 
     // -----------------------------------------------------------------------

--- a/apps/api/test/memories/memories-trips.integration.spec.ts
+++ b/apps/api/test/memories/memories-trips.integration.spec.ts
@@ -1,0 +1,777 @@
+// DB_GATED: requires a real PostgreSQL with migrations applied. Reachability is
+// probed synchronously at module load via `describeMaybeDb`, so with no database
+// the whole suite is registered as `describe.skip` and reports SKIPPED — never a
+// green PASS that asserted nothing. See test/helpers/db-probe.helper.ts.
+//
+// WHY THIS SUITE IS DB-BACKED AND NOT MOCKED
+// ------------------------------------------
+// Issue #304's acceptance criteria are statements about ROWS: "a seeded home
+// cluster plus a 5-day away cluster yields exactly one trip memory", "late
+// uploads that extend a trip refresh the SAME row", "a tombstoned trip is never
+// resurrected even when boundaries shift", "a circle with no geo data skips
+// cleanly". Against a mocked Prisma each of those would assert that the code
+// called the mock the way the author expected — a restatement of the
+// implementation, not evidence that the unique index held or that the overlap
+// match actually found the row. The clustering algebra IS unit tested with no
+// database in src/memories/curators/trip-clustering.spec.ts; everything here is
+// specifically the part only a real database can prove.
+//
+// Time is pinned: `ctx.now` is a fixed instant, so the 24-month home window and
+// the 18-month trip lookback are deterministic and fixtures can be seeded on
+// exact dates relative to them.
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { randomUUID } from 'crypto';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { TripCurator } from '../../src/memories/curators/trip.curator';
+import { MemoryCuratorContext } from '../../src/memories/curators/memory-curator.interface';
+import { resolveMemoriesSettings } from '../../src/memories/memories-settings.util';
+import { MemoriesSettingsValue } from '../../src/common/types/settings.types';
+
+function resolveDatabaseUrl(): string {
+  if (process.env['DATABASE_URL']) return process.env['DATABASE_URL'] as string;
+  const host = process.env['POSTGRES_HOST'] ?? 'localhost';
+  const port = process.env['POSTGRES_PORT'] ?? '5432';
+  const user = process.env['POSTGRES_USER'] ?? 'postgres';
+  const password = process.env['POSTGRES_PASSWORD'] ?? 'postgres';
+  const db = process.env['POSTGRES_DB'] ?? 'appdb';
+  return `postgresql://${user}:${encodeURIComponent(password)}@${host}:${port}/${db}`;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+
+/** Fixed clock. Home window opens 2024-08-09; trip lookback opens 2025-02-09. */
+const NOW = new Date(Date.UTC(2026, 7, 9, 12, 0, 0));
+
+/** San José, Costa Rica — home. */
+const HOME = { lat: 9.9281, lng: -84.0907, locality: 'San José', admin1: 'San José' };
+/** Tamarindo, Guanacaste — ~180 km from home, well past the 50 km default. */
+const AWAY = { lat: 10.2993, lng: -85.8371, locality: 'Tamarindo', admin1: 'Guanacaste' };
+/** Puerto Viejo, Limón — a second, unrelated destination. */
+const AWAY2 = { lat: 9.6558, lng: -82.7546, locality: 'Puerto Viejo', admin1: 'Limón' };
+
+describeMaybeDb('Memories — Trips curator (DB_GATED: real PostgreSQL)', () => {
+  let prisma: PrismaClient;
+  let curation: MemoryCurationService;
+  let curator: TripCurator;
+
+  const userId = randomUUID();
+  const circleId = randomUUID();
+  /** A second circle used for the no-geo / empty cases. */
+  const otherCircleId = randomUUID();
+  const createdStorageObjectIds: string[] = [];
+
+  function ctx(over: Partial<MemoryCuratorContext> = {}): MemoryCuratorContext {
+    return {
+      circleId,
+      settings: resolveMemoriesSettings(undefined),
+      now: NOW,
+      backfill: false,
+      ...over,
+    };
+  }
+
+  function settingsWithTrips(trips: Partial<MemoriesSettingsValue['trips']>): MemoriesSettingsValue {
+    return resolveMemoriesSettings({ trips } as Partial<MemoriesSettingsValue>);
+  }
+
+  interface SeedItemOptions {
+    capturedAt: Date;
+    circle?: string;
+    lat?: number | null;
+    lng?: number | null;
+    locality?: string | null;
+    admin1?: string | null;
+    country?: string | null;
+    favorite?: boolean;
+    type?: 'photo' | 'video';
+    durationMs?: number | null;
+    archivedAt?: Date | null;
+    deletedAt?: Date | null;
+    socialMediaSource?: string | null;
+    duplicateGroupId?: string | null;
+  }
+
+  async function seedItem(options: SeedItemOptions): Promise<string> {
+    const storageObjectId = randomUUID();
+    createdStorageObjectIds.push(storageObjectId);
+    await prisma.storageObject.create({
+      data: {
+        id: storageObjectId,
+        name: `${storageObjectId}.jpg`,
+        size: BigInt(2048),
+        mimeType: 'image/jpeg',
+        storageKey: `memories-trips/${storageObjectId}`,
+        status: 'ready',
+        uploadedById: userId,
+      },
+    });
+    const item = await prisma.mediaItem.create({
+      data: {
+        storageObjectId,
+        circleId: options.circle ?? circleId,
+        addedById: userId,
+        type: options.type ?? 'photo',
+        source: 'web',
+        originalFilename: `${storageObjectId}.jpg`,
+        capturedAt: options.capturedAt,
+        takenLat: options.lat ?? null,
+        takenLng: options.lng ?? null,
+        geoLocality: options.locality ?? null,
+        geoAdmin1: options.admin1 ?? null,
+        geoCountry: options.country ?? null,
+        favorite: options.favorite ?? false,
+        durationMs: options.durationMs ?? null,
+        archivedAt: options.archivedAt ?? null,
+        deletedAt: options.deletedAt ?? null,
+        socialMediaSource: options.socialMediaSource ?? null,
+        duplicateGroupId: options.duplicateGroupId ?? null,
+      },
+      select: { id: true },
+    });
+    return item.id;
+  }
+
+  /** A named place, or `null` for "this day has no coordinates at all". */
+  type Place = { lat: number; lng: number; locality: string; admin1: string } | null;
+
+  /** `count` items on the UTC calendar day `date`, at `place`. */
+  async function seedDay(
+    date: Date,
+    place: Place,
+    count = 4,
+    extra: Partial<SeedItemOptions> = {},
+  ): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i += 1) {
+      ids.push(
+        await seedItem({
+          capturedAt: new Date(date.getTime() + (8 + i) * 3_600_000),
+          lat: place?.lat ?? null,
+          lng: place?.lng ?? null,
+          locality: place?.locality ?? null,
+          admin1: place?.admin1 ?? null,
+          country: place ? 'Costa Rica' : null,
+          ...extra,
+        }),
+      );
+    }
+    return ids;
+  }
+
+  /** UTC midnight of `YYYY-MM-DD`. */
+  function day(iso: string): Date {
+    return new Date(`${iso}T00:00:00.000Z`);
+  }
+
+  /**
+   * A believable home baseline: `days` days at home, four photos each, spread
+   * every four days from 2025-08-15 — inside both the 24-month home window and
+   * the 18-month trip lookback, and comfortably past the 30% modal share.
+   *
+   * The window is deliberately confined to LATE 2025, while every fixture trip
+   * below is in 2026. A home day landing inside a trip's date range would be
+   * pulled into that trip by `curate()`'s date-range slice (correctly — a photo
+   * taken during the trip belongs to it), and a 50/50 split of home and away
+   * coordinates on one day gives the marginal median a meaningless midpoint. Both
+   * are real properties worth knowing about; neither is what these tests are
+   * measuring, so the fixtures keep the two apart.
+   */
+  async function seedHomeBaseline(days = 40, circle = circleId): Promise<void> {
+    for (let i = 0; i < days; i += 1) {
+      const date = new Date(Date.UTC(2025, 7, 15) + i * 4 * 86_400_000);
+      for (let j = 0; j < 4; j += 1) {
+        await seedItem({
+          capturedAt: new Date(date.getTime() + (8 + j) * 3_600_000),
+          circle,
+          lat: HOME.lat,
+          lng: HOME.lng,
+          locality: HOME.locality,
+          admin1: HOME.admin1,
+          country: 'Costa Rica',
+        });
+      }
+    }
+  }
+
+  async function clearMemories(): Promise<void> {
+    await prisma.memory.deleteMany({ where: { circleId: { in: [circleId, otherCircleId] } } });
+  }
+
+  async function clearMedia(): Promise<void> {
+    await prisma.mediaItem.deleteMany({ where: { circleId: { in: [circleId, otherCircleId] } } });
+    if (createdStorageObjectIds.length > 0) {
+      await prisma.storageObject.deleteMany({ where: { id: { in: createdStorageObjectIds } } });
+      createdStorageObjectIds.length = 0;
+    }
+  }
+
+  beforeAll(async () => {
+    const adapter = new PrismaPg({ connectionString: DATABASE_URL });
+    prisma = new PrismaClient({ adapter });
+    await prisma.$connect();
+
+    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    curator = new TripCurator(prisma as unknown as PrismaService, curation);
+
+    await prisma.user.create({
+      data: { id: userId, email: `memories-trips-${userId}@example.test` },
+    });
+    await prisma.circle.create({
+      data: { id: circleId, name: 'Memories Trips Circle', ownerId: userId },
+    });
+    await prisma.circle.create({
+      data: { id: otherCircleId, name: 'Memories Trips Other Circle', ownerId: userId },
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await clearMemories().catch(() => undefined);
+    await clearMedia().catch(() => undefined);
+    await prisma.duplicateGroup.deleteMany({ where: { circleId } }).catch(() => undefined);
+    await prisma.circle.deleteMany({ where: { id: { in: [circleId, otherCircleId] } } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.$disconnect();
+  }, 30000);
+
+  afterEach(async () => {
+    await clearMemories();
+    await clearMedia();
+    await prisma.duplicateGroup.deleteMany({ where: { circleId } });
+  }, 30000);
+
+  // ---------------------------------------------------------------------------
+  // The headline scenario
+  // ---------------------------------------------------------------------------
+
+  it('turns a home cluster plus a 5-day away cluster into exactly one trip memory', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14', '2026-03-15', '2026-03-16']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+
+    const result = await curator.run(ctx());
+
+    expect(result.created).toBe(1);
+    const memories = await prisma.memory.findMany({ where: { circleId, type: 'trip' } });
+    expect(memories).toHaveLength(1);
+
+    const trip = memories[0]!;
+    expect(trip.periodKey).toBe('2026-03-12');
+    expect(trip.subjectKey).toBe('tamarindo');
+    expect(trip.title).toBe('Trip to Tamarindo');
+    expect(trip.subtitle).toBe('March 2026');
+    expect(trip.titleSource).toBe('template');
+    expect(trip.itemCount).toBe(20);
+    expect(trip.expiresAt).toBeNull();
+
+    const meta = trip.meta as Record<string, unknown>;
+    expect(meta['locality']).toBe('Tamarindo');
+    expect(meta['admin1']).toBe('Guanacaste');
+    expect(meta['country']).toBe('Costa Rica');
+    expect(meta['dayCount']).toBe(5);
+    expect(meta['startDate']).toBe('2026-03-12');
+    expect(meta['endDate']).toBe('2026-03-16');
+    expect(meta['homePlace']).toBe('San José');
+    expect(meta['distanceKm'] as number).toBeGreaterThan(150);
+
+    // The curated set is exactly the away days — no home photos leaked in.
+    const items = await prisma.memoryItem.findMany({
+      where: { memoryId: trip.id },
+      orderBy: { position: 'asc' },
+    });
+    const media = await prisma.mediaItem.findMany({
+      where: { id: { in: items.map((i) => i.mediaItemId) } },
+      select: { geoLocality: true },
+    });
+    expect(new Set(media.map((m) => m.geoLocality))).toEqual(new Set(['Tamarindo']));
+    expect(items.map((i) => i.position)).toEqual(items.map((_, idx) => idx));
+    expect(trip.coverMediaItemId).not.toBeNull();
+  }, 120000);
+
+  it('a one-day photo gap mid-trip does not split it, and two trips 3 weeks apart are two memories', async () => {
+    await seedHomeBaseline();
+    // Trip A: 12th, 13th, (nothing on the 14th), 15th, 16th.
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-15', '2026-03-16']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    // Trip B: three weeks later, a different destination.
+    for (const iso of ['2026-04-06', '2026-04-07', '2026-04-08']) {
+      await seedDay(day(iso), AWAY2, 4);
+    }
+
+    const result = await curator.run(ctx());
+
+    expect(result.created).toBe(2);
+    const trips = await prisma.memory.findMany({
+      where: { circleId, type: 'trip' },
+      orderBy: { periodKey: 'asc' },
+    });
+    expect(trips.map((t) => t.periodKey)).toEqual(['2026-03-12', '2026-04-06']);
+    expect(trips.map((t) => t.subjectKey)).toEqual(['tamarindo', 'puerto-viejo']);
+    // The bridged gap is inside the span: 12th..16th is five days.
+    expect((trips[0]!.meta as Record<string, unknown>)['dayCount']).toBe(5);
+    expect((trips[1]!.meta as Record<string, unknown>)['dayCount']).toBe(3);
+    expect(trips[1]!.title).toBe('Trip to Puerto Viejo');
+  }, 120000);
+
+  // ---------------------------------------------------------------------------
+  // Idempotent regeneration & overlap-based refresh
+  // ---------------------------------------------------------------------------
+
+  it('re-running against an unchanged library changes nothing', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+
+    const first = await curator.run(ctx());
+    const before = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'trip' },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+
+    const second = await curator.run(ctx());
+    const after = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'trip' },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+
+    expect(first.created).toBe(1);
+    expect(second.created).toBe(0);
+    expect(second.refreshed).toBe(1);
+    expect(await prisma.memory.count({ where: { circleId, type: 'trip' } })).toBe(1);
+    expect(after.id).toBe(before.id);
+    expect(after.generatedAt).toEqual(before.generatedAt);
+    expect(after.periodKey).toBe(before.periodKey);
+    expect(after.items.map((i) => i.mediaItemId)).toEqual(before.items.map((i) => i.mediaItemId));
+  }, 120000);
+
+  it('late uploads that EXTEND a trip refresh the same row — re-keyed, not duplicated', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-14', '2026-03-15', '2026-03-16']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    await curator.run(ctx());
+
+    const before = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'trip' } });
+    expect(before.periodKey).toBe('2026-03-14');
+
+    // Per-user state must survive the refresh — this is the whole reason
+    // MemoryUserState is a separate table.
+    const seenAt = new Date(Date.UTC(2026, 7, 1));
+    await prisma.memoryUserState.create({
+      data: { memoryId: before.id, userId, seenAt, favoritedAt: seenAt },
+    });
+
+    // A second camera's photos land: the trip actually started two days earlier
+    // and ran a day longer. The detected boundaries — and therefore the identity
+    // keys — move.
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-17']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    const result = await curator.run(ctx());
+
+    expect(result.created).toBe(0);
+    expect(result.refreshed).toBe(1);
+    // Exactly one row, still the same row, now under the new keys.
+    expect(await prisma.memory.count({ where: { circleId, type: 'trip' } })).toBe(1);
+
+    const after = await prisma.memory.findUniqueOrThrow({ where: { id: before.id } });
+    expect(after.periodKey).toBe('2026-03-12');
+    expect((after.meta as Record<string, unknown>)['endDate']).toBe('2026-03-17');
+    expect(after.itemCount).toBe(24);
+
+    const state = await prisma.memoryUserState.findFirstOrThrow({
+      where: { memoryId: before.id, userId },
+    });
+    expect(state.seenAt).toEqual(seenAt);
+    expect(state.favoritedAt).toEqual(seenAt);
+  }, 120000);
+
+  it('re-keys the subjectKey when a better geocode changes the dominant locality', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    await curator.run(ctx());
+    const before = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'trip' } });
+    expect(before.subjectKey).toBe('tamarindo');
+
+    // A geocode backfill resolves the same coordinates to a nearby town.
+    await prisma.mediaItem.updateMany({
+      where: { circleId, geoLocality: 'Tamarindo' },
+      data: { geoLocality: 'Playa Grande' },
+    });
+    const result = await curator.run(ctx());
+
+    expect(result.refreshed).toBe(1);
+    expect(await prisma.memory.count({ where: { circleId, type: 'trip' } })).toBe(1);
+    const after = await prisma.memory.findUniqueOrThrow({ where: { id: before.id } });
+    expect(after.subjectKey).toBe('playa-grande');
+    // The membership did not move at all, so #303's anti-churn rule would
+    // normally preserve the title — leaving a memory keyed "playa-grande" and
+    // titled "Trip to Tamarindo" forever. A drifted subject is a falsified
+    // title, not an aged one, so the curator passes `retitle`.
+    expect(after.title).toBe('Trip to Playa Grande');
+    expect(after.titleSource).toBe('template');
+  }, 120000);
+
+  it('does NOT retitle when only the item set grew — #303 anti-churn still holds', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    await curator.run(ctx());
+    const before = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'trip' } });
+
+    // Stand in for #306 having written an AI title over the template.
+    await prisma.memory.update({
+      where: { id: before.id },
+      data: {
+        title: 'Five days of salt and sunburn',
+        narrative: 'AI narrative',
+        titleSource: 'ai',
+        titleModel: 'gpt-test',
+      },
+    });
+
+    // One photo joins a 12-item trip: well below the 30% material threshold, and
+    // the place is unchanged, so nothing may touch the AI title.
+    await seedDay(day('2026-03-13'), AWAY, 1);
+    await curator.run(ctx());
+
+    const after = await prisma.memory.findUniqueOrThrow({ where: { id: before.id } });
+    expect(after.title).toBe('Five days of salt and sunburn');
+    expect(after.titleSource).toBe('ai');
+    expect(after.narrative).toBe('AI narrative');
+    expect(after.itemCount).toBe(13);
+  }, 120000);
+
+  // ---------------------------------------------------------------------------
+  // The tombstone contract
+  // ---------------------------------------------------------------------------
+
+  it('NEVER resurrects a deleted trip, even when its detected boundaries shift', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-14', '2026-03-15', '2026-03-16']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    await curator.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'trip' } });
+    const deletedAt = new Date();
+    await prisma.memory.update({ where: { id: memory.id }, data: { deletedAt } });
+    const tombstoned = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+
+    // Extend the trip so the run would carry DIFFERENT keys than the tombstone.
+    // A key-only tombstone check would sail straight past this and insert.
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-17']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    const result = await curator.run(ctx());
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.refreshed).toBe(0);
+    expect(await prisma.memory.count({ where: { circleId, type: 'trip' } })).toBe(1);
+
+    const after = await prisma.memory.findUniqueOrThrow({
+      where: { id: memory.id },
+      include: { items: true },
+    });
+    expect(after.deletedAt).toEqual(deletedAt);
+    expect(after.periodKey).toBe(tombstoned.periodKey);
+    expect(after.itemCount).toBe(tombstoned.itemCount);
+    expect(after.refreshedAt).toEqual(tombstoned.refreshedAt);
+    expect(after.updatedAt).toEqual(tombstoned.updatedAt);
+  }, 120000);
+
+  it('a tombstoned trip does not block an unrelated trip in the same circle', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    await curator.run(ctx());
+    await prisma.memory.updateMany({
+      where: { circleId, type: 'trip' },
+      data: { deletedAt: new Date() },
+    });
+
+    for (const iso of ['2026-05-01', '2026-05-02', '2026-05-03']) {
+      await seedDay(day(iso), AWAY2, 4);
+    }
+    const result = await curator.run(ctx());
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.created).toBe(1);
+    const live = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'trip', deletedAt: null },
+    });
+    expect(live.periodKey).toBe('2026-05-01');
+  }, 120000);
+
+  // ---------------------------------------------------------------------------
+  // Graceful degradation
+  // ---------------------------------------------------------------------------
+
+  it('produces nothing and does not throw for an empty circle', async () => {
+    const result = await curator.run(ctx({ circleId: otherCircleId }));
+
+    expect(result).toEqual({ created: 0, refreshed: 0, skipped: 0, tombstoned: 0 });
+    expect(await prisma.memory.count({ where: { circleId: otherCircleId } })).toBe(0);
+  });
+
+  it('skips cleanly when the circle has media but NO geo data at all', async () => {
+    // The epic's failure-mode matrix: "no geo => trips curator skips, all other
+    // types unaffected".
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14', '2026-03-15']) {
+      await seedDay(day(iso), null, 5);
+    }
+
+    const result = await curator.run(ctx());
+
+    expect(result).toEqual({ created: 0, refreshed: 0, skipped: 0, tombstoned: 0 });
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(0);
+  }, 60000);
+
+  it('skips when no locality holds a 30% share — a travel-only archive has no home', async () => {
+    // Four destinations in four DIFFERENT provinces, evenly split: nowhere is a
+    // center of gravity at either level, so neither the locality pass nor the
+    // admin1 fallback can name a home. (Distinct admin1s matter — two towns in
+    // one province would hand the fallback a 50% share and a home after all,
+    // which is correct behavior and a different test.)
+    const places = [
+      AWAY,
+      AWAY2,
+      { lat: 9.9763, lng: -84.8267, locality: 'Jacó', admin1: 'Puntarenas' },
+      { lat: 10.4806, lng: -84.6447, locality: 'La Fortuna', admin1: 'Alajuela' },
+    ];
+    let offset = 0;
+    for (const place of places) {
+      for (let i = 0; i < 3; i += 1) {
+        await seedDay(new Date(Date.UTC(2026, 2, 1) + offset * 86_400_000), place, 4);
+        offset += 1;
+      }
+    }
+
+    const result = await curator.run(ctx());
+
+    expect(result.created).toBe(0);
+    expect(await prisma.memory.count({ where: { circleId, type: 'trip' } })).toBe(0);
+  }, 120000);
+
+  // ---------------------------------------------------------------------------
+  // Thresholds
+  // ---------------------------------------------------------------------------
+
+  it('enforces trips.minDays', async () => {
+    await seedHomeBaseline();
+    // A single away day: below the default minDays of 2.
+    await seedDay(day('2026-03-12'), AWAY, 12);
+
+    const result = await curator.run(ctx());
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await prisma.memory.count({ where: { circleId, type: 'trip' } })).toBe(0);
+  }, 120000);
+
+  it('enforces trips.minItems', async () => {
+    await seedHomeBaseline();
+    // Three days away, 4 photos each = 12 candidates. Default minItems is 10, so
+    // this qualifies; raising it to 20 must reject the very same fixture.
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+
+    expect((await curator.run(ctx())).created).toBe(1);
+    await clearMemories();
+
+    const strict = await curator.run(ctx({ settings: settingsWithTrips({ minItems: 20 }) }));
+    expect(strict.created).toBe(0);
+    expect(strict.skipped).toBe(1);
+  }, 120000);
+
+  it('enforces trips.minDistanceKm — a day just down the road is not a trip', async () => {
+    await seedHomeBaseline();
+    // Cartago: ~20 km from San José, under the 50 km default.
+    const nearby = { lat: 9.8644, lng: -83.9194, locality: 'Cartago', admin1: 'Cartago' };
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), nearby, 4);
+    }
+
+    expect((await curator.run(ctx())).created).toBe(0);
+
+    // Drop the threshold below that distance and the same days become a trip.
+    const loose = await curator.run(ctx({ settings: settingsWithTrips({ minDistanceKm: 5 }) }));
+    expect(loose.created).toBe(1);
+    const trip = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'trip' } });
+    expect(trip.subjectKey).toBe('cartago');
+  }, 120000);
+
+  it('honours trips.lookbackMonths, and backfill mode ignores it', async () => {
+    await seedHomeBaseline();
+    // Three years back: outside both the 18-month default lookback and the
+    // 24-month home window, so only a backfill can see it.
+    for (const iso of ['2023-03-12', '2023-03-13', '2023-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+
+    expect((await curator.run(ctx())).created).toBe(0);
+
+    const backfilled = await curator.run(ctx({ backfill: true }));
+    expect(backfilled.created).toBe(1);
+    const trip = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'trip' } });
+    expect(trip.periodKey).toBe('2023-03-12');
+    expect(trip.subtitle).toBe('March 2023');
+  }, 120000);
+
+  // ---------------------------------------------------------------------------
+  // Shared curation engine behaviors, exercised through this curator
+  // ---------------------------------------------------------------------------
+
+  it('excludes archived, trashed and social-media items from a trip', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+    // Each violates exactly one base-filter predicate, all inside the trip range.
+    for (const extra of [
+      { archivedAt: new Date() },
+      { deletedAt: new Date() },
+      { socialMediaSource: 'tiktok' },
+    ]) {
+      await seedItem({
+        capturedAt: new Date(Date.UTC(2026, 2, 13, 20)),
+        lat: AWAY.lat,
+        lng: AWAY.lng,
+        locality: AWAY.locality,
+        admin1: AWAY.admin1,
+        country: 'Costa Rica',
+        ...extra,
+      });
+    }
+
+    await curator.run(ctx());
+
+    const trip = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'trip' },
+      include: { items: true },
+    });
+    expect(trip.itemCount).toBe(12);
+    const media = await prisma.mediaItem.findMany({
+      where: { id: { in: trip.items.map((i) => i.mediaItemId) } },
+      select: { archivedAt: true, deletedAt: true, socialMediaSource: true },
+    });
+    for (const m of media) {
+      expect(m.archivedAt).toBeNull();
+      expect(m.deletedAt).toBeNull();
+      expect(m.socialMediaSource).toBeNull();
+    }
+  }, 120000);
+
+  it('collapses near-duplicates and caps videos at three', async () => {
+    await seedHomeBaseline();
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+    }
+
+    // Six favorite videos inside the range — the cap must hold at three, and the
+    // cover must stay a photo.
+    for (let i = 0; i < 6; i += 1) {
+      await seedItem({
+        capturedAt: new Date(Date.UTC(2026, 2, 13, 12, i)),
+        lat: AWAY.lat,
+        lng: AWAY.lng,
+        locality: AWAY.locality,
+        admin1: AWAY.admin1,
+        country: 'Costa Rica',
+        type: 'video',
+        durationMs: 15_000,
+        favorite: true,
+      });
+    }
+
+    // A duplicate group of three photos must contribute exactly one item.
+    const group = await prisma.duplicateGroup.create({
+      data: { circleId, status: 'pending', mediaCount: 3 },
+      select: { id: true },
+    });
+    const members: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      members.push(
+        await seedItem({
+          capturedAt: new Date(Date.UTC(2026, 2, 14, 15, i)),
+          lat: AWAY.lat,
+          lng: AWAY.lng,
+          locality: AWAY.locality,
+          admin1: AWAY.admin1,
+          country: 'Costa Rica',
+          duplicateGroupId: group.id,
+        }),
+      );
+    }
+    await prisma.duplicateGroup.update({
+      where: { id: group.id },
+      data: { suggestedBestItemId: members[1] },
+    });
+
+    await curator.run(ctx());
+
+    const trip = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'trip' },
+      include: { items: true },
+    });
+    const ids = trip.items.map((i) => i.mediaItemId);
+    const media = await prisma.mediaItem.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, type: true },
+    });
+    expect(media.filter((m) => m.type === 'video')).toHaveLength(3);
+    // Exactly the group's own suggested best represents the duplicate group.
+    expect(ids.filter((id) => members.includes(id))).toEqual([members[1]!]);
+
+    const cover = await prisma.mediaItem.findUniqueOrThrow({
+      where: { id: trip.coverMediaItemId! },
+      select: { type: true },
+    });
+    expect(cover.type).toBe('photo');
+  }, 120000);
+
+  it('does not leak another circle\'s away days into a trip', async () => {
+    await seedHomeBaseline();
+    await seedHomeBaseline(6, otherCircleId);
+    for (const iso of ['2026-03-12', '2026-03-13', '2026-03-14']) {
+      await seedDay(day(iso), AWAY, 4);
+      for (let i = 0; i < 4; i += 1) {
+        await seedItem({
+          capturedAt: new Date(day(iso).getTime() + (8 + i) * 3_600_000),
+          circle: otherCircleId,
+          lat: AWAY2.lat,
+          lng: AWAY2.lng,
+          locality: AWAY2.locality,
+          admin1: AWAY2.admin1,
+          country: 'Costa Rica',
+        });
+      }
+    }
+
+    await curator.run(ctx());
+
+    const trip = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'trip' },
+      include: { items: true },
+    });
+    expect(trip.itemCount).toBe(12);
+    const media = await prisma.mediaItem.findMany({
+      where: { id: { in: trip.items.map((i) => i.mediaItemId) } },
+      select: { circleId: true },
+    });
+    expect(new Set(media.map((m) => m.circleId))).toEqual(new Set([circleId]));
+  }, 120000);
+});

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.3 (data model + generation plumbing + curation engine & On This Day) |
+| **Version** | 0.4 (data model + generation plumbing + curation engine, On This Day & Trips) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303); §5–§8 and §10 are placeholders for later issues in epic #300 |
+| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304); §5–§8 and §10 are placeholders for later issues in epic #300 |
 
 ---
 
@@ -361,7 +361,98 @@ The pre-existing `media_items_captured_md_idx` (migration `20260615000000_media_
 
 **Retention tail.** `OnThisDayCurator.purge()` hard-deletes this circle's `on_this_day` rows whose `expiresAt` is more than 30 days past — **tombstoned or not**. Ignoring the tombstone here is safe rather than a contradiction of §2.5: the tombstone's job is "do not recreate this memory", and once the anchor day is a month gone the curator has no reason to generate that `periodKey` again until the date comes back around a year later, by which point the underlying library has changed and the memory is legitimately a new one. Keeping the tombstones forever would accumulate one unreadable row per (day × year) for the life of the deployment. The tail runs at the end of every generation job rather than on its own cron: the work is proportional to what generation just produced, it must not run when the feature is off, and a separate schedule would be a second thing to reason about for one batched `deleteMany`.
 
-### 4.8 Idempotent regeneration — `upsertMemory()`
+### 4.8 The Trips curator
+
+Issue [#304](https://github.com/marinoscar/MemoriaHub/issues/304). Trips are the only memory type that requires real clustering, and the only one that needs a fact the library has never held: where **home** is. Everything below follows from inferring that one fact and then asking, day by day, "were we away?".
+
+The decision algebra is pure and lives in `apps/api/src/memories/curators/trip-clustering.ts` (no Prisma, no Nest, no clock); `trip.curator.ts` is the I/O half — one streaming scan in, curated memories out.
+
+| Field | Value |
+|---|---|
+| `periodKey` | trip start date, ISO `YYYY-MM-DD` |
+| `subjectKey` | slugified dominant locality (ASCII-folded, dash-separated, e.g. `guanacaste`); `''` when nothing was reverse-geocoded |
+| `expiresAt` | `NULL` — unlike On This Day, a trip stays interesting |
+| `meta` | `{ locality, admin1, country, distanceKm, dayCount, startDate, endDate, homePlace, homeLevel, generatorVersion }` |
+
+#### Home inference
+
+Over the circle's coordinate-bearing candidates from a **fixed 24-month window**, the modal `geoLocality` holding a **>= 30% share** is home, and its mean lat/lng is the home centroid.
+
+The window is deliberately **not** a setting and is deliberately not `trips.lookbackMonths`. Home is a slow-moving fact about a family, while the lookback answers "how far back do we look for trips?"; tying them together would mean an admin narrowing the trip window to three months silently re-infers home from one quarter's photos — exactly the case where a long vacation can outvote the house. Two years is long enough that no single trip can be modal, short enough to follow a real relocation.
+
+**Locality first, `geoAdmin1` as a fallback at the same 30% floor.** `geoLocality` is the level a person would name, but it is also the level most likely to be sparse: offline reverse geocoding frequently resolves a region and not a town, and a rural library can have `geoAdmin1` on nearly everything and `geoLocality` on almost nothing. Trying locality alone would report "home unknown" for a circle whose home is obvious one level up. The fallback keeps the *same* floor rather than a looser one — a coarser geography is easier to be modal in, so failing to clear 30% even there means there is genuinely no home here.
+
+**No home ⇒ no trips, and that is a normal outcome, not an error.** A travel-only archive, a circle spanning three countries, or a library that was never geocoded has no center of gravity, and every day would read as "away from" a place that is not home — a wall of bogus trips. The curator logs at `debug` and returns an empty result, satisfying the epic's failure-mode row "no geo data ⇒ trips curator skips, all other types unaffected". There is no `memories.trips.homeOverride` in v1; modal inference is zero-config and new-install friendly, and an override can be added later with no schema change.
+
+#### Away-day classification
+
+Candidates in the trip window are grouped by **UTC calendar day**, and each day gets one of three verdicts against home:
+
+| Verdict | Condition | Effect on a run |
+|---|---|---|
+| `away` | >= 3 candidates **and** the day's **median** coordinate is farther than `trips.minDistanceKm` from home — or, with no coordinates at all, >= 3 candidates whose modal `geoAdmin1` differs from home's | anchors/extends a run |
+| `home` | >= 3 candidates and the median is within `minDistanceKm` | **terminates** a run |
+| `neutral` | anything else (too few candidates, no usable signal) | consumes gap budget, never splits |
+
+**The median, not the mean.** One mis-geotagged frame — a phone that cached a stale fix, a scan with a hand-entered coordinate — would drag a mean hundreds of kilometers and invent a trip. Latitude and longitude are taken independently (a *marginal* median): not the geometric median, but O(n log n), dependency-free, and identical for the compact same-day clusters this actually sees.
+
+**A thin day is neutral even when it is far away.** One airport-layover photo should not open a trip, and one photo taken at home mid-vacation should not close one. Requiring evidence in both directions is what makes the classification stable.
+
+**The coordinate-less fallback can only ever ADD an away day.** A matching `geoAdmin1` is weak evidence of being home (adjacent regions are minutes apart) while a differing one is strong evidence of being away, so a mismatch classifies `away` and everything else stays `neutral` — never `home`.
+
+#### Trip assembly
+
+Away days merge into runs tolerating **one** gap day. A single photo-less day mid-week is a day you did not take pictures, not the end of the trip.
+
+A `home` day inside that tolerance still **terminates** the run: it is positive evidence the trip ended, not merely an absence of evidence. Treating it as a gap would fuse a weekend away, a quiet week at home, and the next weekend away into one eleven-day "trip". Runs are also trimmed to away days at both ends, so a trip never reports a start date on which nothing said "away".
+
+A run becomes a memory when it spans >= `trips.minDays` calendar days **and** yields >= `trips.minItems` items after curation. Two cheap floors are checked before any query — span, and raw candidate count across the run's days — so a run that cannot possibly qualify never pays for a curation pass. Item selection itself is entirely §4.2–§4.5's shared engine: same base filter, same scoring, same burst/duplicate collapse, same diversity buckets, same 3-video cap, same `maxItemsPerMemory`.
+
+The **dominant place** (locality → admin1 → country) is resolved from the run's day aggregates — every candidate in range — rather than from the curated items. A 30-item selection is a quality sample, not a geographic one, and naming a trip after whichever town contributed the sharpest photos would be arbitrary.
+
+#### Identity and refresh stability
+
+This is the subtle part. A trip's detected boundaries **move** when new uploads land: a second camera's photos can reveal that the trip started two days earlier. Because `periodKey` is the start date, the identity keys move with them — so matching a re-detected trip to its existing memory **by key equality would mint a duplicate on every late import**.
+
+Instead, a re-detected run is paired with the existing `trip` memory whose **day range it overlaps by >= 50%**, and that row is **re-keyed in place** (`UPDATE`, not a competing insert — the unique index permits it, since the row already owns the old slot).
+
+The denominator is the load-bearing detail: overlap is measured against the **shorter** of the two spans, not their union. A 3-day trip growing into a 10-day one scores `3/3 = 1.0` and refreshes; Jaccard would score it `3/10 = 0.30` and create the duplicate this rule exists to prevent. The trade — a short range fully inside a much longer one always matches — is accepted, because a 2-day run inside an existing 30-day trip really is part of that trip. Matching is greedy in descending overlap order and one-to-one on both sides, so neither a run nor a memory is ever claimed twice, and the better fit wins over whichever run happened to be chronologically first.
+
+Overlap is computed against `meta.startDate`/`meta.endDate` — the **detected** day range — rather than `periodStart`/`periodEnd`, which describe the curated item set and are often narrower (a trip's first and last day frequently lose their photos to the diversity cap). Rows written before those meta keys existed fall back to the period columns.
+
+**Tombstoned trips take part in matching.** This is what makes §2.5's contract hold here at all: `upsertMemory`'s own tombstone check is keyed on `(periodKey, subjectKey)`, and a shifted boundary carries *different* keys, so a key-only check would sail straight past a deleted trip and insert a fresh one. A run overlapping a tombstone is refused before any curation work.
+
+**A drifted subject re-titles.** When a better reverse-geocode changes the dominant locality, the row is re-keyed *and* `upsertMemory` is called with `retitle: true` — an optional flag (default `false`, so every other caller is unchanged) added for exactly this case. §4.9's anti-churn rule exists to protect a title that is still accurate; a memory keyed `playa-grande` and titled "Trip to Tamarindo" is not aged, it is falsified. An ordinary refresh — one photo joining — still preserves the title, AI ones included.
+
+If the slot a re-key would move into is already held by a *different* memory, the row keeps its current identity and refreshes there instead. The keys are an identity, not data: a stale-but-stable one beats either a failed unique-index write or deleting a memory a user may have favorited.
+
+#### Backfill
+
+`payload.backfill === true` drops `lookbackMonths` and sweeps the whole library; the home window stays fixed at 24 months either way. This is a single in-memory pass per circle, the same precedent as the `location_inference` sweep.
+
+**Memory is flat in library size** because the scan aggregates as it streams and **never retains media-item ids**: a qualifying run re-selects its items through `curate()` with a date-range `where` afterwards, so the ~95% of days spent at home cost two floats and a few tallies each. `MAX_SCAN_ROWS` (500 000) is a crash guard on the per-day coordinate samples, not a tuning knob.
+
+#### Query plan — no new index
+
+Verified with `EXPLAIN (ANALYZE, BUFFERS)` over a seeded 30 000-item circle: the scan is served by the **existing** `media_items_gallery_idx` (`(circle_id, captured_at DESC, id DESC) WHERE deleted_at IS NULL AND archived_at IS NULL`, migration `20260716000000_media_gallery_index`) as an `Index Scan Backward` with **no sort node** — a btree scans either direction, so the index's `DESC` declaration costs nothing here — leaving only `social_media_source IS NULL` as a cheap filter:
+
+```
+Limit (actual time=0.065..4.324 rows=1000)
+  ->  Index Scan Backward using media_items_gallery_idx on media_items
+        Index Cond: ((circle_id = $1) AND (captured_at IS NOT NULL) AND (captured_at >= $2))
+        Filter: (social_media_source IS NULL)
+```
+
+So #304 adds **no migration**. The one known cost is inherited from §4.2's `loadCandidates`: Prisma's typed `where` cannot express a row-value comparison `(captured_at, id) > ($1, $2)`, so the keyset predicate is emitted as an `OR` and lands as a `Filter` rather than an `Index Cond` — page *N* re-walks the pages before it. It is bounded (~2.5 M index-entry visits across a 70 000-item circle, low seconds inside a daily background job) and dropping to raw SQL to avoid it would also give up the structural guarantee that `memoryCandidateBaseWhere()` is applied by the engine rather than by the caller.
+
+#### Known gaps
+
+- **A day straddling the ±180° antimeridian gets a meaningless median longitude**, and the home centroid has the same weakness (it is a plain mean). Both would misclassify a Fiji/Kiribati-area day. Documented rather than solved: the fix is circular-mean arithmetic like `interpolateLng`'s in the location-inference engine, and it is not worth the complexity until someone is affected.
+- **A day whose photos are split ~50/50 between home and a destination** can produce a marginal median that is at neither — a phantom point built from one cluster's latitude and the other's longitude. Real travel days are not bimodal; a fixture of ours was, which is how this surfaced.
+- **A trip that no longer detects is not deleted**, per §4.12's general rule — the curator only upserts runs that still qualify.
+- **`trips.minItems` above `maxItemsPerMemory`** can never be satisfied, since curation caps the selection first. Both are admin-settable within their own bounds and the combination is not cross-validated.
+
+### 4.9 Idempotent regeneration — `upsertMemory()`
 
 Every curator writes through this one method, keyed on `@@unique([circleId, type, periodKey, subjectKey])`.
 
@@ -377,9 +468,9 @@ Every curator writes through this one method, keyed on `@@unique([circleId, type
 
 `meta.generatorVersion` (currently `1`) is stamped centrally on every write. Bump it when scoring or selection changes in a way that would produce a different item set from identical inputs — it is the only way to tell, after the fact, which algorithm produced a given memory.
 
-### 4.9 Registry and per-curator error isolation
+### 4.10 Registry and per-curator error isolation
 
-Curators are injected as an array under the `MEMORY_CURATORS` token (`memoryCuratorsProvider` in `on-this-day.curator.ts`), so #304 and #305 add a provider plus one entry in that factory and touch nothing else. `MemoryGenerationHandler` iterates it:
+Curators are injected as an array under the `MEMORY_CURATORS` token (`memoryCuratorsProvider`, which moved to its own `curators/memory-curators.provider.ts` in #304 once it imported more than one curator — a file that also *defines* a curator importing its siblings is a needless coupling and an easy way to grow an import cycle), so #305 adds a provider plus one entry in that factory and touches nothing else. Order is execution order, cheapest-first: On This Day runs two bounded functional-index queries, Trips streams the circle's geo history. `MemoryGenerationHandler` iterates it:
 
 - each curator is gated by **its own** `memories.<type>.enabled` toggle, checked via `MemoryCurator.isEnabled(settings)` rather than a stringly-typed settings key on the registry entry;
 - each `run()` is **individually try/caught**, and so is each `purge()`;
@@ -390,11 +481,11 @@ This is a correctness requirement, not politeness. The seven types are independe
 
 One wall clock (`ctx.now`) is captured once by the handler and shared by every curator, so a run that straddles midnight cannot have one curator anchoring on today and the next on tomorrow.
 
-### 4.10 Settings resolution
+### 4.11 Settings resolution
 
 `resolveMemoriesSettings()` deep-merges the stored `memories.*` namespace over `DEFAULT_SYSTEM_SETTINGS.memories` **once per generation job**, so curators read `settings.onThisDay.minItems` unconditionally and never carry their own `?? 10` fallbacks. The namespace is genuinely optional on an older JSONB row — that is what makes it migration-free (§9.2) — and per-curator fallbacks would be a fourth hand-maintained copy of every default, on top of the three §9.3 already warns about.
 
-### 4.11 Known gaps
+### 4.12 Known gaps
 
 - **A period that falls below `minItems` after items are removed keeps its existing memory.** Curators only upsert periods that still qualify; they do not delete a memory whose material has since been trashed. Its `MemoryItem` rows for hard-deleted media cascade away and `itemCount` is corrected on the next refresh, but a memory whose items were all *soft*-deleted lingers until read-time filtering ([#307](https://github.com/marinoscar/MemoriaHub/issues/307)) hides it. Deleting it automatically was rejected for v1: a curator silently destroying a memory a user may have favorited is a worse failure than a stale one.
 - **Backfill is unchunked.** A full On This Day backfill for a dense circle is up to 366 anchors × `lookbackYears` curations in one job, which can approach `ENRICHMENT_JOB_TIMEOUT_MS`. It is memory-safe (nothing accumulates across anchors) and restartable (every write is idempotent), but chunking the admin backfill into multiple jobs belongs to #315.
@@ -509,5 +600,6 @@ Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/is
 | Version | Date | Author | Changes |
 |---|---|---|---|
 | 0.1 | August 2026 | AI Assistant | Initial specification for issue #301: the `MemoryType` enum, the `Memory`/`MemoryItem`/`MemoryUserState` data model, the `periodKey`/`subjectKey` semantics, the tombstone contract, cascade summary, and alternatives considered. Sections 3–10 are placeholders for later issues in epic #300. |
+| 0.4 | August 2026 | AI Assistant | Issue #304: added §4.8 (the Trips curator — fixed-24-month home inference with the 30% modal-share floor and the same-floor `geoAdmin1` fallback, median-based three-way away/home/neutral day classification and the coordinate-less metadata fallback that can only add an away day, gap-tolerant run merging where a home day terminates rather than bridges, the >=50%-of-the-SHORTER-span overlap matching that re-keys a boundary-shifted trip in place instead of duplicating it, tombstone participation in that matching, the `retitle` flag for a drifted subject, backfill and its flat-memory streaming aggregation, the EXPLAIN-verified reuse of `media_items_gallery_idx` with no new migration, and known gaps). Renumbered the former §4.8–§4.11 to §4.9–§4.12 so the curator sections sit together. §5–§8 and §10 remain placeholders. |
 | 0.3 | August 2026 | AI Assistant | Issue #303: filled in §4 (Curation Engine — the structural base filter, constant-memory keyset candidate streaming with per-page batched signal lookups, the scoring weights and the neutral-NULL-sharpness rule, the pure-score-vs-selectionScore split for the long-video preference, burst/duplicate collapse and its burst-wins precedence, time-bucket diversity with the 3-video cap, deterministic ordering and the never-a-video cover rule, template titles for all seven types, the On This Day curator with its today+tomorrow anchors / one-query-per-anchor design / new circle-scoped functional index / backfill anchor widening / retention tail, the `upsertMemory()` idempotency and tombstone contract with its Jaccard title-preservation rule, the curator registry and per-curator error isolation, settings resolution, and known gaps). §5–§8 and §10 remain placeholders. |
 | 0.2 | August 2026 | AI Assistant | Issue #302: filled in §3 (Generation — `MemoriesGenerationTask`'s three gates and zero-cost-when-off contract, the mandatory `skipDedup: true` rationale, the server-only `MemoryGenerationHandler` and its no-node-pair system-mode inference, job labels, and the `JobReason.backfill` deviation from the issue text) and §9 (Settings — `features.memories` + the `MEMORIES_ENABLED` kill-switch and their shared `isMemoriesEnabled()` gate, the full `memories.*` bounds/defaults table, the three-hand-maintained-copies pitfall, and `ai.features.memories` with its up-front credential validation). §4–§8 and §10 remain placeholders. |


### PR DESCRIPTION
## Summary

The Trips curator: infers the circle's home location, classifies away-days, clusters them into trips, and curates each into a `trip` memory via #303's existing engine. Registered under the existing `MEMORY_CURATORS` token — no parallel scoring/selection/upsert path.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Related Issues

Relates to #300
Fixes #304

## Changes Made

**New** — `common/geo/haversine.util.ts` (the single `haversineKm`), `memories/curators/trip-clustering.ts` (pure algebra — no Prisma, Nest, or clock), `trip.curator.ts`, `memory-curators.provider.ts` (registry extracted out of `on-this-day.curator.ts`), plus 44 unit tests and 18 DB-backed integration tests.

**Modified** — `location-inference.service.ts` (re-exports the moved helper so its importers and golden-value spec are untouched), `memories.module.ts`, `memory-curation.types.ts` / `memory-curation.service.ts` (`retitle` flag), `docs/specs/memories.md` §4.8.

**No migration.** The issue asked to verify with EXPLAIN first: against a seeded 30k-item circle the scan is already an `Index Scan Backward using media_items_gallery_idx` with **no sort node** and `social_media_source IS NULL` as the only filter. So no index was needed, and the `prisma migrate dev` drop hazard never arose.

### The three mechanisms, and why each is shaped this way

**Home inference** uses a fixed 24-month window — deliberately *not* `lookbackMonths`. Narrowing the window to the trip lookback would let a single long vacation outvote the actual house. Modal `geoLocality` holding ≥30% of geocoded items plus its centroid; falls back to modal `geoAdmin1` at the same floor, because offline geocoding frequently resolves a region but not a town. No qualifying place ⇒ empty result and a `debug` log, never a throw.

**Clustering** classifies each day `away`/`home`/`neutral` from the **median** of that day's coordinates, so one stale GPS fix cannot invent a trip. Runs merge across ≤1 gap day, but a `home` day *terminates* a run — it is positive evidence the trip ended, not missing evidence, and treating it as a gap would fuse two consecutive weekends into one bogus 11-day "trip".

**≥50% overlap refresh** is measured against the **shorter** span, not the union. This is load-bearing: a 3-day trip that grows to 10 days scores 1.0 and refreshes in place, whereas Jaccard scores it 0.30 and creates exactly the duplicate the rule exists to prevent. Tombstoned trips participate in matching — that is what makes the contract hold, because `upsertMemory`'s own check is keyed on `(periodKey, subjectKey)` and a shifted trip boundary carries *different* keys, so a key-only check would happily insert a fresh copy of a deleted trip.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
memories + trip suites:  Test Suites: 11 passed, 11 total
                         Tests:     239 passed, 239 total

full test:ci:            287 suites / 6879 tests passed
```

Only failures are the pre-existing malformed-UUID fixture suites (`circles/migration-backfill`, `notifications/notification-dedup`), verified failing identically at the base commit. Trips suites were re-run 3× and 2× to check for flakiness — stable.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Two changes outside this issue's strict scope, both worth a reviewer's opinion:

**1. A small additive change to #303's engine (`retitle`).** A trip whose locality drifted after a re-geocode would be re-keyed to `playa-grande` while keeping the title "Trip to Tamarindo" *forever* — #303's anti-churn rule only resets titles on ≥30% membership change, and membership hadn't moved. Added an optional `retitle` flag to `UpsertMemoryInput` (default `false`, every existing caller byte-identical), set only when the subject genuinely drifted. Rationale: anti-churn should protect a title that is still *accurate*, not one that has been *falsified*. A test pins the unchanged behavior for the ordinary case. Happy to revert this and document the stale title as a known gap instead.

**2. Fixed a pre-existing flakiness in #302's scheduling spec.** It asserted on `sweep()`'s **deployment-wide** `enqueued`/`skipped` counters, so any circle created by a suite in a parallel Jest worker broke it — and the new Trips suite creates two. Those assertions now go through the suite's own circles' rows, which is what the file's own comment already claimed it did. It was passing before only by scheduling luck.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_