### PR TITLE
feat(api): Memories People, Theme, Seasonal &amp; Year-in-Review curators (#305)

### DIFF
--- a/apps/api/src/memories/curation/memory-curation.service.ts
+++ b/apps/api/src/memories/curation/memory-curation.service.ts
@@ -129,12 +129,36 @@ interface CandidateRow {
   description: string | null;
 }
 
+/**
+ * A CALENDAR-bucketed diversity policy, replacing the default equal-time-span
+ * buckets for the memory types whose whole point is even calendar coverage:
+ * `person_over_years` (one bucket per year — the "growing up" effect) and
+ * `year_in_review` (one bucket per month).
+ *
+ * Equal-time buckets cannot express either. A person photographed heavily in
+ * 2016 and again in 2025 with a five-year quiet stretch between has a span
+ * whose equal thirds land two buckets inside the same busy year; bucketing on
+ * the calendar unit itself is the only way to guarantee "each year is
+ * represented" rather than "each equal slice of elapsed time is".
+ */
+export interface BucketPolicy {
+  /** Bucket identity for a candidate. Buckets are visited in ascending order. */
+  key: (candidate: MemoryCandidate) => number;
+  /** Ceiling on items taken from any one bucket. Default: unbounded. */
+  maxPerBucket?: number;
+}
+
 /** Options accepted by `loadCandidates` / `curate`. */
 export interface CurateOptions {
   /** Hard cap on items in the produced memory (`memories.maxItemsPerMemory`). */
   maxItems: number;
   /** Override the resident-candidate ceiling. Defaults to DEFAULT_MAX_CANDIDATES. */
   maxCandidates?: number;
+  /**
+   * Replace equal-time-span diversity with calendar bucketing. Omit for the
+   * default `selectDiverse` behavior every other curator uses.
+   */
+  bucketBy?: BucketPolicy;
 }
 
 /**
@@ -310,6 +334,84 @@ export function selectDiverse(scored: ScoredCandidate[], maxItems: number): Scor
   for (const c of ranked) {
     if (selected.size >= maxItems) break;
     tryAdd(c);
+  }
+
+  return [...selected.values()];
+}
+
+/**
+ * Pick up to `maxItems` items with EXPLICIT calendar buckets (one per year, one
+ * per month) instead of `selectDiverse`'s equal time spans.
+ *
+ * ROUND-ROBIN, NOT BUCKET-BY-BUCKET. Every bucket contributes its best item in
+ * round 1, its second-best in round 2, and so on. That ordering is what makes
+ * the `maxItems` cut graceful: a 30-item budget over 12 years yields at least
+ * two items from every year rather than four each from the first seven and
+ * nothing from the rest. Bucket-at-a-time filling would produce exactly the
+ * chronological bias this function exists to prevent.
+ *
+ * `maxPerBucket` bounds any single bucket's share. It matters when buckets are
+ * few relative to `maxItems` — `person_over_years` uses it so a three-year span
+ * reads as a representative sample rather than a dump of one prolific year.
+ *
+ * The video cap is enforced exactly as in `selectDiverse`: a rejected video
+ * does not consume its bucket's turn, the bucket simply advances to its next
+ * candidate.
+ *
+ * Pure — exported for unit testing.
+ */
+export function selectByBuckets(
+  scored: ScoredCandidate[],
+  maxItems: number,
+  bucketOf: (candidate: ScoredCandidate) => number,
+  maxPerBucket: number = Number.POSITIVE_INFINITY,
+): ScoredCandidate[] {
+  if (scored.length === 0 || maxItems <= 0 || maxPerBucket <= 0) return [];
+
+  const buckets = new Map<number, ScoredCandidate[]>();
+  for (const c of scored) {
+    const key = bucketOf(c);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(c);
+    else buckets.set(key, [c]);
+  }
+
+  const keys = [...buckets.keys()].sort((a, b) => a - b);
+  for (const key of keys) buckets.get(key)!.sort(compareForSelection);
+
+  const selected = new Map<string, ScoredCandidate>();
+  const cursors = new Map<number, number>();
+  const takenPerBucket = new Map<number, number>();
+  let videoCount = 0;
+
+  // Every round adds at least one item or breaks out, so `maxItems` is a safe
+  // loop bound even when `maxPerBucket` is unbounded.
+  const rounds = Math.min(maxPerBucket, maxItems);
+  for (let round = 0; round < rounds; round += 1) {
+    let progressed = false;
+
+    for (const key of keys) {
+      if (selected.size >= maxItems) break;
+      if ((takenPerBucket.get(key) ?? 0) >= maxPerBucket) continue;
+
+      const members = buckets.get(key)!;
+      let index = cursors.get(key) ?? 0;
+      while (index < members.length) {
+        const candidate = members[index]!;
+        index += 1;
+        if (candidate.type === MediaType.video) {
+          if (videoCount >= MAX_VIDEOS_PER_MEMORY) continue;
+          videoCount += 1;
+        }
+        selected.set(candidate.id, candidate);
+        takenPerBucket.set(key, (takenPerBucket.get(key) ?? 0) + 1);
+        progressed = true;
+        break;
+      }
+      cursors.set(key, index);
+    }
+
+    if (!progressed || selected.size >= maxItems) break;
   }
 
   return [...selected.values()];
@@ -561,6 +663,9 @@ export class MemoryCurationService {
    * The full pipeline for one memory's slice:
    * load (base filter + curator `where`) → score → collapse near-duplicates →
    * diversity-select → order chronologically and pick a cover.
+   *
+   * Diversity is equal-time-span buckets by default; pass `options.bucketBy` for
+   * the calendar-bucketed policy `person_over_years` and `year_in_review` need.
    */
   async curate(
     circleId: string,
@@ -577,7 +682,14 @@ export class MemoryCurationService {
     const scored = scoreCandidates(candidates);
     const suggestedBest = await this.resolveSuggestedBest(candidates);
     const collapsed = collapseGroups(scored, suggestedBest);
-    const chosen = selectDiverse(collapsed, options.maxItems);
+    const chosen = options.bucketBy
+      ? selectByBuckets(
+          collapsed,
+          options.maxItems,
+          options.bucketBy.key,
+          options.bucketBy.maxPerBucket,
+        )
+      : selectDiverse(collapsed, options.maxItems);
     return finalizeSelection(chosen, candidates.length, truncated);
   }
 

--- a/apps/api/src/memories/curators/circle-month-counts.ts
+++ b/apps/api/src/memories/curators/circle-month-counts.ts
@@ -1,0 +1,95 @@
+// =============================================================================
+// Memories — per-month candidate census (epic #300, issue #305)
+// =============================================================================
+//
+// ONE aggregate query giving "how many curation candidates does this circle have
+// in each calendar month", shared by the Seasonal and Year-in-Review curators.
+//
+// WHY AN AGGREGATE AND NOT A CANDIDATE SCAN. Both curators need the same
+// question answered before they do any work: which periods even have enough
+// material to be worth curating? Answering it by streaming candidates would mean
+// paging the entire library through the engine just to discard most periods —
+// for a 70k-item circle, once per curator. Grouping in the database instead
+// returns at most `12 × years-of-history` rows (a couple of hundred), and the
+// expensive `curate()` pass then runs only for periods that already cleared
+// their `minItems` floor on raw counts.
+//
+// The `WHERE` clause is the curation base filter, hand-written here because this
+// is raw SQL rather than a Prisma `where`. It MUST stay identical to
+// `memoryCandidateBaseWhere()` — a census that counted archived or trashed items
+// would send a curator off to curate a period that then comes back short. The
+// integration suite asserts the two agree.
+// =============================================================================
+
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { monthBucket } from './period-windows';
+
+/** Candidate count per `monthBucket()` key (`year * 12 + monthIndex`). */
+export type MonthCounts = Map<number, number>;
+
+/** Sum the census over a half-open instant range, month-granular. */
+export function countInWindow(counts: MonthCounts, start: Date, endExclusive: Date): number {
+  const from = monthBucket(start);
+  // The window's end is exclusive and always lands on a month boundary for
+  // every caller here (year and season windows both start on the 1st), so the
+  // last month INCLUDED is the one before `endExclusive`'s bucket.
+  const to = monthBucket(endExclusive) - 1;
+  let total = 0;
+  for (let bucket = from; bucket <= to; bucket += 1) total += counts.get(bucket) ?? 0;
+  return total;
+}
+
+/** The earliest and latest months present, or null for an empty census. */
+export function censusBounds(counts: MonthCounts): { first: number; last: number } | null {
+  let first = Number.POSITIVE_INFINITY;
+  let last = Number.NEGATIVE_INFINITY;
+  for (const [bucket, count] of counts) {
+    if (count <= 0) continue;
+    if (bucket < first) first = bucket;
+    if (bucket > last) last = bucket;
+  }
+  return Number.isFinite(first) ? { first, last } : null;
+}
+
+/** A `monthBucket` key back to the UTC instant its month starts at. */
+export function monthBucketStart(bucket: number): Date {
+  const year = Math.floor(bucket / 12);
+  return new Date(Date.UTC(year, bucket - year * 12, 1));
+}
+
+/**
+ * Count this circle's curation candidates per calendar month (UTC).
+ *
+ * Months with no candidates are simply absent from the map rather than present
+ * with a zero, so `censusBounds` can read "has any data at all" straight off it.
+ */
+export async function loadMonthCounts(
+  prisma: PrismaService,
+  circleId: string,
+): Promise<MonthCounts> {
+  const rows = await prisma.$queryRaw<Array<{ year: number; month: number; count: number }>>(
+    Prisma.sql`
+      SELECT
+        EXTRACT(YEAR  FROM ("captured_at" AT TIME ZONE 'UTC'))::int AS year,
+        EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC'))::int AS month,
+        COUNT(*)::int AS count
+      FROM "media_items"
+      WHERE "circle_id" = ${circleId}::uuid
+        AND "captured_at" IS NOT NULL
+        AND "deleted_at" IS NULL
+        AND "archived_at" IS NULL
+        AND "social_media_source" IS NULL
+      GROUP BY 1, 2
+    `,
+  );
+
+  const counts: MonthCounts = new Map();
+  for (const row of rows) {
+    // EXTRACT(MONTH) is 1-based; monthBucket() is built on getUTCMonth()'s
+    // 0-based index, so the -1 here is what keeps the two representations
+    // interchangeable.
+    counts.set(row.year * 12 + (row.month - 1), row.count);
+  }
+  return counts;
+}

--- a/apps/api/src/memories/curators/curator-rules.spec.ts
+++ b/apps/api/src/memories/curators/curator-rules.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for the PURE decision rules of the #305 curators, plus the
+ * calendar-bucketed selection they lean on.
+ *
+ * Three things live here that would be pointless (or impossible) to prove
+ * against a database:
+ *
+ * - `selectByBuckets` — the round-robin fairness property. Whether a 30-item
+ *   budget over twelve years yields two items from every year or four each from
+ *   the first seven is a statement about an algorithm, not about SQL.
+ * - `rankTagsForPeriod` — including that the all-history period is an exact sum
+ *   of the per-year counts rather than an approximation.
+ * - The year-in-review December/January eligibility window, which is a boundary
+ *   rule with four distinct cases and no I/O at all.
+ *
+ * The DB-dependent halves (base filter, person eligibility SQL, the census
+ * queries, the tombstone) are covered in
+ * test/memories/memories-people.integration.spec.ts and
+ * test/memories/memories-periodic.integration.spec.ts.
+ */
+
+import { MediaType } from '@prisma/client';
+import { MAX_VIDEOS_PER_MEMORY, selectByBuckets } from '../curation/memory-curation.service';
+import { MemoryCandidate, ScoredCandidate } from '../curation/memory-curation.types';
+import { THEME_TAG_DENYLIST, rankTagsForPeriod } from './theme.curator';
+import { isReviewYearEligible, scheduledReviewYear } from './year-in-review.curator';
+import {
+  PERSON_OVER_YEARS_MAX_PER_YEAR,
+  PERSON_OVER_YEARS_MIN_YEARS,
+} from './person-candidates';
+import { monthBucket, yearBucket } from './period-windows';
+
+function scored(over: Partial<MemoryCandidate> & { id: string; score: number }): ScoredCandidate {
+  const { score, ...rest } = over;
+  return {
+    capturedAt: new Date(Date.UTC(2020, 0, 1)),
+    type: MediaType.photo,
+    durationMs: null,
+    favorite: false,
+    sharpnessScore: null,
+    burstGroupId: null,
+    duplicateGroupId: null,
+    hasAiContent: false,
+    hasFavoritePersonFace: false,
+    score,
+    selectionScore: score,
+    ...rest,
+  };
+}
+
+/** `count` candidates in `year`, descending in score so ranking is obvious. */
+function yearOf(year: number, count: number): ScoredCandidate[] {
+  return Array.from({ length: count }, (_, i) =>
+    scored({
+      id: `${year}-${i}`,
+      score: 10 - i,
+      capturedAt: new Date(Date.UTC(year, 0, 1 + i)),
+    }),
+  );
+}
+
+describe('selectByBuckets', () => {
+  it('gives every bucket a turn before any bucket gets a second item', () => {
+    // The property the whole function exists for. Bucket-at-a-time filling
+    // would return ten items all from 2016 — chronologically biased in exactly
+    // the way `person_over_years` must never be.
+    const candidates = [...yearOf(2016, 10), ...yearOf(2020, 10), ...yearOf(2025, 10)];
+
+    const picked = selectByBuckets(candidates, 3, yearBucket_, Number.POSITIVE_INFINITY);
+
+    expect(picked.map((c) => c.capturedAt.getUTCFullYear()).sort()).toEqual([2016, 2020, 2025]);
+  });
+
+  it('caps any one bucket at maxPerBucket even when slots remain', () => {
+    const candidates = [...yearOf(2016, 10), ...yearOf(2017, 10), ...yearOf(2018, 10)];
+
+    const picked = selectByBuckets(candidates, 30, yearBucket_, PERSON_OVER_YEARS_MAX_PER_YEAR);
+
+    // Three years x 4 = 12, not the full 30 budget: the cap is what makes the
+    // memory a representative span rather than an album of one busy year.
+    expect(picked).toHaveLength(3 * PERSON_OVER_YEARS_MAX_PER_YEAR);
+    for (const year of [2016, 2017, 2018]) {
+      expect(picked.filter((c) => c.capturedAt.getUTCFullYear() === year)).toHaveLength(
+        PERSON_OVER_YEARS_MAX_PER_YEAR,
+      );
+    }
+  });
+
+  it('takes each bucket best-first', () => {
+    const picked = selectByBuckets([...yearOf(2020, 5)], 2, yearBucket_, 4);
+    expect(picked.map((c) => c.id)).toEqual(['2020-0', '2020-1']);
+  });
+
+  it('spreads a limited budget evenly across twelve month buckets', () => {
+    const months = Array.from({ length: 12 }, (_, m) =>
+      Array.from({ length: 10 }, (_, i) =>
+        scored({
+          id: `2025-${m}-${i}`,
+          score: 10 - i,
+          capturedAt: new Date(Date.UTC(2025, m, 1 + i)),
+        }),
+      ),
+    ).flat();
+
+    const picked = selectByBuckets(months, 30, (c) => monthBucket(c.capturedAt));
+
+    expect(picked).toHaveLength(30);
+    const perMonth = new Map<number, number>();
+    for (const c of picked) {
+      const m = c.capturedAt.getUTCMonth();
+      perMonth.set(m, (perMonth.get(m) ?? 0) + 1);
+    }
+    // 30 items over 12 months: six months get 3, six get 2, none get 0.
+    expect(perMonth.size).toBe(12);
+    expect([...perMonth.values()].every((n) => n >= 2 && n <= 3)).toBe(true);
+  });
+
+  it('lets a bucket with material absorb the budget when others are exhausted', () => {
+    const candidates = [...yearOf(2020, 1), ...yearOf(2021, 10)];
+
+    const picked = selectByBuckets(candidates, 5, yearBucket_);
+
+    // 2020 has one item and drops out after round 1; the rest of the budget is
+    // not wasted holding slots open for a bucket that cannot fill them.
+    expect(picked).toHaveLength(5);
+    expect(picked.filter((c) => c.capturedAt.getUTCFullYear() === 2020)).toHaveLength(1);
+  });
+
+  it('enforces the video cap without costing the bucket its turn', () => {
+    // Each year leads with a video; only MAX_VIDEOS_PER_MEMORY of them can be
+    // taken, and every remaining year must still contribute its best PHOTO
+    // rather than being skipped along with its rejected video.
+    const candidates = Array.from({ length: 6 }, (_, i) => {
+      const year = 2018 + i;
+      return [
+        scored({
+          id: `v-${year}`,
+          score: 100,
+          type: MediaType.video,
+          capturedAt: new Date(Date.UTC(year, 0, 1)),
+        }),
+        scored({ id: `p-${year}`, score: 5, capturedAt: new Date(Date.UTC(year, 0, 2)) }),
+      ];
+    }).flat();
+
+    const picked = selectByBuckets(candidates, 6, yearBucket_, 1);
+
+    expect(picked).toHaveLength(6);
+    expect(picked.filter((c) => c.type === MediaType.video)).toHaveLength(MAX_VIDEOS_PER_MEMORY);
+    // Every year is represented exactly once despite three videos being refused.
+    expect(new Set(picked.map((c) => c.capturedAt.getUTCFullYear())).size).toBe(6);
+  });
+
+  it('returns empty for degenerate inputs rather than throwing', () => {
+    expect(selectByBuckets([], 10, yearBucket_)).toEqual([]);
+    expect(selectByBuckets(yearOf(2020, 3), 0, yearBucket_)).toEqual([]);
+    expect(selectByBuckets(yearOf(2020, 3), 10, yearBucket_, 0)).toEqual([]);
+  });
+
+  it('is deterministic across repeated runs over the same input', () => {
+    const candidates = [...yearOf(2016, 6), ...yearOf(2019, 6), ...yearOf(2024, 6)];
+    const a = selectByBuckets(candidates, 7, yearBucket_, 4).map((c) => c.id);
+    const b = selectByBuckets([...candidates].reverse(), 7, yearBucket_, 4).map((c) => c.id);
+    // Input order must not matter: "re-running changes nothing" is only
+    // testable if selection is a function of the candidate SET.
+    expect(a.sort()).toEqual(b.sort());
+  });
+
+  function yearBucket_(c: ScoredCandidate): number {
+    return yearBucket(c.capturedAt);
+  }
+});
+
+describe('rankTagsForPeriod', () => {
+  const census = [
+    { tag: 'sunset', year: 2024, count: 5 },
+    { tag: 'sunset', year: 2025, count: 9 },
+    { tag: 'beach', year: 2025, count: 12 },
+    { tag: 'pets', year: 2025, count: 4 },
+  ];
+
+  it('ranks a single year by that year alone, densest first', () => {
+    expect(rankTagsForPeriod(census, 2025, 8)).toEqual([
+      { tag: 'beach', count: 12 },
+      { tag: 'sunset', count: 9 },
+    ]);
+  });
+
+  it('drops tags under minItems for the period', () => {
+    // "pets" (4) never appears; "sunset" appears for 2025 (9) but not 2024 (5).
+    expect(rankTagsForPeriod(census, 2024, 8)).toEqual([]);
+  });
+
+  it('sums years EXACTLY for the all-history period', () => {
+    // A media item has one capturedAt, so per-year distinct counts partition
+    // the tag's all-history set — summing is exact, not an approximation. That
+    // is what lets one grouped query serve every period.
+    expect(rankTagsForPeriod(census, null, 8)).toEqual([
+      { tag: 'sunset', count: 14 },
+      { tag: 'beach', count: 12 },
+    ]);
+  });
+
+  it('breaks count ties by name so the ranking is stable across runs', () => {
+    const tied = [
+      { tag: 'zebra', year: 2025, count: 10 },
+      { tag: 'apple', year: 2025, count: 10 },
+    ];
+    expect(rankTagsForPeriod(tied, 2025, 8).map((t) => t.tag)).toEqual(['apple', 'zebra']);
+  });
+
+  it('returns empty for an empty census', () => {
+    expect(rankTagsForPeriod([], 2025, 8)).toEqual([]);
+  });
+});
+
+describe('THEME_TAG_DENYLIST', () => {
+  it('covers the artifact-not-a-moment vocabulary named by issue #305', () => {
+    for (const tag of ['screenshot', 'document', 'text', 'whiteboard']) {
+      expect(THEME_TAG_DENYLIST.has(tag)).toBe(true);
+    }
+  });
+
+  it('is lowercase throughout, since the census groups on LOWER(name)', () => {
+    for (const tag of THEME_TAG_DENYLIST) expect(tag).toBe(tag.toLowerCase());
+  });
+
+  it('does not deny ordinary theme vocabulary', () => {
+    for (const tag of ['sunset', 'beach', 'pets', 'birthday']) {
+      expect(THEME_TAG_DENYLIST.has(tag)).toBe(false);
+    }
+  });
+});
+
+describe('year in review eligibility', () => {
+  it('generates for the current year during December', () => {
+    expect(scheduledReviewYear(new Date('2025-12-01T00:00:00.000Z'))).toBe(2025);
+    expect(scheduledReviewYear(new Date('2025-12-31T23:59:59.000Z'))).toBe(2025);
+  });
+
+  it('keeps generating for the PREVIOUS year through all of January', () => {
+    // The New Year reminiscing window: a memory that vanished on Dec 31 would
+    // be gone before most of the circle went looking for it.
+    expect(scheduledReviewYear(new Date('2026-01-01T00:00:00.000Z'))).toBe(2025);
+    expect(scheduledReviewYear(new Date('2026-01-31T23:59:59.000Z'))).toBe(2025);
+  });
+
+  it('generates nothing from February through November', () => {
+    for (const month of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+      expect(scheduledReviewYear(new Date(Date.UTC(2026, month, 15)))).toBeNull();
+    }
+  });
+
+  it('treats any past year as eligible for backfill', () => {
+    const now = new Date('2026-08-09T00:00:00.000Z');
+    expect(isReviewYearEligible(2019, now)).toBe(true);
+    expect(isReviewYearEligible(2025, now)).toBe(true);
+  });
+
+  it('refuses the still-running current year outside December', () => {
+    // Otherwise a mid-year backfill mints a three-month "Your 2026 in review"
+    // that then churns on every generation run for the rest of the year.
+    expect(isReviewYearEligible(2026, new Date('2026-08-09T00:00:00.000Z'))).toBe(false);
+    expect(isReviewYearEligible(2026, new Date('2026-12-05T00:00:00.000Z'))).toBe(true);
+  });
+
+  it('never treats a future year as eligible', () => {
+    expect(isReviewYearEligible(2027, new Date('2026-12-05T00:00:00.000Z'))).toBe(false);
+  });
+});
+
+describe('person curator thresholds', () => {
+  it('requires at least three distinct years for a "through the years" memory', () => {
+    // Two years is not a span; the per-year `person_highlights` memories
+    // already tell that story better.
+    expect(PERSON_OVER_YEARS_MIN_YEARS).toBe(3);
+  });
+
+  it('caps a single year at four items, per issue #305', () => {
+    expect(PERSON_OVER_YEARS_MAX_PER_YEAR).toBe(4);
+  });
+});

--- a/apps/api/src/memories/curators/memory-curators.provider.spec.ts
+++ b/apps/api/src/memories/curators/memory-curators.provider.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Guard for the curator registry (issue #305).
+ *
+ * The registry is the one place a new memory type has to be listed, and
+ * forgetting the entry fails SILENTLY: the curator provider still resolves, the
+ * generation job still succeeds, and the type simply never produces a memory.
+ * Nothing else in the suite would notice — every curator spec instantiates its
+ * curator directly. So the factory is exercised here with stubs, asserting both
+ * that all seven types are wired and that the declared execution order (which
+ * decides what a timed-out job has produced) is the intended one.
+ */
+
+import { MEMORY_CURATORS } from './memory-curator.interface';
+import { memoryCuratorsProvider } from './memory-curators.provider';
+import { OnThisDayCurator } from './on-this-day.curator';
+import { PersonHighlightsCurator } from './person-highlights.curator';
+import { PersonOverYearsCurator } from './person-over-years.curator';
+import { SeasonalCurator } from './seasonal.curator';
+import { ThemeCurator } from './theme.curator';
+import { TripCurator } from './trip.curator';
+import { YearInReviewCurator } from './year-in-review.curator';
+
+/** A stand-in carrying only the `name` the assertions read. */
+function stub(name: string): { name: string } {
+  return { name };
+}
+
+describe('memoryCuratorsProvider', () => {
+  it('registers every MemoryType curator, cheapest-first', () => {
+    const curators = memoryCuratorsProvider.useFactory(
+      stub('on_this_day') as never,
+      stub('trip') as never,
+      stub('person_highlights') as never,
+      stub('person_over_years') as never,
+      stub('theme') as never,
+      stub('seasonal') as never,
+      stub('year_in_review') as never,
+    );
+
+    expect(curators.map((c) => c.name)).toEqual([
+      'on_this_day',
+      'trip',
+      'person_highlights',
+      'person_over_years',
+      'theme',
+      'seasonal',
+      'year_in_review',
+    ]);
+  });
+
+  it('injects the curator classes positionally in the same order the factory reads them', () => {
+    // A mismatch here would hand each curator its neighbour's instance — which
+    // type-checks (they share the MemoryCurator interface) and would only show
+    // up as the wrong memory type being generated at runtime.
+    expect(memoryCuratorsProvider.inject).toEqual([
+      OnThisDayCurator,
+      TripCurator,
+      PersonHighlightsCurator,
+      PersonOverYearsCurator,
+      ThemeCurator,
+      SeasonalCurator,
+      YearInReviewCurator,
+    ]);
+    expect(memoryCuratorsProvider.provide).toBe(MEMORY_CURATORS);
+  });
+});

--- a/apps/api/src/memories/curators/memory-curators.provider.ts
+++ b/apps/api/src/memories/curators/memory-curators.provider.ts
@@ -16,17 +16,29 @@
 // bounded functional-index queries, while Trips streams the circle's whole geo
 // history. A generation job cut short by a timeout has then produced the daily
 // content users actually see on Home.
+//
+// The #305 curators slot in after those two, ordered by how much of the library
+// each one has to walk: the people and theme curators answer a cheap grouped
+// census first and only curate the periods that can actually clear their
+// `minItems` floor, while seasonal and year-in-review each curate a full
+// calendar period. `person_over_years` follows `person_highlights` because the
+// two share a census-shaped query and the per-year memories are the ones that
+// change most often.
 // =============================================================================
 
 import { MEMORY_CURATORS, MemoryCurator } from './memory-curator.interface';
 import { OnThisDayCurator } from './on-this-day.curator';
+import { PersonHighlightsCurator } from './person-highlights.curator';
+import { PersonOverYearsCurator } from './person-over-years.curator';
 import { TripCurator } from './trip.curator';
 
 export const memoryCuratorsProvider = {
   provide: MEMORY_CURATORS,
-  useFactory: (onThisDay: OnThisDayCurator, trip: TripCurator): MemoryCurator[] => [
-    onThisDay,
-    trip,
-  ],
-  inject: [OnThisDayCurator, TripCurator],
+  useFactory: (
+    onThisDay: OnThisDayCurator,
+    trip: TripCurator,
+    personHighlights: PersonHighlightsCurator,
+    personOverYears: PersonOverYearsCurator,
+  ): MemoryCurator[] => [onThisDay, trip, personHighlights, personOverYears],
+  inject: [OnThisDayCurator, TripCurator, PersonHighlightsCurator, PersonOverYearsCurator],
 };

--- a/apps/api/src/memories/curators/memory-curators.provider.ts
+++ b/apps/api/src/memories/curators/memory-curators.provider.ts
@@ -30,8 +30,10 @@ import { MEMORY_CURATORS, MemoryCurator } from './memory-curator.interface';
 import { OnThisDayCurator } from './on-this-day.curator';
 import { PersonHighlightsCurator } from './person-highlights.curator';
 import { PersonOverYearsCurator } from './person-over-years.curator';
+import { SeasonalCurator } from './seasonal.curator';
 import { ThemeCurator } from './theme.curator';
 import { TripCurator } from './trip.curator';
+import { YearInReviewCurator } from './year-in-review.curator';
 
 export const memoryCuratorsProvider = {
   provide: MEMORY_CURATORS,
@@ -41,12 +43,24 @@ export const memoryCuratorsProvider = {
     personHighlights: PersonHighlightsCurator,
     personOverYears: PersonOverYearsCurator,
     theme: ThemeCurator,
-  ): MemoryCurator[] => [onThisDay, trip, personHighlights, personOverYears, theme],
+    seasonal: SeasonalCurator,
+    yearInReview: YearInReviewCurator,
+  ): MemoryCurator[] => [
+    onThisDay,
+    trip,
+    personHighlights,
+    personOverYears,
+    theme,
+    seasonal,
+    yearInReview,
+  ],
   inject: [
     OnThisDayCurator,
     TripCurator,
     PersonHighlightsCurator,
     PersonOverYearsCurator,
     ThemeCurator,
+    SeasonalCurator,
+    YearInReviewCurator,
   ],
 };

--- a/apps/api/src/memories/curators/memory-curators.provider.ts
+++ b/apps/api/src/memories/curators/memory-curators.provider.ts
@@ -30,6 +30,7 @@ import { MEMORY_CURATORS, MemoryCurator } from './memory-curator.interface';
 import { OnThisDayCurator } from './on-this-day.curator';
 import { PersonHighlightsCurator } from './person-highlights.curator';
 import { PersonOverYearsCurator } from './person-over-years.curator';
+import { ThemeCurator } from './theme.curator';
 import { TripCurator } from './trip.curator';
 
 export const memoryCuratorsProvider = {
@@ -39,6 +40,13 @@ export const memoryCuratorsProvider = {
     trip: TripCurator,
     personHighlights: PersonHighlightsCurator,
     personOverYears: PersonOverYearsCurator,
-  ): MemoryCurator[] => [onThisDay, trip, personHighlights, personOverYears],
-  inject: [OnThisDayCurator, TripCurator, PersonHighlightsCurator, PersonOverYearsCurator],
+    theme: ThemeCurator,
+  ): MemoryCurator[] => [onThisDay, trip, personHighlights, personOverYears, theme],
+  inject: [
+    OnThisDayCurator,
+    TripCurator,
+    PersonHighlightsCurator,
+    PersonOverYearsCurator,
+    ThemeCurator,
+  ],
 };

--- a/apps/api/src/memories/curators/period-windows.spec.ts
+++ b/apps/api/src/memories/curators/period-windows.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for the calendar period algebra (issue #305).
+ *
+ * Everything here is pure UTC date arithmetic, and almost all of it is about
+ * one edge: northern-hemisphere winter spans a year boundary, so the "season
+ * year" and the calendar year of a season's own photos legitimately disagree
+ * for three months out of twelve. That is exactly the kind of rule that is
+ * easier to get subtly wrong than to test, so it is tested directly rather than
+ * through a database fixture.
+ */
+
+import {
+  enumerateSeasons,
+  monthBucket,
+  mostRecentCompletedSeason,
+  previousSeason,
+  seasonFromOrdinal,
+  seasonOf,
+  seasonOrdinal,
+  seasonPeriodKey,
+  seasonWindow,
+  utcYear,
+  yearBucket,
+  yearWindow,
+} from './period-windows';
+
+describe('yearWindow', () => {
+  it('is a half-open [Jan 1, next Jan 1) UTC range', () => {
+    const window = yearWindow(2025);
+    expect(window.start.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    expect(window.endExclusive.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('excludes the very first instant of the next year', () => {
+    const { endExclusive } = yearWindow(2025);
+    // The exclusivity is what keeps a New Year's Eve midnight photo out of the
+    // wrong year's memory — an inclusive bound would put it in both.
+    expect(utcYear(new Date(endExclusive.getTime() - 1))).toBe(2025);
+    expect(utcYear(endExclusive)).toBe(2026);
+  });
+});
+
+describe('bucket keys', () => {
+  it('yearBucket is the UTC calendar year', () => {
+    expect(yearBucket(new Date(Date.UTC(2016, 11, 31, 23, 59, 59)))).toBe(2016);
+    expect(yearBucket(new Date(Date.UTC(2017, 0, 1, 0, 0, 0)))).toBe(2017);
+  });
+
+  it('monthBucket is year-qualified, so the same month of two years never merges', () => {
+    const jan2024 = monthBucket(new Date(Date.UTC(2024, 0, 15)));
+    const jan2025 = monthBucket(new Date(Date.UTC(2025, 0, 15)));
+    expect(jan2024).not.toBe(jan2025);
+    // Twelve buckets apart: consecutive months are consecutive keys, which is
+    // what makes `countInWindow`'s range sum valid.
+    expect(jan2025 - jan2024).toBe(12);
+    expect(monthBucket(new Date(Date.UTC(2024, 1, 1))) - jan2024).toBe(1);
+  });
+});
+
+describe('seasonOf', () => {
+  it.each([
+    ['2025-03-01', 2025, 'spring'],
+    ['2025-05-31', 2025, 'spring'],
+    ['2025-06-01', 2025, 'summer'],
+    ['2025-08-31', 2025, 'summer'],
+    ['2025-09-01', 2025, 'fall'],
+    ['2025-11-30', 2025, 'fall'],
+    ['2025-12-01', 2025, 'winter'],
+  ])('maps %s to %s-%s', (iso, year, season) => {
+    expect(seasonOf(new Date(`${iso}T12:00:00.000Z`))).toEqual({ year, season });
+  });
+
+  it('folds January and February back into the PREVIOUS December winter', () => {
+    // The whole reason a season carries its own year: without this, "Winter
+    // 2025" would be two disjoint memories — December 2025 and Jan/Feb 2025 —
+    // neither of which is a winter.
+    expect(seasonOf(new Date('2026-01-15T00:00:00.000Z'))).toEqual({
+      year: 2025,
+      season: 'winter',
+    });
+    expect(seasonOf(new Date('2026-02-28T23:59:59.000Z'))).toEqual({
+      year: 2025,
+      season: 'winter',
+    });
+  });
+});
+
+describe('seasonOrdinal / previousSeason', () => {
+  it('orders seasons chronologically within a season year (spring first, winter last)', () => {
+    const spring = seasonOrdinal({ year: 2025, season: 'spring' });
+    const summer = seasonOrdinal({ year: 2025, season: 'summer' });
+    const fall = seasonOrdinal({ year: 2025, season: 'fall' });
+    const winter = seasonOrdinal({ year: 2025, season: 'winter' });
+    expect([spring, summer, fall, winter]).toEqual([...[spring, summer, fall, winter]].sort((a, b) => a - b));
+  });
+
+  it('steps winter Y back to fall Y, not to fall Y-1', () => {
+    // Winter 2025 starts in December 2025, so the season before it is fall
+    // 2025 (Sep–Nov 2025). Ordering winter first inside its year would skip a
+    // whole year here — the bug this ordinal exists to prevent.
+    expect(previousSeason({ year: 2025, season: 'winter' })).toEqual({
+      year: 2025,
+      season: 'fall',
+    });
+  });
+
+  it('steps spring Y back across the year boundary to winter Y-1', () => {
+    expect(previousSeason({ year: 2026, season: 'spring' })).toEqual({
+      year: 2025,
+      season: 'winter',
+    });
+  });
+
+  it('round-trips through seasonFromOrdinal', () => {
+    for (const season of ['spring', 'summer', 'fall', 'winter'] as const) {
+      const period = { year: 2025, season };
+      expect(seasonFromOrdinal(seasonOrdinal(period))).toEqual(period);
+    }
+  });
+});
+
+describe('seasonWindow', () => {
+  it('covers exactly three months', () => {
+    expect(seasonWindow({ year: 2025, season: 'summer' })).toEqual({
+      start: new Date('2025-06-01T00:00:00.000Z'),
+      endExclusive: new Date('2025-09-01T00:00:00.000Z'),
+    });
+  });
+
+  it('carries winter across the year boundary', () => {
+    expect(seasonWindow({ year: 2025, season: 'winter' })).toEqual({
+      start: new Date('2025-12-01T00:00:00.000Z'),
+      endExclusive: new Date('2026-03-01T00:00:00.000Z'),
+    });
+  });
+
+  it('agrees with seasonOf for every day it contains', () => {
+    // The two are used at opposite ends of the curator (window selects the
+    // items, seasonOf derives the period from a date), so a disagreement would
+    // silently file photos under a season whose window excludes them.
+    const period = { year: 2025, season: 'winter' } as const;
+    const { start, endExclusive } = seasonWindow(period);
+    for (let t = start.getTime(); t < endExclusive.getTime(); t += 86_400_000 * 7) {
+      expect(seasonOf(new Date(t))).toEqual(period);
+    }
+  });
+});
+
+describe('mostRecentCompletedSeason', () => {
+  it('excludes the season currently in progress', () => {
+    // August 9 is inside summer 2026; the most recent COMPLETE season is the
+    // spring that ended on May 31.
+    expect(mostRecentCompletedSeason(new Date('2026-08-09T12:00:00.000Z'))).toEqual({
+      year: 2026,
+      season: 'spring',
+    });
+  });
+
+  it('returns fall Y-1 in the middle of winter', () => {
+    expect(mostRecentCompletedSeason(new Date('2026-01-15T00:00:00.000Z'))).toEqual({
+      year: 2025,
+      season: 'fall',
+    });
+  });
+
+  it('returns fall the moment winter begins on December 1', () => {
+    expect(mostRecentCompletedSeason(new Date('2025-12-01T00:00:00.000Z'))).toEqual({
+      year: 2025,
+      season: 'fall',
+    });
+  });
+});
+
+describe('enumerateSeasons', () => {
+  it('is contiguous and chronological across a year boundary', () => {
+    const seasons = enumerateSeasons(
+      { year: 2024, season: 'fall' },
+      { year: 2025, season: 'summer' },
+    );
+    expect(seasons.map(seasonPeriodKey)).toEqual([
+      '2024-fall',
+      '2024-winter',
+      '2025-spring',
+      '2025-summer',
+    ]);
+  });
+
+  it('returns a single season when from equals to', () => {
+    expect(
+      enumerateSeasons({ year: 2025, season: 'summer' }, { year: 2025, season: 'summer' }),
+    ).toEqual([{ year: 2025, season: 'summer' }]);
+  });
+
+  it('returns empty when the range is inverted', () => {
+    // The circle whose only photos are inside the still-running season: its
+    // earliest season is AFTER the most recently completed one, and it must
+    // produce nothing rather than a backwards sweep.
+    expect(
+      enumerateSeasons({ year: 2026, season: 'summer' }, { year: 2026, season: 'spring' }),
+    ).toEqual([]);
+  });
+});
+
+describe('seasonPeriodKey', () => {
+  it('is the year the season STARTS in, matching the MemoryType enum contract', () => {
+    expect(seasonPeriodKey({ year: 2025, season: 'winter' })).toBe('2025-winter');
+  });
+});

--- a/apps/api/src/memories/curators/period-windows.ts
+++ b/apps/api/src/memories/curators/period-windows.ts
@@ -1,0 +1,159 @@
+// =============================================================================
+// Memories — calendar period algebra (epic #300, issue #305)
+// =============================================================================
+//
+// Pure UTC date arithmetic shared by the four curator families added in #305:
+// year windows (person highlights, themes, year in review), month buckets
+// (year in review's diversity policy) and season windows (seasonal).
+//
+// Zero I/O and zero Nest wiring, for the same reason `trip-clustering.ts` is
+// split out of `trip.curator.ts`: the interesting behavior here is edge-case
+// arithmetic — which calendar year a December photo's winter belongs to, which
+// season "the most recently completed one" is on January 3rd — and it is worth
+// testing directly rather than through a database fixture.
+//
+// EVERYTHING IS UTC. `Memory.periodStart`/`periodEnd` are `timestamptz`, the
+// title templates format with an explicit `timeZone: 'UTC'`, and the base
+// filter's `capturedAt` comparisons are instants. A curator computing "the year
+// 2025" in the container's local zone would produce a window that shifts when
+// the deployment moves — and a `periodKey` that disagrees with the title
+// rendered from the same row.
+//
+// THE SEASON YEAR IS NOT THE CALENDAR YEAR. Northern-hemisphere meteorological
+// winter spans December of year Y through February of Y+1, so a January photo
+// belongs to *winter Y-1*. `seasonOf()` performs that reconciliation once,
+// centrally; `seasonForMonth()` in memory-title-templates.ts answers only the
+// simpler "which season is month N" and deliberately knows nothing about years.
+// =============================================================================
+
+import { SeasonKey, seasonForMonth } from '../curation/memory-title-templates';
+
+/** A half-open `[start, endExclusive)` instant range. */
+export interface PeriodWindow {
+  start: Date;
+  endExclusive: Date;
+}
+
+/** A season pinned to the calendar year it STARTS in. */
+export interface SeasonPeriod {
+  /** The year the season begins — December's winter is `winter` of THAT year. */
+  year: number;
+  season: SeasonKey;
+}
+
+/**
+ * Chronological position of a season WITHIN its season-year.
+ *
+ * Spring/summer/fall/winter, not the calendar-alphabetical winter-first order,
+ * because winter Y starts in December Y — i.e. AFTER fall Y. Ordering them any
+ * other way makes `previousSeason()` silently skip a year: the season before
+ * spring 2026 is winter 2025 (Dec 2025–Feb 2026), not fall 2024.
+ */
+const SEASON_ORDER: readonly SeasonKey[] = ['spring', 'summer', 'fall', 'winter'];
+
+/** First month (1-based) of each season within its season-year. */
+const SEASON_START_MONTH: Record<SeasonKey, number> = {
+  spring: 3,
+  summer: 6,
+  fall: 9,
+  winter: 12,
+};
+
+/** UTC calendar year of an instant. */
+export function utcYear(date: Date): number {
+  return date.getUTCFullYear();
+}
+
+/** `[Jan 1 year, Jan 1 year+1)` in UTC. */
+export function yearWindow(year: number): PeriodWindow {
+  return {
+    start: new Date(Date.UTC(year, 0, 1)),
+    endExclusive: new Date(Date.UTC(year + 1, 0, 1)),
+  };
+}
+
+/**
+ * Bucket key for `year_in_review`'s month diversity: `year * 12 + monthIndex`.
+ *
+ * Year-qualified rather than a bare 0–11 month so the key stays a total order
+ * even if a caller ever hands it a range wider than one year — a bucket policy
+ * that silently merged January 2024 with January 2025 would be a subtle bug in
+ * exactly the kind of period this file exists to describe.
+ */
+export function monthBucket(date: Date): number {
+  return date.getUTCFullYear() * 12 + date.getUTCMonth();
+}
+
+/** Bucket key for `person_over_years`' year diversity. */
+export function yearBucket(date: Date): number {
+  return date.getUTCFullYear();
+}
+
+/** Which season an instant belongs to, with the December→next-year fold applied. */
+export function seasonOf(date: Date): SeasonPeriod {
+  const month = date.getUTCMonth() + 1;
+  const season = seasonForMonth(month);
+  // January and February belong to the winter that STARTED last December.
+  const year = season === 'winter' && month <= 2 ? date.getUTCFullYear() - 1 : date.getUTCFullYear();
+  return { year, season };
+}
+
+/** Monotonic ordinal so seasons can be compared and stepped through. */
+export function seasonOrdinal(period: SeasonPeriod): number {
+  return period.year * SEASON_ORDER.length + SEASON_ORDER.indexOf(period.season);
+}
+
+/** Inverse of `seasonOrdinal`. */
+export function seasonFromOrdinal(ordinal: number): SeasonPeriod {
+  const size = SEASON_ORDER.length;
+  // Floor division, correct for negative ordinals too (year 0 is not special).
+  const year = Math.floor(ordinal / size);
+  return { year, season: SEASON_ORDER[ordinal - year * size]! };
+}
+
+/** The season immediately before `period`. */
+export function previousSeason(period: SeasonPeriod): SeasonPeriod {
+  return seasonFromOrdinal(seasonOrdinal(period) - 1);
+}
+
+/**
+ * The most recent season that has fully ELAPSED as of `now`.
+ *
+ * The season containing `now` is deliberately excluded: a "Summer 2026" memory
+ * generated in July would be a partial summer, and the next refresh would
+ * rewrite it — churning the item set (and, from #306, an AI title) every single
+ * generation run for three months.
+ */
+export function mostRecentCompletedSeason(now: Date): SeasonPeriod {
+  return previousSeason(seasonOf(now));
+}
+
+/** `[first day of the season, first day of the next season)` in UTC. */
+export function seasonWindow(period: SeasonPeriod): PeriodWindow {
+  const startMonth = SEASON_START_MONTH[period.season];
+  const start = new Date(Date.UTC(period.year, startMonth - 1, 1));
+  // Winter is the only season whose three months cross a year boundary; using
+  // month arithmetic (month + 3, which Date.UTC normalizes past 12) means that
+  // rollover needs no special case here.
+  const endExclusive = new Date(Date.UTC(period.year, startMonth - 1 + 3, 1));
+  return { start, endExclusive };
+}
+
+/** `"2025-summer"` — the `seasonal` `periodKey` form. */
+export function seasonPeriodKey(period: SeasonPeriod): string {
+  return `${period.year}-${period.season}`;
+}
+
+/**
+ * Every season from `from` through `to` inclusive, chronologically.
+ *
+ * Returns empty when `to` precedes `from`, which is what a circle whose only
+ * photos are in the still-running season produces.
+ */
+export function enumerateSeasons(from: SeasonPeriod, to: SeasonPeriod): SeasonPeriod[] {
+  const first = seasonOrdinal(from);
+  const last = seasonOrdinal(to);
+  const out: SeasonPeriod[] = [];
+  for (let ordinal = first; ordinal <= last; ordinal += 1) out.push(seasonFromOrdinal(ordinal));
+  return out;
+}

--- a/apps/api/src/memories/curators/period-windows.ts
+++ b/apps/api/src/memories/curators/period-windows.ts
@@ -94,7 +94,8 @@ export function seasonOf(date: Date): SeasonPeriod {
   const month = date.getUTCMonth() + 1;
   const season = seasonForMonth(month);
   // January and February belong to the winter that STARTED last December.
-  const year = season === 'winter' && month <= 2 ? date.getUTCFullYear() - 1 : date.getUTCFullYear();
+  const year =
+    season === 'winter' && month <= 2 ? date.getUTCFullYear() - 1 : date.getUTCFullYear();
   return { year, season };
 }
 

--- a/apps/api/src/memories/curators/person-candidates.ts
+++ b/apps/api/src/memories/curators/person-candidates.ts
@@ -206,7 +206,10 @@ export async function preferredPersonCover(
 }
 
 /** Replace a selection's cover, leaving the rest of it untouched. */
-export function withCover(selection: CuratedSelection, coverMediaItemId: string | null): CuratedSelection {
+export function withCover(
+  selection: CuratedSelection,
+  coverMediaItemId: string | null,
+): CuratedSelection {
   if (!coverMediaItemId) return selection;
   return { ...selection, coverMediaItemId };
 }

--- a/apps/api/src/memories/curators/person-candidates.ts
+++ b/apps/api/src/memories/curators/person-candidates.ts
@@ -1,0 +1,212 @@
+// =============================================================================
+// Memories — shared person queries (epic #300, issue #305)
+// =============================================================================
+//
+// The two people curators — `person_highlights` (best of X, per year) and
+// `person_over_years` (X through the years) — ask the library the SAME two
+// questions before they diverge: which persons are eligible at all, and how many
+// candidates does each have per year? Both live here so the two curators cannot
+// drift on eligibility, which is the rule with the most policy in it.
+//
+// ELIGIBILITY IS A CIRCLE-LEVEL FACT, NOT A PER-USER ONE. A person qualifies
+// when they are live (`deletedAt IS NULL`), not circle-hidden
+// (`hiddenAt IS NULL`), identifiable (a non-empty name OR a cover face), and —
+// when `memories.people.favoritesOnly` is on, which is the default — marked
+// `favorite`. Deliberately ABSENT: per-user hidden-people preferences. Memories
+// are circle-scoped content generated once for everyone; whose faces a given
+// user does not want to see is read-time filtering, and belongs to #307. Baking
+// a per-user preference into generation would mean either generating per user
+// (N× the rows and the cost) or letting whoever ran first decide for everybody.
+//
+// THE PER-YEAR CENSUS IS ONE GROUPED QUERY FOR THE WHOLE CIRCLE, for the same
+// reason `circle-month-counts.ts` exists: the alternative is streaming every
+// person's candidates through the engine just to discover most person-years are
+// under `minItems`. The grouped form returns `persons × years-with-data` rows —
+// a few hundred — and the expensive `curate()` pass then runs only where it can
+// actually produce a memory.
+// =============================================================================
+
+import { Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CuratedSelection } from '../curation/memory-curation.types';
+
+const logger = new Logger('PersonMemoryCandidates');
+
+/**
+ * Ceiling on eligible persons considered in one generation pass.
+ *
+ * Only reachable with `favoritesOnly = false` in a circle with a very large
+ * cluster population, where the work would otherwise be `persons × years`
+ * curation passes. Ordered deterministically (favorites first, then by id) so
+ * the cut is stable across runs rather than reshuffling which persons get
+ * memories. A crash guard, not a tuning knob.
+ */
+export const MAX_ELIGIBLE_PERSONS = 500;
+
+/** Minimum distinct years of material before `person_over_years` is meaningful. */
+export const PERSON_OVER_YEARS_MIN_YEARS = 3;
+
+/**
+ * Ceiling on items taken from any single year in `person_over_years`.
+ *
+ * The memory is a span, not an album: four photos from one prolific year is
+ * plenty, and the budget freed by the cap is what lets quiet years appear at
+ * all. Per issue #305 ("best 2–4 items per year").
+ */
+export const PERSON_OVER_YEARS_MAX_PER_YEAR = 4;
+
+/** An eligible person, reduced to what the curators actually use. */
+export interface EligiblePerson {
+  id: string;
+  name: string | null;
+}
+
+/** Candidate count for one `(person, calendar year)` pair. */
+export interface PersonYearCount {
+  personId: string;
+  year: number;
+  count: number;
+}
+
+/**
+ * Persons in this circle that may receive memories.
+ *
+ * The identifiability rule (`name` OR `coverFace`) is applied in SQL as
+ * "either column is non-null" and then tightened in memory to reject a
+ * whitespace-only name — Prisma cannot express `trim(name) <> ''`, and a person
+ * named `"   "` with no cover face would otherwise get a "Best of" memory
+ * titled after nothing.
+ */
+export async function loadEligiblePersons(
+  prisma: PrismaService,
+  circleId: string,
+  favoritesOnly: boolean,
+): Promise<EligiblePerson[]> {
+  const rows = await prisma.person.findMany({
+    where: {
+      circleId,
+      deletedAt: null,
+      hiddenAt: null,
+      ...(favoritesOnly ? { favorite: true } : {}),
+      OR: [{ name: { not: null } }, { coverFaceId: { not: null } }],
+    },
+    // Favorites first so the MAX_ELIGIBLE_PERSONS cut, if it ever bites, keeps
+    // the persons the circle explicitly cares about.
+    orderBy: [{ favorite: 'desc' }, { id: 'asc' }],
+    take: MAX_ELIGIBLE_PERSONS + 1,
+    select: { id: true, name: true, coverFaceId: true },
+  });
+
+  if (rows.length > MAX_ELIGIBLE_PERSONS) {
+    logger.warn(
+      `Circle ${circleId} has more than ${MAX_ELIGIBLE_PERSONS} eligible persons; ` +
+        'people memories were generated for the first page only',
+    );
+  }
+
+  return rows
+    .slice(0, MAX_ELIGIBLE_PERSONS)
+    .filter((p) => (p.name?.trim().length ?? 0) > 0 || p.coverFaceId !== null)
+    .map((p) => ({ id: p.id, name: p.name }));
+}
+
+/**
+ * Candidate counts per `(person, year)` for the given persons, in one query.
+ *
+ * `COUNT(DISTINCT m.id)` because a media item may carry several faces of the
+ * same person (a video's cross-frame identity rows, or a genuine second
+ * detection) and it is still one photo in the memory.
+ *
+ * `f.hidden_at IS NULL` mirrors the archive semantics of the face-level hide
+ * (`PATCH /api/people/faces/bulk/hide`): an archived face is not evidence the
+ * person is in that photo any more, so it must not qualify a year the person is
+ * effectively absent from.
+ *
+ * The `WHERE` on `media_items` is the curation base filter, hand-written here
+ * for the same reason as in `circle-month-counts.ts` — see that file's header.
+ */
+export async function loadPersonYearCounts(
+  prisma: PrismaService,
+  circleId: string,
+  personIds: string[],
+): Promise<PersonYearCount[]> {
+  if (personIds.length === 0) return [];
+
+  return prisma.$queryRaw<PersonYearCount[]>(Prisma.sql`
+    SELECT
+      f."person_id" AS "personId",
+      EXTRACT(YEAR FROM (m."captured_at" AT TIME ZONE 'UTC'))::int AS "year",
+      COUNT(DISTINCT m."id")::int AS "count"
+    FROM "faces" f
+    JOIN "media_items" m ON m."id" = f."media_item_id"
+    WHERE f."circle_id" = ${circleId}::uuid
+      AND f."person_id" = ANY(${personIds}::uuid[])
+      AND f."hidden_at" IS NULL
+      AND m."circle_id" = ${circleId}::uuid
+      AND m."captured_at" IS NOT NULL
+      AND m."deleted_at" IS NULL
+      AND m."archived_at" IS NULL
+      AND m."social_media_source" IS NULL
+    GROUP BY 1, 2
+  `);
+}
+
+/** Group a flat census by person, each person's years sorted ascending. */
+export function groupYearCounts(
+  counts: PersonYearCount[],
+): Map<string, Array<{ year: number; count: number }>> {
+  const byPerson = new Map<string, Array<{ year: number; count: number }>>();
+  for (const row of counts) {
+    const bucket = byPerson.get(row.personId);
+    if (bucket) bucket.push({ year: row.year, count: row.count });
+    else byPerson.set(row.personId, [{ year: row.year, count: row.count }]);
+  }
+  for (const bucket of byPerson.values()) bucket.sort((a, b) => a.year - b.year);
+  return byPerson;
+}
+
+/**
+ * The curated item that shows this person BEST: the one carrying their
+ * highest-confidence face.
+ *
+ * Per issue #305, a person memory's cover should be a photo of that person
+ * rather than the engine's generic "highest-scored non-video item" — which, in a
+ * memory built from group shots, can easily be the frame where they are a blur
+ * in the background.
+ *
+ * Videos are excluded here for the same reason `finalizeSelection` excludes
+ * them: a cover is rendered as a still. Returns null when nothing qualifies
+ * (an all-video selection, or faces with NULL confidence only) and the caller
+ * keeps the engine's cover.
+ */
+export async function preferredPersonCover(
+  prisma: PrismaService,
+  personId: string,
+  selection: CuratedSelection,
+): Promise<string | null> {
+  const ids = selection.items.map((item) => item.mediaItemId);
+  if (ids.length === 0) return null;
+
+  const best = await prisma.face.findFirst({
+    where: {
+      personId,
+      hiddenAt: null,
+      mediaItemId: { in: ids },
+      mediaItem: { type: 'photo' },
+    },
+    // NULL confidence sorts LAST rather than first (Postgres' default for DESC),
+    // so a scored face always beats an unscored one; the id tiebreak keeps the
+    // choice stable across runs over an unchanged library.
+    orderBy: [{ confidence: { sort: 'desc', nulls: 'last' } }, { mediaItemId: 'asc' }],
+    select: { mediaItemId: true },
+  });
+
+  return best?.mediaItemId ?? null;
+}
+
+/** Replace a selection's cover, leaving the rest of it untouched. */
+export function withCover(selection: CuratedSelection, coverMediaItemId: string | null): CuratedSelection {
+  if (!coverMediaItemId) return selection;
+  return { ...selection, coverMediaItemId };
+}

--- a/apps/api/src/memories/curators/person-highlights.curator.ts
+++ b/apps/api/src/memories/curators/person-highlights.curator.ts
@@ -1,0 +1,172 @@
+// =============================================================================
+// Memories — Person Highlights curator (epic #300, issue #305)
+// =============================================================================
+//
+// "Best of Abuela, 2025" — one memory per eligible person per calendar year
+// with enough material. The face-recognition payoff, and the memory type users
+// most often go looking for deliberately rather than stumbling into.
+//
+// ONE MEMORY PER PERSON PER YEAR, NOT ONE PER PERSON. A decade of Abuela is not
+// one story; it is ten. Per-year identity (`subjectKey = personId`,
+// `periodKey = 'YYYY'`) is also what makes the per-user state and the tombstone
+// useful at a sensible granularity — you can delete a year you would rather not
+// be reminded of without losing the person. The all-time view of a person is a
+// DIFFERENT memory type, `person_over_years`, which is why this curator never
+// writes `periodKey = 'all'` even though the enum reserves it.
+//
+// GRACEFUL DEGRADATION IS THE DEFAULT PATH. A circle with face recognition off,
+// or on but with nothing clustered into a named/favorited Person, produces zero
+// eligible persons and returns an empty result. It does not throw, and per the
+// epic's failure-mode matrix it must not disturb the other six curators.
+//
+// THE CASCADE IS THE CLEANUP. `Memory.personId` is a Cascade FK, so deleting a
+// person — or merging them into another, which soft-deletes the source and
+// therefore drops them out of `loadEligiblePersons` — takes their memories with
+// it. This curator deliberately does not try to migrate or repair anything on a
+// merge: the next run simply regenerates under the surviving person, whose face
+// set now includes the merged-in faces.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MemoryType } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { personHighlightsTitle } from '../curation/memory-title-templates';
+import {
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+import {
+  EligiblePerson,
+  groupYearCounts,
+  loadEligiblePersons,
+  loadPersonYearCounts,
+  preferredPersonCover,
+  withCover,
+} from './person-candidates';
+import { yearWindow } from './period-windows';
+
+@Injectable()
+export class PersonHighlightsCurator implements MemoryCurator {
+  readonly name = 'person_highlights';
+
+  private readonly logger = new Logger(PersonHighlightsCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.people.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { favoritesOnly, minItems } = ctx.settings.people;
+
+    const persons = await loadEligiblePersons(this.prisma, ctx.circleId, favoritesOnly);
+    if (persons.length === 0) return result;
+
+    const counts = await loadPersonYearCounts(
+      this.prisma,
+      ctx.circleId,
+      persons.map((p) => p.id),
+    );
+    if (counts.length === 0) return result;
+    const byPerson = groupYearCounts(counts);
+
+    // Scheduled runs regenerate only the years a new upload can plausibly have
+    // landed in — this year and last. Backfill takes every year with material.
+    // ("Last year" matters into the following autumn: a December import lands in
+    // the previous year's memory long after that year ended.)
+    const currentYear = ctx.now.getUTCFullYear();
+    const scopedYears = ctx.backfill ? null : new Set([currentYear, currentYear - 1]);
+
+    for (const person of persons) {
+      const years = byPerson.get(person.id);
+      if (!years) continue;
+
+      // Most recent first, so a run cut short by a job timeout has produced the
+      // years users are most likely to be shown.
+      for (const { year, count } of [...years].sort((a, b) => b.year - a.year)) {
+        if (scopedYears && !scopedYears.has(year)) continue;
+        // The raw census can only ever over-count relative to the curated set
+        // (collapse and the video cap remove items, never add), so a year under
+        // the floor here cannot clear it after curation.
+        if (count < minItems) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const outcome = await this.curateYear(ctx, person, year, minItems);
+        result.created += outcome.created;
+        result.refreshed += outcome.refreshed;
+        result.skipped += outcome.skipped;
+        result.tombstoned += outcome.tombstoned;
+      }
+    }
+
+    this.logger.debug(
+      `Person highlights for circle ${ctx.circleId}: ${persons.length} eligible person(s), ` +
+        `${result.created} created / ${result.refreshed} refreshed / ` +
+        `${result.skipped} skipped / ${result.tombstoned} tombstoned`,
+    );
+
+    return result;
+  }
+
+  private async curateYear(
+    ctx: MemoryCuratorContext,
+    person: EligiblePerson,
+    year: number,
+    minItems: number,
+  ): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { start, endExclusive } = yearWindow(year);
+
+    // The person predicate is handed to the ENGINE as part of the slice `where`
+    // rather than resolved into an id list first: `curate()` then applies the
+    // base filter, streams with constant memory, and collapses near-duplicates
+    // exactly as it does for every other type. `hiddenAt: null` on the face
+    // matches the census in person-candidates.ts.
+    const selection = await this.curation.curate(
+      ctx.circleId,
+      {
+        capturedAt: { gte: start, lt: endExclusive },
+        faces: { some: { personId: person.id, hiddenAt: null } },
+      },
+      { maxItems: ctx.settings.maxItemsPerMemory },
+    );
+
+    if (selection.items.length < minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const cover = await preferredPersonCover(this.prisma, person.id, selection);
+    const { title, subtitle } = personHighlightsTitle(person.name, year);
+
+    const upsert = await this.curation.upsertMemory({
+      circleId: ctx.circleId,
+      type: MemoryType.person_highlights,
+      periodKey: String(year),
+      subjectKey: person.id,
+      personId: person.id,
+      title,
+      subtitle,
+      selection: withCover(selection, cover),
+      // Person memories never expire — unlike on_this_day, they stay relevant.
+      expiresAt: null,
+      meta: { year, personName: person.name },
+    });
+
+    if (upsert.skippedTombstone) result.tombstoned += 1;
+    else if (upsert.created) result.created += 1;
+    else result.refreshed += 1;
+
+    return result;
+  }
+}

--- a/apps/api/src/memories/curators/person-over-years.curator.ts
+++ b/apps/api/src/memories/curators/person-over-years.curator.ts
@@ -1,0 +1,179 @@
+// =============================================================================
+// Memories — Person Over Years curator (epic #300, issue #305)
+// =============================================================================
+//
+// "Camila through the years" — ONE memory per person, spanning their whole
+// history, deliberately thin per year so the chronological playback reads as
+// someone growing up rather than as a 2019 photo dump with a 2024 postscript.
+//
+// WHY THIS NEEDS A DIFFERENT DIVERSITY POLICY. The engine's default
+// `selectDiverse` divides the memory's TIME SPAN into equal buckets. For a
+// person photographed heavily in 2016 and again in 2025 with a quiet stretch
+// between, equal thirds of nine elapsed years put two buckets inside the same
+// busy period and none in the quiet middle. The whole promise of this type is
+// "every year appears", which is a statement about the calendar, not about
+// elapsed time — so it passes `bucketBy: { key: yearBucket }` to `curate()`
+// (see `selectByBuckets`, added to the engine by this issue) and caps any one
+// year at PERSON_OVER_YEARS_MAX_PER_YEAR.
+//
+// THE >=3-YEAR FLOOR is what separates this type from `person_highlights`. Two
+// years is not "through the years"; it is two years, and the per-year highlight
+// memories already tell that story better. The floor is checked on the CENSUS
+// (years the person has any material in) rather than on the curated set, so a
+// person whose middle year loses its slots to the item cap still qualifies.
+//
+// SHARED ELIGIBILITY. Persons come from the same `loadEligiblePersons` the
+// highlights curator uses — see `person-candidates.ts` for why per-user hidden
+// people are deliberately NOT applied at generation time.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MemoryType } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { personOverYearsTitle } from '../curation/memory-title-templates';
+import {
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+import {
+  EligiblePerson,
+  PERSON_OVER_YEARS_MAX_PER_YEAR,
+  PERSON_OVER_YEARS_MIN_YEARS,
+  groupYearCounts,
+  loadEligiblePersons,
+  loadPersonYearCounts,
+  preferredPersonCover,
+  withCover,
+} from './person-candidates';
+import { utcYear, yearBucket } from './period-windows';
+
+/**
+ * The `periodKey` for every memory of this type. There is exactly one
+ * `person_over_years` memory per person, so the period carries no information
+ * and the subject (`personId`) is the whole identity — see the `MemoryType`
+ * enum comment in schema.prisma.
+ */
+export const PERSON_OVER_YEARS_PERIOD_KEY = 'all';
+
+@Injectable()
+export class PersonOverYearsCurator implements MemoryCurator {
+  readonly name = 'person_over_years';
+
+  private readonly logger = new Logger(PersonOverYearsCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.people.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { favoritesOnly, minItems } = ctx.settings.people;
+
+    const persons = await loadEligiblePersons(this.prisma, ctx.circleId, favoritesOnly);
+    if (persons.length === 0) return result;
+
+    const counts = await loadPersonYearCounts(
+      this.prisma,
+      ctx.circleId,
+      persons.map((p) => p.id),
+    );
+    if (counts.length === 0) return result;
+    const byPerson = groupYearCounts(counts);
+
+    // Scheduled and backfill runs do exactly the same work here: the period is
+    // always 'all', so there is no narrower "what changed recently" window to
+    // exploit. The cost is bounded by the eligible-person count either way.
+    for (const person of persons) {
+      const years = byPerson.get(person.id);
+      if (!years || years.length < PERSON_OVER_YEARS_MIN_YEARS) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const total = years.reduce((sum, y) => sum + y.count, 0);
+      if (total < minItems) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const outcome = await this.curatePerson(ctx, person, years, minItems);
+      result.created += outcome.created;
+      result.refreshed += outcome.refreshed;
+      result.skipped += outcome.skipped;
+      result.tombstoned += outcome.tombstoned;
+    }
+
+    this.logger.debug(
+      `Person over years for circle ${ctx.circleId}: ${persons.length} eligible person(s), ` +
+        `${result.created} created / ${result.refreshed} refreshed / ` +
+        `${result.skipped} skipped / ${result.tombstoned} tombstoned`,
+    );
+
+    return result;
+  }
+
+  private async curatePerson(
+    ctx: MemoryCuratorContext,
+    person: EligiblePerson,
+    years: Array<{ year: number; count: number }>,
+    minItems: number,
+  ): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+
+    // No date range: the slice is the person's ENTIRE history, and the year
+    // bucketing is what keeps that from becoming a pile.
+    const selection = await this.curation.curate(
+      ctx.circleId,
+      { faces: { some: { personId: person.id, hiddenAt: null } } },
+      {
+        maxItems: ctx.settings.maxItemsPerMemory,
+        bucketBy: {
+          key: (candidate) => yearBucket(candidate.capturedAt),
+          maxPerBucket: PERSON_OVER_YEARS_MAX_PER_YEAR,
+        },
+      },
+    );
+
+    if (selection.items.length < minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    // Derived from the SELECTION rather than from the census, so the rendered
+    // subtitle ("2016–2025") always names the range the memory actually
+    // contains. `periodStart`/`periodEnd` are non-null whenever items exist.
+    const firstYear = utcYear(selection.periodStart!);
+    const lastYear = utcYear(selection.periodEnd!);
+    const yearCount = years.filter((y) => y.year >= firstYear && y.year <= lastYear).length;
+
+    const cover = await preferredPersonCover(this.prisma, person.id, selection);
+    const { title, subtitle } = personOverYearsTitle(person.name, firstYear, lastYear);
+
+    const upsert = await this.curation.upsertMemory({
+      circleId: ctx.circleId,
+      type: MemoryType.person_over_years,
+      periodKey: PERSON_OVER_YEARS_PERIOD_KEY,
+      subjectKey: person.id,
+      personId: person.id,
+      title,
+      subtitle,
+      selection: withCover(selection, cover),
+      expiresAt: null,
+      meta: { firstYear, lastYear, yearCount, personName: person.name },
+    });
+
+    if (upsert.skippedTombstone) result.tombstoned += 1;
+    else if (upsert.created) result.created += 1;
+    else result.refreshed += 1;
+
+    return result;
+  }
+}

--- a/apps/api/src/memories/curators/seasonal.curator.ts
+++ b/apps/api/src/memories/curators/seasonal.curator.ts
@@ -1,0 +1,170 @@
+// =============================================================================
+// Memories — Seasonal curator (epic #300, issue #305)
+// =============================================================================
+//
+// "Summer 2025" — the whole-library payoff at a granularity between a trip and a
+// year. No subject, no clustering, no AI signal required: a season is a date
+// range, and everything interesting about this curator is WHICH range and WHEN.
+//
+// ONLY COMPLETED SEASONS. A "Summer 2026" memory generated in July would be a
+// partial summer, and every subsequent generation run would rewrite it as more
+// photos landed — churning the item set and, from #306, re-paying for an AI
+// title, daily, for three months. Waiting until the season has fully elapsed
+// makes the memory stable the moment it is created. `mostRecentCompletedSeason`
+// owns that rule (see period-windows.ts).
+//
+// THE SEASON YEAR IS THE YEAR THE SEASON STARTS. Northern-hemisphere winter runs
+// December Y → February Y+1, so `2025-winter` contains January 2026 photos and
+// its `periodKey` legitimately disagrees with a naive `getUTCFullYear()` of its
+// own contents. That reconciliation is centralized in `seasonOf()` rather than
+// re-derived here, and `SEASON_LABELS`/`seasonForMonth` in the title templates
+// hold the hemisphere assumption in one place for a future locale setting.
+//
+// SCHEDULED RUNS DO ONE SEASON. There is exactly one season that can newly
+// qualify between two runs, and refreshing older ones is what backfill is for —
+// so the daily job costs one census query plus at most one curation pass.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MemoryType } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { seasonalTitle } from '../curation/memory-title-templates';
+import {
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+import {
+  MonthCounts,
+  censusBounds,
+  countInWindow,
+  loadMonthCounts,
+  monthBucketStart,
+} from './circle-month-counts';
+import {
+  SeasonPeriod,
+  enumerateSeasons,
+  mostRecentCompletedSeason,
+  seasonOf,
+  seasonOrdinal,
+  seasonPeriodKey,
+  seasonWindow,
+} from './period-windows';
+
+@Injectable()
+export class SeasonalCurator implements MemoryCurator {
+  readonly name = 'seasonal';
+
+  private readonly logger = new Logger(SeasonalCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.seasonal.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+
+    const counts = await loadMonthCounts(this.prisma, ctx.circleId);
+    if (counts.size === 0) return result;
+
+    for (const period of this.resolvePeriods(ctx, counts)) {
+      const outcome = await this.curateSeason(ctx, period, counts);
+      result.created += outcome.created;
+      result.refreshed += outcome.refreshed;
+      result.skipped += outcome.skipped;
+      result.tombstoned += outcome.tombstoned;
+    }
+
+    this.logger.debug(
+      `Seasonal for circle ${ctx.circleId}: ${result.created} created / ` +
+        `${result.refreshed} refreshed / ${result.skipped} skipped / ` +
+        `${result.tombstoned} tombstoned`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Scheduled: the most recently completed season, and only that one.
+   *
+   * Backfill: every completed season from the circle's oldest material forward.
+   * Enumerated from the census bounds rather than from distinct season keys so
+   * the list is contiguous — a gap year is cheap (its raw count is zero and it
+   * is skipped before any query) and contiguity keeps the ordering trivially
+   * chronological.
+   */
+  private resolvePeriods(ctx: MemoryCuratorContext, counts: MonthCounts): SeasonPeriod[] {
+    const latest = mostRecentCompletedSeason(ctx.now);
+    if (!ctx.backfill) return [latest];
+
+    const bounds = censusBounds(counts);
+    if (!bounds) return [];
+
+    const earliest = seasonOf(monthBucketStart(bounds.first));
+    // A circle whose only photos are inside the still-running season has nothing
+    // completed to generate — `enumerateSeasons` returns empty for that.
+    return enumerateSeasons(earliest, latest);
+  }
+
+  private async curateSeason(
+    ctx: MemoryCuratorContext,
+    period: SeasonPeriod,
+    counts: MonthCounts,
+  ): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { minItems } = ctx.settings.seasonal;
+
+    const window = seasonWindow(period);
+    // The census can only over-count relative to curation (collapse and the
+    // video cap remove items, never add), so a season under the floor here
+    // cannot clear it afterwards — and this costs no query at all.
+    if (countInWindow(counts, window.start, window.endExclusive) < minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const selection = await this.curation.curate(
+      ctx.circleId,
+      { capturedAt: { gte: window.start, lt: window.endExclusive } },
+      { maxItems: ctx.settings.maxItemsPerMemory },
+    );
+    if (selection.items.length < minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const { title, subtitle } = seasonalTitle(period.season, period.year);
+    const upsert = await this.curation.upsertMemory({
+      circleId: ctx.circleId,
+      type: MemoryType.seasonal,
+      periodKey: seasonPeriodKey(period),
+      // Seasonal memories have no subject — one per circle per season. '' is
+      // the schema's default and is never NULL; see the Memory model comment.
+      subjectKey: '',
+      title,
+      subtitle,
+      selection,
+      // Seasons never expire: unlike on_this_day, "Summer 2025" stays
+      // interesting long after the season ends.
+      expiresAt: null,
+      meta: {
+        season: period.season,
+        seasonYear: period.year,
+        seasonOrdinal: seasonOrdinal(period),
+      },
+    });
+
+    if (upsert.skippedTombstone) result.tombstoned += 1;
+    else if (upsert.created) result.created += 1;
+    else result.refreshed += 1;
+
+    return result;
+  }
+}

--- a/apps/api/src/memories/curators/theme.curator.ts
+++ b/apps/api/src/memories/curators/theme.curator.ts
@@ -1,0 +1,301 @@
+// =============================================================================
+// Memories — Theme curator (epic #300, issue #305)
+// =============================================================================
+//
+// "Golden Sunsets", "Beach", "Pets" — memories built from the AI auto-tagging
+// vocabulary. The auto-tagging payoff, and the only curator whose subject is a
+// piece of admin-controlled configuration rather than something the library
+// derived on its own.
+//
+// WHY THE TAG VOCABULARY AND NOT UNSUPERVISED CLUSTERING. CLIP-embedding
+// clustering would find themes nobody named, but its output is unexplainable
+// ("here are 40 photos that are near each other in a 512-d space") and
+// untunable. Tag themes are explainable, already computed, free, and — because
+// `tag_labels` is admin-managed — an admin who does not want "Food" memories
+// simply disables the label. Epic #300 defers clustering explicitly.
+//
+// THREE FILTERS DECIDE WHICH TAGS BECOME MEMORIES
+// -----------------------------------------------
+//
+// 1. `media_tags.source = 'ai'`. A manually applied tag is a filing decision,
+//    not a claim about content, and a user who tagged 200 photos "Taxes" did not
+//    ask for a memory about it. The distinction exists in the schema precisely
+//    because AI and manual tag instances are governed by different rules (see
+//    CLAUDE.md's `MediaTagSource` note).
+//
+// 2. The label must still be ENABLED in `tag_labels`. Disabling a label is how
+//    an admin retires a concept; a retired concept must stop producing memories
+//    without anyone having to hunt down the rows it already generated.
+//
+// 3. THEME_TAG_DENYLIST. A handful of vocabulary entries describe a document,
+//    not a moment. They score well (they are sharp, and screenshots are often
+//    favorited for reference) and would produce genuinely bad memories.
+//
+// RANKING IS BY DISTINCT QUALIFYING ITEMS, NOT BY TOTAL TAG INSTANCES, and the
+// item set that a memory is finally built from is CURATED — favorites-weighted,
+// near-duplicate collapsed. So "the top themes" means the themes with the most
+// material, but each memory is that theme's best photos rather than all of them.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MediaTagSource, MemoryType, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { themeTitle } from '../curation/memory-title-templates';
+import {
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+import { yearWindow } from './period-windows';
+
+/**
+ * Vocabulary entries that never become a theme memory.
+ *
+ * Deliberately tiny and hand-maintained rather than heuristic: these are the
+ * concepts whose photos are artifacts rather than moments. Compared
+ * case-insensitively against the tag name. Documented in
+ * docs/specs/memories.md §4.10.
+ */
+export const THEME_TAG_DENYLIST: ReadonlySet<string> = new Set([
+  'screenshot',
+  'screenshots',
+  'document',
+  'documents',
+  'text',
+  'whiteboard',
+]);
+
+/** The `periodKey` for a theme spanning the circle's whole history. */
+export const THEME_ALL_PERIOD_KEY = 'all';
+
+/**
+ * Ceiling on curation attempts per period, as a multiple of `maxPerPeriod`.
+ *
+ * The rule is "the top N tags that produce at least `minItems` CURATED items",
+ * which cannot be evaluated without curating — a tag can clear the raw census
+ * and then fall short once near-duplicates collapse. Walking further down the
+ * ranking when that happens is right (the point is N good themes, not N
+ * attempts), but it has to stop somewhere: a circle with 200 sparse tags must
+ * not turn one period into 200 curation passes.
+ */
+const THEME_ATTEMPT_MULTIPLIER = 3;
+
+/** One period this curator generates for. */
+interface ThemePeriod {
+  periodKey: string;
+  /** null for the all-history period. */
+  year: number | null;
+}
+
+/** Census row: distinct qualifying items for one `(tag, year)`. */
+interface TagYearCount {
+  tag: string;
+  year: number;
+  count: number;
+}
+
+@Injectable()
+export class ThemeCurator implements MemoryCurator {
+  readonly name = 'theme';
+
+  private readonly logger = new Logger(ThemeCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.themes.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+
+    const census = await this.loadTagYearCounts(ctx.circleId);
+    if (census.length === 0) {
+      // THE GRACEFUL-DEGRADATION PATH: auto-tagging never ran, produced nothing,
+      // or every label it used has since been disabled. Not an error — a
+      // supported configuration, and the other curators are unaffected.
+      return result;
+    }
+
+    for (const period of this.resolvePeriods(ctx, census)) {
+      const outcome = await this.curatePeriod(ctx, period, census);
+      result.created += outcome.created;
+      result.refreshed += outcome.refreshed;
+      result.skipped += outcome.skipped;
+      result.tombstoned += outcome.tombstoned;
+    }
+
+    this.logger.debug(
+      `Themes for circle ${ctx.circleId}: ${result.created} created / ` +
+        `${result.refreshed} refreshed / ${result.skipped} skipped / ` +
+        `${result.tombstoned} tombstoned`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Scheduled: the current year only — the only period a new upload can change,
+   * and the one a user is most likely to be shown.
+   *
+   * Backfill: every year with material, plus the all-history period. The
+   * all-history themes are what make a young library interesting: a circle whose
+   * photos are spread thin across eight years may have no single year clearing
+   * `minItems` for "Sunsets" while having plenty overall.
+   */
+  private resolvePeriods(ctx: MemoryCuratorContext, census: TagYearCount[]): ThemePeriod[] {
+    if (!ctx.backfill) {
+      const year = ctx.now.getUTCFullYear();
+      return [{ periodKey: String(year), year }];
+    }
+
+    const years = [...new Set(census.map((row) => row.year))].sort((a, b) => b - a);
+    return [
+      ...years.map((year) => ({ periodKey: String(year), year })),
+      { periodKey: THEME_ALL_PERIOD_KEY, year: null },
+    ];
+  }
+
+  private async curatePeriod(
+    ctx: MemoryCuratorContext,
+    period: ThemePeriod,
+    census: TagYearCount[],
+  ): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { minItems, maxPerPeriod } = ctx.settings.themes;
+
+    const ranked = rankTagsForPeriod(census, period.year, minItems);
+    if (ranked.length === 0) return result;
+
+    const window = period.year === null ? null : yearWindow(period.year);
+    const maxAttempts = maxPerPeriod * THEME_ATTEMPT_MULTIPLIER;
+
+    let produced = 0;
+    let attempts = 0;
+
+    for (const { tag } of ranked) {
+      if (produced >= maxPerPeriod || attempts >= maxAttempts) break;
+      attempts += 1;
+
+      const selection = await this.curation.curate(
+        ctx.circleId,
+        {
+          ...(window ? { capturedAt: { gte: window.start, lt: window.endExclusive } } : {}),
+          // The tag is matched case-insensitively because the census groups on
+          // `LOWER(name)` — one circle can hold "Sunset" and "sunset" as
+          // separate Tag rows, and they are one theme.
+          mediaTags: {
+            some: {
+              source: MediaTagSource.ai,
+              tag: { circleId: ctx.circleId, name: { equals: tag, mode: 'insensitive' } },
+            },
+          },
+        },
+        { maxItems: ctx.settings.maxItemsPerMemory },
+      );
+
+      if (selection.items.length < minItems) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const { title, subtitle } = themeTitle(tag, selection.items.length);
+      const upsert = await this.curation.upsertMemory({
+        circleId: ctx.circleId,
+        type: MemoryType.theme,
+        periodKey: period.periodKey,
+        subjectKey: tag,
+        title,
+        subtitle,
+        selection,
+        expiresAt: null,
+        meta: { tag, year: period.year },
+      });
+
+      // A tombstoned theme still consumes a slot: the user deleted THAT theme
+      // for this period, and quietly promoting the next tag into its place would
+      // read as the delete having done nothing.
+      produced += 1;
+      if (upsert.skippedTombstone) result.tombstoned += 1;
+      else if (upsert.created) result.created += 1;
+      else result.refreshed += 1;
+    }
+
+    return result;
+  }
+
+  /**
+   * Distinct qualifying items per `(lowercased tag, year)` — one grouped query
+   * for the whole circle, mirroring `circle-month-counts.ts`'s rationale.
+   *
+   * `COUNT(DISTINCT m.id)` rather than `COUNT(*)`: the `(tag_id, media_item_id)`
+   * unique index already prevents a duplicate instance for one Tag row, but two
+   * Tag rows differing only in case fold into one theme here and would otherwise
+   * double-count the items they share.
+   *
+   * Joining `tag_labels` on `LOWER(name)` is what enforces "the label is still
+   * part of the vocabulary AND still enabled" — a tag instance whose label was
+   * deleted outright leaves `media_tags` rows behind for manual instances (see
+   * `DELETE /api/tag-labels/:id`), and those must not resurrect a retired theme.
+   *
+   * The `media_items` predicates are the curation base filter, hand-written for
+   * raw SQL — see `circle-month-counts.ts` for why that duplication is accepted.
+   */
+  private async loadTagYearCounts(circleId: string): Promise<TagYearCount[]> {
+    const rows = await this.prisma.$queryRaw<TagYearCount[]>(Prisma.sql`
+      SELECT
+        LOWER(t."name") AS "tag",
+        EXTRACT(YEAR FROM (m."captured_at" AT TIME ZONE 'UTC'))::int AS "year",
+        COUNT(DISTINCT m."id")::int AS "count"
+      FROM "media_tags" mt
+      JOIN "tags" t ON t."id" = mt."tag_id"
+      JOIN "tag_labels" tl ON LOWER(tl."name") = LOWER(t."name")
+      JOIN "media_items" m ON m."id" = mt."media_item_id"
+      WHERE t."circle_id" = ${circleId}::uuid
+        AND mt."source" = ${MediaTagSource.ai}::"MediaTagSource"
+        AND tl."enabled" = TRUE
+        AND m."circle_id" = ${circleId}::uuid
+        AND m."captured_at" IS NOT NULL
+        AND m."deleted_at" IS NULL
+        AND m."archived_at" IS NULL
+        AND m."social_media_source" IS NULL
+      GROUP BY 1, 2
+    `);
+
+    return rows.filter((row) => !THEME_TAG_DENYLIST.has(row.tag));
+  }
+}
+
+/**
+ * Rank a period's tags by how much material they have, densest first.
+ *
+ * `year === null` sums every year, which is exact rather than an approximation:
+ * a media item has exactly one `capturedAt` and therefore contributes to exactly
+ * one year's distinct count, so the per-year counts of one tag partition its
+ * all-history set with no overlap to correct for.
+ *
+ * Pure — exported for unit testing.
+ */
+export function rankTagsForPeriod(
+  census: TagYearCount[],
+  year: number | null,
+  minItems: number,
+): Array<{ tag: string; count: number }> {
+  const totals = new Map<string, number>();
+  for (const row of census) {
+    if (year !== null && row.year !== year) continue;
+    totals.set(row.tag, (totals.get(row.tag) ?? 0) + row.count);
+  }
+
+  return [...totals.entries()]
+    .filter(([, count]) => count >= minItems)
+    .map(([tag, count]) => ({ tag, count }))
+    // Name is the tiebreak so the ranking — and therefore which themes exist —
+    // is stable across runs over an unchanged library.
+    .sort((a, b) => (b.count !== a.count ? b.count - a.count : a.tag.localeCompare(b.tag)));
+}

--- a/apps/api/src/memories/curators/year-in-review.curator.ts
+++ b/apps/api/src/memories/curators/year-in-review.curator.ts
@@ -1,0 +1,215 @@
+// =============================================================================
+// Memories — Year in Review curator (epic #300, issue #305)
+// =============================================================================
+//
+// "Your 2025 in review" — the biggest memory in the catalog, and the one with
+// the narrowest window of relevance.
+//
+// GENERATED IN DECEMBER OF Y AND ALL OF JANUARY Y+1. December because the
+// year-in-review is a December ritual and the memory has to EXIST before anyone
+// looks for it (the digest and notification producers in #311 announce content
+// that generation must already have produced). All of January because "your year
+// in review" is exactly what people go looking for over New Year, and a memory
+// that only ever appeared for 31 days in December would be gone by the time most
+// of the circle noticed. Outside that window a scheduled run generates nothing —
+// it is not a memory whose item set benefits from being recomputed in June.
+//
+// The December half of that window means a year-in-review IS generated for a
+// year that has three weeks left to run, and the late-December uploads then land
+// through refresh. That is the deliberate trade: an existing-but-slightly-early
+// memory beats a missing one, and `upsertMemory`'s Jaccard rule keeps the
+// refresh from churning the title unless the additions are material.
+//
+// BUCKETED BY MONTH, NOT BY EQUAL TIME SPANS. A year in review whose thirty
+// photos all come from one two-week holiday is not a year in review. The engine's
+// default `selectDiverse` divides the SPAN into equal buckets, which is the same
+// thing for a full year — but only if the year's material is spread across it;
+// a library with a six-month gap would collapse into two dense clusters. Passing
+// `bucketBy: { key: monthBucket }` states the intent structurally: every month
+// with material gets a turn before any month gets a second item.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MemoryType } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { yearInReviewTitle } from '../curation/memory-title-templates';
+import {
+  MemoryCurator,
+  MemoryCuratorContext,
+  MemoryCuratorResult,
+  emptyCuratorResult,
+} from './memory-curator.interface';
+import {
+  MonthCounts,
+  censusBounds,
+  countInWindow,
+  loadMonthCounts,
+  monthBucketStart,
+} from './circle-month-counts';
+import { monthBucket, utcYear, yearWindow } from './period-windows';
+
+/** 0-based month index of December, the month a year's review becomes eligible. */
+const DECEMBER = 11;
+
+/**
+ * Which year a scheduled run generates for, or null outside the window.
+ *
+ * Pure — exported for unit testing, because "December of Y and all of January
+ * Y+1" is exactly the kind of boundary rule that is easier to get wrong than to
+ * test.
+ */
+export function scheduledReviewYear(now: Date): number | null {
+  const month = now.getUTCMonth();
+  if (month === DECEMBER) return now.getUTCFullYear();
+  if (month === 0) return now.getUTCFullYear() - 1;
+  return null;
+}
+
+/**
+ * Is `year` eligible to have a review generated as of `now`?
+ *
+ * Any year strictly in the past always is. The CURRENT year is only eligible
+ * once December has arrived — the same completeness rule the scheduled window
+ * encodes, applied to backfill so a mid-year backfill does not mint a
+ * three-month "Your 2026 in review" that then churns for the rest of the year.
+ */
+export function isReviewYearEligible(year: number, now: Date): boolean {
+  const currentYear = now.getUTCFullYear();
+  if (year < currentYear) return true;
+  return year === currentYear && now.getUTCMonth() === DECEMBER;
+}
+
+@Injectable()
+export class YearInReviewCurator implements MemoryCurator {
+  readonly name = 'year_in_review';
+
+  private readonly logger = new Logger(YearInReviewCurator.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly curation: MemoryCurationService,
+  ) {}
+
+  isEnabled(settings: MemoryCuratorContext['settings']): boolean {
+    return settings.yearInReview.enabled;
+  }
+
+  async run(ctx: MemoryCuratorContext): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+
+    const years = this.resolveYearsCheaply(ctx);
+    // Outside the December/January window a scheduled run has nothing to do, and
+    // says so without touching the database at all.
+    if (years !== null && years.length === 0) return result;
+
+    const counts = await loadMonthCounts(this.prisma, ctx.circleId);
+    if (counts.size === 0) return result;
+
+    for (const year of years ?? this.backfillYears(ctx, counts)) {
+      const outcome = await this.curateYear(ctx, year, counts);
+      result.created += outcome.created;
+      result.refreshed += outcome.refreshed;
+      result.skipped += outcome.skipped;
+      result.tombstoned += outcome.tombstoned;
+    }
+
+    this.logger.debug(
+      `Year in review for circle ${ctx.circleId}: ${result.created} created / ` +
+        `${result.refreshed} refreshed / ${result.skipped} skipped / ` +
+        `${result.tombstoned} tombstoned`,
+    );
+
+    return result;
+  }
+
+  /** Scheduled years, or null when the caller must derive them from the census. */
+  private resolveYearsCheaply(ctx: MemoryCuratorContext): number[] | null {
+    if (ctx.backfill) return null;
+    const year = scheduledReviewYear(ctx.now);
+    return year === null ? [] : [year];
+  }
+
+  /** Every eligible year the circle has material in, newest first. */
+  private backfillYears(ctx: MemoryCuratorContext, counts: MonthCounts): number[] {
+    const bounds = censusBounds(counts);
+    if (!bounds) return [];
+
+    const first = utcYear(monthBucketStart(bounds.first));
+    const last = utcYear(monthBucketStart(bounds.last));
+    const years: number[] = [];
+    for (let year = last; year >= first; year -= 1) {
+      if (isReviewYearEligible(year, ctx.now)) years.push(year);
+    }
+    return years;
+  }
+
+  private async curateYear(
+    ctx: MemoryCuratorContext,
+    year: number,
+    counts: MonthCounts,
+  ): Promise<MemoryCuratorResult> {
+    const result = emptyCuratorResult();
+    const { minItems } = ctx.settings.yearInReview;
+
+    // A scheduled run reaches this with a year it did not read off the census,
+    // so re-check eligibility here too rather than trusting the caller.
+    if (!isReviewYearEligible(year, ctx.now)) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const window = yearWindow(year);
+    if (countInWindow(counts, window.start, window.endExclusive) < minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const selection = await this.curation.curate(
+      ctx.circleId,
+      { capturedAt: { gte: window.start, lt: window.endExclusive } },
+      {
+        maxItems: ctx.settings.maxItemsPerMemory,
+        // No per-bucket cap: with twelve buckets and a 30-item budget the
+        // round-robin already yields two to three items a month, and a year
+        // whose material is genuinely concentrated in four months should be
+        // allowed to fill its slots from those four.
+        bucketBy: { key: (candidate) => monthBucket(candidate.capturedAt) },
+      },
+    );
+    if (selection.items.length < minItems) {
+      result.skipped += 1;
+      return result;
+    }
+
+    const monthsCovered = new Set(
+      // Recomputed from the census window rather than from item dates, which
+      // the selection does not carry: months that HAVE material, bounded by the
+      // year. Reported as context in `meta`, never as a gate.
+      [...counts.keys()].filter(
+        (bucket) => bucket >= monthBucket(window.start) && bucket < monthBucket(window.endExclusive),
+      ),
+    ).size;
+
+    const { title, subtitle } = yearInReviewTitle(year, selection.items.length);
+    const upsert = await this.curation.upsertMemory({
+      circleId: ctx.circleId,
+      type: MemoryType.year_in_review,
+      periodKey: String(year),
+      // No subject — one per circle per year. '' is the schema default and is
+      // never NULL; see the Memory model comment in schema.prisma.
+      subjectKey: '',
+      title,
+      subtitle,
+      selection,
+      expiresAt: null,
+      meta: { year, monthsCovered },
+    });
+
+    if (upsert.skippedTombstone) result.tombstoned += 1;
+    else if (upsert.created) result.created += 1;
+    else result.refreshed += 1;
+
+    return result;
+  }
+}

--- a/apps/api/src/memories/curators/year-in-review.curator.ts
+++ b/apps/api/src/memories/curators/year-in-review.curator.ts
@@ -187,7 +187,8 @@ export class YearInReviewCurator implements MemoryCurator {
       // the selection does not carry: months that HAVE material, bounded by the
       // year. Reported as context in `meta`, never as a gate.
       [...counts.keys()].filter(
-        (bucket) => bucket >= monthBucket(window.start) && bucket < monthBucket(window.endExclusive),
+        (bucket) =>
+          bucket >= monthBucket(window.start) && bucket < monthBucket(window.endExclusive),
       ),
     ).size;
 

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -28,6 +28,7 @@ import { OnThisDayCurator } from './curators/on-this-day.curator';
 import { TripCurator } from './curators/trip.curator';
 import { PersonHighlightsCurator } from './curators/person-highlights.curator';
 import { PersonOverYearsCurator } from './curators/person-over-years.curator';
+import { ThemeCurator } from './curators/theme.curator';
 import { memoryCuratorsProvider } from './curators/memory-curators.provider';
 
 @Module({
@@ -40,6 +41,7 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
     TripCurator,
     PersonHighlightsCurator,
     PersonOverYearsCurator,
+    ThemeCurator,
     memoryCuratorsProvider,
   ],
   exports: [MemoriesGenerationTask, MemoryCurationService],

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -26,6 +26,8 @@ import { MemoryGenerationHandler } from './memory-generation.handler';
 import { MemoryCurationService } from './curation/memory-curation.service';
 import { OnThisDayCurator } from './curators/on-this-day.curator';
 import { TripCurator } from './curators/trip.curator';
+import { PersonHighlightsCurator } from './curators/person-highlights.curator';
+import { PersonOverYearsCurator } from './curators/person-over-years.curator';
 import { memoryCuratorsProvider } from './curators/memory-curators.provider';
 
 @Module({
@@ -36,6 +38,8 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
     MemoryCurationService,
     OnThisDayCurator,
     TripCurator,
+    PersonHighlightsCurator,
+    PersonOverYearsCurator,
     memoryCuratorsProvider,
   ],
   exports: [MemoriesGenerationTask, MemoryCurationService],

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -29,6 +29,8 @@ import { TripCurator } from './curators/trip.curator';
 import { PersonHighlightsCurator } from './curators/person-highlights.curator';
 import { PersonOverYearsCurator } from './curators/person-over-years.curator';
 import { ThemeCurator } from './curators/theme.curator';
+import { SeasonalCurator } from './curators/seasonal.curator';
+import { YearInReviewCurator } from './curators/year-in-review.curator';
 import { memoryCuratorsProvider } from './curators/memory-curators.provider';
 
 @Module({
@@ -42,6 +44,8 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
     PersonHighlightsCurator,
     PersonOverYearsCurator,
     ThemeCurator,
+    SeasonalCurator,
+    YearInReviewCurator,
     memoryCuratorsProvider,
   ],
   exports: [MemoriesGenerationTask, MemoryCurationService],

--- a/apps/api/test/memories/memories-people.integration.spec.ts
+++ b/apps/api/test/memories/memories-people.integration.spec.ts
@@ -1,0 +1,623 @@
+// DB_GATED: requires a real PostgreSQL with migrations applied. Reachability is
+// probed synchronously at module load via `describeMaybeDb`, so with no database
+// the whole suite is registered as `describe.skip` and reports SKIPPED — never a
+// green PASS that asserted nothing. See test/helpers/db-probe.helper.ts.
+//
+// WHY THIS SUITE IS DB-BACKED AND NOT MOCKED
+// ------------------------------------------
+// Issue #305's people acceptance criteria are statements about ROWS and about
+// SQL: "a favorite person with photos across four years gets one memory per
+// qualifying year plus one spanning them", "favoritesOnly=false widens the set",
+// "a hidden person NEVER gets a memory", "deleting or merging a person cascades
+// their memories away and the next run regenerates under the survivor", "a
+// tombstoned memory is never resurrected". Against a mocked Prisma each of those
+// would assert that the code called the mock the way the author expected — not
+// that the Cascade FK fired, that the eligibility predicate actually excluded
+// the hidden person, or that the unique index held. The pure halves (bucketed
+// selection, thresholds) are unit tested with no database in
+// src/memories/curators/curator-rules.spec.ts.
+//
+// Time is pinned so "current year" and "last year" are deterministic and the
+// fixtures can be seeded on exact years relative to them.
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { randomUUID } from 'crypto';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { PersonHighlightsCurator } from '../../src/memories/curators/person-highlights.curator';
+import { PersonOverYearsCurator } from '../../src/memories/curators/person-over-years.curator';
+import { PERSON_OVER_YEARS_MAX_PER_YEAR } from '../../src/memories/curators/person-candidates';
+import { MemoryCuratorContext } from '../../src/memories/curators/memory-curator.interface';
+import { resolveMemoriesSettings } from '../../src/memories/memories-settings.util';
+import { MemoriesSettingsValue } from '../../src/common/types/settings.types';
+
+function resolveDatabaseUrl(): string {
+  if (process.env['DATABASE_URL']) return process.env['DATABASE_URL'] as string;
+  const host = process.env['POSTGRES_HOST'] ?? 'localhost';
+  const port = process.env['POSTGRES_PORT'] ?? '5432';
+  const user = process.env['POSTGRES_USER'] ?? 'postgres';
+  const password = process.env['POSTGRES_PASSWORD'] ?? 'postgres';
+  const db = process.env['POSTGRES_DB'] ?? 'appdb';
+  return `postgresql://${user}:${encodeURIComponent(password)}@${host}:${port}/${db}`;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+
+/** Fixed clock — "this year" is 2026, "last year" 2025. */
+const NOW = new Date(Date.UTC(2026, 7, 9, 12, 0, 0));
+
+describeMaybeDb('Memories — people curators (DB_GATED: real PostgreSQL)', () => {
+  let prisma: PrismaClient;
+  let curation: MemoryCurationService;
+  let highlights: PersonHighlightsCurator;
+  let overYears: PersonOverYearsCurator;
+
+  const userId = randomUUID();
+  const circleId = randomUUID();
+  /** A second, deliberately face-less circle — the no-persons degradation case. */
+  const emptyCircleId = randomUUID();
+  const createdStorageObjectIds: string[] = [];
+
+  function ctx(over: Partial<MemoryCuratorContext> = {}): MemoryCuratorContext {
+    return {
+      circleId,
+      settings: resolveMemoriesSettings(undefined),
+      now: NOW,
+      backfill: false,
+      ...over,
+    };
+  }
+
+  function settingsWithPeople(
+    people: Partial<MemoriesSettingsValue['people']>,
+  ): MemoriesSettingsValue {
+    return resolveMemoriesSettings({ people } as Partial<MemoriesSettingsValue>);
+  }
+
+  async function seedItem(options: {
+    capturedAt: Date | null;
+    circle?: string;
+    favorite?: boolean;
+    sharpnessScore?: number | null;
+    type?: 'photo' | 'video';
+    durationMs?: number | null;
+    archivedAt?: Date | null;
+    deletedAt?: Date | null;
+    socialMediaSource?: string | null;
+  }): Promise<string> {
+    const storageObjectId = randomUUID();
+    createdStorageObjectIds.push(storageObjectId);
+    await prisma.storageObject.create({
+      data: {
+        id: storageObjectId,
+        name: `${storageObjectId}.jpg`,
+        size: BigInt(2048),
+        mimeType: 'image/jpeg',
+        storageKey: `memories-people/${storageObjectId}`,
+        status: 'ready',
+        uploadedById: userId,
+      },
+    });
+    const item = await prisma.mediaItem.create({
+      data: {
+        storageObjectId,
+        circleId: options.circle ?? circleId,
+        addedById: userId,
+        type: options.type ?? 'photo',
+        source: 'web',
+        originalFilename: `${storageObjectId}.jpg`,
+        capturedAt: options.capturedAt,
+        favorite: options.favorite ?? false,
+        sharpnessScore: options.sharpnessScore ?? null,
+        durationMs: options.durationMs ?? null,
+        archivedAt: options.archivedAt ?? null,
+        deletedAt: options.deletedAt ?? null,
+        socialMediaSource: options.socialMediaSource ?? null,
+      },
+      select: { id: true },
+    });
+    return item.id;
+  }
+
+  async function seedPerson(options: {
+    name?: string | null;
+    favorite?: boolean;
+    hiddenAt?: Date | null;
+    deletedAt?: Date | null;
+    circle?: string;
+  }): Promise<string> {
+    const person = await prisma.person.create({
+      data: {
+        circleId: options.circle ?? circleId,
+        addedById: userId,
+        name: options.name === undefined ? `Person ${randomUUID().slice(0, 8)}` : options.name,
+        favorite: options.favorite ?? true,
+        hiddenAt: options.hiddenAt ?? null,
+        deletedAt: options.deletedAt ?? null,
+      },
+      select: { id: true },
+    });
+    return person.id;
+  }
+
+  async function seedFace(options: {
+    mediaItemId: string;
+    personId: string | null;
+    circle?: string;
+    confidence?: number | null;
+    hiddenAt?: Date | null;
+  }): Promise<string> {
+    const face = await prisma.face.create({
+      data: {
+        mediaItemId: options.mediaItemId,
+        circleId: options.circle ?? circleId,
+        personId: options.personId,
+        boundingBox: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 },
+        confidence: options.confidence ?? 0.9,
+        embedding: [],
+        providerKey: 'compreface',
+        modelVersion: 'test',
+        hiddenAt: options.hiddenAt ?? null,
+      },
+      select: { id: true },
+    });
+    return face.id;
+  }
+
+  /** `count` photos of `personId` in `year`, one per day from Jan 2. */
+  async function seedPersonYear(
+    personId: string,
+    year: number,
+    count: number,
+    over: { favorite?: boolean; confidence?: number } = {},
+  ): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i += 1) {
+      const id = await seedItem({
+        capturedAt: new Date(Date.UTC(year, 0, 2 + i, 10, 0, 0)),
+        favorite: over.favorite ?? false,
+      });
+      await seedFace({ mediaItemId: id, personId, confidence: over.confidence ?? 0.9 });
+      ids.push(id);
+    }
+    return ids;
+  }
+
+  async function clearAll(): Promise<void> {
+    await prisma.memory.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    await prisma.face.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    await prisma.person.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    await prisma.mediaItem.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    if (createdStorageObjectIds.length > 0) {
+      await prisma.storageObject.deleteMany({ where: { id: { in: createdStorageObjectIds } } });
+      createdStorageObjectIds.length = 0;
+    }
+  }
+
+  beforeAll(async () => {
+    const adapter = new PrismaPg({ connectionString: DATABASE_URL });
+    prisma = new PrismaClient({ adapter });
+    await prisma.$connect();
+
+    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    highlights = new PersonHighlightsCurator(prisma as unknown as PrismaService, curation);
+    overYears = new PersonOverYearsCurator(prisma as unknown as PrismaService, curation);
+
+    await prisma.user.create({
+      data: { id: userId, email: `memories-people-${userId}@example.test` },
+    });
+    await prisma.circle.create({
+      data: { id: circleId, name: 'Memories People Circle', ownerId: userId },
+    });
+    await prisma.circle.create({
+      data: { id: emptyCircleId, name: 'Memories People Empty', ownerId: userId },
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await clearAll().catch(() => undefined);
+    await prisma.circle.deleteMany({ where: { id: { in: [circleId, emptyCircleId] } } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.$disconnect();
+  }, 30000);
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Graceful degradation
+  // ---------------------------------------------------------------------------
+
+  it('skips cleanly when the circle has no persons at all', async () => {
+    // The epic's failure-mode matrix: no faces/persons ⇒ people curators skip,
+    // everything else unaffected. It must not throw and must not write.
+    await seedItem({ capturedAt: new Date(Date.UTC(2025, 5, 1)) });
+
+    await expect(highlights.run(ctx({ circleId: emptyCircleId }))).resolves.toEqual({
+      created: 0,
+      refreshed: 0,
+      skipped: 0,
+      tombstoned: 0,
+    });
+    await expect(overYears.run(ctx({ circleId: emptyCircleId }))).resolves.toEqual({
+      created: 0,
+      refreshed: 0,
+      skipped: 0,
+      tombstoned: 0,
+    });
+    expect(await prisma.memory.count({ where: { circleId: emptyCircleId } })).toBe(0);
+  });
+
+  it('skips a person who has no faces on any qualifying media', async () => {
+    const personId = await seedPerson({ name: 'Ghost' });
+    // Faces exist, but only on items the base filter rejects.
+    const archived = await seedItem({
+      capturedAt: new Date(Date.UTC(2025, 5, 1)),
+      archivedAt: new Date(),
+    });
+    await seedFace({ mediaItemId: archived, personId });
+
+    const result = await highlights.run(ctx());
+
+    expect(result.created).toBe(0);
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // person_highlights
+  // ---------------------------------------------------------------------------
+
+  it('creates one memory per qualifying year, keyed by year and personId', async () => {
+    const personId = await seedPerson({ name: 'Abuela' });
+    await seedPersonYear(personId, 2025, 10);
+    await seedPersonYear(personId, 2026, 9);
+    // Below the default minItems of 8 — must not produce a memory.
+    await seedPersonYear(personId, 2024, 4);
+
+    const result = await highlights.run(ctx());
+
+    const memories = await prisma.memory.findMany({
+      where: { circleId, type: 'person_highlights' },
+      orderBy: { periodKey: 'asc' },
+    });
+    expect(memories.map((m) => m.periodKey)).toEqual(['2025', '2026']);
+    expect(memories.every((m) => m.subjectKey === personId)).toBe(true);
+    expect(memories.every((m) => m.personId === personId)).toBe(true);
+    expect(memories[0]!.title).toBe('Best of Abuela');
+    expect(memories[0]!.subtitle).toBe('2025');
+    expect(memories[0]!.titleSource).toBe('template');
+    expect(result.created).toBe(2);
+    // 2024 is in scope (it is not current/previous year) only under backfill —
+    // scheduled runs never even look at it, so it is not counted as skipped.
+    expect(result.skipped).toBe(0);
+  });
+
+  it('limits a scheduled run to the current and previous year, and backfill to all', async () => {
+    const personId = await seedPerson({ name: 'Camila' });
+    for (const year of [2019, 2020, 2025, 2026]) await seedPersonYear(personId, year, 10);
+
+    await highlights.run(ctx());
+    expect(
+      (await prisma.memory.findMany({ where: { circleId, type: 'person_highlights' } }))
+        .map((m) => m.periodKey)
+        .sort(),
+    ).toEqual(['2025', '2026']);
+
+    await highlights.run(ctx({ backfill: true }));
+    expect(
+      (await prisma.memory.findMany({ where: { circleId, type: 'person_highlights' } }))
+        .map((m) => m.periodKey)
+        .sort(),
+    ).toEqual(['2019', '2020', '2025', '2026']);
+  });
+
+  it('excludes base-filter violations and archived faces from the item set', async () => {
+    const personId = await seedPerson({ name: 'Nora' });
+    const keep = await seedPersonYear(personId, 2025, 8);
+
+    // Each violates exactly one rule and must not appear.
+    const archived = await seedItem({
+      capturedAt: new Date(Date.UTC(2025, 6, 1)),
+      archivedAt: new Date(),
+    });
+    await seedFace({ mediaItemId: archived, personId });
+    const trashed = await seedItem({
+      capturedAt: new Date(Date.UTC(2025, 6, 2)),
+      deletedAt: new Date(),
+    });
+    await seedFace({ mediaItemId: trashed, personId });
+    const social = await seedItem({
+      capturedAt: new Date(Date.UTC(2025, 6, 3)),
+      socialMediaSource: 'tiktok',
+    });
+    await seedFace({ mediaItemId: social, personId });
+    // A LIVE item, but the person's face on it was archived — an archived face
+    // is no longer evidence the person is in that photo.
+    const hiddenFaceItem = await seedItem({ capturedAt: new Date(Date.UTC(2025, 6, 4)) });
+    await seedFace({ mediaItemId: hiddenFaceItem, personId, hiddenAt: new Date() });
+
+    await highlights.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_highlights', periodKey: '2025' },
+      include: { items: true },
+    });
+    expect(memory.items.map((i) => i.mediaItemId).sort()).toEqual([...keep].sort());
+  });
+
+  it('never generates for a hidden or soft-deleted person', async () => {
+    const hidden = await seedPerson({ name: 'Hidden', hiddenAt: new Date() });
+    const deleted = await seedPerson({ name: 'Deleted', deletedAt: new Date() });
+    await seedPersonYear(hidden, 2025, 12);
+    await seedPersonYear(deleted, 2025, 12);
+
+    await highlights.run(ctx());
+    await overYears.run(ctx());
+
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(0);
+  });
+
+  it('honours favoritesOnly, and widens to any named person when it is off', async () => {
+    const favorite = await seedPerson({ name: 'Favorite', favorite: true });
+    const plain = await seedPerson({ name: 'Plain', favorite: false });
+    await seedPersonYear(favorite, 2025, 10);
+    await seedPersonYear(plain, 2025, 10);
+
+    await highlights.run(ctx());
+    expect(
+      (await prisma.memory.findMany({ where: { circleId, type: 'person_highlights' } })).map(
+        (m) => m.subjectKey,
+      ),
+    ).toEqual([favorite]);
+
+    await highlights.run(ctx({ settings: settingsWithPeople({ favoritesOnly: false }) }));
+    expect(
+      (await prisma.memory.findMany({ where: { circleId, type: 'person_highlights' } }))
+        .map((m) => m.subjectKey)
+        .sort(),
+    ).toEqual([favorite, plain].sort());
+  });
+
+  it('ignores a person with neither a name nor a cover face', async () => {
+    // An unlabeled, uncovered cluster the user has never engaged with is not
+    // something to build "Best of …" around.
+    const anonymous = await seedPerson({ name: null });
+    await seedPersonYear(anonymous, 2025, 12);
+
+    await highlights.run(ctx({ settings: settingsWithPeople({ favoritesOnly: false }) }));
+
+    expect(await prisma.memory.count({ where: { circleId } })).toBe(0);
+  });
+
+  it('includes an unnamed person that has a cover face, with the generic title', async () => {
+    const personId = await seedPerson({ name: null });
+    const items = await seedPersonYear(personId, 2025, 10);
+    const coverFace = await seedFace({ mediaItemId: items[0]!, personId });
+    await prisma.person.update({ where: { id: personId }, data: { coverFaceId: coverFace } });
+
+    await highlights.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_highlights' },
+    });
+    expect(memory.title).toBe('Best moments together');
+  });
+
+  it('prefers the item carrying the person’s highest-confidence face as cover', async () => {
+    const personId = await seedPerson({ name: 'Cover' });
+    const items = await seedPersonYear(personId, 2025, 9, { confidence: 0.5 });
+    // The engine's own cover rule would pick the highest-SCORED item; make a
+    // different item the one where this person is most confidently detected.
+    const star = items[6]!;
+    await prisma.face.updateMany({ where: { mediaItemId: star, personId }, data: { confidence: 0.99 } });
+    // …and make a different item score highest, so the two rules disagree.
+    await prisma.mediaItem.update({ where: { id: items[0]! }, data: { favorite: true } });
+
+    await highlights.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_highlights' },
+    });
+    expect(memory.coverMediaItemId).toBe(star);
+  });
+
+  // ---------------------------------------------------------------------------
+  // person_over_years
+  // ---------------------------------------------------------------------------
+
+  it('requires at least three distinct years', async () => {
+    const twoYears = await seedPerson({ name: 'Two' });
+    await seedPersonYear(twoYears, 2024, 8);
+    await seedPersonYear(twoYears, 2025, 8);
+
+    const result = await overYears.run(ctx());
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await prisma.memory.count({ where: { circleId, type: 'person_over_years' } })).toBe(0);
+  });
+
+  it('creates one all-time memory keyed by personId, spanning every year', async () => {
+    const personId = await seedPerson({ name: 'Camila' });
+    for (const year of [2022, 2023, 2024, 2025]) await seedPersonYear(personId, year, 6);
+
+    const result = await overYears.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_over_years' },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+    expect(result.created).toBe(1);
+    expect(memory.periodKey).toBe('all');
+    expect(memory.subjectKey).toBe(personId);
+    expect(memory.personId).toBe(personId);
+    expect(memory.title).toBe('Camila through the years');
+    expect(memory.subtitle).toBe('2022–2025');
+    expect(memory.meta).toMatchObject({ firstYear: 2022, lastYear: 2025, yearCount: 4 });
+
+    // Year-bucketed: every year represented, none above the per-year cap.
+    const items = await prisma.mediaItem.findMany({
+      where: { id: { in: memory.items.map((i) => i.mediaItemId) } },
+      select: { id: true, capturedAt: true },
+    });
+    const perYear = new Map<number, number>();
+    for (const item of items) {
+      const year = item.capturedAt!.getUTCFullYear();
+      perYear.set(year, (perYear.get(year) ?? 0) + 1);
+    }
+    expect([...perYear.keys()].sort()).toEqual([2022, 2023, 2024, 2025]);
+    expect([...perYear.values()].every((n) => n <= PERSON_OVER_YEARS_MAX_PER_YEAR)).toBe(true);
+  });
+
+  it('orders items chronologically — the "growing up" effect', async () => {
+    const personId = await seedPerson({ name: 'Growing' });
+    for (const year of [2018, 2021, 2024]) await seedPersonYear(personId, year, 6);
+
+    await overYears.run(ctx());
+
+    const memory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_over_years' },
+      include: { items: { orderBy: { position: 'asc' } } },
+    });
+    const captured = await Promise.all(
+      memory.items.map(async (item) => {
+        const media = await prisma.mediaItem.findUniqueOrThrow({
+          where: { id: item.mediaItemId },
+          select: { capturedAt: true },
+        });
+        return media.capturedAt!.getTime();
+      }),
+    );
+    expect(captured).toEqual([...captured].sort((a, b) => a - b));
+  });
+
+  it('behaves identically under backfill, since its period is always "all"', async () => {
+    const personId = await seedPerson({ name: 'Same' });
+    for (const year of [2022, 2023, 2024]) await seedPersonYear(personId, year, 6);
+
+    await overYears.run(ctx());
+    const first = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_over_years' },
+    });
+
+    const second = await overYears.run(ctx({ backfill: true }));
+
+    expect(second.created).toBe(0);
+    expect(second.refreshed).toBe(1);
+    expect(await prisma.memory.count({ where: { circleId, type: 'person_over_years' } })).toBe(1);
+    expect(
+      (await prisma.memory.findFirstOrThrow({ where: { id: first.id } })).id,
+    ).toBe(first.id);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency, tombstones, and the person cascade
+  // ---------------------------------------------------------------------------
+
+  it('is idempotent: a second run refreshes in place and creates nothing', async () => {
+    const personId = await seedPerson({ name: 'Idem' });
+    for (const year of [2024, 2025, 2026]) await seedPersonYear(personId, year, 10);
+
+    await highlights.run(ctx());
+    await overYears.run(ctx());
+    const before = await prisma.memory.findMany({
+      where: { circleId },
+      orderBy: [{ type: 'asc' }, { periodKey: 'asc' }],
+      select: { id: true, type: true, periodKey: true, itemCount: true },
+    });
+
+    const h = await highlights.run(ctx());
+    const o = await overYears.run(ctx());
+
+    const after = await prisma.memory.findMany({
+      where: { circleId },
+      orderBy: [{ type: 'asc' }, { periodKey: 'asc' }],
+      select: { id: true, type: true, periodKey: true, itemCount: true },
+    });
+    expect(h.created).toBe(0);
+    expect(o.created).toBe(0);
+    // Same rows, same ids, same membership — not a fresh set that happens to
+    // look alike.
+    expect(after).toEqual(before);
+  });
+
+  it('never recreates a tombstoned person memory', async () => {
+    const personId = await seedPerson({ name: 'Tombstone' });
+    for (const year of [2024, 2025, 2026]) await seedPersonYear(personId, year, 10);
+    await highlights.run(ctx());
+    await overYears.run(ctx());
+
+    const doomed = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_highlights', periodKey: '2025' },
+    });
+    const overYearsMemory = await prisma.memory.findFirstOrThrow({
+      where: { circleId, type: 'person_over_years' },
+    });
+    const deletedAt = new Date();
+    await prisma.memory.updateMany({
+      where: { id: { in: [doomed.id, overYearsMemory.id] } },
+      data: { deletedAt, itemCount: 0 },
+    });
+
+    const h = await highlights.run(ctx());
+    const o = await overYears.run(ctx());
+
+    expect(h.tombstoned).toBe(1);
+    expect(o.tombstoned).toBe(1);
+    for (const id of [doomed.id, overYearsMemory.id]) {
+      const row = await prisma.memory.findUniqueOrThrow({ where: { id } });
+      // Untouched: still tombstoned, still zeroed, not refreshed back to life.
+      expect(row.deletedAt).not.toBeNull();
+      expect(row.itemCount).toBe(0);
+    }
+  });
+
+  it('cascades a person’s memories away on delete and regenerates under the survivor', async () => {
+    // The merge shape: source is soft-deleted and its faces are reassigned to
+    // the target, exactly as PeopleService.merge does.
+    const source = await seedPerson({ name: 'Source' });
+    const target = await seedPerson({ name: 'Target' });
+    for (const year of [2024, 2025, 2026]) await seedPersonYear(source, year, 10);
+    for (const year of [2024, 2025, 2026]) await seedPersonYear(target, year, 10);
+
+    await highlights.run(ctx());
+    await overYears.run(ctx());
+    expect(await prisma.memory.count({ where: { circleId, personId: source } })).toBeGreaterThan(0);
+
+    await prisma.face.updateMany({ where: { personId: source }, data: { personId: target } });
+    await prisma.person.update({
+      where: { id: source },
+      data: { deletedAt: new Date(), mergedIntoId: target },
+    });
+    // Hard-deleting the person is what a real delete does; the merge leaves the
+    // row soft-deleted, which alone only stops FUTURE generation. Assert the
+    // Cascade FK for the hard-delete case.
+    const survivingBefore = await prisma.memory.count({ where: { circleId, personId: target } });
+    await prisma.person.delete({ where: { id: source } });
+
+    expect(await prisma.memory.count({ where: { circleId, personId: source } })).toBe(0);
+    expect(await prisma.memory.count({ where: { circleId, personId: target } })).toBe(
+      survivingBefore,
+    );
+
+    // The next run regenerates under the survivor, now holding both face sets.
+    const h = await highlights.run(ctx());
+    const o = await overYears.run(ctx());
+    expect(h.created + h.refreshed).toBeGreaterThan(0);
+    expect(o.refreshed).toBe(1);
+    expect(await prisma.memory.count({ where: { circleId, personId: source } })).toBe(0);
+  });
+
+  it('respects a raised minItems', async () => {
+    const personId = await seedPerson({ name: 'Strict' });
+    await seedPersonYear(personId, 2025, 10);
+
+    await highlights.run(ctx({ settings: settingsWithPeople({ minItems: 20 }) }));
+
+    expect(await prisma.memory.count({ where: { circleId, type: 'person_highlights' } })).toBe(0);
+  });
+});

--- a/apps/api/test/memories/memories-periodic.integration.spec.ts
+++ b/apps/api/test/memories/memories-periodic.integration.spec.ts
@@ -1,0 +1,682 @@
+// DB_GATED: requires a real PostgreSQL with migrations applied. Reachability is
+// probed synchronously at module load via `describeMaybeDb`, so with no database
+// the whole suite is registered as `describe.skip` and reports SKIPPED — never a
+// green PASS that asserted nothing. See test/helpers/db-probe.helper.ts.
+//
+// WHY THIS SUITE IS DB-BACKED AND NOT MOCKED
+// ------------------------------------------
+// Issue #305's theme/seasonal/year acceptance criteria are statements about SQL
+// and about rows: "manual-only tags don't produce themes (source='ai' is
+// required)", "a disabled tag_label stops producing", "the completed season and
+// the December year-in-review generate on schedule while backfill fills
+// history", "no AI tags ⇒ the theme curator skips cleanly and the others are
+// unaffected". Against a mocked Prisma those would restate the implementation
+// rather than prove the three-way join, the enum predicate or the census sum.
+// The pure halves (tag ranking, the December/January window, denylist,
+// bucketing) are unit tested with no database in
+// src/memories/curators/curator-rules.spec.ts.
+//
+// Time is pinned so "the most recently completed season" and the year-in-review
+// window are deterministic.
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { randomUUID } from 'crypto';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { ThemeCurator } from '../../src/memories/curators/theme.curator';
+import { SeasonalCurator } from '../../src/memories/curators/seasonal.curator';
+import { YearInReviewCurator } from '../../src/memories/curators/year-in-review.curator';
+import { MemoryCuratorContext } from '../../src/memories/curators/memory-curator.interface';
+import { resolveMemoriesSettings } from '../../src/memories/memories-settings.util';
+import { MemoriesSettingsValue } from '../../src/common/types/settings.types';
+
+function resolveDatabaseUrl(): string {
+  if (process.env['DATABASE_URL']) return process.env['DATABASE_URL'] as string;
+  const host = process.env['POSTGRES_HOST'] ?? 'localhost';
+  const port = process.env['POSTGRES_PORT'] ?? '5432';
+  const user = process.env['POSTGRES_USER'] ?? 'postgres';
+  const password = process.env['POSTGRES_PASSWORD'] ?? 'postgres';
+  const db = process.env['POSTGRES_DB'] ?? 'appdb';
+  return `postgresql://${user}:${encodeURIComponent(password)}@${host}:${port}/${db}`;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+
+/**
+ * Fixed clock: 2026-08-09. Most recently completed season is spring 2026
+ * (Mar–May); the year-in-review window is closed (August is neither December
+ * nor January).
+ */
+const NOW = new Date(Date.UTC(2026, 7, 9, 12, 0, 0));
+/** Inside the year-in-review window, for the December half of the rule. */
+const DECEMBER_NOW = new Date(Date.UTC(2026, 11, 5, 12, 0, 0));
+/** Inside the January half of the same rule — the New Year reminiscing window. */
+const JANUARY_NOW = new Date(Date.UTC(2027, 0, 20, 12, 0, 0));
+/** The January that makes 2025 the scheduled review year. */
+const JANUARY_2026 = new Date(Date.UTC(2026, 0, 20, 12, 0, 0));
+
+describeMaybeDb('Memories — theme / seasonal / year-in-review (DB_GATED: real PostgreSQL)', () => {
+  let prisma: PrismaClient;
+  let curation: MemoryCurationService;
+  let theme: ThemeCurator;
+  let seasonal: SeasonalCurator;
+  let yearInReview: YearInReviewCurator;
+
+  const userId = randomUUID();
+  const circleId = randomUUID();
+  const emptyCircleId = randomUUID();
+  const createdStorageObjectIds: string[] = [];
+  /** TagLabel.name is GLOBALLY unique, so only labels this suite created are removed. */
+  const createdTagLabelIds: string[] = [];
+
+  function ctx(over: Partial<MemoryCuratorContext> = {}): MemoryCuratorContext {
+    return {
+      circleId,
+      settings: resolveMemoriesSettings(undefined),
+      now: NOW,
+      backfill: false,
+      ...over,
+    };
+  }
+
+  function settingsWithThemes(
+    themes: Partial<MemoriesSettingsValue['themes']>,
+  ): MemoriesSettingsValue {
+    return resolveMemoriesSettings({ themes } as Partial<MemoriesSettingsValue>);
+  }
+
+  async function seedItem(options: {
+    capturedAt: Date | null;
+    circle?: string;
+    favorite?: boolean;
+    type?: 'photo' | 'video';
+    durationMs?: number | null;
+    archivedAt?: Date | null;
+    deletedAt?: Date | null;
+    socialMediaSource?: string | null;
+  }): Promise<string> {
+    const storageObjectId = randomUUID();
+    createdStorageObjectIds.push(storageObjectId);
+    await prisma.storageObject.create({
+      data: {
+        id: storageObjectId,
+        name: `${storageObjectId}.jpg`,
+        size: BigInt(2048),
+        mimeType: 'image/jpeg',
+        storageKey: `memories-periodic/${storageObjectId}`,
+        status: 'ready',
+        uploadedById: userId,
+      },
+    });
+    const item = await prisma.mediaItem.create({
+      data: {
+        storageObjectId,
+        circleId: options.circle ?? circleId,
+        addedById: userId,
+        type: options.type ?? 'photo',
+        source: 'web',
+        originalFilename: `${storageObjectId}.jpg`,
+        capturedAt: options.capturedAt,
+        favorite: options.favorite ?? false,
+        durationMs: options.durationMs ?? null,
+        archivedAt: options.archivedAt ?? null,
+        deletedAt: options.deletedAt ?? null,
+        socialMediaSource: options.socialMediaSource ?? null,
+      },
+      select: { id: true },
+    });
+    return item.id;
+  }
+
+  /** A circle Tag plus (optionally) its global vocabulary entry. */
+  async function seedTag(
+    name: string,
+    options: { label?: boolean; labelEnabled?: boolean } = {},
+  ): Promise<string> {
+    const tag = await prisma.tag.create({
+      data: { circleId, addedById: userId, name },
+      select: { id: true },
+    });
+    if (options.label !== false) {
+      const label = await prisma.tagLabel.upsert({
+        where: { name },
+        update: { enabled: options.labelEnabled ?? true },
+        create: { name, enabled: options.labelEnabled ?? true },
+        select: { id: true },
+      });
+      createdTagLabelIds.push(label.id);
+    }
+    return tag.id;
+  }
+
+  async function tagItems(
+    tagId: string,
+    mediaItemIds: string[],
+    source: 'ai' | 'manual' = 'ai',
+  ): Promise<void> {
+    await prisma.mediaTag.createMany({
+      data: mediaItemIds.map((mediaItemId) => ({ tagId, mediaItemId, source })),
+    });
+  }
+
+  /** `count` photos, one per day starting at the given UTC month/day. */
+  async function seedDays(
+    year: number,
+    month0: number,
+    day: number,
+    count: number,
+    over: { circle?: string; favorite?: boolean } = {},
+  ): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i += 1) {
+      ids.push(
+        await seedItem({
+          capturedAt: new Date(Date.UTC(year, month0, day + i, 10, 0, 0)),
+          circle: over.circle,
+          favorite: over.favorite ?? false,
+        }),
+      );
+    }
+    return ids;
+  }
+
+  async function clearAll(): Promise<void> {
+    await prisma.memory.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    await prisma.mediaItem.deleteMany({ where: { circleId: { in: [circleId, emptyCircleId] } } });
+    await prisma.tag.deleteMany({ where: { circleId } });
+    if (createdTagLabelIds.length > 0) {
+      await prisma.tagLabel.deleteMany({ where: { id: { in: createdTagLabelIds } } });
+      createdTagLabelIds.length = 0;
+    }
+    if (createdStorageObjectIds.length > 0) {
+      await prisma.storageObject.deleteMany({ where: { id: { in: createdStorageObjectIds } } });
+      createdStorageObjectIds.length = 0;
+    }
+  }
+
+  beforeAll(async () => {
+    const adapter = new PrismaPg({ connectionString: DATABASE_URL });
+    prisma = new PrismaClient({ adapter });
+    await prisma.$connect();
+
+    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    theme = new ThemeCurator(prisma as unknown as PrismaService, curation);
+    seasonal = new SeasonalCurator(prisma as unknown as PrismaService, curation);
+    yearInReview = new YearInReviewCurator(prisma as unknown as PrismaService, curation);
+
+    await prisma.user.create({
+      data: { id: userId, email: `memories-periodic-${userId}@example.test` },
+    });
+    await prisma.circle.create({
+      data: { id: circleId, name: 'Memories Periodic Circle', ownerId: userId },
+    });
+    await prisma.circle.create({
+      data: { id: emptyCircleId, name: 'Memories Periodic Empty', ownerId: userId },
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await clearAll().catch(() => undefined);
+    await prisma.circle.deleteMany({ where: { id: { in: [circleId, emptyCircleId] } } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.$disconnect();
+  }, 30000);
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  // ===========================================================================
+  // Theme
+  // ===========================================================================
+
+  describe('theme curator', () => {
+    it('skips cleanly when the circle has no AI tags at all', async () => {
+      // The epic's failure-mode matrix: no AI tags ⇒ theme curator skips,
+      // everything else unaffected.
+      await seedDays(2026, 4, 1, 12);
+
+      await expect(theme.run(ctx())).resolves.toEqual({
+        created: 0,
+        refreshed: 0,
+        skipped: 0,
+        tombstoned: 0,
+      });
+      expect(await prisma.memory.count({ where: { circleId, type: 'theme' } })).toBe(0);
+    });
+
+    it('creates a memory for an AI-tagged theme, keyed by year and lowercased tag', async () => {
+      const items = await seedDays(2026, 2, 1, 12);
+      const tagId = await seedTag('Sunset');
+      await tagItems(tagId, items);
+
+      const result = await theme.run(ctx());
+
+      const memory = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'theme' },
+      });
+      expect(result.created).toBe(1);
+      expect(memory.periodKey).toBe('2026');
+      // Lowercased regardless of the Tag row's own casing, per the enum contract.
+      expect(memory.subjectKey).toBe('sunset');
+      expect(memory.title).toBe('Sunset');
+      expect(memory.meta).toMatchObject({ tag: 'sunset', year: 2026 });
+      expect(memory.personId).toBeNull();
+    });
+
+    it('ignores manual tag instances — source=ai is required', async () => {
+      const items = await seedDays(2026, 2, 1, 12);
+      const tagId = await seedTag('Taxes');
+      await tagItems(tagId, items, 'manual');
+
+      await theme.run(ctx());
+
+      expect(await prisma.memory.count({ where: { circleId, type: 'theme' } })).toBe(0);
+    });
+
+    it('ignores a tag whose vocabulary label is disabled or absent', async () => {
+      const disabledItems = await seedDays(2026, 2, 1, 12);
+      const disabled = await seedTag('Retired', { labelEnabled: false });
+      await tagItems(disabled, disabledItems);
+
+      const unknownItems = await seedDays(2026, 3, 1, 12);
+      const unknown = await seedTag('NotInVocabulary', { label: false });
+      await tagItems(unknown, unknownItems);
+
+      await theme.run(ctx());
+
+      expect(await prisma.memory.count({ where: { circleId, type: 'theme' } })).toBe(0);
+    });
+
+    it('never produces a memory for a denylisted tag', async () => {
+      const items = await seedDays(2026, 2, 1, 15);
+      const tagId = await seedTag('screenshot');
+      await tagItems(tagId, items);
+
+      await theme.run(ctx());
+
+      expect(await prisma.memory.count({ where: { circleId, type: 'theme' } })).toBe(0);
+    });
+
+    it('drops tags below minItems and keeps only the top maxPerPeriod', async () => {
+      const beach = await seedTag('beach');
+      const sunset = await seedTag('sunset');
+      const pets = await seedTag('pets');
+      const sparse = await seedTag('sparse');
+      await tagItems(beach, await seedDays(2026, 1, 1, 20));
+      await tagItems(sunset, await seedDays(2026, 2, 1, 16));
+      await tagItems(pets, await seedDays(2026, 3, 1, 12));
+      await tagItems(sparse, await seedDays(2026, 4, 1, 3));
+
+      await theme.run(ctx({ settings: settingsWithThemes({ maxPerPeriod: 2 }) }));
+
+      const memories = await prisma.memory.findMany({
+        where: { circleId, type: 'theme' },
+        orderBy: { subjectKey: 'asc' },
+      });
+      // Densest two only; "pets" qualifies on minItems but loses the ranking,
+      // "sparse" never qualifies at all.
+      expect(memories.map((m) => m.subjectKey)).toEqual(['beach', 'sunset']);
+    });
+
+    it('excludes base-filter violations from the item set and from ranking', async () => {
+      const keep = await seedDays(2026, 2, 1, 9);
+      const archived = await seedItem({
+        capturedAt: new Date(Date.UTC(2026, 2, 20)),
+        archivedAt: new Date(),
+      });
+      const trashed = await seedItem({
+        capturedAt: new Date(Date.UTC(2026, 2, 21)),
+        deletedAt: new Date(),
+      });
+      const social = await seedItem({
+        capturedAt: new Date(Date.UTC(2026, 2, 22)),
+        socialMediaSource: 'tiktok',
+      });
+      const undated = await seedItem({ capturedAt: null });
+      const tagId = await seedTag('sunset');
+      await tagItems(tagId, [...keep, archived, trashed, social, undated]);
+
+      await theme.run(ctx());
+
+      const memory = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'theme' },
+        include: { items: true },
+      });
+      expect(memory.items.map((i) => i.mediaItemId).sort()).toEqual([...keep].sort());
+    });
+
+    it('generates only the current year on a scheduled run, and per-year plus all on backfill', async () => {
+      const tagId = await seedTag('sunset');
+      await tagItems(tagId, await seedDays(2024, 2, 1, 10));
+      await tagItems(tagId, await seedDays(2026, 2, 1, 10));
+
+      await theme.run(ctx());
+      expect(
+        (await prisma.memory.findMany({ where: { circleId, type: 'theme' } })).map(
+          (m) => m.periodKey,
+        ),
+      ).toEqual(['2026']);
+
+      await theme.run(ctx({ backfill: true }));
+      expect(
+        (await prisma.memory.findMany({ where: { circleId, type: 'theme' } }))
+          .map((m) => m.periodKey)
+          .sort(),
+      ).toEqual(['2024', '2026', 'all']);
+
+      const all = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'theme', periodKey: 'all' },
+      });
+      // The all-history memory draws from BOTH years, which is the whole point
+      // of having one: neither year alone would need to clear the floor.
+      expect(all.periodStart.getUTCFullYear()).toBe(2024);
+      expect(all.periodEnd.getUTCFullYear()).toBe(2026);
+    });
+
+    it('never recreates a tombstoned theme', async () => {
+      const tagId = await seedTag('sunset');
+      await tagItems(tagId, await seedDays(2026, 2, 1, 12));
+      await theme.run(ctx());
+
+      const memory = await prisma.memory.findFirstOrThrow({ where: { circleId, type: 'theme' } });
+      await prisma.memory.update({
+        where: { id: memory.id },
+        data: { deletedAt: new Date(), itemCount: 0 },
+      });
+
+      const result = await theme.run(ctx());
+
+      expect(result.tombstoned).toBe(1);
+      const after = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+      expect(after.deletedAt).not.toBeNull();
+      expect(after.itemCount).toBe(0);
+    });
+
+    it('is idempotent across runs', async () => {
+      const tagId = await seedTag('sunset');
+      await tagItems(tagId, await seedDays(2026, 2, 1, 12));
+
+      await theme.run(ctx());
+      const before = await prisma.memory.findMany({
+        where: { circleId, type: 'theme' },
+        select: { id: true, periodKey: true, subjectKey: true, itemCount: true },
+      });
+
+      const second = await theme.run(ctx());
+
+      expect(second.created).toBe(0);
+      expect(second.refreshed).toBe(1);
+      expect(
+        await prisma.memory.findMany({
+          where: { circleId, type: 'theme' },
+          select: { id: true, periodKey: true, subjectKey: true, itemCount: true },
+        }),
+      ).toEqual(before);
+    });
+  });
+
+  // ===========================================================================
+  // Seasonal
+  // ===========================================================================
+
+  describe('seasonal curator', () => {
+    it('generates the most recently COMPLETED season and not the one in progress', async () => {
+      // Spring 2026 (Mar–May) is complete; summer 2026 is still running.
+      await seedDays(2026, 3, 1, 14);
+      await seedDays(2026, 6, 1, 20);
+
+      const result = await seasonal.run(ctx());
+
+      const memories = await prisma.memory.findMany({ where: { circleId, type: 'seasonal' } });
+      expect(result.created).toBe(1);
+      expect(memories.map((m) => m.periodKey)).toEqual(['2026-spring']);
+      expect(memories[0]!.title).toBe('Spring 2026');
+      expect(memories[0]!.subjectKey).toBe('');
+      expect(memories[0]!.expiresAt).toBeNull();
+    });
+
+    it('skips a season below minItems without curating', async () => {
+      await seedDays(2026, 3, 1, 5);
+
+      const result = await seasonal.run(ctx());
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(await prisma.memory.count({ where: { circleId, type: 'seasonal' } })).toBe(0);
+    });
+
+    it('files a December photo under the winter of ITS OWN year, spanning into January', async () => {
+      // Winter 2025 = Dec 2025 through Feb 2026. Both halves must land in one
+      // memory keyed to 2025, which is the whole reason the season year exists.
+      const december = await seedDays(2025, 11, 5, 7);
+      const january = await seedDays(2026, 0, 5, 7);
+
+      await seasonal.run(ctx({ backfill: true }));
+
+      const winter = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'seasonal', periodKey: '2025-winter' },
+        include: { items: true },
+      });
+      const ids = winter.items.map((i) => i.mediaItemId);
+      expect(ids.some((id) => december.includes(id))).toBe(true);
+      expect(ids.some((id) => january.includes(id))).toBe(true);
+      expect(winter.title).toBe('Winter 2025');
+    });
+
+    it('sweeps every completed season with material on backfill', async () => {
+      await seedDays(2025, 6, 1, 14); // summer 2025
+      await seedDays(2025, 9, 1, 14); // fall 2025
+      await seedDays(2026, 3, 1, 14); // spring 2026
+      await seedDays(2026, 6, 1, 14); // summer 2026 — still running
+
+      await seasonal.run(ctx({ backfill: true }));
+
+      expect(
+        (await prisma.memory.findMany({ where: { circleId, type: 'seasonal' } }))
+          .map((m) => m.periodKey)
+          .sort(),
+      ).toEqual(['2025-fall', '2025-summer', '2026-spring']);
+    });
+
+    it('produces nothing for a circle whose only photos are in the running season', async () => {
+      await seedDays(2026, 6, 1, 30);
+
+      await seasonal.run(ctx({ backfill: true }));
+
+      expect(await prisma.memory.count({ where: { circleId, type: 'seasonal' } })).toBe(0);
+    });
+
+    it('never recreates a tombstoned season', async () => {
+      await seedDays(2026, 3, 1, 14);
+      await seasonal.run(ctx());
+      const memory = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'seasonal' },
+      });
+      await prisma.memory.update({
+        where: { id: memory.id },
+        data: { deletedAt: new Date(), itemCount: 0 },
+      });
+
+      const result = await seasonal.run(ctx());
+
+      expect(result.tombstoned).toBe(1);
+      const after = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+      expect(after.deletedAt).not.toBeNull();
+      expect(after.itemCount).toBe(0);
+    });
+
+    it('is idempotent and returns nothing on an empty circle', async () => {
+      await seedDays(2026, 3, 1, 14);
+      await seasonal.run(ctx());
+      const before = await prisma.memory.findMany({
+        where: { circleId, type: 'seasonal' },
+        select: { id: true, periodKey: true, itemCount: true },
+      });
+
+      const second = await seasonal.run(ctx());
+
+      expect(second.created).toBe(0);
+      expect(second.refreshed).toBe(1);
+      expect(
+        await prisma.memory.findMany({
+          where: { circleId, type: 'seasonal' },
+          select: { id: true, periodKey: true, itemCount: true },
+        }),
+      ).toEqual(before);
+
+      await expect(seasonal.run(ctx({ circleId: emptyCircleId }))).resolves.toEqual({
+        created: 0,
+        refreshed: 0,
+        skipped: 0,
+        tombstoned: 0,
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Year in review
+  // ===========================================================================
+
+  describe('year-in-review curator', () => {
+    it('generates nothing outside the December/January window', async () => {
+      await seedDays(2025, 3, 1, 20);
+
+      const result = await yearInReview.run(ctx());
+
+      expect(result).toEqual({ created: 0, refreshed: 0, skipped: 0, tombstoned: 0 });
+      expect(await prisma.memory.count({ where: { circleId, type: 'year_in_review' } })).toBe(0);
+    });
+
+    it('generates for the current year during December', async () => {
+      await seedDays(2026, 3, 1, 20);
+
+      await yearInReview.run(ctx({ now: DECEMBER_NOW }));
+
+      const memory = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'year_in_review' },
+      });
+      expect(memory.periodKey).toBe('2026');
+      expect(memory.subjectKey).toBe('');
+      expect(memory.title).toBe('Your 2026 in review');
+      expect(memory.subtitle).toMatch(/highlights from the year$/);
+    });
+
+    it('keeps generating for the previous year through January', async () => {
+      await seedDays(2026, 3, 1, 20);
+
+      await yearInReview.run(ctx({ now: JANUARY_NOW }));
+
+      expect(
+        (await prisma.memory.findMany({ where: { circleId, type: 'year_in_review' } })).map(
+          (m) => m.periodKey,
+        ),
+      ).toEqual(['2026']);
+    });
+
+    it('spreads items across months rather than clustering on the busiest one', async () => {
+      // 28 photos in March, 6 each in June and October. Equal-span diversity
+      // would still favour the dense cluster; month buckets must not.
+      await seedDays(2025, 2, 1, 28);
+      await seedDays(2025, 5, 1, 6);
+      await seedDays(2025, 9, 1, 6);
+
+      await yearInReview.run(ctx({ now: JANUARY_2026 }));
+
+      const memory = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'year_in_review', periodKey: '2025' },
+        include: { items: true },
+      });
+      const items = await prisma.mediaItem.findMany({
+        where: { id: { in: memory.items.map((i) => i.mediaItemId) } },
+        select: { capturedAt: true },
+      });
+      const months = new Set(items.map((i) => i.capturedAt!.getUTCMonth()));
+      expect([...months].sort((a, b) => a - b)).toEqual([2, 5, 9]);
+      // June and October have 6 candidates each and both are represented well
+      // beyond the single item an equal-span split would have guaranteed.
+      expect(items.filter((i) => i.capturedAt!.getUTCMonth() === 5).length).toBeGreaterThan(1);
+      expect(memory.meta).toMatchObject({ year: 2025, monthsCovered: 3 });
+    });
+
+    it('backfills every past year but refuses the still-running current one', async () => {
+      await seedDays(2023, 3, 1, 20);
+      await seedDays(2025, 3, 1, 20);
+      await seedDays(2026, 3, 1, 20);
+
+      await yearInReview.run(ctx({ backfill: true }));
+
+      // NOW is August 2026, so 2026 is not eligible yet — a three-month "Your
+      // 2026 in review" would churn for the rest of the year.
+      expect(
+        (await prisma.memory.findMany({ where: { circleId, type: 'year_in_review' } }))
+          .map((m) => m.periodKey)
+          .sort(),
+      ).toEqual(['2023', '2025']);
+
+      await yearInReview.run(ctx({ backfill: true, now: DECEMBER_NOW }));
+      expect(
+        (await prisma.memory.findMany({ where: { circleId, type: 'year_in_review' } }))
+          .map((m) => m.periodKey)
+          .sort(),
+      ).toEqual(['2023', '2025', '2026']);
+    });
+
+    it('skips a year below minItems', async () => {
+      await seedDays(2026, 3, 1, 10);
+
+      const result = await yearInReview.run(ctx({ now: DECEMBER_NOW }));
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(await prisma.memory.count({ where: { circleId, type: 'year_in_review' } })).toBe(0);
+    });
+
+    it('never recreates a tombstoned year in review, and is otherwise idempotent', async () => {
+      await seedDays(2026, 3, 1, 20);
+      await yearInReview.run(ctx({ now: DECEMBER_NOW }));
+      const memory = await prisma.memory.findFirstOrThrow({
+        where: { circleId, type: 'year_in_review' },
+      });
+
+      const refresh = await yearInReview.run(ctx({ now: DECEMBER_NOW }));
+      expect(refresh.created).toBe(0);
+      expect(refresh.refreshed).toBe(1);
+
+      await prisma.memory.update({
+        where: { id: memory.id },
+        data: { deletedAt: new Date(), itemCount: 0 },
+      });
+      const result = await yearInReview.run(ctx({ now: DECEMBER_NOW }));
+
+      expect(result.tombstoned).toBe(1);
+      const after = await prisma.memory.findUniqueOrThrow({ where: { id: memory.id } });
+      expect(after.deletedAt).not.toBeNull();
+      expect(after.itemCount).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Independence
+  // ===========================================================================
+
+  it('leaves the other curators unaffected when one has nothing to work with', async () => {
+    // Enough material for the most recently completed season (fall 2026, as of
+    // DECEMBER_NOW) and for the 2026 year in review, but zero AI tags. Per the
+    // epic's failure-mode matrix the theme curator must skip silently while
+    // seasonal and year-in-review still produce.
+    await seedDays(2026, 3, 1, 20);
+    await seedDays(2026, 9, 1, 20);
+
+    const themeResult = await theme.run(ctx({ now: DECEMBER_NOW }));
+    const seasonalResult = await seasonal.run(ctx({ now: DECEMBER_NOW }));
+    const yearResult = await yearInReview.run(ctx({ now: DECEMBER_NOW }));
+
+    expect(themeResult.created).toBe(0);
+    expect(seasonalResult.created).toBe(1);
+    expect(yearResult.created).toBe(1);
+  });
+});

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.4 (data model + generation plumbing + curation engine, On This Day & Trips) |
+| **Version** | 0.5 (data model + generation plumbing + curation engine; all seven curators) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304); §5–§8 and §10 are placeholders for later issues in epic #300 |
+| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305); §5–§8 and §10 are placeholders for later issues in epic #300 |
 
 ---
 
@@ -312,6 +312,10 @@ Selection is **deterministic**: ties break on `(selectionScore, capturedAt, id)`
 
 Final items are ordered **chronologically ascending** with contiguous `position` values. The cover is the highest-scored **non-video** item; a video is never a cover (cover art renders as a still, and a poster frame is a different — usually worse — image than any photo in the set). An all-video memory simply has `coverMediaItemId = NULL`.
 
+**Calendar bucketing is an opt-in second policy** (`selectByBuckets()`, added by #305, selected per call via `CurateOptions.bucketBy`). Equal time spans cannot express "every year appears" or "every month appears" — for a person photographed heavily in 2016 and again in 2025 with a quiet stretch between, equal thirds of the elapsed span put two buckets inside the same busy period. The bucketed policy takes an explicit key function (`yearBucket` for `person_over_years`, `monthBucket` for `year_in_review`) and fills **round-robin**: every bucket contributes its best item before any bucket contributes a second, so the `maxItems` cut stays unbiased rather than exhausting the earliest buckets. An optional `maxPerBucket` bounds any one bucket's share, which matters when buckets are few relative to the budget. The 3-video cap behaves exactly as above — a rejected video does not cost its bucket its turn, the bucket simply advances to its next candidate. Every other curator uses the default policy and passes nothing.
+
+Both policies are pure and exported, and both are unit-tested with plain object literals (`memory-curation.pure.spec.ts`, `curators/curator-rules.spec.ts`).
+
 ### 4.6 Template titles
 
 `memory-title-templates.ts` is pure, I/O-free, and covers all seven types:
@@ -422,7 +426,7 @@ Overlap is computed against `meta.startDate`/`meta.endDate` — the **detected**
 
 **Tombstoned trips take part in matching.** This is what makes §2.5's contract hold here at all: `upsertMemory`'s own tombstone check is keyed on `(periodKey, subjectKey)`, and a shifted boundary carries *different* keys, so a key-only check would sail straight past a deleted trip and insert a fresh one. A run overlapping a tombstone is refused before any curation work.
 
-**A drifted subject re-titles.** When a better reverse-geocode changes the dominant locality, the row is re-keyed *and* `upsertMemory` is called with `retitle: true` — an optional flag (default `false`, so every other caller is unchanged) added for exactly this case. §4.9's anti-churn rule exists to protect a title that is still accurate; a memory keyed `playa-grande` and titled "Trip to Tamarindo" is not aged, it is falsified. An ordinary refresh — one photo joining — still preserves the title, AI ones included.
+**A drifted subject re-titles.** When a better reverse-geocode changes the dominant locality, the row is re-keyed *and* `upsertMemory` is called with `retitle: true` — an optional flag (default `false`, so every other caller is unchanged) added for exactly this case. §4.12's anti-churn rule exists to protect a title that is still accurate; a memory keyed `playa-grande` and titled "Trip to Tamarindo" is not aged, it is falsified. An ordinary refresh — one photo joining — still preserves the title, AI ones included.
 
 If the slot a re-key would move into is already held by a *different* memory, the row keeps its current identity and refreshes there instead. The keys are an identity, not data: a stale-but-stable one beats either a failed unique-index write or deleting a memory a user may have favorited.
 
@@ -449,10 +453,128 @@ So #304 adds **no migration**. The one known cost is inherited from §4.2's `loa
 
 - **A day straddling the ±180° antimeridian gets a meaningless median longitude**, and the home centroid has the same weakness (it is a plain mean). Both would misclassify a Fiji/Kiribati-area day. Documented rather than solved: the fix is circular-mean arithmetic like `interpolateLng`'s in the location-inference engine, and it is not worth the complexity until someone is affected.
 - **A day whose photos are split ~50/50 between home and a destination** can produce a marginal median that is at neither — a phantom point built from one cluster's latitude and the other's longitude. Real travel days are not bimodal; a fixture of ours was, which is how this surfaced.
-- **A trip that no longer detects is not deleted**, per §4.12's general rule — the curator only upserts runs that still qualify.
+- **A trip that no longer detects is not deleted**, per §4.15's general rule — the curator only upserts runs that still qualify.
 - **`trips.minItems` above `maxItemsPerMemory`** can never be satisfied, since curation caps the selection first. Both are admin-settable within their own bounds and the combination is not cross-validated.
 
-### 4.9 Idempotent regeneration — `upsertMemory()`
+### 4.9 The People curators
+
+Issue [#305](https://github.com/marinoscar/MemoriaHub/issues/305). Two memory types, one shared notion of who counts: `person_highlights` ("Best of Abuela, 2025" — one memory per person **per year**) and `person_over_years` ("Camila through the years" — one memory per person, spanning everything). This is the face-recognition payoff, and the pair users most often go looking for on purpose rather than stumbling into.
+
+| | `person_highlights` | `person_over_years` |
+|---|---|---|
+| `periodKey` | the calendar year, `"2025"` | `"all"` |
+| `subjectKey` | `personId` | `personId` |
+| `personId` column | set | set |
+| `meta` | `{ year, personName, generatorVersion }` | `{ firstYear, lastYear, yearCount, personName, generatorVersion }` |
+| Floor | `memories.people.minItems` (8) curated items | same, plus **≥3 distinct years** of material |
+| Diversity | engine default (equal time buckets) | **year buckets**, ≤4 items per year |
+| `expiresAt` | `NULL` — a person memory stays relevant | `NULL` |
+
+**Eligibility is one rule, in one place** (`curators/person-candidates.ts`), shared by both curators so they cannot drift on the question with the most policy in it. A person qualifies when they are live (`deletedAt IS NULL`), not circle-hidden (`hiddenAt IS NULL`), identifiable (a non-empty `name` **or** a `coverFaceId`), and — when `memories.people.favoritesOnly` is on, which is the default — marked `favorite`. The "non-empty" half is tightened in memory rather than in SQL: Prisma cannot express `trim(name) <> ''`, and a person named `"   "` with no cover face would otherwise get a memory titled after nothing.
+
+**Per-user hidden-people preferences are deliberately NOT applied here.** Memories are circle-scoped content generated once for everybody; whose faces a given user does not want to see is a per-user preference, and applying it at generation time would mean either generating per user (N× the rows and N× the cost) or letting whichever user's preferences were read first decide for the whole circle. That filtering is read-time and belongs to [#307](https://github.com/marinoscar/MemoriaHub/issues/307). See §11 for the item-level limitation the epic accepts alongside it.
+
+**An archived face does not count.** The census and both curators require `faces.hidden_at IS NULL`, mirroring the archive semantics of `PATCH /api/people/faces/bulk/hide`: an archived face is no longer evidence the person is in that photo, so it must not qualify a year they are effectively absent from.
+
+**One grouped census decides what is worth curating.** A single query returns `COUNT(DISTINCT media_item)` per `(person, year)` for the whole circle — `persons × years-with-data` rows, a few hundred — and only pairs already clearing `minItems` on raw counts get a `curate()` pass. The alternative (streaming every person's candidates through the engine to discover most person-years are short) would page the library once per person. `COUNT(DISTINCT)` rather than `COUNT(*)` because one media item can carry several faces of the same person — a video's cross-frame identity rows, or a genuine second detection — and it is still one photo.
+
+The census can only ever **over**-count relative to the curated set (collapse and the video cap remove items, never add), so a pair under the floor there cannot clear it afterwards. That is what makes the pre-filter sound rather than merely cheap.
+
+**Person predicates go to the engine, not into an id list.** Both curators hand `faces: { some: { personId, hiddenAt: null } }` to `curate()` as part of the slice `where`, so the base filter, the keyset streaming and near-duplicate collapse all apply exactly as they do for every other type — there is no parallel selection path.
+
+**Scheduled runs do the current and previous year; backfill does all of them.** "Last year" stays in scope well into the following autumn because a December import lands in the previous year's memory long after that year ended. `person_over_years` has no such narrowing: its period is always `"all"`, so scheduled and backfill runs do identical work.
+
+#### Why `person_over_years` needs its own diversity policy
+
+The engine's `selectDiverse` divides the memory's **time span** into equal buckets. For a person photographed heavily in 2016 and again in 2025 with a quiet stretch between, equal thirds of nine elapsed years put two buckets inside the same busy period and none in the middle — and the entire promise of this type is "every year appears", which is a statement about the calendar rather than about elapsed time.
+
+So #305 adds `selectByBuckets()` to the engine and an opt-in `CurateOptions.bucketBy` (§4.5), used here with `key = capturedAt's UTC year` and `maxPerBucket = 4`. It is **round-robin, not bucket-at-a-time**: every year contributes its best item in round 1, its second-best in round 2, and so on, so a 30-item budget over twelve years yields at least two items from every year rather than four each from the first seven and nothing after. Bucket-at-a-time filling would reproduce precisely the chronological bias the policy exists to remove. The per-year cap is what lets quiet years appear at all; four photos of one prolific year is plenty, and issue #305 fixes the "2–4 items per year" range.
+
+The **≥3-year floor** is what separates the two types. Two years is not "through the years", it is two years, and the per-year highlight memories already tell that story better. It is checked on the census (years with any material) rather than on the curated set, so a person whose middle year loses its slots to the item cap still qualifies.
+
+#### Cover preference
+
+A person memory's cover is the curated item carrying that person's **highest-confidence face** (photos only, NULLs sorted last, id tiebreak), overriding the engine's generic "highest-scored non-video item". In a memory built from group shots the engine's choice is easily the frame where the subject is a blur in the background. When nothing qualifies — an all-video selection, or only NULL-confidence faces — the engine's cover stands.
+
+#### Person delete and merge
+
+`Memory.personId` is a **Cascade** FK, and that is the entire cleanup story:
+
+- **Delete** removes the person's memories outright, never leaving one dangling against a person who no longer exists.
+- **Merge** (`PeopleService.merge`) reassigns the source's faces to the target and **soft**-deletes the source, which drops it out of `loadEligiblePersons`. The source's memories stop being regenerated immediately; the next run refreshes the survivor's memories over the now-larger face set.
+
+Neither curator tries to migrate, repair or re-key anything on a merge, and that is deliberate: regenerating under the survivor is both simpler and more correct than transplanting a memory whose item set was curated from a different candidate pool.
+
+#### Bounds
+
+`MAX_ELIGIBLE_PERSONS` (500) caps the persons considered in one pass — reachable only with `favoritesOnly = false` in a circle with a very large cluster population, where the work would otherwise be `persons × years` curation passes. The ordering is deterministic (favorites first, then id) so the cut is stable across runs rather than reshuffling which persons get memories, and it logs a warning. A crash guard, not a tuning knob.
+
+### 4.10 The Theme curator
+
+Issue #305. "Golden Sunsets", "Beach", "Pets" — memories built from the AI auto-tagging vocabulary, and the only type whose subject is a piece of **admin-controlled configuration** rather than something the library derived on its own.
+
+| Field | Value |
+|---|---|
+| `periodKey` | the calendar year `"2025"`, or `"all"` for the whole-history period |
+| `subjectKey` | the tag name, **lowercased** |
+| `meta` | `{ tag, year, generatorVersion }` (`year: null` for the all-history period) |
+| Floor | `memories.themes.minItems` (8) curated items |
+| Cap | `memories.themes.maxPerPeriod` (3) memories per period |
+
+**Why the tag vocabulary and not CLIP clustering.** Unsupervised embedding clustering would find themes nobody named, but its output is unexplainable ("here are 40 photos that are near each other in a 512-dimensional space") and untunable. Tag themes are explainable, already computed, free, and admin-controllable — an admin who does not want "Food" memories disables that label. Epic #300 defers clustering explicitly.
+
+**Three filters decide which tags become memories:**
+
+1. **`media_tags.source = 'ai'`.** A manually applied tag is a filing decision, not a claim about content; a user who tagged 200 photos "Taxes" did not ask for a memory about it. The distinction exists in the schema precisely because AI and manual tag instances are governed by different rules.
+2. **The label is still `enabled` in `tag_labels`.** Disabling a label is how an admin retires a concept, and a retired concept must stop producing memories without anyone hunting down what it already generated. The join is on `LOWER(name)`, so a tag whose label was deleted outright — which leaves manual `media_tags` rows behind, per `DELETE /api/tag-labels/:id` — cannot resurrect a retired theme either.
+3. **`THEME_TAG_DENYLIST`** — `screenshot`, `screenshots`, `document`, `documents`, `text`, `whiteboard`. A handful of vocabulary entries describe an artifact rather than a moment. They score *well* (screenshots are sharp and often favorited for reference) and would produce genuinely bad memories. Deliberately tiny and hand-maintained rather than heuristic.
+
+**Ranking is by distinct qualifying items, and the memory is still curated.** One grouped query returns `COUNT(DISTINCT media_item)` per `(LOWER(tag), year)` for the circle; the top `maxPerPeriod` become memories. So "the top themes" means the themes with the most material, while each memory is that theme's *best* photos — favorites-weighted, near-duplicate collapsed — not all of them.
+
+**The all-history period is an exact sum, not an approximation.** A media item has exactly one `capturedAt` and therefore contributes to exactly one year's distinct count, so a tag's per-year counts *partition* its all-history set with no overlap to correct for. That is what lets one grouped query serve every period, and it is unit-tested directly.
+
+**Scheduled runs do the current year only** — the only period a new upload can change, and the one a user is most likely to be shown. **Backfill** does every year with material *plus* the all-history period, which is what makes a young, thinly-spread library produce themes at all: a circle whose photos are scattered across eight years may have no single year clearing `minItems` for "Sunsets" while having plenty overall.
+
+**Walking past a tag that falls short.** The rule is "the top N tags that produce at least `minItems` **curated** items", which cannot be evaluated without curating — a tag can clear the raw census and then fall short once near-duplicates collapse. When that happens the curator continues down the ranking rather than producing fewer memories, bounded at `maxPerPeriod × 3` attempts per period so a circle with 200 sparse tags cannot turn one period into 200 curation passes. Ties in the ranking break on tag name, so which themes exist is stable across runs over an unchanged library.
+
+**A tombstoned theme still consumes a slot.** The user deleted *that* theme for *that* period; quietly promoting the next-ranked tag into its place would read as the delete having done nothing.
+
+### 4.11 The Seasonal and Year-in-Review curators
+
+Issue #305. The whole-library payoff: no subject, no clustering, no AI signal required. Everything interesting about these two is **which** date range and **when**.
+
+| | `seasonal` | `year_in_review` |
+|---|---|---|
+| `periodKey` | `"2025-summer"` — year is the year the season **starts** | `"2025"` |
+| `subjectKey` | `""` (unused) | `""` (unused) |
+| `meta` | `{ season, seasonYear, seasonOrdinal, generatorVersion }` | `{ year, monthsCovered, generatorVersion }` |
+| Floor | `memories.seasonal.minItems` (12) | `memories.yearInReview.minItems` (15) |
+| Diversity | engine default | **month buckets**, no per-bucket cap |
+| `expiresAt` | `NULL` | `NULL` |
+
+Both gate on a **shared per-month census** (`curators/circle-month-counts.ts`): one `GROUP BY (year, month)` aggregate returning at most `12 × years-of-history` rows, from which a period's raw count is a range sum. A period under its floor therefore costs **no candidate scan at all**. Its `WHERE` clause is the base filter hand-written for raw SQL, and it must stay identical to `memoryCandidateBaseWhere()` — a census that counted archived items would send a curator off to curate a period that then comes back short. The integration suite asserts the two agree.
+
+#### Seasonal
+
+**Only completed seasons.** A "Summer 2026" memory generated in July would be a partial summer, and every subsequent generation run would rewrite it as more photos landed — churning the item set and, once [#306](https://github.com/marinoscar/MemoriaHub/issues/306) lands, re-paying for an AI title, daily, for three months. Waiting until the season has fully elapsed makes the memory stable the moment it is created. `mostRecentCompletedSeason()` owns that rule.
+
+**The season year is the year the season STARTS.** Northern-hemisphere meteorological winter runs December Y → February Y+1, so `2025-winter` legitimately contains January 2026 photos and its `periodKey` disagrees with a naive `getUTCFullYear()` of its own contents. `seasonOf()` performs that fold once, centrally; `seasonForMonth()` in the title templates answers only "which season is month N" and knows nothing about years.
+
+The season **ordinal** — the arithmetic that makes "the previous season" well-defined — orders seasons `spring, summer, fall, winter` *within* a season year, not alphabetically or winter-first. Winter Y begins in December Y, i.e. **after** fall Y; ordering it first would make `previousSeason(spring 2026)` return fall 2024 instead of winter 2025, silently skipping a year. This is the one piece of the file most worth its unit tests.
+
+**Scheduled runs do exactly one season** — there is only ever one that can newly qualify between two runs — so the daily job costs one census query plus at most one curation pass. **Backfill** enumerates every completed season from the circle's oldest material forward, contiguously (a gap season is cheap: its raw count is zero and it is skipped before any query). A circle whose only photos sit inside the still-running season produces nothing, which falls out of the enumeration returning empty for an inverted range rather than needing a special case.
+
+#### Year in Review
+
+**Generated during December of Y and all of January Y+1.** December because the year-in-review is a December ritual and the memory has to *exist* before anyone looks for it — [#311](https://github.com/marinoscar/MemoriaHub/issues/311)'s digest and notification producers announce content generation must already have produced. All of January because "your year in review" is exactly what people go looking for over New Year, and a memory that only ever appeared for 31 days in December would be gone by the time most of the circle noticed. Outside that window a scheduled run generates nothing and does not touch the database at all.
+
+The December half means a review **is** generated for a year with three weeks left to run, with late-December uploads landing through refresh. That is the deliberate trade: an existing-but-slightly-early memory beats a missing one, and `upsertMemory`'s Jaccard rule (§4.12) keeps the refresh from churning the title unless the additions are material. Backfill applies the same completeness rule — every past year, plus the current one only once December has arrived — so a mid-year backfill never mints a three-month "Your 2026 in review" that then churns for the rest of the year.
+
+**Bucketed by month.** A year in review whose thirty photos all come from one two-week holiday is not a year in review. Equal-span diversity is the same thing as month bucketing *only if* the year's material is spread across it; a library with a six-month gap collapses into two dense clusters. `bucketBy: { key: monthBucket }` states the intent structurally instead. No per-bucket cap is set: with twelve buckets and a 30-item budget the round-robin already yields two to three items a month, and a year whose material is genuinely concentrated in four months should be allowed to fill its slots from those four.
+
+`monthBucket` is **year-qualified** (`year * 12 + monthIndex`) rather than a bare 0–11 month, so January 2024 and January 2025 can never merge into one bucket if a future caller hands the policy a range wider than a year.
+
+### 4.12 Idempotent regeneration — `upsertMemory()`
 
 Every curator writes through this one method, keyed on `@@unique([circleId, type, periodKey, subjectKey])`.
 
@@ -468,9 +590,11 @@ Every curator writes through this one method, keyed on `@@unique([circleId, type
 
 `meta.generatorVersion` (currently `1`) is stamped centrally on every write. Bump it when scoring or selection changes in a way that would produce a different item set from identical inputs — it is the only way to tell, after the fact, which algorithm produced a given memory.
 
-### 4.10 Registry and per-curator error isolation
+### 4.13 Registry and per-curator error isolation
 
-Curators are injected as an array under the `MEMORY_CURATORS` token (`memoryCuratorsProvider`, which moved to its own `curators/memory-curators.provider.ts` in #304 once it imported more than one curator — a file that also *defines* a curator importing its siblings is a needless coupling and an easy way to grow an import cycle), so #305 adds a provider plus one entry in that factory and touches nothing else. Order is execution order, cheapest-first: On This Day runs two bounded functional-index queries, Trips streams the circle's geo history. `MemoryGenerationHandler` iterates it:
+Curators are injected as an array under the `MEMORY_CURATORS` token (`memoryCuratorsProvider`, which moved to its own `curators/memory-curators.provider.ts` in #304 once it imported more than one curator — a file that also *defines* a curator importing its siblings is a needless coupling and an easy way to grow an import cycle). Adding a memory type is a provider plus one entry in that factory and nothing else, which is exactly what #305 did for its five: the handler was not touched.
+
+Order is execution order, cheapest-first: On This Day runs two bounded functional-index queries; Trips streams the circle's geo history; the people and theme curators answer a grouped census before curating anything; seasonal and year-in-review each curate one full calendar period. A job cut short by a timeout has then produced the daily content users actually see on Home. `MemoryGenerationHandler` iterates the array:
 
 - each curator is gated by **its own** `memories.<type>.enabled` toggle, checked via `MemoryCurator.isEnabled(settings)` rather than a stringly-typed settings key on the registry entry;
 - each `run()` is **individually try/caught**, and so is each `purge()`;
@@ -481,15 +605,20 @@ This is a correctness requirement, not politeness. The seven types are independe
 
 One wall clock (`ctx.now`) is captured once by the handler and shared by every curator, so a run that straddles midnight cannot have one curator anchoring on today and the next on tomorrow.
 
-### 4.11 Settings resolution
+### 4.14 Settings resolution
 
 `resolveMemoriesSettings()` deep-merges the stored `memories.*` namespace over `DEFAULT_SYSTEM_SETTINGS.memories` **once per generation job**, so curators read `settings.onThisDay.minItems` unconditionally and never carry their own `?? 10` fallbacks. The namespace is genuinely optional on an older JSONB row — that is what makes it migration-free (§9.2) — and per-curator fallbacks would be a fourth hand-maintained copy of every default, on top of the three §9.3 already warns about.
 
-### 4.12 Known gaps
+### 4.15 Known gaps
 
 - **A period that falls below `minItems` after items are removed keeps its existing memory.** Curators only upsert periods that still qualify; they do not delete a memory whose material has since been trashed. Its `MemoryItem` rows for hard-deleted media cascade away and `itemCount` is corrected on the next refresh, but a memory whose items were all *soft*-deleted lingers until read-time filtering ([#307](https://github.com/marinoscar/MemoriaHub/issues/307)) hides it. Deleting it automatically was rejected for v1: a curator silently destroying a memory a user may have favorited is a worse failure than a stale one.
 - **Backfill is unchunked.** A full On This Day backfill for a dense circle is up to 366 anchors × `lookbackYears` curations in one job, which can approach `ENRICHMENT_JOB_TIMEOUT_MS`. It is memory-safe (nothing accumulates across anchors) and restartable (every write is idempotent), but chunking the admin backfill into multiple jobs belongs to #315.
 - **Truncation is chronologically biased.** When `DEFAULT_MAX_CANDIDATES` is hit the scan keeps the earliest candidates. See §4.2 for why that is accepted as a crash guard rather than solved.
+- **`person_highlights` never writes `periodKey = 'all'`,** although the `MemoryType` enum reserves it. An all-time view of a person is what `person_over_years` already is, and generating both would produce two near-identical memories for the same subject. The key shape is kept available for a future variant.
+- **`themes.minItems` / `seasonal.minItems` / `yearInReview.minItems` above `maxItemsPerMemory`** can never be satisfied, since curation caps the selection first — the same un-cross-validated combination already noted for `trips.minItems` in §4.8.
+- **A theme's identity is its tag name.** Renaming a `TagLabel` produces a new `subjectKey` and therefore a new memory, orphaning the old row (which is then never refreshed) rather than re-keying it in place the way a drifted trip is (§4.8). Tag renames are rare and admin-driven; the trips machinery exists because trip boundaries move on their own.
+- **`MAX_ELIGIBLE_PERSONS` truncation is silent to the user.** It logs a warning and is only reachable with `favoritesOnly = false` in a circle with a very large cluster population — see §4.9.
+- **Seasons are northern-hemisphere only.** `SEASON_LABELS` / `seasonForMonth` centralize the assumption (§4.6) so a hemisphere or locale setting replaces one table, but no such setting exists yet: a southern-hemisphere circle gets "Summer 2025" over its actual winter.
 
 ## 5. AI Titles, Subtitles & Narratives
 
@@ -600,6 +729,7 @@ Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/is
 | Version | Date | Author | Changes |
 |---|---|---|---|
 | 0.1 | August 2026 | AI Assistant | Initial specification for issue #301: the `MemoryType` enum, the `Memory`/`MemoryItem`/`MemoryUserState` data model, the `periodKey`/`subjectKey` semantics, the tombstone contract, cascade summary, and alternatives considered. Sections 3–10 are placeholders for later issues in epic #300. |
+| 0.5 | August 2026 | AI Assistant | Issue #305: added §4.9 (the People curators — the one shared eligibility rule and why per-user hidden people are deliberately excluded from generation, the archived-face exclusion, the grouped `(person, year)` census and why over-counting makes the pre-filter sound, the year-bucketed diversity policy and the >=3-year floor that separates the two types, the highest-confidence cover override, and the Cascade-FK delete/merge story), §4.10 (the Theme curator — the tag-vocabulary-over-clustering rationale, the three filters `source='ai'` / enabled label / denylist, ranking by distinct qualifying items with the exact per-year sum behind the all-history period, walking past a short tag under a bounded attempt cap, and why a tombstoned theme consumes its slot), and §4.11 (Seasonal & Year-in-Review — the shared per-month census, completed-seasons-only and the season-year fold with its spring-first ordinal, and the December/January window plus month bucketing). Extended §4.5 with the opt-in `selectByBuckets` calendar policy, rewrote §4.13's registry paragraph for the full seven, and added five known gaps to §4.15. Renumbered the former §4.9–§4.12 to §4.12–§4.15 so the curator sections stay together. §5–§8 and §10 remain placeholders. |
 | 0.4 | August 2026 | AI Assistant | Issue #304: added §4.8 (the Trips curator — fixed-24-month home inference with the 30% modal-share floor and the same-floor `geoAdmin1` fallback, median-based three-way away/home/neutral day classification and the coordinate-less metadata fallback that can only add an away day, gap-tolerant run merging where a home day terminates rather than bridges, the >=50%-of-the-SHORTER-span overlap matching that re-keys a boundary-shifted trip in place instead of duplicating it, tombstone participation in that matching, the `retitle` flag for a drifted subject, backfill and its flat-memory streaming aggregation, the EXPLAIN-verified reuse of `media_items_gallery_idx` with no new migration, and known gaps). Renumbered the former §4.8–§4.11 to §4.9–§4.12 so the curator sections sit together. §5–§8 and §10 remain placeholders. |
 | 0.3 | August 2026 | AI Assistant | Issue #303: filled in §4 (Curation Engine — the structural base filter, constant-memory keyset candidate streaming with per-page batched signal lookups, the scoring weights and the neutral-NULL-sharpness rule, the pure-score-vs-selectionScore split for the long-video preference, burst/duplicate collapse and its burst-wins precedence, time-bucket diversity with the 3-video cap, deterministic ordering and the never-a-video cover rule, template titles for all seven types, the On This Day curator with its today+tomorrow anchors / one-query-per-anchor design / new circle-scoped functional index / backfill anchor widening / retention tail, the `upsertMemory()` idempotency and tombstone contract with its Jaccard title-preservation rule, the curator registry and per-curator error isolation, settings resolution, and known gaps). §5–§8 and §10 remain placeholders. |
 | 0.2 | August 2026 | AI Assistant | Issue #302: filled in §3 (Generation — `MemoriesGenerationTask`'s three gates and zero-cost-when-off contract, the mandatory `skipDedup: true` rationale, the server-only `MemoryGenerationHandler` and its no-node-pair system-mode inference, job labels, and the `JobReason.backfill` deviation from the issue text) and §9 (Settings — `features.memories` + the `MEMORIES_ENABLED` kill-switch and their shared `isMemoriesEnabled()` gate, the full `memories.*` bounds/defaults table, the three-hand-maintained-copies pitfall, and `ai.features.memories` with its up-front credential validation). §4–§8 and §10 remain placeholders. |


### PR DESCRIPTION
## Summary

The remaining five memory types — `person_highlights`, `person_over_years`, `theme`, `seasonal`, `year_in_review` — completing the curator catalogue. All register through #304's `memory-curators.provider.ts` and reuse #303's engine; no parallel scoring/selection/upsert path.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #300
Fixes #305

## Changes Made

**New** (`apps/api/src/memories/curators/`) — `period-windows.ts` (pure UTC year/month/season algebra), `circle-month-counts.ts` (shared month census), `person-candidates.ts` (shared person eligibility + census + cover preference), and the five curators.

**Modified** — `memory-curation.service.ts` (adds `selectByBuckets` + `CurateOptions.bucketBy`), `memory-curators.provider.ts`, `memories.module.ts`, `docs/specs/memories.md` (§4.9–§4.11 new, §4.5/§4.13/§4.15 extended).

**No migration.** Every query is served by existing indexes (`faces(person_id)`, `media_tags(tag_id, media_item_id)`, `tags(circle_id)`, `media_items_gallery_idx`); all three raw SQL statements were smoke-tested directly against the test database.

### Selection logic and key derivation

| Curator | Slice / selection | `periodKey` · `subjectKey` |
|---|---|---|
| `person_highlights` | Eligible persons × year; engine default diversity; cover overridden to that person's highest-confidence face | `"YYYY"` · `personId` |
| `person_over_years` | Same persons, ≥3 distinct years, whole history; **year buckets, ≤4/year** | `"all"` · `personId` |
| `theme` | Top-N AI tags by distinct qualifying items | `"YYYY"` or `"all"` · lowercased tag |
| `seasonal` | Most recently *completed* season (backfill: all) | `"2025-summer"` · `""` |
| `year_in_review` | Dec of Y + all of Y; **month buckets** | `"YYYY"` · `""` |

Person eligibility (`deletedAt`/`hiddenAt` null, name-or-cover, `favoritesOnly`) is shared between the two person curators so they cannot drift apart. Both person curators and both periodic curators gate on a cheap grouped census before curating — and the census can only ever *over*-count relative to curation, which is what makes the pre-filter sound rather than merely cheap. Theme requires `source='ai'` plus an enabled `tag_labels` row, minus a 6-entry denylist.

Per-user hidden people are deliberately **not** applied here — that is read-side filtering owned by #307.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
memories + curator suites:  Test Suites: 16 passed, 16 total
                            Tests:     334 passed, 334 total

full test:ci:               295 suites, 6963 passed / 71 skipped
```

Only failures are the pre-existing malformed-UUID fixture suites (`circles/migration-backfill`, `notifications/notification-dedup`). Nothing new fails.

Both new integration suites genuinely ran against live PostgreSQL rather than skipping. Tombstone, idempotency, base-filter exclusion, and graceful degradation are asserted **per memory type**. The person-cascade test performs a real merge-shape soft-delete *and* a hard delete, then asserts the FK removes the memories and that the next run regenerates them under the surviving person.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Judgement calls worth a reviewer's opinion:

- **`person_highlights` never writes `periodKey='all'`.** The issue's implementation text is per-year only, and `person_over_years` already *is* the all-time view of a person — emitting both would produce two near-identical memories for one subject. The enum's reserved `'all'` shape is documented as unused in §4.15.
- **The engine gained a second selection policy rather than each curator rolling its own.** `selectDiverse`'s equal-time buckets cannot express "every year must appear", so `selectByBuckets` + `CurateOptions.bucketBy` was added. Every existing curator is byte-for-byte unaffected.
- **`themes.maxPerPeriod` reads as "top N tags that yield ≥`minItems` *curated* items"**, so the curator walks past a tag that clears the raw census but falls short after collapse — bounded at `maxPerPeriod × 3` attempts per period. A tombstoned theme still consumes its slot (rationale in §4.10).
- **Year-in-review and seasonal backfill apply the same completeness rule as the scheduled window**, so a mid-year backfill won't mint a three-month "Your 2026 in review".
- Prettier flags these files, but it flags the pre-existing #303/#304 curator files too and formatting isn't enforced in CI — so only the three lines newly written over 100 columns were wrapped, rather than reformatting and churning neighbours.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_