### PR TITLE
feat(api): Memories AI titles, subtitles &amp; narratives with template fallback (#306)

### DIFF
--- a/apps/api/src/ai/providers/ai-provider.interface.ts
+++ b/apps/api/src/ai/providers/ai-provider.interface.ts
@@ -32,6 +32,21 @@ export interface ChatRequest {
   system?: string;
   messages: ChatMessage[];
   tools?: AiToolDef[];
+  /**
+   * Sampling temperature, forwarded verbatim when set and omitted entirely
+   * when absent — so every existing caller keeps the provider's own default.
+   *
+   * Added for Memories title generation (epic #300, issue #306), which wants
+   * moderate creativity (~0.7) rather than the near-deterministic output the
+   * agentic-search path relies on.
+   *
+   * CAVEAT: some newer OpenAI reasoning models accept only the default
+   * temperature and reject an explicit value with a 400. That is a graceful
+   * degradation for the one caller that sets it (memory titling falls back to
+   * deterministic templates), but it is the reason this stays opt-in rather
+   * than becoming a default on `ChatRequest`.
+   */
+  temperature?: number;
 }
 
 export type ChatStreamEvent =

--- a/apps/api/src/ai/providers/anthropic.provider.ts
+++ b/apps/api/src/ai/providers/anthropic.provider.ts
@@ -86,6 +86,7 @@ export class AnthropicProvider implements AiProvider {
       model: req.model || ANTHROPIC_DEFAULT_MODEL,
       max_tokens: 16000,
       messages,
+      ...(req.temperature !== undefined && { temperature: req.temperature }),
       ...(req.system && { system: req.system }),
       ...(tools && { tools }),
     };

--- a/apps/api/src/ai/providers/openai.provider.ts
+++ b/apps/api/src/ai/providers/openai.provider.ts
@@ -132,6 +132,7 @@ export class OpenAiProvider implements AiProvider {
       model: req.model,
       stream: true,
       messages,
+      ...(req.temperature !== undefined && { temperature: req.temperature }),
       ...(tools && {
         tools,
         // Limit to one tool call per response so the per-tool assistant+result

--- a/apps/api/src/memories/curation/memory-curation.service.ts
+++ b/apps/api/src/memories/curation/memory-curation.service.ts
@@ -40,11 +40,23 @@
 //    material change (Jaccard distance >= 30% on the media-item id set) resets
 //    titling. Without this, every generation run would discard and re-pay for
 //    AI titles because one photo joined.
+//
+// 5. AI TITLING RUNS OUTSIDE THE WRITE TRANSACTION (#306). `MemoryTitleService`
+//    makes a network call bounded at 10 seconds; doing that inside
+//    `$transaction` would hold row locks and a pool connection for its whole
+//    duration. Every fact the prompt needs comes from the selection the curator
+//    already computed, so titling happens BEFORE the transaction opens — and it
+//    happens only on the two paths that reset titling (create, and a material
+//    refresh), never on a minor refresh. Its result is optional by contract: a
+//    `null` means "write the template", which is exactly what this file did
+//    before #306 existed.
 // =============================================================================
 
 import { Injectable, Logger } from '@nestjs/common';
 import { MediaTagSource, MediaType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { MemoryTitleService } from '../titles/memory-title.service';
+import { MemoryAiTitle } from '../titles/memory-title.types';
 import {
   CuratedItem,
   CuratedSelection,
@@ -489,7 +501,10 @@ function chunk<T>(items: T[], size: number): T[][] {
 export class MemoryCurationService {
   private readonly logger = new Logger(MemoryCurationService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly titles: MemoryTitleService,
+  ) {}
 
   /**
    * Stream every candidate matching the base filter AND the curator's `where`,
@@ -732,7 +747,9 @@ export class MemoryCurationService {
 
     if (!existing) {
       try {
-        const memoryId = await this.createMemory(input, subjectKey);
+        // AFTER the tombstone check, BEFORE the transaction — see header note 5.
+        const aiTitle = await this.generateAiTitle(input);
+        const memoryId = await this.createMemory(input, subjectKey, aiTitle);
         return { memoryId, created: true, materiallyChanged: true, skippedTombstone: false };
       } catch (err) {
         // A concurrent generation pass won the race on the unique key. Re-read
@@ -770,7 +787,64 @@ export class MemoryCurationService {
     } as Prisma.InputJsonValue;
   }
 
-  private async createMemory(input: UpsertMemoryInput, subjectKey: string): Promise<string> {
+  /**
+   * Ask #306's titling service for an AI title, or `null` for the template.
+   *
+   * Never throws: `MemoryTitleService.generate` is total by contract, and the
+   * absent-run case (no `titling` on the input) short-circuits to templates
+   * without touching the service at all.
+   */
+  private async generateAiTitle(input: UpsertMemoryInput): Promise<MemoryAiTitle | null> {
+    if (!input.titling) return null;
+    return this.titles.generate(
+      {
+        type: input.type,
+        templateTitle: input.title,
+        templateSubtitle: input.subtitle ?? null,
+        meta: input.meta ?? null,
+        mediaItemIds: input.selection.items.map((item) => item.mediaItemId),
+        periodStart: input.selection.periodStart,
+        periodEnd: input.selection.periodEnd,
+      },
+      input.titling,
+    );
+  }
+
+  /**
+   * The five title columns for one write, from the AI result when there is one
+   * and from the caller's template when there is not. One helper so the create
+   * and material-refresh paths cannot drift — in particular so neither can
+   * write `titleSource: 'ai'` without also writing `titleModel`.
+   */
+  private titleColumns(input: UpsertMemoryInput, aiTitle: MemoryAiTitle | null) {
+    if (aiTitle) {
+      return {
+        title: aiTitle.title,
+        // The model's own subtitle wins, but a model that returned none falls
+        // back to the template's rather than leaving the card bare.
+        subtitle: aiTitle.subtitle ?? input.subtitle ?? null,
+        narrative: aiTitle.narrative,
+        titleSource: 'ai',
+        titleModel: aiTitle.model,
+      };
+    }
+    return {
+      title: input.title,
+      subtitle: input.subtitle ?? null,
+      // Narrative is an AI-only field; a template-titled memory has none, and
+      // writing an empty string instead of NULL would make "has a narrative"
+      // untestable downstream.
+      narrative: null,
+      titleSource: 'template',
+      titleModel: null,
+    };
+  }
+
+  private async createMemory(
+    input: UpsertMemoryInput,
+    subjectKey: string,
+    aiTitle: MemoryAiTitle | null,
+  ): Promise<string> {
     const now = new Date();
     const { periodStart, periodEnd } = this.resolvePeriod(input, now);
 
@@ -782,14 +856,7 @@ export class MemoryCurationService {
           periodKey: input.periodKey,
           subjectKey,
           personId: input.personId ?? null,
-          title: input.title,
-          subtitle: input.subtitle ?? null,
-          // Narrative is an AI-only field (#306); a template-titled memory has
-          // none, and writing an empty string instead of NULL would make
-          // "has a narrative" untestable downstream.
-          narrative: null,
-          titleSource: 'template',
-          titleModel: null,
+          ...this.titleColumns(input, aiTitle),
           coverMediaItemId: input.selection.coverMediaItemId,
           periodStart,
           periodEnd,
@@ -835,6 +902,12 @@ export class MemoryCurationService {
     // #311's digest) reads independently.
     const resetTitle = materiallyChanged || input.retitle === true;
 
+    // Only a title RESET is worth a model call: a minor refresh keeps whatever
+    // the row already carries, which is the whole anti-churn rule (header note
+    // 4) and the reason #306's cost story works at all. Outside the
+    // transaction, as always.
+    const aiTitle = resetTitle ? await this.generateAiTitle(input) : null;
+
     await this.prisma.$transaction(async (tx) => {
       // Replace rather than diff: MemoryItem carries no per-item user state, so
       // a wholesale replacement is both simpler and cheaper than computing an
@@ -866,17 +939,11 @@ export class MemoryCurationService {
           // Titling is preserved on a minor refresh — including an AI title and
           // narrative from #306. On a MATERIAL change (or an explicit `retitle`)
           // the old title may now describe a set, or a place, that no longer
-          // exists, so it is reset to the template and handed back to AI
-          // re-titling on a later pass.
-          ...(resetTitle
-            ? {
-                title: input.title,
-                subtitle: input.subtitle ?? null,
-                narrative: null,
-                titleSource: 'template',
-                titleModel: null,
-              }
-            : {}),
+          // exists, so it is rewritten: freshly AI-generated when titling is
+          // configured and the call succeeded, and reset to the deterministic
+          // template otherwise (which also clears a stale `titleModel` and a
+          // narrative that no longer describes the contents).
+          ...(resetTitle ? this.titleColumns(input, aiTitle) : {}),
         },
       });
     });

--- a/apps/api/src/memories/curation/memory-curation.types.ts
+++ b/apps/api/src/memories/curation/memory-curation.types.ts
@@ -9,6 +9,7 @@
 // =============================================================================
 
 import { MediaType, MemoryType } from '@prisma/client';
+import type { MemoryTitleRun } from '../titles/memory-title.types';
 
 /**
  * One media item considered for inclusion in a memory, hydrated with exactly
@@ -102,6 +103,16 @@ export interface UpsertMemoryInput {
    * protect a title that is still accurate, not one that has been falsified.
    */
   retitle?: boolean;
+  /**
+   * The generation job's AI-titling budget (#306), created once per job by
+   * `MemoryGenerationHandler` and carried on `MemoryCuratorContext.titling`.
+   *
+   * OMITTING IT MEANS TEMPLATE TITLES ONLY — deliberately fail-safe, so a
+   * curator (or a unit test) that does not thread it degrades to the documented
+   * floor instead of making unbudgeted model calls. Every curator passes
+   * `titling: ctx.titling`.
+   */
+  titling?: MemoryTitleRun;
 }
 
 /** Outcome of one `upsertMemory` call. */

--- a/apps/api/src/memories/curators/memory-curator.interface.ts
+++ b/apps/api/src/memories/curators/memory-curator.interface.ts
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { MemoriesSettingsValue } from '../../common/types/settings.types';
+import type { MemoryTitleRun } from '../titles/memory-title.types';
 
 /** DI token for the ordered curator registry. */
 export const MEMORY_CURATORS = Symbol('MEMORY_CURATORS');
@@ -39,6 +40,17 @@ export interface MemoryCuratorContext {
    * this circle's library supports". Scheduled runs are always `false`.
    */
   backfill: boolean;
+  /**
+   * The run's AI-titling budget and circuit breaker (#306), created ONCE by the
+   * handler and shared by every curator so a provider rate limit stops the
+   * whole job's titling and a backfill's 100-call cap is job-wide rather than
+   * per curator.
+   *
+   * Every curator forwards it verbatim as `titling: ctx.titling` on its
+   * `upsertMemory` call. Optional so a test can construct a context without it
+   * — which yields template titles, the documented floor.
+   */
+  titling?: MemoryTitleRun;
 }
 
 /** What one curator did, for logging and the handler's run summary. */

--- a/apps/api/src/memories/curators/on-this-day.curator.ts
+++ b/apps/api/src/memories/curators/on-this-day.curator.ts
@@ -250,6 +250,8 @@ export class OnThisDayCurator implements MemoryCurator {
 
       const upsert = await this.curation.upsertMemory({
         circleId: ctx.circleId,
+        // #306: the run-wide AI-titling budget/circuit breaker.
+        titling: ctx.titling,
         type: MemoryType.on_this_day,
         periodKey,
         subjectKey: String(sourceYear),

--- a/apps/api/src/memories/curators/person-highlights.curator.ts
+++ b/apps/api/src/memories/curators/person-highlights.curator.ts
@@ -151,6 +151,8 @@ export class PersonHighlightsCurator implements MemoryCurator {
 
     const upsert = await this.curation.upsertMemory({
       circleId: ctx.circleId,
+      // #306: the run-wide AI-titling budget/circuit breaker.
+      titling: ctx.titling,
       type: MemoryType.person_highlights,
       periodKey: String(year),
       subjectKey: person.id,

--- a/apps/api/src/memories/curators/person-over-years.curator.ts
+++ b/apps/api/src/memories/curators/person-over-years.curator.ts
@@ -159,6 +159,8 @@ export class PersonOverYearsCurator implements MemoryCurator {
 
     const upsert = await this.curation.upsertMemory({
       circleId: ctx.circleId,
+      // #306: the run-wide AI-titling budget/circuit breaker.
+      titling: ctx.titling,
       type: MemoryType.person_over_years,
       periodKey: PERSON_OVER_YEARS_PERIOD_KEY,
       subjectKey: person.id,

--- a/apps/api/src/memories/curators/seasonal.curator.ts
+++ b/apps/api/src/memories/curators/seasonal.curator.ts
@@ -143,6 +143,8 @@ export class SeasonalCurator implements MemoryCurator {
     const { title, subtitle } = seasonalTitle(period.season, period.year);
     const upsert = await this.curation.upsertMemory({
       circleId: ctx.circleId,
+      // #306: the run-wide AI-titling budget/circuit breaker.
+      titling: ctx.titling,
       type: MemoryType.seasonal,
       periodKey: seasonPeriodKey(period),
       // Seasonal memories have no subject — one per circle per season. '' is

--- a/apps/api/src/memories/curators/theme.curator.ts
+++ b/apps/api/src/memories/curators/theme.curator.ts
@@ -207,6 +207,8 @@ export class ThemeCurator implements MemoryCurator {
       const { title, subtitle } = themeTitle(tag, selection.items.length);
       const upsert = await this.curation.upsertMemory({
         circleId: ctx.circleId,
+        // #306: the run-wide AI-titling budget/circuit breaker.
+        titling: ctx.titling,
         type: MemoryType.theme,
         periodKey: period.periodKey,
         subjectKey: tag,

--- a/apps/api/src/memories/curators/trip.curator.ts
+++ b/apps/api/src/memories/curators/trip.curator.ts
@@ -479,6 +479,8 @@ export class TripCurator implements MemoryCurator {
 
     const upsert = await this.curation.upsertMemory({
       circleId: ctx.circleId,
+      // #306: the run-wide AI-titling budget/circuit breaker.
+      titling: ctx.titling,
       type: MemoryType.trip,
       periodKey: identity.periodKey,
       subjectKey: identity.subjectKey,

--- a/apps/api/src/memories/curators/year-in-review.curator.ts
+++ b/apps/api/src/memories/curators/year-in-review.curator.ts
@@ -195,6 +195,8 @@ export class YearInReviewCurator implements MemoryCurator {
     const { title, subtitle } = yearInReviewTitle(year, selection.items.length);
     const upsert = await this.curation.upsertMemory({
       circleId: ctx.circleId,
+      // #306: the run-wide AI-titling budget/circuit breaker.
+      titling: ctx.titling,
       type: MemoryType.year_in_review,
       periodKey: String(year),
       // No subject — one per circle per year. '' is the schema default and is

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -21,6 +21,8 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { SettingsModule } from '../settings/settings.module';
 import { EnrichmentModule } from '../enrichment/enrichment.module';
+import { AiModule } from '../ai/ai.module';
+import { MemoryTitleService } from './titles/memory-title.service';
 import { MemoriesGenerationTask } from './memories-generation.task';
 import { MemoryGenerationHandler } from './memory-generation.handler';
 import { MemoryCurationService } from './curation/memory-curation.service';
@@ -34,11 +36,16 @@ import { YearInReviewCurator } from './curators/year-in-review.curator';
 import { memoryCuratorsProvider } from './curators/memory-curators.provider';
 
 @Module({
-  imports: [PrismaModule, SettingsModule, EnrichmentModule],
+  // AiModule supplies AiSettingsService (ai.features.memories + the decrypted
+  // credential) and AiProviderRegistry to MemoryTitleService (#306). The edge
+  // points one way only — AiModule imports SettingsModule and nothing else —
+  // so there is no cycle to break.
+  imports: [PrismaModule, SettingsModule, EnrichmentModule, AiModule],
   providers: [
     MemoriesGenerationTask,
     MemoryGenerationHandler,
     MemoryCurationService,
+    MemoryTitleService,
     OnThisDayCurator,
     TripCurator,
     PersonHighlightsCurator,

--- a/apps/api/src/memories/memory-generation.handler.spec.ts
+++ b/apps/api/src/memories/memory-generation.handler.spec.ts
@@ -26,8 +26,10 @@ import { SystemSettingsService } from '../settings/system-settings/system-settin
 import {
   MEMORY_CURATORS,
   MemoryCurator,
+  MemoryCuratorContext,
   MemoryCuratorResult,
 } from './curators/memory-curator.interface';
+import { MemoryTitleService } from './titles/memory-title.service';
 
 function makeJob(overrides: Partial<EnrichmentJob> = {}): EnrichmentJob {
   return {
@@ -59,6 +61,7 @@ describe('MemoryGenerationHandler', () => {
   let handler: MemoryGenerationHandler;
   let registry: EnrichmentHandlerRegistry;
   let settings: { getSettings: jest.Mock };
+  let titles: { beginRun: jest.Mock };
   let curators: MemoryCurator[];
 
   const originalEnv = process.env['MEMORIES_ENABLED'];
@@ -70,6 +73,7 @@ describe('MemoryGenerationHandler', () => {
         MemoryGenerationHandler,
         EnrichmentHandlerRegistry,
         { provide: SystemSettingsService, useValue: settings },
+        { provide: MemoryTitleService, useValue: titles },
         { provide: MEMORY_CURATORS, useValue: curators },
       ],
     }).compile();
@@ -81,6 +85,17 @@ describe('MemoryGenerationHandler', () => {
   beforeEach(async () => {
     settings = {
       getSettings: jest.fn().mockResolvedValue({ features: { memories: true } }),
+    };
+    // The handler only ever OPENS the titling budget (#306); `generate` is
+    // reached through MemoryCurationService, which these fake curators replace.
+    titles = {
+      beginRun: jest.fn((options: { backfill: boolean; aiTitlesEnabled: boolean }) => ({
+        ...options,
+        maxAiCalls: options.backfill ? 100 : Number.POSITIVE_INFINITY,
+        aiCalls: 0,
+        stopped: false,
+        stopReason: null,
+      })),
     };
     delete process.env['MEMORIES_ENABLED'];
     await build();
@@ -215,5 +230,45 @@ describe('MemoryGenerationHandler', () => {
     await handler.process(makeJob({ payload: { backfill: true } as never }));
 
     expect(curator.run.mock.calls[0]![0].backfill).toBe(true);
+  });
+
+  // --- #306: the run-wide AI-titling budget ---------------------------------
+
+  it('AI TITLING: opens ONE titling run per job and shares it with every curator', async () => {
+    const a = fakeCurator('a');
+    const b = fakeCurator('b');
+    await build([a, b]);
+
+    await handler.process(makeJob());
+
+    // One budget per job, not one per curator — a provider rate limit must stop
+    // titling for the whole run, and a backfill cap must be job-wide.
+    expect(titles.beginRun).toHaveBeenCalledTimes(1);
+    const runA = (a.run.mock.calls[0]![0] as MemoryCuratorContext).titling;
+    const runB = (b.run.mock.calls[0]![0] as MemoryCuratorContext).titling;
+    expect(runA).toBeDefined();
+    expect(runB).toBe(runA);
+  });
+
+  it('AI TITLING: passes the resolved memories.aiTitles.enabled flag through', async () => {
+    settings.getSettings.mockResolvedValue({
+      features: { memories: true },
+      memories: { aiTitles: { enabled: false } },
+    });
+    const curator = fakeCurator('a');
+    await build([curator]);
+
+    await handler.process(makeJob());
+
+    expect(titles.beginRun).toHaveBeenCalledWith({ backfill: false, aiTitlesEnabled: false });
+  });
+
+  it('AI TITLING: a backfill job opens a backfill-capped budget', async () => {
+    const curator = fakeCurator('a');
+    await build([curator]);
+
+    await handler.process(makeJob({ payload: { backfill: true } as never }));
+
+    expect(titles.beginRun).toHaveBeenCalledWith({ backfill: true, aiTitlesEnabled: true });
   });
 });

--- a/apps/api/src/memories/memory-generation.handler.ts
+++ b/apps/api/src/memories/memory-generation.handler.ts
@@ -31,6 +31,7 @@ import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.regi
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { isMemoriesEnabled } from '../common/types/settings.types';
 import { resolveMemoriesSettings } from './memories-settings.util';
+import { MemoryTitleService } from './titles/memory-title.service';
 import {
   MEMORY_CURATORS,
   MemoryCurator,
@@ -52,6 +53,7 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
   constructor(
     private readonly registry: EnrichmentHandlerRegistry,
     private readonly systemSettings: SystemSettingsService,
+    private readonly titles: MemoryTitleService,
     @Inject(MEMORY_CURATORS) private readonly curators: MemoryCurator[],
   ) {}
 
@@ -84,9 +86,20 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
     }
 
     const payload = (job.payload as unknown as MemoryGenerationPayload | null) ?? {};
+    const memoriesSettings = resolveMemoriesSettings(settings.memories);
+    // ONE titling budget for the whole job (#306), shared by every curator: a
+    // provider rate limit must stop titling for the rest of the run, and a
+    // backfill's 100-call cap is job-wide, not per curator. It is created here
+    // rather than held on MemoryTitleService because that service is a
+    // singleton and several `memory_generation` jobs can run concurrently.
+    const titling = this.titles.beginRun({
+      backfill: payload.backfill === true,
+      aiTitlesEnabled: memoriesSettings.aiTitles.enabled,
+    });
     const ctx: MemoryCuratorContext = {
       circleId: job.circleId,
-      settings: resolveMemoriesSettings(settings.memories),
+      settings: memoriesSettings,
+      titling,
       // ONE wall clock for the whole run: a pass that straddles midnight must
       // not have curator A anchoring on today and curator B on tomorrow.
       now: new Date(),
@@ -143,6 +156,11 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
       tombstoned,
       purged,
       failedCurators: failed,
+      // #306 audit: how much titling this run actually paid for, and whether it
+      // gave up early. `aiTitleStopReason` is the one-line explanation for a run
+      // whose memories are mostly template-titled despite a configured provider.
+      aiTitleCalls: titling.aiCalls,
+      aiTitleStopReason: titling.stopReason,
     });
   }
 }

--- a/apps/api/src/memories/titles/__snapshots__/memory-title.prompts.spec.ts.snap
+++ b/apps/api/src/memories/titles/__snapshots__/memory-title.prompts.spec.ts.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`MEMORY_TITLE_SYSTEM_PROMPT is a stable constant 1`] = `
+"You write titles for a private family photo app. A "memory" is a small,
+automatically curated collection of a family's own photos and videos.
+
+Voice: warm, specific and human — the way someone would describe the
+collection to their own family. Never saccharine, never advertising copy,
+never a listicle. No emojis. No exclamation marks unless genuinely earned,
+and never more than one. Do not invent people, places or events that the
+supplied facts do not mention; if the facts are thin, stay general rather
+than fabricating detail. Do not address the reader or refer to yourself.
+
+You are given facts about one memory, including the deterministic fallback
+title the app would otherwise use. Improve on it when the facts support
+something better; stay close to it when they do not.
+
+Respond with ONLY a JSON object, no code fences and no commentary:
+{"title": string, "subtitle": string, "narrative": string}
+- "title": at most 60 characters.
+- "subtitle": at most 80 characters; a short line of
+  context such as the place or the date range. May be an empty string.
+- "narrative": at most 240 characters; one or two
+  sentences describing what this collection holds. May be an empty string."
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots on_this_day 1`] = `
+"Memory type: On this day (an anniversary of a past day)
+Items in the collection: 8
+Date: 2019-03-12
+Years ago: 6
+People pictured: Camila
+Common tags: beach (6), sunset (3)
+Sample photo descriptions:
+- Two children building a sandcastle at the water line.
+Fallback title: On this day — 6 years ago
+Fallback subtitle: March 12, 2019"
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots person_highlights 1`] = `
+"Memory type: Highlights of one person
+Items in the collection: 8
+Date range: 2025-01-06 to 2025-12-22
+Year: 2025
+People pictured: Abuela
+Fallback title: Best of Abuela
+Fallback subtitle: 2025"
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots person_over_years 1`] = `
+"Memory type: One person across many years
+Items in the collection: 8
+Date range: 2016-05-02 to 2025-11-30
+People pictured: Camila
+Fallback title: Camila through the years
+Fallback subtitle: 2016–2025"
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots seasonal 1`] = `
+"Memory type: One season
+Items in the collection: 8
+Date range: 2025-06-02 to 2025-08-28
+Year: 2025
+Season: summer
+Fallback title: Summer 2025"
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots theme 1`] = `
+"Memory type: A theme drawn from photo tags
+Items in the collection: 8
+Date: 2019-03-12
+Year: 2025
+Theme tag: sunset
+Common tags: sunset (14)
+Fallback title: Golden Sunsets
+Fallback subtitle: 14 favorite moments"
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots trip 1`] = `
+"Memory type: A trip away from home
+Items in the collection: 24
+Date range: 2023-03-04 to 2023-03-09
+Place: Tamarindo, Guanacaste, Costa Rica
+People pictured: Camila, Abuela
+Common tags: beach (14), surf (5)
+Sample photo descriptions:
+- A long stretch of empty beach at golden hour.
+Fallback title: Trip to Guanacaste
+Fallback subtitle: March 2023"
+`;
+
+exports[`buildMemoryTitleUserPrompt — per-type snapshots year_in_review 1`] = `
+"Memory type: A whole year in review
+Items in the collection: 30
+Date range: 2025-01-01 to 2025-12-31
+Year: 2025
+Fallback title: Your 2025 in review
+Fallback subtitle: 30 highlights from the year"
+`;

--- a/apps/api/src/memories/titles/memory-title.parse.spec.ts
+++ b/apps/api/src/memories/titles/memory-title.parse.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Response-parsing tests (epic #300, issue #306).
+ *
+ * `parseMemoryTitleResponse` is the single place a model's answer becomes a
+ * value the app will persist, and #306 requires it to be TOTAL: every malformed
+ * shape resolves to `null` ("use the template"), never to an exception. These
+ * tests enumerate the shapes real models actually emit — a ```json fence, a
+ * chatty preamble, a `null` subtitle, a 400-character title — plus the
+ * degenerate ones, and assert that none of them throw.
+ */
+
+import {
+  capText,
+  extractJsonObject,
+  parseMemoryTitleResponse,
+} from './memory-title.parse';
+import {
+  NARRATIVE_MAX_CHARS,
+  SUBTITLE_MAX_CHARS,
+  TITLE_MAX_CHARS,
+} from './memory-title.prompts';
+
+describe('extractJsonObject', () => {
+  it('passes a bare object through', () => {
+    expect(extractJsonObject('{"title":"x"}')).toBe('{"title":"x"}');
+  });
+
+  it('strips a ```json fence', () => {
+    expect(extractJsonObject('```json\n{"title":"x"}\n```')).toBe('{"title":"x"}');
+  });
+
+  it('strips a bare ``` fence', () => {
+    expect(extractJsonObject('```\n{"title":"x"}\n```')).toBe('{"title":"x"}');
+  });
+
+  it('slices away a chatty preamble and sign-off', () => {
+    expect(extractJsonObject('Sure! Here you go:\n{"title":"x"}\nHope that helps.')).toBe(
+      '{"title":"x"}',
+    );
+  });
+
+  it('returns null when there is no brace pair', () => {
+    expect(extractJsonObject('I cannot help with that.')).toBeNull();
+    expect(extractJsonObject('')).toBeNull();
+    expect(extractJsonObject('} {')).toBeNull();
+  });
+});
+
+describe('capText', () => {
+  it('collapses whitespace', () => {
+    expect(capText('  a \n b\tc  ', 50)).toBe('a b c');
+  });
+
+  it('truncates with an ellipsis and never exceeds the cap', () => {
+    const capped = capText('x'.repeat(200), 60);
+    expect(capped).toHaveLength(60);
+    expect(capped.endsWith('…')).toBe(true);
+  });
+});
+
+describe('parseMemoryTitleResponse — success', () => {
+  it('parses the well-formed happy path', () => {
+    expect(
+      parseMemoryTitleResponse(
+        '{"title":"Five golden days","subtitle":"Tamarindo, March 2023","narrative":"Sunsets and surf."}',
+      ),
+    ).toEqual({
+      title: 'Five golden days',
+      subtitle: 'Tamarindo, March 2023',
+      narrative: 'Sunsets and surf.',
+    });
+  });
+
+  it('parses through a fence and a preamble', () => {
+    expect(
+      parseMemoryTitleResponse('Here:\n```json\n{"title":"A quiet week"}\n```\nDone.'),
+    ).toEqual({ title: 'A quiet week', subtitle: null, narrative: null });
+  });
+
+  it('normalizes a null / empty / whitespace subtitle and narrative to null', () => {
+    expect(
+      parseMemoryTitleResponse('{"title":"T","subtitle":null,"narrative":"   "}'),
+    ).toEqual({ title: 'T', subtitle: null, narrative: null });
+  });
+
+  it('enforces every length cap regardless of what the model returned', () => {
+    const parsed = parseMemoryTitleResponse(
+      JSON.stringify({
+        title: 'a'.repeat(400),
+        subtitle: 'b'.repeat(400),
+        narrative: 'c'.repeat(4000),
+      }),
+    )!;
+    expect(parsed.title).toHaveLength(TITLE_MAX_CHARS);
+    expect(parsed.subtitle).toHaveLength(SUBTITLE_MAX_CHARS);
+    expect(parsed.narrative).toHaveLength(NARRATIVE_MAX_CHARS);
+  });
+
+  it('recovers the object from a single-element array wrapper', () => {
+    // A by-product of the first-brace/last-brace slice, and a welcome one: a
+    // model that wrapped its answer in an array still produced a usable title.
+    expect(parseMemoryTitleResponse('[{"title":"x"}]')).toEqual({
+      title: 'x',
+      subtitle: null,
+      narrative: null,
+    });
+  });
+
+  it('collapses embedded newlines — these are single-line UI fields', () => {
+    expect(parseMemoryTitleResponse('{"title":"A\\nB"}')!.title).toBe('A B');
+  });
+});
+
+describe('parseMemoryTitleResponse — every failure returns null, never throws', () => {
+  const cases: Array<[string, string]> = [
+    ['empty output', ''],
+    ['prose with no JSON', 'I am sorry, I cannot do that.'],
+    ['truncated JSON', '{"title":"unfinished'],
+    ['an object missing "title"', '{"subtitle":"x","narrative":"y"}'],
+    ['a non-string title', '{"title":42}'],
+    ['a null title', '{"title":null}'],
+    ['an empty title', '{"title":""}'],
+    ['a whitespace-only title', '{"title":"   "}'],
+    ['trailing-comma JSON', '{"title":"x",}'],
+    ['a JSON string, not an object', '"just a string"'],
+  ];
+
+  it.each(cases)('%s', (_label, raw) => {
+    expect(() => parseMemoryTitleResponse(raw)).not.toThrow();
+    expect(parseMemoryTitleResponse(raw)).toBeNull();
+  });
+
+  it('ignores unexpected extra keys rather than rejecting the response', () => {
+    // Rejecting on an extra key would turn a usable answer into a template
+    // fallback for no benefit — strictness here buys nothing.
+    expect(
+      parseMemoryTitleResponse('{"title":"T","confidence":0.9,"tags":["a"]}'),
+    ).toEqual({ title: 'T', subtitle: null, narrative: null });
+  });
+});

--- a/apps/api/src/memories/titles/memory-title.parse.ts
+++ b/apps/api/src/memories/titles/memory-title.parse.ts
@@ -1,0 +1,107 @@
+// =============================================================================
+// Memories — defensive parsing of the model's titling response (issue #306)
+// =============================================================================
+//
+// Pure and total: `parseMemoryTitleResponse` NEVER throws. Every malformed
+// shape a model can emit — prose around the JSON, a ```json fence, a trailing
+// apology, a null subtitle, an object with the right keys and the wrong types,
+// a 400-character "title" — resolves to either a clean result or `null`, and
+// `null` means "use the template".
+//
+// That totality is the point. The caller's failure handling is one branch
+// (`null` ⇒ template), so there is no path where a surprising response shape
+// escapes as an exception and reaches the curator, whose contract is that
+// titling can never fail a generation run.
+// =============================================================================
+
+import { z } from 'zod';
+import { NARRATIVE_MAX_CHARS, SUBTITLE_MAX_CHARS, TITLE_MAX_CHARS } from './memory-title.prompts';
+
+/** A validated, length-capped titling result. `title` is always non-empty. */
+export interface ParsedMemoryTitle {
+  title: string;
+  subtitle: string | null;
+  narrative: string | null;
+}
+
+/**
+ * Subtitle/narrative accept `null` as well as a string because "I have nothing
+ * to add here" is a legitimate answer, and a model asked for an empty string
+ * will often send `null` instead. A missing or wrongly-typed TITLE, by
+ * contrast, fails the whole parse — a memory with no title is not a partial
+ * success, it is the template case.
+ */
+const responseSchema = z.object({
+  title: z.string(),
+  subtitle: z.string().nullish(),
+  narrative: z.string().nullish(),
+});
+
+/**
+ * Reduce raw model output to the JSON object inside it.
+ *
+ * Two independent repairs, in order:
+ *  1. strip a ``` / ```json fence, which several models emit despite being
+ *     told not to;
+ *  2. slice from the first `{` to the last `}`, which removes a leading
+ *     "Sure, here you go:" and a trailing sign-off in one step.
+ *
+ * Returns null when there is no brace pair at all.
+ */
+export function extractJsonObject(raw: string): string | null {
+  let text = raw.trim();
+
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(text);
+  if (fenced?.[1]) text = fenced[1].trim();
+
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+  return text.slice(start, end + 1);
+}
+
+/**
+ * Collapse whitespace, then hard-cap length with an ellipsis so the result is
+ * ALWAYS <= `maxChars` — the caps are a storage/UI contract, not a hint to the
+ * model, so they are enforced here regardless of what came back.
+ */
+export function capText(value: string, maxChars: number): string {
+  const flat = value.replace(/\s+/g, ' ').trim();
+  if (flat.length <= maxChars) return flat;
+  return `${flat.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
+/** Empty string and whitespace both normalize to `null` for optional fields. */
+function optional(value: string | null | undefined, maxChars: number): string | null {
+  if (typeof value !== 'string') return null;
+  const capped = capText(value, maxChars);
+  return capped.length > 0 ? capped : null;
+}
+
+/**
+ * Parse, validate and cap. Returns `null` for every failure mode: unparseable
+ * text, valid JSON of the wrong shape, or a blank title.
+ */
+export function parseMemoryTitleResponse(raw: string): ParsedMemoryTitle | null {
+  const json = extractJsonObject(raw);
+  if (!json) return null;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  const parsed = responseSchema.safeParse(value);
+  if (!parsed.success) return null;
+
+  const title = capText(parsed.data.title, TITLE_MAX_CHARS);
+  if (title.length === 0) return null;
+
+  return {
+    title,
+    subtitle: optional(parsed.data.subtitle, SUBTITLE_MAX_CHARS),
+    narrative: optional(parsed.data.narrative, NARRATIVE_MAX_CHARS),
+  };
+}

--- a/apps/api/src/memories/titles/memory-title.prompts.spec.ts
+++ b/apps/api/src/memories/titles/memory-title.prompts.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Prompt-builder tests (epic #300, issue #306).
+ *
+ * The per-type snapshots are the point of this file. A prompt has no type
+ * errors and no test failures of its own, so a wording change — a dropped fact,
+ * a re-ordered block, a new field quietly added to the context — is invisible in
+ * a diff unless the rendered output is asserted somewhere. #306 asks for exactly
+ * this: "unit-test the builder output snapshot per memory type so prompt drift
+ * is visible in review."
+ *
+ * The remaining tests guard the two properties snapshots cannot: the input caps
+ * are enforced by the BUILDER (so no call site can widen what is sent), and the
+ * privacy boundary holds (no ids of any kind reach the prompt).
+ */
+
+import { MemoryType } from '@prisma/client';
+import {
+  DESCRIPTION_MAX_CHARS,
+  MAX_PROMPT_DESCRIPTIONS,
+  MAX_PROMPT_PERSON_NAMES,
+  MAX_PROMPT_TAGS,
+  MEMORY_TITLE_SYSTEM_PROMPT,
+  MemoryTitleFacts,
+  NARRATIVE_MAX_CHARS,
+  SUBTITLE_MAX_CHARS,
+  TITLE_MAX_CHARS,
+  buildMemoryTitleUserPrompt,
+} from './memory-title.prompts';
+
+function facts(over: Partial<MemoryTitleFacts> = {}): MemoryTitleFacts {
+  return {
+    type: MemoryType.on_this_day,
+    itemCount: 8,
+    periodStart: new Date('2019-03-12T09:00:00.000Z'),
+    periodEnd: new Date('2019-03-12T21:30:00.000Z'),
+    templateTitle: 'On this day — 6 years ago',
+    templateSubtitle: 'March 12, 2019',
+    place: null,
+    personNames: [],
+    topTags: [],
+    descriptions: [],
+    yearsAgo: null,
+    themeTag: null,
+    season: null,
+    year: null,
+    ...over,
+  };
+}
+
+describe('MEMORY_TITLE_SYSTEM_PROMPT', () => {
+  it('states the JSON contract and every length cap the parser enforces', () => {
+    // The caps live in ONE place and are both told to the model and enforced on
+    // parse; a cap changed in only one of those two spots is the bug this guards.
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toContain(String(TITLE_MAX_CHARS));
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toContain(String(SUBTITLE_MAX_CHARS));
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toContain(String(NARRATIVE_MAX_CHARS));
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toContain('{"title": string, "subtitle": string, "narrative": string}');
+  });
+
+  it('carries the tone rules the epic asked for', () => {
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toMatch(/No emojis/);
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toMatch(/exclamation marks/);
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toMatch(/family photo app/);
+  });
+
+  it('is a stable constant', () => {
+    expect(MEMORY_TITLE_SYSTEM_PROMPT).toMatchSnapshot();
+  });
+});
+
+describe('buildMemoryTitleUserPrompt — per-type snapshots', () => {
+  it('on_this_day', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.on_this_day,
+          yearsAgo: 6,
+          topTags: [
+            { name: 'beach', count: 6 },
+            { name: 'sunset', count: 3 },
+          ],
+          descriptions: ['Two children building a sandcastle at the water line.'],
+          personNames: ['Camila'],
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('trip', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.trip,
+          itemCount: 24,
+          periodStart: new Date('2023-03-04T00:00:00.000Z'),
+          periodEnd: new Date('2023-03-09T00:00:00.000Z'),
+          templateTitle: 'Trip to Guanacaste',
+          templateSubtitle: 'March 2023',
+          place: { locality: 'Tamarindo', admin1: 'Guanacaste', country: 'Costa Rica' },
+          personNames: ['Camila', 'Abuela'],
+          topTags: [
+            { name: 'beach', count: 14 },
+            { name: 'surf', count: 5 },
+          ],
+          descriptions: ['A long stretch of empty beach at golden hour.'],
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('person_highlights', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.person_highlights,
+          templateTitle: 'Best of Abuela',
+          templateSubtitle: '2025',
+          year: 2025,
+          personNames: ['Abuela'],
+          periodStart: new Date('2025-01-06T00:00:00.000Z'),
+          periodEnd: new Date('2025-12-22T00:00:00.000Z'),
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('person_over_years', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.person_over_years,
+          templateTitle: 'Camila through the years',
+          templateSubtitle: '2016–2025',
+          personNames: ['Camila'],
+          periodStart: new Date('2016-05-02T00:00:00.000Z'),
+          periodEnd: new Date('2025-11-30T00:00:00.000Z'),
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('theme', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.theme,
+          templateTitle: 'Golden Sunsets',
+          templateSubtitle: '14 favorite moments',
+          themeTag: 'sunset',
+          year: 2025,
+          topTags: [{ name: 'sunset', count: 14 }],
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('seasonal', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.seasonal,
+          templateTitle: 'Summer 2025',
+          templateSubtitle: null,
+          season: 'summer',
+          year: 2025,
+          periodStart: new Date('2025-06-02T00:00:00.000Z'),
+          periodEnd: new Date('2025-08-28T00:00:00.000Z'),
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('year_in_review', () => {
+    expect(
+      buildMemoryTitleUserPrompt(
+        facts({
+          type: MemoryType.year_in_review,
+          itemCount: 30,
+          templateTitle: 'Your 2025 in review',
+          templateSubtitle: '30 highlights from the year',
+          year: 2025,
+          periodStart: new Date('2025-01-01T00:00:00.000Z'),
+          periodEnd: new Date('2025-12-31T00:00:00.000Z'),
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('renders a single-day range as one date, not "X to X"', () => {
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({
+        periodStart: new Date('2019-03-12T09:00:00.000Z'),
+        periodEnd: new Date('2019-03-12T21:30:00.000Z'),
+      }),
+    );
+    expect(prompt).toContain('Date: 2019-03-12');
+    expect(prompt).not.toContain(' to ');
+  });
+
+  it('omits every optional block when the facts are empty (new install)', () => {
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({ periodStart: null, periodEnd: null, templateSubtitle: null }),
+    );
+    expect(prompt).not.toMatch(/Place:|People pictured:|Common tags:|Sample photo descriptions:/);
+    expect(prompt).toContain('Fallback title: On this day — 6 years ago');
+  });
+});
+
+describe('buildMemoryTitleUserPrompt — input caps are enforced by the builder', () => {
+  it('sends at most MAX_PROMPT_TAGS tags', () => {
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({
+        topTags: Array.from({ length: MAX_PROMPT_TAGS + 5 }, (_, i) => ({
+          name: `tag${i}`,
+          count: 100 - i,
+        })),
+      }),
+    );
+    const line = prompt.split('\n').find((l) => l.startsWith('Common tags:'))!;
+    expect(line.split(', ')).toHaveLength(MAX_PROMPT_TAGS);
+    expect(line).not.toContain(`tag${MAX_PROMPT_TAGS}`);
+  });
+
+  it('sends at most MAX_PROMPT_DESCRIPTIONS descriptions', () => {
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({
+        descriptions: Array.from({ length: MAX_PROMPT_DESCRIPTIONS + 4 }, (_, i) => `desc ${i}`),
+      }),
+    );
+    expect(prompt.split('\n').filter((l) => l.startsWith('- '))).toHaveLength(
+      MAX_PROMPT_DESCRIPTIONS,
+    );
+  });
+
+  it('truncates each description to DESCRIPTION_MAX_CHARS', () => {
+    const prompt = buildMemoryTitleUserPrompt(facts({ descriptions: ['x'.repeat(900)] }));
+    const line = prompt.split('\n').find((l) => l.startsWith('- '))!;
+    expect(line.length - 2).toBe(DESCRIPTION_MAX_CHARS);
+    expect(line.endsWith('…')).toBe(true);
+  });
+
+  it('sends at most MAX_PROMPT_PERSON_NAMES names', () => {
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({ personNames: ['a', 'b', 'c', 'd', 'e', 'f', 'g'] }),
+    );
+    const line = prompt.split('\n').find((l) => l.startsWith('People pictured:'))!;
+    expect(line.slice('People pictured: '.length).split(', ')).toHaveLength(
+      MAX_PROMPT_PERSON_NAMES,
+    );
+  });
+
+  it('collapses newlines inside a description so the "- " list stays one line each', () => {
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({ descriptions: ['first line\nsecond line\n\nthird'] }),
+    );
+    expect(prompt.split('\n').filter((l) => l.startsWith('- '))).toHaveLength(1);
+    expect(prompt).toContain('- first line second line third');
+  });
+});
+
+describe('buildMemoryTitleUserPrompt — privacy boundary', () => {
+  it('cannot leak ids: the facts type has no field to carry one', () => {
+    // MemoryTitleFacts is the COMPLETE list of what may be sent. Media item
+    // ids, the circle id, the person id and storage keys are absent by
+    // construction — this asserts the rendered output over a maximal fact set.
+    const prompt = buildMemoryTitleUserPrompt(
+      facts({
+        type: MemoryType.trip,
+        place: { locality: 'Tamarindo', admin1: 'Guanacaste', country: 'Costa Rica' },
+        personNames: ['Camila'],
+        topTags: [{ name: 'beach', count: 4 }],
+        descriptions: ['A beach at golden hour.'],
+        yearsAgo: 6,
+        year: 2023,
+        season: 'summer',
+        themeTag: 'sunset',
+      }),
+    );
+    expect(prompt).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  });
+});

--- a/apps/api/src/memories/titles/memory-title.prompts.ts
+++ b/apps/api/src/memories/titles/memory-title.prompts.ts
@@ -1,0 +1,205 @@
+// =============================================================================
+// Memories — the AI titling prompt, in one file (epic #300, issue #306)
+// =============================================================================
+//
+// Pure, zero-I/O, zero-Nest: the system prompt constant plus the per-type
+// context builder that turns already-computed facts into the user message.
+//
+// WHY THE PROMPT IS ISOLATED HERE. A prompt is the least reviewable thing in a
+// codebase — it has no type errors and no test failures of its own, so drift is
+// invisible in a diff unless the output is asserted somewhere. Every builder
+// output is snapshotted per memory type in memory-title.prompts.spec.ts, which
+// makes a wording change show up as a reviewable diff instead of a silent
+// behavioral change in production.
+//
+// WHAT MAY LEAVE THE DEPLOYMENT. Metadata only — never image bytes (rejected in
+// #306 for cost/latency at library scale; the tags and descriptions below are
+// themselves already AI-derived from pixels, so the visual signal arrives
+// secondhand and free). And within metadata, only what the issue enumerates:
+// memory type, date range, place names, person names, top AI tags with counts,
+// up to five truncated AI descriptions, item count, years-ago.
+//
+// Absent BY CONSTRUCTION, because this builder takes facts rather than rows:
+// no ids of any kind (media item, circle, person, user), no file names, no
+// storage keys, no GPS coordinates, no EXIF. `MemoryTitleFacts` is the complete
+// list of what can be sent, and memory-title.prompts.spec.ts asserts that a
+// rendered prompt contains no UUID.
+// =============================================================================
+
+import { MemoryType } from '@prisma/client';
+
+// --- Output caps (mirrored in the system prompt AND enforced on parse) -------
+
+/** Hard cap on the generated title. */
+export const TITLE_MAX_CHARS = 60;
+/** Hard cap on the generated subtitle. */
+export const SUBTITLE_MAX_CHARS = 80;
+/** Hard cap on the generated narrative blurb. */
+export const NARRATIVE_MAX_CHARS = 240;
+
+// --- Input caps --------------------------------------------------------------
+
+/** Most AI tags described to the model, highest count first. */
+export const MAX_PROMPT_TAGS = 10;
+/** Most item descriptions included. */
+export const MAX_PROMPT_DESCRIPTIONS = 5;
+/** Each description is truncated to this many characters. */
+export const DESCRIPTION_MAX_CHARS = 200;
+/** Most person names included. */
+export const MAX_PROMPT_PERSON_NAMES = 5;
+
+/**
+ * The system prompt. One exported constant, per #306 — the tone rules are a
+ * product decision, not an implementation detail, and they belong somewhere a
+ * reviewer can find without reading the service.
+ */
+export const MEMORY_TITLE_SYSTEM_PROMPT = [
+  'You write titles for a private family photo app. A "memory" is a small,',
+  'automatically curated collection of a family\'s own photos and videos.',
+  '',
+  'Voice: warm, specific and human — the way someone would describe the',
+  'collection to their own family. Never saccharine, never advertising copy,',
+  'never a listicle. No emojis. No exclamation marks unless genuinely earned,',
+  'and never more than one. Do not invent people, places or events that the',
+  'supplied facts do not mention; if the facts are thin, stay general rather',
+  'than fabricating detail. Do not address the reader or refer to yourself.',
+  '',
+  'You are given facts about one memory, including the deterministic fallback',
+  'title the app would otherwise use. Improve on it when the facts support',
+  'something better; stay close to it when they do not.',
+  '',
+  'Respond with ONLY a JSON object, no code fences and no commentary:',
+  '{"title": string, "subtitle": string, "narrative": string}',
+  `- "title": at most ${TITLE_MAX_CHARS} characters.`,
+  `- "subtitle": at most ${SUBTITLE_MAX_CHARS} characters; a short line of`,
+  '  context such as the place or the date range. May be an empty string.',
+  `- "narrative": at most ${NARRATIVE_MAX_CHARS} characters; one or two`,
+  '  sentences describing what this collection holds. May be an empty string.',
+].join('\n');
+
+/** Human-readable label per memory type, used to open the fact block. */
+const TYPE_LABELS: Record<MemoryType, string> = {
+  on_this_day: 'On this day (an anniversary of a past day)',
+  trip: 'A trip away from home',
+  person_highlights: 'Highlights of one person',
+  person_over_years: 'One person across many years',
+  theme: 'A theme drawn from photo tags',
+  seasonal: 'One season',
+  year_in_review: 'A whole year in review',
+};
+
+/**
+ * The complete set of facts that may be described to the model.
+ *
+ * Every field is optional-by-emptiness rather than optional-by-absence, so the
+ * renderer never has to distinguish "not applicable to this type" from "we have
+ * no value" — both simply omit the line.
+ */
+export interface MemoryTitleFacts {
+  type: MemoryType;
+  itemCount: number;
+  periodStart: Date | null;
+  periodEnd: Date | null;
+  templateTitle: string;
+  templateSubtitle: string | null;
+  /** Trips: the dominant place, already narrowed by the curator. */
+  place: { locality?: string | null; admin1?: string | null; country?: string | null } | null;
+  /** Named people recognized in the selected items. */
+  personNames: string[];
+  /** Top AI-applied tags with per-memory item counts, highest first. */
+  topTags: Array<{ name: string; count: number }>;
+  /** AI-written descriptions of individual items. */
+  descriptions: string[];
+  /** `on_this_day` only: how far back the source photos are. */
+  yearsAgo: number | null;
+  /** `theme` only: the tag the memory is built from. */
+  themeTag: string | null;
+  /** `seasonal` only: 'winter' | 'spring' | 'summer' | 'fall'. */
+  season: string | null;
+  /** `seasonal` / `year_in_review` / `person_highlights`: the calendar year. */
+  year: number | null;
+}
+
+const isoDay = (date: Date): string => date.toISOString().slice(0, 10);
+
+/** Collapse whitespace and hard-truncate — model input, not prose. */
+function condense(text: string, maxChars: number): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length <= maxChars ? flat : `${flat.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
+/**
+ * Render the user message for one memory.
+ *
+ * Deterministic: identical facts render an identical string, byte for byte.
+ * That is what makes the per-type snapshots in the spec meaningful, and it is
+ * also what would let a future response cache key on this string.
+ *
+ * The input caps (`MAX_PROMPT_TAGS`, `MAX_PROMPT_DESCRIPTIONS`,
+ * `DESCRIPTION_MAX_CHARS`, `MAX_PROMPT_PERSON_NAMES`) are applied HERE rather
+ * than by the caller, so no call site can widen what gets sent.
+ */
+export function buildMemoryTitleUserPrompt(facts: MemoryTitleFacts): string {
+  const lines: string[] = [];
+
+  lines.push(`Memory type: ${TYPE_LABELS[facts.type]}`);
+  lines.push(`Items in the collection: ${facts.itemCount}`);
+
+  if (facts.periodStart && facts.periodEnd) {
+    const start = isoDay(facts.periodStart);
+    const end = isoDay(facts.periodEnd);
+    lines.push(start === end ? `Date: ${start}` : `Date range: ${start} to ${end}`);
+  }
+
+  if (facts.yearsAgo !== null) {
+    lines.push(`Years ago: ${facts.yearsAgo}`);
+  }
+  if (facts.year !== null) {
+    lines.push(`Year: ${facts.year}`);
+  }
+  if (facts.season) {
+    lines.push(`Season: ${facts.season}`);
+  }
+  if (facts.themeTag) {
+    lines.push(`Theme tag: ${facts.themeTag}`);
+  }
+
+  if (facts.place) {
+    const parts = [facts.place.locality, facts.place.admin1, facts.place.country]
+      .map((p) => p?.trim())
+      .filter((p): p is string => !!p);
+    if (parts.length > 0) lines.push(`Place: ${parts.join(', ')}`);
+  }
+
+  const people = facts.personNames
+    .map((n) => n.trim())
+    .filter((n) => n.length > 0)
+    .slice(0, MAX_PROMPT_PERSON_NAMES);
+  if (people.length > 0) {
+    lines.push(`People pictured: ${people.join(', ')}`);
+  }
+
+  const tags = facts.topTags
+    .filter((t) => t.name.trim().length > 0)
+    .slice(0, MAX_PROMPT_TAGS)
+    .map((t) => `${t.name.trim()} (${t.count})`);
+  if (tags.length > 0) {
+    lines.push(`Common tags: ${tags.join(', ')}`);
+  }
+
+  const descriptions = facts.descriptions
+    .map((d) => condense(d, DESCRIPTION_MAX_CHARS))
+    .filter((d) => d.length > 0)
+    .slice(0, MAX_PROMPT_DESCRIPTIONS);
+  if (descriptions.length > 0) {
+    lines.push('Sample photo descriptions:');
+    for (const d of descriptions) lines.push(`- ${d}`);
+  }
+
+  lines.push(`Fallback title: ${facts.templateTitle}`);
+  if (facts.templateSubtitle) {
+    lines.push(`Fallback subtitle: ${facts.templateSubtitle}`);
+  }
+
+  return lines.join('\n');
+}

--- a/apps/api/src/memories/titles/memory-title.service.spec.ts
+++ b/apps/api/src/memories/titles/memory-title.service.spec.ts
@@ -1,0 +1,444 @@
+/**
+ * MemoryTitleService tests (epic #300, issue #306).
+ *
+ * NO NETWORK, EVER. The provider is a hand-written `AiProvider` double handed
+ * back by a stubbed `AiProviderRegistry`, so nothing in this file can reach the
+ * OpenAI or Anthropic SDKs at all — this is a level below the repo's
+ * `jest.mock('openai')` convention and is strictly stronger, because a mocked
+ * SDK still requires the production code to route through it.
+ *
+ * The acceptance criteria of #306 are almost entirely a list of failure modes
+ * and the single behavior they must all share: fall back to the template,
+ * without throwing and without failing the generation job. So the shape of this
+ * file is one test per failure mode, each asserting the same two things —
+ * `generate` resolved to `null`, and the run was not left in a state that would
+ * corrupt the rest of the job.
+ */
+
+import { Logger } from '@nestjs/common';
+import { MemoryType } from '@prisma/client';
+import type {
+  AiProvider,
+  ChatRequest,
+  ChatStreamEvent,
+} from '../../ai/providers/ai-provider.interface';
+import { AiProviderRegistry } from '../../ai/providers/ai-provider.registry';
+import { AiSettingsService } from '../../ai/ai-settings.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  BACKFILL_AI_TITLE_CAP,
+  MEMORY_TITLE_TEMPERATURE,
+  MEMORY_TITLE_TIMEOUT_MS,
+  MemoryTitleService,
+} from './memory-title.service';
+import { MemoryTitleRequest } from './memory-title.types';
+
+const GOOD_RESPONSE =
+  '{"title":"Five golden days","subtitle":"Tamarindo, March 2023","narrative":"Sunsets, surf and a first swim."}';
+
+function request(over: Partial<MemoryTitleRequest> = {}): MemoryTitleRequest {
+  return {
+    type: MemoryType.trip,
+    templateTitle: 'Trip to Guanacaste',
+    templateSubtitle: 'March 2023',
+    meta: { locality: 'Tamarindo', admin1: 'Guanacaste', country: 'Costa Rica' },
+    mediaItemIds: ['item-1', 'item-2'],
+    periodStart: new Date('2023-03-04T00:00:00.000Z'),
+    periodEnd: new Date('2023-03-09T00:00:00.000Z'),
+    ...over,
+  };
+}
+
+/** Prisma double: the three bounded fact lookups, all trivially satisfiable. */
+function fakePrisma(over: Record<string, unknown> = {}): PrismaService {
+  return {
+    mediaTag: { findMany: jest.fn().mockResolvedValue([{ tag: { name: 'beach' } }]) },
+    mediaItem: { findMany: jest.fn().mockResolvedValue([{ description: 'A beach.' }]) },
+    face: { findMany: jest.fn().mockResolvedValue([{ person: { name: 'Camila' } }]) },
+    ...over,
+  } as unknown as PrismaService;
+}
+
+/** An AiProvider whose `chat` is driven by the supplied async generator body. */
+function fakeProvider(
+  chat: (req: ChatRequest) => AsyncIterable<ChatStreamEvent>,
+): { provider: AiProvider; requests: ChatRequest[] } {
+  const requests: ChatRequest[] = [];
+  const provider = {
+    key: 'openai',
+    chat: (_creds: unknown, req: ChatRequest) => {
+      requests.push(req);
+      return chat(req);
+    },
+  } as unknown as AiProvider;
+  return { provider, requests };
+}
+
+/** The common case: emit `text` once, then `done`. */
+function textProvider(text: string) {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  return fakeProvider(async function* () {
+    yield { type: 'text', text } as ChatStreamEvent;
+    yield { type: 'done' } as ChatStreamEvent;
+  });
+}
+
+describe('MemoryTitleService', () => {
+  let service: MemoryTitleService;
+  let aiSettings: { resolveMemoriesConfig: jest.Mock; resolveCredentials: jest.Mock };
+  let registry: { get: jest.Mock };
+  let prisma: PrismaService;
+  let debug: jest.SpyInstance;
+  let error: jest.SpyInstance;
+  let warn: jest.SpyInstance;
+
+  function build(provider?: AiProvider): void {
+    registry = { get: jest.fn().mockReturnValue(provider) };
+    service = new MemoryTitleService(
+      prisma,
+      aiSettings as unknown as AiSettingsService,
+      registry as unknown as AiProviderRegistry,
+    );
+  }
+
+  beforeEach(() => {
+    prisma = fakePrisma();
+    aiSettings = {
+      resolveMemoriesConfig: jest.fn().mockResolvedValue({ provider: 'openai', model: 'gpt-x' }),
+      resolveCredentials: jest.fn().mockResolvedValue({ apiKey: 'sk-test' }),
+    };
+    // Degradation is the NORMAL path (#306) — it must never surface as an
+    // error- or warn-level log, which is asserted in every fallback test below.
+    debug = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    error = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    build(textProvider(GOOD_RESPONSE).provider);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Every fallback path shares this: nothing louder than debug is emitted. */
+  function expectQuietDegradation(): void {
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug).toHaveBeenCalled();
+  }
+
+  // --- beginRun -------------------------------------------------------------
+
+  describe('beginRun', () => {
+    it('opens an uncapped budget for a scheduled run', () => {
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+      expect(run).toEqual({
+        enabled: true,
+        backfill: false,
+        maxAiCalls: Number.POSITIVE_INFINITY,
+        aiCalls: 0,
+        stopped: false,
+        stopReason: null,
+      });
+    });
+
+    it('caps a backfill run at BACKFILL_AI_TITLE_CAP calls', () => {
+      expect(service.beginRun({ backfill: true, aiTitlesEnabled: true }).maxAiCalls).toBe(
+        BACKFILL_AI_TITLE_CAP,
+      );
+    });
+  });
+
+  // --- success --------------------------------------------------------------
+
+  describe('the configured happy path', () => {
+    it('returns the parsed title, subtitle, narrative and the model id', async () => {
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toEqual({
+        title: 'Five golden days',
+        subtitle: 'Tamarindo, March 2023',
+        narrative: 'Sunsets, surf and a first swim.',
+        // titleModel audit value — the whole point of the column.
+        model: 'gpt-x',
+      });
+      expect(run.aiCalls).toBe(1);
+      expect(run.stopped).toBe(false);
+    });
+
+    it('sends the system prompt, the fact block and a moderate temperature', async () => {
+      const { provider, requests } = textProvider(GOOD_RESPONSE);
+      build(provider);
+
+      await service.generate(
+        request(),
+        service.beginRun({ backfill: false, aiTitlesEnabled: true }),
+      );
+
+      const sent = requests[0]!;
+      expect(sent.model).toBe('gpt-x');
+      expect(sent.temperature).toBe(MEMORY_TITLE_TEMPERATURE);
+      expect(sent.system).toContain('family photo app');
+      expect(sent.messages).toHaveLength(1);
+      expect(sent.messages[0]!.role).toBe('user');
+      expect(sent.messages[0]!.content).toContain('Place: Tamarindo, Guanacaste, Costa Rica');
+      expect(sent.messages[0]!.content).toContain('Fallback title: Trip to Guanacaste');
+      // METADATA ONLY: no image bytes, and no ids of any kind.
+      expect(sent.messages[0]!.content).not.toContain('item-1');
+    });
+
+    it('reports an omitted subtitle/narrative as null rather than inventing one', async () => {
+      // Substituting the TEMPLATE subtitle here would be the wrong layer: this
+      // service reports what the model said, and MemoryCurationService.
+      // titleColumns decides what to persist when a field came back empty.
+      build(textProvider('{"title":"A quiet week"}').provider);
+
+      await expect(
+        service.generate(request(), service.beginRun({ backfill: false, aiTitlesEnabled: true })),
+      ).resolves.toEqual({
+        title: 'A quiet week',
+        subtitle: null,
+        narrative: null,
+        model: 'gpt-x',
+      });
+    });
+
+    it('names the memory subject first among the people it sends', async () => {
+      const { provider, requests } = textProvider(GOOD_RESPONSE);
+      build(provider);
+      (prisma.face.findMany as jest.Mock).mockResolvedValue([
+        { person: { name: 'Bystander' } },
+        { person: { name: 'Abuela' } },
+      ]);
+
+      await service.generate(
+        request({ type: MemoryType.person_highlights, meta: { personName: 'Abuela', year: 2025 } }),
+        service.beginRun({ backfill: false, aiTitlesEnabled: true }),
+      );
+
+      expect(requests[0]!.messages[0]!.content).toContain('People pictured: Abuela, Bystander');
+    });
+  });
+
+  // --- configuration gates: no provider call at all -------------------------
+
+  describe('configuration gates (no provider call is made)', () => {
+    it('memories.aiTitles.enabled = false → template, and the config is never read', async () => {
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: false });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      // The epic requires "off ⇒ templates only, and no provider call at all".
+      expect(aiSettings.resolveMemoriesConfig).not.toHaveBeenCalled();
+      expect(registry.get).not.toHaveBeenCalled();
+      expect(run.aiCalls).toBe(0);
+    });
+
+    it('ai.features.memories unset → template, and no provider is resolved', async () => {
+      aiSettings.resolveMemoriesConfig.mockResolvedValue(null);
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(registry.get).not.toHaveBeenCalled();
+      expect(run.aiCalls).toBe(0);
+      expectQuietDegradation();
+    });
+
+    it('credential missing or disabled → template', async () => {
+      // resolveCredentials throws a 400 for both cases; the service must not.
+      aiSettings.resolveCredentials.mockRejectedValue(new Error('Provider "openai" is disabled'));
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(run.aiCalls).toBe(0);
+      expectQuietDegradation();
+    });
+
+    it('an unknown provider key → template', async () => {
+      registry.get.mockImplementation(() => {
+        throw new Error('Unknown AI provider: nope');
+      });
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(run.aiCalls).toBe(0);
+      expectQuietDegradation();
+    });
+  });
+
+  // --- call-time failures ---------------------------------------------------
+
+  describe('call-time failures', () => {
+    it('an HTTP/network error → template, and the run keeps going', async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      build(
+        fakeProvider(async function* () {
+          throw Object.assign(new Error('Internal Server Error'), { status: 500 });
+          // eslint-disable-next-line no-unreachable
+          yield { type: 'done' } as ChatStreamEvent;
+        }).provider,
+      );
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      // A 500 is not a throttle: the run must NOT stop titling everything else.
+      expect(run.stopped).toBe(false);
+      // The attempt still cost the provider work, so it consumes budget.
+      expect(run.aiCalls).toBe(1);
+      expectQuietDegradation();
+    });
+
+    it('a hung provider → template at the hard timeout, and the stream is closed', async () => {
+      jest.useFakeTimers();
+      const returned = jest.fn();
+      const hung: AiProvider = {
+        key: 'openai',
+        chat: () => ({
+          [Symbol.asyncIterator]: () => ({
+            // Never resolves — the exact stall the timeout exists for.
+            next: () => new Promise<IteratorResult<ChatStreamEvent>>(() => undefined),
+            return: async () => {
+              returned();
+              return { done: true, value: undefined };
+            },
+          }),
+        }),
+      } as unknown as AiProvider;
+      build(hung);
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      const pending = service.generate(request(), run);
+      // Let the pre-call awaits (config, credentials, facts) settle first.
+      await jest.advanceTimersByTimeAsync(0);
+      await jest.advanceTimersByTimeAsync(MEMORY_TITLE_TIMEOUT_MS + 1);
+
+      await expect(pending).resolves.toBeNull();
+      expect(returned).toHaveBeenCalled();
+      expect(run.stopped).toBe(false);
+      expect(run.aiCalls).toBe(1);
+      jest.useRealTimers();
+      expectQuietDegradation();
+    });
+
+    it('malformed (non-JSON) output → template', async () => {
+      build(textProvider('I am sorry, I cannot title that.').provider);
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(run.aiCalls).toBe(1);
+      expectQuietDegradation();
+    });
+
+    it('valid JSON with an empty title → template', async () => {
+      build(textProvider('{"title":"","narrative":"lovely"}').provider);
+
+      await expect(
+        service.generate(request(), service.beginRun({ backfill: false, aiTitlesEnabled: true })),
+      ).resolves.toBeNull();
+      expectQuietDegradation();
+    });
+
+    it('an empty stream (no text at all) → template', async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      build(
+        fakeProvider(async function* () {
+          yield { type: 'done' } as ChatStreamEvent;
+        }).provider,
+      );
+
+      await expect(
+        service.generate(request(), service.beginRun({ backfill: false, aiTitlesEnabled: true })),
+      ).resolves.toBeNull();
+      expectQuietDegradation();
+    });
+
+    it('a failing fact lookup → template, never a thrown error into the curator', async () => {
+      (prisma.mediaTag.findMany as jest.Mock).mockRejectedValue(new Error('db exploded'));
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(run.aiCalls).toBe(0);
+      expectQuietDegradation();
+    });
+  });
+
+  // --- rate limiting --------------------------------------------------------
+
+  describe('rate limiting stops the run without failing the job', () => {
+    it.each([
+      ['429', 429],
+      ['529 (Anthropic overloaded)', 529],
+    ])('a %s stops AI titling for the remainder of the run', async (_label, status) => {
+      let calls = 0;
+      // eslint-disable-next-line @typescript-eslint/require-await
+      build(
+        fakeProvider(async function* () {
+          calls += 1;
+          throw Object.assign(new Error('Too Many Requests'), { status });
+          // eslint-disable-next-line no-unreachable
+          yield { type: 'done' } as ChatStreamEvent;
+        }).provider,
+      );
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(run.stopped).toBe(true);
+      expect(run.stopReason).toBe('rate_limited');
+
+      // Every subsequent memory in this run is templated WITHOUT another call —
+      // #306 rejects routing this through the enrichment deferral path, because
+      // deferring a whole generation job over a cosmetic field is worse.
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      await expect(service.generate(request(), run)).resolves.toBeNull();
+      expect(calls).toBe(1);
+      expect(run.aiCalls).toBe(1);
+      expectQuietDegradation();
+    });
+  });
+
+  // --- cost control ---------------------------------------------------------
+
+  describe('backfill cost control', () => {
+    it('makes at most BACKFILL_AI_TITLE_CAP calls per backfill job', async () => {
+      let calls = 0;
+      // eslint-disable-next-line @typescript-eslint/require-await
+      build(
+        fakeProvider(async function* () {
+          calls += 1;
+          yield { type: 'text', text: GOOD_RESPONSE } as ChatStreamEvent;
+          yield { type: 'done' } as ChatStreamEvent;
+        }).provider,
+      );
+      const run = service.beginRun({ backfill: true, aiTitlesEnabled: true });
+
+      const results = [];
+      for (let i = 0; i < BACKFILL_AI_TITLE_CAP + 5; i += 1) {
+        results.push(await service.generate(request(), run));
+      }
+
+      expect(calls).toBe(BACKFILL_AI_TITLE_CAP);
+      expect(results.slice(0, BACKFILL_AI_TITLE_CAP).every((r) => r !== null)).toBe(true);
+      // Beyond the cap: templates, not failures.
+      expect(results.slice(BACKFILL_AI_TITLE_CAP).every((r) => r === null)).toBe(true);
+      expect(run.stopReason).toBe('budget_exhausted');
+    });
+
+    it('a scheduled (non-backfill) run is uncapped', async () => {
+      let calls = 0;
+      // eslint-disable-next-line @typescript-eslint/require-await
+      build(
+        fakeProvider(async function* () {
+          calls += 1;
+          yield { type: 'text', text: GOOD_RESPONSE } as ChatStreamEvent;
+          yield { type: 'done' } as ChatStreamEvent;
+        }).provider,
+      );
+      const run = service.beginRun({ backfill: false, aiTitlesEnabled: true });
+
+      for (let i = 0; i < BACKFILL_AI_TITLE_CAP + 5; i += 1) {
+        await service.generate(request(), run);
+      }
+
+      expect(calls).toBe(BACKFILL_AI_TITLE_CAP + 5);
+      expect(run.stopped).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/memories/titles/memory-title.service.ts
+++ b/apps/api/src/memories/titles/memory-title.service.ts
@@ -1,0 +1,425 @@
+// =============================================================================
+// Memories — AI titles, subtitles & narratives (epic #300, issue #306)
+// =============================================================================
+//
+// Turns a memory the curation engine is about to write into a warm, human
+// title + subtitle + narrative, using the admin-selected `ai.features.memories`
+// provider and model. Called from `MemoryCurationService.upsertMemory` for new
+// memories and for memories whose membership moved materially (>= 30% Jaccard
+// distance) — never for a minor refresh, which is what stops every generation
+// run from re-paying for a title that is still accurate.
+//
+// THE ONE RULE THIS FILE EXISTS TO ENFORCE
+// ----------------------------------------
+// `generate()` NEVER throws and never blocks generation. It returns
+// `MemoryAiTitle` or `null`, and `null` means "write the deterministic
+// template". EVERY failure mode resolves to `null`:
+//
+//   • `memories.aiTitles.enabled` is off        → null, and no provider call
+//   • `ai.features.memories` is unset           → null, and no provider call
+//   • the provider has no enabled credential    → null
+//   • the provider key is not in the registry   → null
+//   • the run's backfill budget is spent        → null, and no provider call
+//   • an earlier call in this run was throttled → null, and no provider call
+//   • HTTP error / network failure              → null
+//   • the call exceeds the 10s hard timeout     → null
+//   • the response is not JSON, or is JSON of
+//     the wrong shape, or has an empty title    → null
+//
+// Logged at DEBUG, not ERROR: on a deployment with no AI provider configured —
+// a supported, documented configuration — falling back is the NORMAL path, and
+// logging it as an error would train operators to ignore the log. Templates are
+// the permanent floor of the feature, not a broken state (see
+// curation/memory-title-templates.ts).
+//
+// WHY THE PROVIDER IS CALLED OUTSIDE THE WRITE TRANSACTION. A 10-second model
+// call inside `upsertMemory`'s `$transaction` would hold row locks and a pool
+// connection for the whole call. The facts a prompt needs come from the
+// selection the curator already computed, so titling runs entirely BEFORE the
+// transaction opens — see MemoryCurationService.
+//
+// RATE LIMITS STOP THE RUN, THEY DO NOT FAIL THE JOB. A 429/529 sets
+// `run.stopped` and every remaining memory in that job is templated. Routing it
+// through the enrichment rate-limit-deferral path was explicitly rejected in
+// #306: that would defer a whole `memory_generation` job — whose real output is
+// the memories — over a cosmetic field.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { MediaTagSource, MemoryType } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AiSettingsService } from '../../ai/ai-settings.service';
+import { AiProviderRegistry } from '../../ai/providers/ai-provider.registry';
+import type { ChatStreamEvent } from '../../ai/providers/ai-provider.interface';
+import { classifyRateLimit } from '../../enrichment/rate-limit.error';
+import { parseMemoryTitleResponse } from './memory-title.parse';
+import {
+  MAX_PROMPT_DESCRIPTIONS,
+  MAX_PROMPT_PERSON_NAMES,
+  MAX_PROMPT_TAGS,
+  MEMORY_TITLE_SYSTEM_PROMPT,
+  MemoryTitleFacts,
+  buildMemoryTitleUserPrompt,
+} from './memory-title.prompts';
+import { MemoryAiTitle, MemoryTitleRequest, MemoryTitleRun } from './memory-title.types';
+
+/**
+ * Hard wall-clock budget for one titling call, per #306.
+ *
+ * Bounds the WHOLE stream, not each chunk: a provider that dribbles one token
+ * every nine seconds is just as effective a stall as one that never answers,
+ * and `memory_generation` shares the enrichment worker's slots with real work.
+ */
+export const MEMORY_TITLE_TIMEOUT_MS = 10_000;
+
+/** Moderate creativity — these are warm titles, not deterministic extraction. */
+export const MEMORY_TITLE_TEMPERATURE = 0.7;
+
+/**
+ * Ceiling on provider calls during ONE admin backfill job (#306 cost control).
+ *
+ * A 70k-item library backfill can create thousands of memories in a single job;
+ * without this it would fire thousands of model calls in one unattended run.
+ * Beyond the cap everything is templated, and the next scheduled run titles
+ * more (each run gets a fresh budget), so the library converges instead of
+ * billing for itself all at once.
+ */
+export const BACKFILL_AI_TITLE_CAP = 100;
+
+/**
+ * Defensive ceiling on accumulated response text. A well-behaved answer is a
+ * few hundred bytes; a model stuck in a repetition loop would otherwise grow an
+ * unbounded string inside a worker that is already memory-sensitive.
+ */
+const MAX_RESPONSE_CHARS = 8_000;
+
+/** Distinguishable from a provider error so the log line can say which. */
+class MemoryTitleTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Memory title generation exceeded ${ms}ms`);
+    this.name = 'MemoryTitleTimeoutError';
+  }
+}
+
+/**
+ * Read a chat stream to completion, bounded by an absolute deadline.
+ *
+ * Each `next()` is raced against the REMAINING budget rather than a fresh
+ * timeout, so the total is bounded even when every individual chunk arrives
+ * promptly. On timeout the iterator's `return()` is invoked (fire-and-forget —
+ * awaiting it would re-block on the very network call that just stalled) so the
+ * underlying generator can release its HTTP connection.
+ */
+async function collectChatText(
+  stream: AsyncIterable<ChatStreamEvent>,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  const iterator = stream[Symbol.asyncIterator]();
+  let text = '';
+  let closed = false;
+
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    void Promise.resolve(iterator.return?.(undefined)).catch(() => undefined);
+  };
+
+  try {
+    for (;;) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) throw new MemoryTitleTimeoutError(timeoutMs);
+
+      let timer: NodeJS.Timeout | undefined;
+      const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new MemoryTitleTimeoutError(timeoutMs)), remaining);
+        // Never hold the process (or a Jest run) open on this timer.
+        timer.unref?.();
+      });
+
+      let step: IteratorResult<ChatStreamEvent>;
+      try {
+        step = await Promise.race([iterator.next(), timeout]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+
+      if (step.done) break;
+      const event = step.value;
+      if (event.type === 'text') {
+        text += event.text;
+        if (text.length > MAX_RESPONSE_CHARS) {
+          throw new Error(`Memory title response exceeded ${MAX_RESPONSE_CHARS} characters`);
+        }
+      } else if (event.type === 'done') {
+        break;
+      }
+    }
+  } finally {
+    close();
+  }
+
+  return text;
+}
+
+/** Read a `meta` key as a number, tolerating the JSONB round-trip. */
+function metaNumber(meta: Record<string, unknown> | null, key: string): number | null {
+  const value = meta?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** Read a `meta` key as a non-empty string. */
+function metaString(meta: Record<string, unknown> | null, key: string): string | null {
+  const value = meta?.[key];
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+@Injectable()
+export class MemoryTitleService {
+  private readonly logger = new Logger(MemoryTitleService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly aiSettings: AiSettingsService,
+    private readonly registry: AiProviderRegistry,
+  ) {}
+
+  /**
+   * Open a per-job budget. Called ONCE by `MemoryGenerationHandler`, carried on
+   * `MemoryCuratorContext.titling`, and handed to `upsertMemory` by curators.
+   *
+   * `aiTitlesEnabled` comes from the settings the handler already resolved for
+   * the run, so a disabled feature costs neither a settings read nor a provider
+   * call per memory.
+   */
+  beginRun(options: { backfill: boolean; aiTitlesEnabled: boolean }): MemoryTitleRun {
+    return {
+      enabled: options.aiTitlesEnabled,
+      backfill: options.backfill,
+      maxAiCalls: options.backfill ? BACKFILL_AI_TITLE_CAP : Number.POSITIVE_INFINITY,
+      aiCalls: 0,
+      stopped: false,
+      stopReason: null,
+    };
+  }
+
+  /**
+   * Produce an AI title for one memory, or `null` to use the template.
+   *
+   * Total by construction — see this file's header for the complete failure
+   * list, every entry of which lands on `null`.
+   */
+  async generate(request: MemoryTitleRequest, run: MemoryTitleRun): Promise<MemoryAiTitle | null> {
+    if (!run.enabled || run.stopped) return null;
+
+    if (run.aiCalls >= run.maxAiCalls) {
+      // Announce the cap exactly once per run, at the moment it bites.
+      if (!run.stopped) {
+        run.stopped = true;
+        run.stopReason = 'budget_exhausted';
+        this.logger.debug(
+          `Memory AI titling budget of ${run.maxAiCalls} calls reached for this backfill run; ` +
+            'remaining memories use template titles',
+        );
+      }
+      return null;
+    }
+
+    const config = await this.aiSettings.resolveMemoriesConfig();
+    if (!config) {
+      this.logger.debug('No ai.features.memories provider configured; using template titles');
+      return null;
+    }
+
+    let creds: { apiKey: string; baseUrl?: string };
+    try {
+      // Throws (400) when the provider row is absent or disabled — exactly the
+      // "credential missing/disabled" degradation path.
+      creds = await this.aiSettings.resolveCredentials(config.provider);
+    } catch (err) {
+      this.logger.debug(
+        `Memory AI titling: no usable credential for provider "${config.provider}" ` +
+          `(${err instanceof Error ? err.message : String(err)}); using template titles`,
+      );
+      return null;
+    }
+
+    let provider;
+    try {
+      provider = this.registry.get(config.provider);
+    } catch (err) {
+      this.logger.debug(
+        `Memory AI titling: unknown provider "${config.provider}" ` +
+          `(${err instanceof Error ? err.message : String(err)}); using template titles`,
+      );
+      return null;
+    }
+
+    let userPrompt: string;
+    try {
+      const facts = await this.collectFacts(request);
+      userPrompt = buildMemoryTitleUserPrompt(facts);
+    } catch (err) {
+      // A fact lookup is plain SQL against already-known ids; if it fails, the
+      // memory itself is still perfectly writable with its template title.
+      this.logger.debug(
+        `Memory AI titling: failed to assemble prompt facts ` +
+          `(${err instanceof Error ? err.message : String(err)}); using template titles`,
+      );
+      return null;
+    }
+
+    // Charged BEFORE the call: an attempt that times out or 500s has cost the
+    // provider work and the run wall-clock, so it must consume budget too —
+    // otherwise a persistently failing provider would retry uncapped.
+    run.aiCalls += 1;
+
+    let raw: string;
+    try {
+      raw = await collectChatText(
+        provider.chat(creds, {
+          model: config.model,
+          system: MEMORY_TITLE_SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: userPrompt }],
+          temperature: MEMORY_TITLE_TEMPERATURE,
+        }),
+        MEMORY_TITLE_TIMEOUT_MS,
+      );
+    } catch (err) {
+      const rateLimit = classifyRateLimit(err);
+      if (rateLimit) {
+        run.stopped = true;
+        run.stopReason = 'rate_limited';
+        this.logger.debug(
+          `Memory AI titling rate-limited by "${config.provider}" (${rateLimit.message}); ` +
+            'remaining memories in this run use template titles',
+        );
+      } else {
+        this.logger.debug(
+          `Memory AI titling call failed (${err instanceof Error ? err.message : String(err)}); ` +
+            'using template titles',
+        );
+      }
+      return null;
+    }
+
+    const parsed = parseMemoryTitleResponse(raw);
+    if (!parsed) {
+      this.logger.debug(
+        `Memory AI titling: unusable response from "${config.provider}"/"${config.model}" ` +
+          `(${raw.length} chars); using template titles`,
+      );
+      return null;
+    }
+
+    return {
+      title: parsed.title,
+      subtitle: parsed.subtitle,
+      narrative: parsed.narrative,
+      model: config.model,
+    };
+  }
+
+  /**
+   * Assemble the metadata the prompt describes.
+   *
+   * Three bounded lookups over the memory's OWN item ids (at most
+   * `memories.maxItemsPerMemory`, capped at 100 by the settings schema), so
+   * these are small `IN (...)` queries, never a library scan. `meta` supplies
+   * everything the curator already knew — place, person name, tag, season,
+   * years-ago — with no second query to re-derive it.
+   */
+  private async collectFacts(request: MemoryTitleRequest): Promise<MemoryTitleFacts> {
+    const ids = request.mediaItemIds;
+    const meta = request.meta ?? null;
+
+    const [tagRows, descriptionRows, faceRows] = await Promise.all([
+      ids.length === 0
+        ? Promise.resolve([])
+        : this.prisma.mediaTag.findMany({
+            where: { mediaItemId: { in: ids }, source: MediaTagSource.ai },
+            select: { tag: { select: { name: true } } },
+          }),
+      ids.length === 0
+        ? Promise.resolve([])
+        : this.prisma.mediaItem.findMany({
+            where: { id: { in: ids }, description: { not: null } },
+            select: { description: true },
+            orderBy: [{ capturedAt: 'asc' }, { id: 'asc' }],
+            take: MAX_PROMPT_DESCRIPTIONS,
+          }),
+      ids.length === 0
+        ? Promise.resolve([])
+        : this.prisma.face.findMany({
+            where: {
+              mediaItemId: { in: ids },
+              personId: { not: null },
+              // Hiding or deleting a person is an explicit "stop surfacing
+              // this"; naming them in a title would defeat that.
+              person: { deletedAt: null, hiddenAt: null, mergedIntoId: null },
+            },
+            select: { person: { select: { name: true } } },
+          }),
+    ]);
+
+    const tagCounts = new Map<string, number>();
+    for (const row of tagRows) {
+      const name = row.tag?.name?.trim();
+      if (!name) continue;
+      tagCounts.set(name, (tagCounts.get(name) ?? 0) + 1);
+    }
+    const topTags = [...tagCounts.entries()]
+      // Count descending, then name ascending — a deterministic order, so the
+      // same memory renders the same prompt on every run.
+      .sort((a, b) => (b[1] !== a[1] ? b[1] - a[1] : a[0].localeCompare(b[0])))
+      .slice(0, MAX_PROMPT_TAGS)
+      .map(([name, count]) => ({ name, count }));
+
+    const personNames = [
+      ...new Set(
+        faceRows
+          .map((f) => f.person?.name?.trim())
+          .filter((n): n is string => !!n && n.length > 0),
+      ),
+    ].slice(0, MAX_PROMPT_PERSON_NAMES);
+
+    // The people curators name their subject in `meta`; put them first so the
+    // subject of the memory is never crowded out by an incidental bystander.
+    const subject = metaString(meta, 'personName');
+    if (subject) {
+      const rest = personNames.filter((n) => n !== subject);
+      personNames.length = 0;
+      personNames.push(subject, ...rest.slice(0, MAX_PROMPT_PERSON_NAMES - 1));
+    }
+
+    const place =
+      metaString(meta, 'locality') || metaString(meta, 'admin1') || metaString(meta, 'country')
+        ? {
+            locality: metaString(meta, 'locality'),
+            admin1: metaString(meta, 'admin1'),
+            country: metaString(meta, 'country'),
+          }
+        : null;
+
+    return {
+      type: request.type,
+      itemCount: ids.length,
+      periodStart: request.periodStart,
+      periodEnd: request.periodEnd,
+      templateTitle: request.templateTitle,
+      templateSubtitle: request.templateSubtitle,
+      place,
+      personNames,
+      topTags,
+      descriptions: descriptionRows
+        .map((r) => r.description ?? '')
+        .filter((d) => d.trim().length > 0),
+      yearsAgo: metaNumber(meta, 'yearsAgo'),
+      themeTag: request.type === MemoryType.theme ? metaString(meta, 'tag') : null,
+      season: metaString(meta, 'season'),
+      year: metaNumber(meta, 'year') ?? metaNumber(meta, 'seasonYear'),
+    };
+  }
+}

--- a/apps/api/src/memories/titles/memory-title.types.ts
+++ b/apps/api/src/memories/titles/memory-title.types.ts
@@ -1,0 +1,74 @@
+// =============================================================================
+// Memories — AI titling types (epic #300, issue #306)
+// =============================================================================
+//
+// Kept in its own dependency-free module so `curation/memory-curation.types.ts`
+// can reference `MemoryTitleRun` without importing the title SERVICE, which in
+// turn imports the curation types. Types-only files break that cycle at the
+// source rather than relying on `import type` erasure to paper over it.
+// =============================================================================
+
+import { MemoryType } from '@prisma/client';
+
+/**
+ * Everything one titling attempt is allowed to know, assembled by the curation
+ * service from the memory it is about to write.
+ *
+ * Deliberately a projection of `UpsertMemoryInput` rather than the input
+ * itself: it names exactly what may travel toward a third-party model, which
+ * makes the privacy boundary reviewable in one place. `circleId`, `userId`,
+ * `personId`, storage keys and file names are absent BY CONSTRUCTION — see
+ * memory-title.prompts.ts.
+ */
+export interface MemoryTitleRequest {
+  type: MemoryType;
+  /** The deterministic template title — the floor the model is asked to beat. */
+  templateTitle: string;
+  templateSubtitle: string | null;
+  /** The curator's `meta` (place, personName, tag, season, yearsAgo, …). */
+  meta: Record<string, unknown> | null;
+  /** Media items in the memory. Used only for DB fact lookups — never sent. */
+  mediaItemIds: string[];
+  periodStart: Date | null;
+  periodEnd: Date | null;
+}
+
+/** A successful AI titling result, ready to write onto the `Memory` row. */
+export interface MemoryAiTitle {
+  title: string;
+  subtitle: string | null;
+  narrative: string | null;
+  /** Persisted to `Memory.titleModel` so the row audits which model wrote it. */
+  model: string;
+}
+
+/**
+ * Mutable, per-generation-job budget and circuit breaker.
+ *
+ * WHY A PASSED OBJECT AND NOT SERVICE STATE. `MemoryTitleService` is a Nest
+ * singleton and the enrichment worker can run several `memory_generation` jobs
+ * concurrently (`ENRICHMENT_WORKER_CONCURRENCY`), so a mutable field on the
+ * service would let one circle's rate-limit trip silently template another
+ * circle's memories — and one circle's backfill would consume another's budget.
+ * The run object is created once per job by `MemoryGenerationHandler`, carried
+ * on `MemoryCuratorContext`, and handed to `upsertMemory` by each curator.
+ *
+ * A missing run means NO AI titling at all. That default is deliberately
+ * fail-safe: a curator (or a test) that forgets to thread it degrades to the
+ * documented template floor rather than making unbudgeted, uncapped model calls.
+ */
+export interface MemoryTitleRun {
+  /** `memories.aiTitles.enabled`, resolved once per job. False ⇒ no call ever. */
+  readonly enabled: boolean;
+  /** True for an admin library backfill (#315), which is what caps the budget. */
+  readonly backfill: boolean;
+  /** Hard ceiling on provider calls for this job. `Infinity` outside backfill. */
+  readonly maxAiCalls: number;
+  /** Provider calls ATTEMPTED so far — a failed call still consumes budget. */
+  aiCalls: number;
+  /** Set once the run has stopped calling the provider for the rest of the job. */
+  stopped: boolean;
+  stopReason: MemoryTitleStopReason | null;
+}
+
+export type MemoryTitleStopReason = 'rate_limited' | 'budget_exhausted';

--- a/apps/api/test/memories/memories-ai-titles.integration.spec.ts
+++ b/apps/api/test/memories/memories-ai-titles.integration.spec.ts
@@ -1,0 +1,343 @@
+// DB_GATED: requires a real PostgreSQL with migrations applied. Reachability is
+// probed synchronously at module load via `describeMaybeDb`, so with no database
+// the whole suite is registered as `describe.skip` and reports SKIPPED — never a
+// green PASS that asserted nothing. See test/helpers/db-probe.helper.ts.
+//
+// WHY THIS SUITE IS DB-BACKED (epic #300, issue #306)
+// ---------------------------------------------------
+// The unit suites next to the service prove that titling produces the right
+// VALUES and degrades on every failure. What they cannot prove is the part
+// #306's acceptance criteria are actually written about: which of those values
+// reaches the `memories` ROW. "`titleSource`/`titleModel` audit which path ran"
+// is a statement about five columns, and the interesting cases are all in
+// `upsertMemory`'s branching — create writes AI columns, a minor refresh
+// PRESERVES them, a material refresh REWRITES them, and a failed call after a
+// successful one must clear `titleModel` and `narrative` rather than leaving a
+// stale model id attached to a template title.
+//
+// NO NETWORK: the title service is a stub (test/memories/memory-title.stub.ts).
+// This suite is about persistence, not about the provider call.
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { randomUUID } from 'crypto';
+import { describeMaybeDb } from '../helpers/db-probe.helper';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { CuratedSelection } from '../../src/memories/curation/memory-curation.types';
+import {
+  MemoryAiTitle,
+  MemoryTitleRequest,
+  MemoryTitleRun,
+} from '../../src/memories/titles/memory-title.types';
+import { stubTitleService } from './memory-title.stub';
+
+function resolveDatabaseUrl(): string {
+  if (process.env['DATABASE_URL']) return process.env['DATABASE_URL'] as string;
+  const host = process.env['POSTGRES_HOST'] ?? 'localhost';
+  const port = process.env['POSTGRES_PORT'] ?? '5432';
+  const user = process.env['POSTGRES_USER'] ?? 'postgres';
+  const password = process.env['POSTGRES_PASSWORD'] ?? 'postgres';
+  const db = process.env['POSTGRES_DB'] ?? 'appdb';
+  return `postgresql://${user}:${encodeURIComponent(password)}@${host}:${port}/${db}`;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+
+const AI_TITLE: MemoryAiTitle = {
+  title: 'Five golden days on the Pacific coast',
+  subtitle: 'Tamarindo, March 2023',
+  narrative: 'Sunsets, surf, and a first swim in the ocean.',
+  model: 'gpt-test-1',
+};
+
+describeMaybeDb('Memories — AI titles persistence (DB_GATED: real PostgreSQL)', () => {
+  let prisma: PrismaClient;
+
+  const userId = randomUUID();
+  const circleId = randomUUID();
+  const createdStorageObjectIds: string[] = [];
+
+  /** Swapped per test to drive the stubbed title service. */
+  let generate: (request: MemoryTitleRequest, run: MemoryTitleRun) => Promise<MemoryAiTitle | null>;
+  let seenRequests: MemoryTitleRequest[];
+  let curation: MemoryCurationService;
+
+  /** A titling budget with AI enabled — what the handler opens for a real run. */
+  function aiRun(): MemoryTitleRun {
+    return {
+      enabled: true,
+      backfill: false,
+      maxAiCalls: Number.POSITIVE_INFINITY,
+      aiCalls: 0,
+      stopped: false,
+      stopReason: null,
+    };
+  }
+
+  async function seedItem(capturedAt: Date): Promise<string> {
+    const storageObjectId = randomUUID();
+    createdStorageObjectIds.push(storageObjectId);
+    await prisma.storageObject.create({
+      data: {
+        id: storageObjectId,
+        name: `${storageObjectId}.jpg`,
+        size: BigInt(2048),
+        mimeType: 'image/jpeg',
+        storageKey: `memories-ai-titles/${storageObjectId}`,
+        status: 'ready',
+        uploadedById: userId,
+      },
+    });
+    const item = await prisma.mediaItem.create({
+      data: {
+        storageObjectId,
+        circleId,
+        addedById: userId,
+        type: 'photo',
+        source: 'web',
+        originalFilename: `${storageObjectId}.jpg`,
+        capturedAt,
+      },
+      select: { id: true },
+    });
+    return item.id;
+  }
+
+  /** A minimal, valid `CuratedSelection` over the supplied item ids. */
+  function selectionOf(ids: string[]): CuratedSelection {
+    return {
+      items: ids.map((mediaItemId, position) => ({ mediaItemId, position, score: 1 })),
+      coverMediaItemId: ids[0] ?? null,
+      periodStart: new Date(Date.UTC(2023, 2, 4)),
+      periodEnd: new Date(Date.UTC(2023, 2, 9)),
+      candidateCount: ids.length,
+      truncated: false,
+    };
+  }
+
+  async function upsertTrip(
+    ids: string[],
+    over: { titling?: MemoryTitleRun; retitle?: boolean } = {},
+  ) {
+    return curation.upsertMemory({
+      circleId,
+      type: 'trip',
+      periodKey: '2023-03-04',
+      subjectKey: 'tamarindo',
+      title: 'Trip to Guanacaste',
+      subtitle: 'March 2023',
+      selection: selectionOf(ids),
+      meta: { locality: 'Tamarindo', country: 'Costa Rica' },
+      ...over,
+    });
+  }
+
+  function readMemory() {
+    return prisma.memory.findFirstOrThrow({
+      where: { circleId },
+      select: {
+        id: true,
+        title: true,
+        subtitle: true,
+        narrative: true,
+        titleSource: true,
+        titleModel: true,
+      },
+    });
+  }
+
+  beforeAll(async () => {
+    const adapter = new PrismaPg({ connectionString: DATABASE_URL });
+    prisma = new PrismaClient({ adapter });
+    await prisma.$connect();
+
+    await prisma.user.create({
+      data: { id: userId, email: `memories-ai-titles-${userId}@example.test` },
+    });
+    await prisma.circle.create({
+      data: { id: circleId, name: 'Memories AI Titles Circle', ownerId: userId },
+    });
+
+    curation = new MemoryCurationService(
+      prisma as unknown as PrismaService,
+      stubTitleService((request, run) => {
+        seenRequests.push(request);
+        return generate(request, run);
+      }),
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await prisma.memory.deleteMany({ where: { circleId } }).catch(() => undefined);
+    await prisma.mediaItem.deleteMany({ where: { circleId } }).catch(() => undefined);
+    await prisma.storageObject
+      .deleteMany({ where: { id: { in: createdStorageObjectIds } } })
+      .catch(() => undefined);
+    await prisma.circle.deleteMany({ where: { id: circleId } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.$disconnect();
+  }, 30000);
+
+  beforeEach(() => {
+    seenRequests = [];
+    generate = () => Promise.resolve(AI_TITLE);
+  });
+
+  afterEach(async () => {
+    await prisma.memory.deleteMany({ where: { circleId } });
+  });
+
+  it('AUDIT: a successful call persists the AI title and stamps titleSource/titleModel', async () => {
+    const ids = [await seedItem(new Date(Date.UTC(2023, 2, 4)))];
+
+    await upsertTrip(ids, { titling: aiRun() });
+
+    expect(await readMemory()).toMatchObject({
+      title: AI_TITLE.title,
+      subtitle: AI_TITLE.subtitle,
+      narrative: AI_TITLE.narrative,
+      titleSource: 'ai',
+      titleModel: 'gpt-test-1',
+    });
+  });
+
+  it('AUDIT: a failed call persists the template and leaves titleModel NULL', async () => {
+    generate = () => Promise.resolve(null);
+    const ids = [await seedItem(new Date(Date.UTC(2023, 2, 4)))];
+
+    await upsertTrip(ids, { titling: aiRun() });
+
+    expect(await readMemory()).toMatchObject({
+      title: 'Trip to Guanacaste',
+      subtitle: 'March 2023',
+      narrative: null,
+      titleSource: 'template',
+      titleModel: null,
+    });
+  });
+
+  it('GRACEFUL DEGRADATION: no titling run at all still writes the memory', async () => {
+    // The "no AI provider configured" deployment, from the engine's point of
+    // view. Generation must not be blocked, and nothing may be called.
+    const ids = [await seedItem(new Date(Date.UTC(2023, 2, 4)))];
+
+    const result = await upsertTrip(ids);
+
+    expect(result.created).toBe(true);
+    expect(seenRequests).toHaveLength(0);
+    expect(await readMemory()).toMatchObject({ titleSource: 'template', titleModel: null });
+  });
+
+  it('sends the curator facts — type, template title, meta and the item ids — to titling', async () => {
+    const ids = [await seedItem(new Date(Date.UTC(2023, 2, 4)))];
+
+    await upsertTrip(ids, { titling: aiRun() });
+
+    expect(seenRequests).toHaveLength(1);
+    expect(seenRequests[0]).toMatchObject({
+      type: 'trip',
+      templateTitle: 'Trip to Guanacaste',
+      templateSubtitle: 'March 2023',
+      meta: { locality: 'Tamarindo', country: 'Costa Rica' },
+      mediaItemIds: ids,
+    });
+  });
+
+  it('ANTI-CHURN: a refresh below the 30% threshold keeps the AI title and makes no call', async () => {
+    // Ten items in, one swapped out: Jaccard distance 2/11 ≈ 0.18 < 0.30.
+    const base: string[] = [];
+    for (let i = 0; i < 10; i += 1) base.push(await seedItem(new Date(Date.UTC(2023, 2, 4, i))));
+    await upsertTrip(base, { titling: aiRun() });
+
+    seenRequests = [];
+    generate = () => Promise.resolve({ ...AI_TITLE, title: 'A DIFFERENT TITLE' });
+    const swapped = [...base.slice(1), await seedItem(new Date(Date.UTC(2023, 2, 9)))];
+    const result = await upsertTrip(swapped, { titling: aiRun() });
+
+    expect(result.materiallyChanged).toBe(false);
+    // No second model call — this is the rule that stops every generation run
+    // from re-paying for a title that is still accurate.
+    expect(seenRequests).toHaveLength(0);
+    expect(await readMemory()).toMatchObject({
+      title: AI_TITLE.title,
+      narrative: AI_TITLE.narrative,
+      titleSource: 'ai',
+      titleModel: 'gpt-test-1',
+    });
+  });
+
+  it('MATERIAL CHANGE: a >=30% membership change re-titles through AI', async () => {
+    const base: string[] = [];
+    for (let i = 0; i < 4; i += 1) base.push(await seedItem(new Date(Date.UTC(2023, 2, 4, i))));
+    await upsertTrip(base, { titling: aiRun() });
+
+    seenRequests = [];
+    generate = () =>
+      Promise.resolve({ ...AI_TITLE, title: 'Six golden days', model: 'gpt-test-2' });
+    const grown = [...base];
+    for (let i = 0; i < 4; i += 1) grown.push(await seedItem(new Date(Date.UTC(2023, 2, 8, i))));
+    const result = await upsertTrip(grown, { titling: aiRun() });
+
+    expect(result.materiallyChanged).toBe(true);
+    expect(seenRequests).toHaveLength(1);
+    expect(await readMemory()).toMatchObject({
+      title: 'Six golden days',
+      titleSource: 'ai',
+      titleModel: 'gpt-test-2',
+    });
+  });
+
+  it('MATERIAL CHANGE: a failed re-title clears the stale model id and narrative', async () => {
+    // The nastiest ordering: an AI-titled memory whose next material refresh
+    // cannot reach the provider. Leaving `titleModel`/`narrative` in place would
+    // attach a model id and a blurb to a title that model never wrote.
+    const base: string[] = [];
+    for (let i = 0; i < 4; i += 1) base.push(await seedItem(new Date(Date.UTC(2023, 2, 4, i))));
+    await upsertTrip(base, { titling: aiRun() });
+    expect(await readMemory()).toMatchObject({ titleSource: 'ai' });
+
+    generate = () => Promise.resolve(null);
+    const grown = [...base];
+    for (let i = 0; i < 4; i += 1) grown.push(await seedItem(new Date(Date.UTC(2023, 2, 8, i))));
+    await upsertTrip(grown, { titling: aiRun() });
+
+    expect(await readMemory()).toMatchObject({
+      title: 'Trip to Guanacaste',
+      narrative: null,
+      titleSource: 'template',
+      titleModel: null,
+    });
+  });
+
+  it('RETITLE: an explicit retitle re-runs AI even on a minor membership change', async () => {
+    // The Trips curator's drifted-subject case (#304): the item set barely
+    // moved, but the memory is no longer named after the same town.
+    const base: string[] = [];
+    for (let i = 0; i < 10; i += 1) base.push(await seedItem(new Date(Date.UTC(2023, 2, 4, i))));
+    await upsertTrip(base, { titling: aiRun() });
+
+    seenRequests = [];
+    generate = () => Promise.resolve({ ...AI_TITLE, title: 'Six days in Nosara' });
+    const result = await upsertTrip(base, { titling: aiRun(), retitle: true });
+
+    expect(result.materiallyChanged).toBe(false);
+    expect(seenRequests).toHaveLength(1);
+    expect(await readMemory()).toMatchObject({ title: 'Six days in Nosara', titleSource: 'ai' });
+  });
+
+  it('TOMBSTONE OUTRANKS TITLING: a deleted memory is never re-titled', async () => {
+    const ids = [await seedItem(new Date(Date.UTC(2023, 2, 4)))];
+    await upsertTrip(ids, { titling: aiRun() });
+    const memory = await readMemory();
+    await prisma.memory.update({ where: { id: memory.id }, data: { deletedAt: new Date() } });
+
+    seenRequests = [];
+    const result = await upsertTrip(ids, { titling: aiRun() });
+
+    expect(result.skippedTombstone).toBe(true);
+    // No model call at all: the tombstone check runs BEFORE any titling.
+    expect(seenRequests).toHaveLength(0);
+  });
+});

--- a/apps/api/test/memories/memories-curation.integration.spec.ts
+++ b/apps/api/test/memories/memories-curation.integration.spec.ts
@@ -27,6 +27,7 @@ import { randomUUID } from 'crypto';
 import { describeMaybeDb } from '../helpers/db-probe.helper';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { neverCalledTitleService } from './memory-title.stub';
 import {
   ON_THIS_DAY_RETENTION_DAYS,
   OnThisDayCurator,
@@ -154,7 +155,12 @@ describeMaybeDb('Memories — curation engine & On This Day (DB_GATED: real Post
 
     // The services take a PrismaService (a Nest-lifecycle subclass of
     // PrismaClient); a raw client satisfies every method they actually call.
-    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    curation = new MemoryCurationService(
+      prisma as unknown as PrismaService,
+      // #306: never invoked here — these contexts carry no `titling` run,
+      // so upsertMemory short-circuits to deterministic template titles.
+      neverCalledTitleService(),
+    );
     curator = new OnThisDayCurator(prisma as unknown as PrismaService, curation);
 
     await prisma.user.create({

--- a/apps/api/test/memories/memories-people.integration.spec.ts
+++ b/apps/api/test/memories/memories-people.integration.spec.ts
@@ -26,6 +26,7 @@ import { randomUUID } from 'crypto';
 import { describeMaybeDb } from '../helpers/db-probe.helper';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { neverCalledTitleService } from './memory-title.stub';
 import { PersonHighlightsCurator } from '../../src/memories/curators/person-highlights.curator';
 import { PersonOverYearsCurator } from '../../src/memories/curators/person-over-years.curator';
 import { PERSON_OVER_YEARS_MAX_PER_YEAR } from '../../src/memories/curators/person-candidates';
@@ -201,7 +202,12 @@ describeMaybeDb('Memories — people curators (DB_GATED: real PostgreSQL)', () =
     prisma = new PrismaClient({ adapter });
     await prisma.$connect();
 
-    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    curation = new MemoryCurationService(
+      prisma as unknown as PrismaService,
+      // #306: never invoked here — these contexts carry no `titling` run,
+      // so upsertMemory short-circuits to deterministic template titles.
+      neverCalledTitleService(),
+    );
     highlights = new PersonHighlightsCurator(prisma as unknown as PrismaService, curation);
     overYears = new PersonOverYearsCurator(prisma as unknown as PrismaService, curation);
 

--- a/apps/api/test/memories/memories-periodic.integration.spec.ts
+++ b/apps/api/test/memories/memories-periodic.integration.spec.ts
@@ -25,6 +25,7 @@ import { randomUUID } from 'crypto';
 import { describeMaybeDb } from '../helpers/db-probe.helper';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { neverCalledTitleService } from './memory-title.stub';
 import { ThemeCurator } from '../../src/memories/curators/theme.curator';
 import { SeasonalCurator } from '../../src/memories/curators/seasonal.curator';
 import { YearInReviewCurator } from '../../src/memories/curators/year-in-review.curator';
@@ -201,7 +202,12 @@ describeMaybeDb('Memories — theme / seasonal / year-in-review (DB_GATED: real 
     prisma = new PrismaClient({ adapter });
     await prisma.$connect();
 
-    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    curation = new MemoryCurationService(
+      prisma as unknown as PrismaService,
+      // #306: never invoked here — these contexts carry no `titling` run,
+      // so upsertMemory short-circuits to deterministic template titles.
+      neverCalledTitleService(),
+    );
     theme = new ThemeCurator(prisma as unknown as PrismaService, curation);
     seasonal = new SeasonalCurator(prisma as unknown as PrismaService, curation);
     yearInReview = new YearInReviewCurator(prisma as unknown as PrismaService, curation);

--- a/apps/api/test/memories/memories-trips.integration.spec.ts
+++ b/apps/api/test/memories/memories-trips.integration.spec.ts
@@ -26,6 +26,7 @@ import { randomUUID } from 'crypto';
 import { describeMaybeDb } from '../helpers/db-probe.helper';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { MemoryCurationService } from '../../src/memories/curation/memory-curation.service';
+import { neverCalledTitleService } from './memory-title.stub';
 import { TripCurator } from '../../src/memories/curators/trip.curator';
 import { MemoryCuratorContext } from '../../src/memories/curators/memory-curator.interface';
 import { resolveMemoriesSettings } from '../../src/memories/memories-settings.util';
@@ -214,7 +215,12 @@ describeMaybeDb('Memories — Trips curator (DB_GATED: real PostgreSQL)', () => 
     prisma = new PrismaClient({ adapter });
     await prisma.$connect();
 
-    curation = new MemoryCurationService(prisma as unknown as PrismaService);
+    curation = new MemoryCurationService(
+      prisma as unknown as PrismaService,
+      // #306: never invoked here — these contexts carry no `titling` run,
+      // so upsertMemory short-circuits to deterministic template titles.
+      neverCalledTitleService(),
+    );
     curator = new TripCurator(prisma as unknown as PrismaService, curation);
 
     await prisma.user.create({

--- a/apps/api/test/memories/memory-title.stub.ts
+++ b/apps/api/test/memories/memory-title.stub.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// Memories — MemoryTitleService test doubles (epic #300, issue #306)
+// =============================================================================
+//
+// `MemoryCurationService` takes a `MemoryTitleService` as of #306. The curator
+// integration suites that predate it never pass a `titling` run on their
+// contexts, so `upsertMemory` short-circuits to template titles and the service
+// is never called — but the constructor still needs an argument.
+//
+// `neverCalledTitleService()` is that argument, and it is deliberately hostile:
+// calling it FAILS the test rather than quietly returning null. A suite that
+// starts exercising AI titling by accident should find out immediately, not
+// discover it as a mysterious extra query.
+// =============================================================================
+
+import { MemoryTitleService } from '../../src/memories/titles/memory-title.service';
+import {
+  MemoryAiTitle,
+  MemoryTitleRequest,
+  MemoryTitleRun,
+} from '../../src/memories/titles/memory-title.types';
+
+/** A `MemoryTitleService` that throws if anything actually calls it. */
+export function neverCalledTitleService(): MemoryTitleService {
+  return {
+    beginRun(): MemoryTitleRun {
+      throw new Error('MemoryTitleService.beginRun was not expected in this suite');
+    },
+    generate(): Promise<MemoryAiTitle | null> {
+      throw new Error('MemoryTitleService.generate was not expected in this suite');
+    },
+  } as unknown as MemoryTitleService;
+}
+
+/**
+ * A `MemoryTitleService` whose `generate` is a supplied function — for suites
+ * that DO exercise titling but must never reach a real AI provider.
+ */
+export function stubTitleService(
+  generate: (request: MemoryTitleRequest, run: MemoryTitleRun) => Promise<MemoryAiTitle | null>,
+): MemoryTitleService {
+  return {
+    beginRun(options: { backfill: boolean; aiTitlesEnabled: boolean }): MemoryTitleRun {
+      return {
+        enabled: options.aiTitlesEnabled,
+        backfill: options.backfill,
+        maxAiCalls: options.backfill ? 100 : Number.POSITIVE_INFINITY,
+        aiCalls: 0,
+        stopped: false,
+        stopReason: null,
+      };
+    },
+    generate,
+  } as unknown as MemoryTitleService;
+}

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.5 (data model + generation plumbing + curation engine; all seven curators) |
+| **Version** | 0.6 (data model + generation plumbing + curation engine; all seven curators; AI titles) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305); §5–§8 and §10 are placeholders for later issues in epic #300 |
+| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305), AI titles / subtitles / narratives (#306); §6–§8 and §10 are placeholders for later issues in epic #300 |
 
 ---
 
@@ -584,7 +584,7 @@ Every curator writes through this one method, keyed on `@@unique([circleId, type
 
 **`MemoryUserState` is untouched by design.** It lives in its own table keyed by memory id, so a refresh that replaces every item preserves seen/hidden/favorited for every user. That is precisely why per-user state was not modeled as columns on `Memory` (§2.4).
 
-**Titles survive a minor refresh.** Membership change is measured as Jaccard **distance** on the media-item id sets; below `MATERIAL_CHANGE_THRESHOLD` (30%) the `title`/`subtitle`/`narrative`/`titleSource`/`titleModel` are all left alone. Without this, one new photo joining a ten-item memory would discard an AI title (#306) and re-pay for it on every generation run forever. At or above 30% the old title may now describe a collection that no longer exists, so it is reset to the template with `titleSource = 'template'`, `titleModel = NULL` and `narrative = NULL`, and handed back to AI re-titling on a later pass.
+**Titles survive a minor refresh.** Membership change is measured as Jaccard **distance** on the media-item id sets; below `MATERIAL_CHANGE_THRESHOLD` (30%) the `title`/`subtitle`/`narrative`/`titleSource`/`titleModel` are all left alone. Without this, one new photo joining a ten-item memory would discard an AI title (#306) and re-pay for it on every generation run forever. At or above 30% the old title may now describe a collection that no longer exists, so it is rewritten: AI re-titling runs in the same pass when it is configured (§5.6), and otherwise the row is reset to the template with `titleSource = 'template'`, `titleModel = NULL` and `narrative = NULL`.
 
 `UpsertMemoryResult` returns `{ memoryId, created, materiallyChanged, skippedTombstone }`. `materiallyChanged` exists for [#311](https://github.com/marinoscar/MemoriaHub/issues/311)'s notification and digest producers, which need "is there anything genuinely new to tell the circle about?" without re-diffing the item set themselves.
 
@@ -622,7 +622,118 @@ One wall clock (`ctx.now`) is captured once by the handler and shared by every c
 
 ## 5. AI Titles, Subtitles & Narratives
 
-Placeholder. Covered by issue [#306](https://github.com/marinoscar/MemoriaHub/issues/306). Expected to define: the `ai.features.memories` `{ provider, model }` config (mirroring `ai.features.tagging`/`search`/`embedding`) and its `PUT /api/ai/features/memories` endpoint, and a `MemoryTitleService` that generates `title`/`subtitle`/`narrative` with a hard timeout and falls back to deterministic templates on any failure — `Memory.titleSource`/`Memory.titleModel` (§2.2) exist specifically to audit which path ran for a given row.
+Template titles (§4.6) are correct everywhere and generic everywhere. `MemoryTitleService` (`apps/api/src/memories/titles/`) upgrades them to warm, specific prose — *"Five golden days on the Pacific coast — sunsets, surf, and Camila's first time in the ocean"* — using the admin-selected `ai.features.memories` provider and model (§9.4), and degrades to the template on **any** failure.
+
+### 5.1 The contract: `generate()` returns a title or `null`, and never throws
+
+`MemoryTitleService.generate()` is **total**. It resolves to a `MemoryAiTitle` or to `null`, and `null` means "write the deterministic template". Every one of the following lands on `null`:
+
+| Condition | Provider called? |
+|---|---|
+| `memories.aiTitles.enabled` is `false` | **no** |
+| `ai.features.memories` is unset (no provider configured) | **no** |
+| The selected provider has no credential, or its credential is disabled | no |
+| The selected provider key is not in `AiProviderRegistry` | no |
+| A backfill run has spent its call budget (§5.5) | **no** |
+| An earlier call in this run was throttled (§5.5) | **no** |
+| HTTP error, network failure, SDK exception | yes |
+| The call exceeds the 10 s hard timeout (§5.4) | yes |
+| The response is not JSON, is JSON of the wrong shape, or has an empty title (§5.3) | yes |
+| A fact lookup for the prompt fails | no |
+
+Three properties follow, and all three are stated success criteria of epic #300:
+
+- **Titling can never fail a generation run.** There is no exception path out of `generate()`, so a curator cannot lose its job's retry budget to a cosmetic field.
+- **A deployment with no AI provider is a supported configuration, not a broken one.** Every fallback logs at **DEBUG**, never `warn` or `error` — logging normal degradation as an error trains operators to ignore the log. The unit suite asserts this directly: each fallback test checks that nothing above debug was emitted.
+- **`titleSource` / `titleModel` audit which path actually ran.** A row is either `('ai', '<model id>')` or `('template', NULL)`; there is no third state and no partial one, because both are written by the one `titleColumns()` helper in `MemoryCurationService`.
+
+### 5.2 What is sent, and what is not
+
+**Metadata only — never image bytes.** Vision-model titling from the actual pixels was rejected for v1 on cost and latency at library scale. It is also largely redundant: the tags and descriptions below were themselves produced by a vision model (§ auto-tagging), so the visual signal arrives secondhand and already paid for.
+
+The complete list of what may leave the deployment is the `MemoryTitleFacts` type in `memory-title.prompts.ts`:
+
+| Fact | Source |
+|---|---|
+| Memory type, item count | the `Memory` being written |
+| Date range (`periodStart`/`periodEnd`, ISO day precision) | the curated selection |
+| Place — locality, admin1, country | `meta` (Trips curator, §4.8) |
+| Person names (≤ 5, subject first) | assigned faces on the selected items, excluding hidden/deleted/merged people |
+| Top AI tags with counts (≤ 10) | `media_tags` with `source = 'ai'` on the selected items |
+| Item descriptions (≤ 5, each truncated to 200 chars) | `MediaItem.description` |
+| Years-ago / theme tag / season / year | `meta` |
+| The deterministic template title and subtitle | §4.6 — the floor the model is asked to beat |
+
+Absent **by construction**, because the builder takes facts rather than rows: media-item ids, the circle id, the person id, the user id, file names, storage keys, GPS coordinates, EXIF. A prompt-builder test asserts that a rendered prompt over a maximal fact set contains no UUID.
+
+All four input caps are enforced **inside the builder**, not by its caller, so no call site can widen what gets sent.
+
+### 5.3 The prompt lives in one file, and its output is snapshotted
+
+`memory-title.prompts.ts` holds the system prompt as a single exported constant plus the per-type context builder. A prompt has no type errors and no test failures of its own, so a wording change is invisible in a diff unless the output is asserted somewhere: `memory-title.prompts.spec.ts` snapshots the rendered prompt for **all seven memory types**, which turns prompt drift into a reviewable diff.
+
+The response contract is strict JSON — `{"title", "subtitle", "narrative"}` — with caps of **60 / 80 / 240** characters. Those caps are stated in the system prompt *and* enforced on parse, from the same three constants, so the two can never disagree.
+
+`parseMemoryTitleResponse()` (`memory-title.parse.ts`) is likewise total: it strips a ``` / ```json fence, slices from the first `{` to the last `}` (which removes a chatty preamble and a sign-off in one step), `JSON.parse`s in a try/catch, validates with zod, normalizes an empty or `null` subtitle/narrative to `NULL`, and hard-caps every field with an ellipsis. A missing, non-string or blank **title** fails the whole parse — a memory with no title is not a partial success, it is the template case. Unknown extra keys are ignored rather than rejected: strictness there would turn a usable answer into a fallback for no benefit.
+
+### 5.4 The hard timeout bounds the whole stream
+
+The provider is called through the existing `AiProvider.chat()` abstraction — the same streaming chat path agentic search uses — not a second HTTP client.
+
+`MEMORY_TITLE_TIMEOUT_MS` is **10 000 ms**, and it bounds the *whole* stream rather than each chunk: each `next()` is raced against the **remaining** budget, so a provider dribbling one token every nine seconds is caught just as a silent one is. On timeout the iterator's `return()` is invoked fire-and-forget — awaiting it would re-block on the very network call that just stalled — so the generator can release its connection. A `MAX_RESPONSE_CHARS` ceiling (8 000) additionally stops a model stuck in a repetition loop from growing an unbounded string inside a memory-sensitive worker.
+
+`MEMORY_TITLE_TEMPERATURE` is `0.7`. Carrying it required adding an **optional** `temperature` to `ChatRequest`, forwarded verbatim by both providers and omitted entirely when unset — so no existing caller's behavior changed.
+
+### 5.5 The run budget: one per job, shared by every curator
+
+`MemoryTitleRun` is a small mutable object created once per `memory_generation` job by `MemoryGenerationHandler.beginRun()`, carried on `MemoryCuratorContext.titling`, and forwarded verbatim by each of the seven curators as `titling: ctx.titling` on their `upsertMemory` call.
+
+**Why a passed object rather than service state.** `MemoryTitleService` is a Nest singleton and the enrichment worker can run several `memory_generation` jobs concurrently (`ENRICHMENT_WORKER_CONCURRENCY`). A mutable field on the service would let one circle's rate-limit trip silently template another circle's memories, and one circle's backfill would consume another's budget.
+
+**An absent run means template titles.** That default is deliberately fail-safe: a curator (or a test) that does not thread it degrades to the documented floor rather than making unbudgeted, uncapped model calls.
+
+The run carries two independent stop conditions:
+
+- **Rate limiting stops the run; it does not fail the job.** A `429` or `529` (Anthropic "Overloaded") — classified by the shared `classifyRateLimit()` — sets `stopped`/`stopReason = 'rate_limited'`, and every remaining memory in the job is templated with no further calls. Routing this through the enrichment rate-limit-deferral path was explicitly rejected: that would defer a whole generation job, whose real output is the memories, over a cosmetic field.
+- **Backfill is capped at `BACKFILL_AI_TITLE_CAP` = 100 calls per job.** A 70k-item library backfill can create thousands of memories in one unattended run; without the cap it would fire thousands of model calls at once. Beyond the cap everything is templated, and each later scheduled run gets a fresh budget, so the library converges instead of billing for itself all at once. Scheduled (non-backfill) runs are uncapped — they produce few memories by construction (typically < 20).
+
+`attempts` are charged **before** the call, so a timing-out or 500-ing provider consumes budget too; otherwise a persistently failing provider would retry uncapped. The job's `memory_generation.completed` log line reports `aiTitleCalls` and `aiTitleStopReason`, which is the one-line explanation for a run whose memories are mostly template-titled despite a configured provider.
+
+### 5.6 Where titling is called from
+
+`MemoryCurationService.upsertMemory()` — the single write path every curator funnels through (§4.12) — and only on the two branches that **reset** titling:
+
+1. **Create.** A new memory is titled on the spot.
+2. **A refresh that resets the title:** membership moved by at least `MATERIAL_CHANGE_THRESHOLD` (30% Jaccard distance), or the curator set `retitle` because the memory's *subject* drifted (the Trips re-keying case, §4.8).
+
+A **minor** refresh calls nothing and keeps whatever the row already carries, including an existing AI title and narrative. That anti-churn rule is what makes the cost story work: without it, one new photo joining a ten-item memory would discard an AI title and re-pay for it on every generation run forever.
+
+Two ordering properties matter and are both tested:
+
+- **The tombstone check comes first.** A user-deleted memory is not re-titled — no model call is made at all.
+- **The model call happens outside the write transaction.** A 10-second call inside `$transaction` would hold row locks and a pool connection for its whole duration. Every fact the prompt needs comes from the selection the curator already computed, so titling completes before the transaction opens.
+
+When a call succeeds but the model returned no subtitle, the **template's** subtitle is written rather than leaving the card bare; the narrative stays `NULL`, since it is an AI-only field. When a *re-title* fails on a memory that previously had an AI title, all five columns are reset together — leaving `titleModel` or `narrative` behind would attach a model id and a blurb to a title that model never wrote.
+
+### 5.7 Testing
+
+No test in this feature can reach a network. The service suite drives a hand-written `AiProvider` double returned by a stubbed `AiProviderRegistry`, which is a level below the repo's `jest.mock('openai')` convention and strictly stronger — a mocked SDK still requires the production code to route through it, whereas here there is no SDK in the graph at all.
+
+| Suite | Covers |
+|---|---|
+| `memory-title.prompts.spec.ts` | per-type prompt snapshots, the four input caps, the no-UUID privacy assertion, cap constants echoed in the system prompt |
+| `memory-title.parse.spec.ts` | fences, preambles, truncated/array/wrong-type/blank-title JSON, length capping, "never throws" over every malformed shape |
+| `memory-title.service.spec.ts` | every row of §5.1's table, the 429/529 stop-the-run behavior, the backfill cap, and that each fallback logs at debug only |
+| `memory-generation.handler.spec.ts` | one budget per job, shared by every curator; the `aiTitles.enabled` flag and the backfill flag reaching `beginRun` |
+| `test/memories/memories-ai-titles.integration.spec.ts` (DB-gated) | the five persisted title columns for success and failure, anti-churn preservation, material-change re-titling, a failed re-title clearing a stale `titleModel`, `retitle`, and the tombstone short-circuit |
+
+### 5.8 Known gaps
+
+- **A reasoning model that rejects an explicit temperature degrades silently.** Some newer OpenAI models accept only their default temperature and answer `400`. That is a clean fallback to templates rather than an outage, but an admin who selects such a model gets template titles with only a debug log to explain it. The Doctor sweep does not yet include an `ai.memories` check.
+- **A failed titling attempt is not retried until the memory changes materially again.** The anti-churn rule (§5.6) is membership-based and does not know *why* a row is template-titled, so a memory templated because the provider was down stays templated until its item set moves by 30%. Retrying template-titled rows on a later run was rejected for v1: it would re-call for every memory on a deployment with no provider configured, which is exactly the case the whole degradation story exists to make free.
+- **The backfill cap is per job, not per library.** A backfill re-run gets a fresh 100 calls. That is intended (it is how a large library converges over several runs), but it means the cap bounds a single unattended run's cost, not the total cost of repeatedly backfilling.
+- **No response cache.** The rendered prompt is deterministic, so identical facts would key a cache exactly — but memories are titled once and then protected by the anti-churn rule, so there is little to hit.
+- **English only.** The system prompt and the template floor are both English; there is no locale setting to hand the model.
 
 ## 6. API
 
@@ -728,6 +839,7 @@ Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/is
 
 | Version | Date | Author | Changes |
 |---|---|---|---|
+| 0.6 | August 2026 | AI Assistant | Issue #306: filled in §5 (AI Titles, Subtitles & Narratives — the total `generate()` contract and the complete failure table with which entries avoid a provider call at all, the metadata-only prompt payload and the absent-by-construction privacy list, the one-file prompt with its per-type snapshots and the strict-JSON/length-cap contract shared between the system prompt and the parser, the 10s whole-stream timeout with its remaining-budget race and fire-and-forget iterator close plus the new optional `ChatRequest.temperature`, the per-job `MemoryTitleRun` budget and why it is a passed object rather than service state, the rate-limit stop-the-run rule and the 100-call backfill cap, the two `upsertMemory` branches that call titling and the tombstone/outside-the-transaction ordering, the no-network test strategy, and five known gaps). §6–§8 and §10 remain placeholders. |
 | 0.1 | August 2026 | AI Assistant | Initial specification for issue #301: the `MemoryType` enum, the `Memory`/`MemoryItem`/`MemoryUserState` data model, the `periodKey`/`subjectKey` semantics, the tombstone contract, cascade summary, and alternatives considered. Sections 3–10 are placeholders for later issues in epic #300. |
 | 0.5 | August 2026 | AI Assistant | Issue #305: added §4.9 (the People curators — the one shared eligibility rule and why per-user hidden people are deliberately excluded from generation, the archived-face exclusion, the grouped `(person, year)` census and why over-counting makes the pre-filter sound, the year-bucketed diversity policy and the >=3-year floor that separates the two types, the highest-confidence cover override, and the Cascade-FK delete/merge story), §4.10 (the Theme curator — the tag-vocabulary-over-clustering rationale, the three filters `source='ai'` / enabled label / denylist, ranking by distinct qualifying items with the exact per-year sum behind the all-history period, walking past a short tag under a bounded attempt cap, and why a tombstoned theme consumes its slot), and §4.11 (Seasonal & Year-in-Review — the shared per-month census, completed-seasons-only and the season-year fold with its spring-first ordinal, and the December/January window plus month bucketing). Extended §4.5 with the opt-in `selectByBuckets` calendar policy, rewrote §4.13's registry paragraph for the full seven, and added five known gaps to §4.15. Renumbered the former §4.9–§4.12 to §4.12–§4.15 so the curator sections stay together. §5–§8 and §10 remain placeholders. |
 | 0.4 | August 2026 | AI Assistant | Issue #304: added §4.8 (the Trips curator — fixed-24-month home inference with the 30% modal-share floor and the same-floor `geoAdmin1` fallback, median-based three-way away/home/neutral day classification and the coordinate-less metadata fallback that can only add an away day, gap-tolerant run merging where a home day terminates rather than bridges, the >=50%-of-the-SHORTER-span overlap matching that re-keys a boundary-shifted trip in place instead of duplicating it, tombstone participation in that matching, the `retitle` flag for a drifted subject, backfill and its flat-memory streaming aggregation, the EXPLAIN-verified reuse of `media_items_gallery_idx` with no new migration, and known gaps). Renumbered the former §4.8–§4.11 to §4.9–§4.12 so the curator sections sit together. §5–§8 and §10 remain placeholders. |


### PR DESCRIPTION
## Summary

AI-generated titles, subtitles and short narratives for memories, with deterministic template fallback on **every** failure path. Reuses the existing `AiProvider.chat()` abstraction rather than introducing a second AI-calling pattern.

The headline property is graceful degradation: a deployment with no AI provider configured gets template titles at zero cost and zero errors, and generation is never blocked by the provider.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #300
Fixes #306

## Changes Made

**New** — `apps/api/src/memories/titles/`: `memory-title.types.ts` (dependency-free so curation types can reference a run without importing the service), `memory-title.prompts.ts` (system prompt + per-type context builder + all caps), `memory-title.parse.ts` (total defensive parser), `memory-title.service.ts`.

**Modified** — `memory-curation.service.ts` (`generateAiTitle()` + a single `titleColumns()` helper shared by create and material-refresh), `memory-generation.handler.ts` (one run per job, logs `aiTitleCalls`/`aiTitleStopReason`), all seven curators (one line each: `titling: ctx.titling`), `memories.module.ts` (imports `AiModule` — one-way edge, no cycle), `ai-provider.interface.ts` + both providers (**optional** `ChatRequest.temperature`, omitted when unset so no existing caller changes), `docs/specs/memories.md` §5.

No migration — every column shipped in #301.

### Prompt / response contract

System prompt: family-photo-app tone, warm not saccharine, no emojis, no invented facts, strict JSON only. User message is a deterministic fact block — type · item count · ISO date range · years-ago/year/season/theme tag · place · ≤5 person names (subject first) · ≤10 AI tags with counts · ≤5 descriptions truncated to 200 chars · the template title as the floor to beat. Response `{"title" ≤60, "subtitle" ≤80, "narrative" ≤240}`.

**Metadata only — no image bytes, and no ids, filenames, storage keys or GPS.** That's true by construction, because the builder takes a `MemoryTitleFacts` value rather than database rows; a test asserts a maximally-populated rendered prompt contains no UUID. Every input cap lives inside the builder so no call site can widen it, and every output cap is re-enforced at parse time from the same constants the system prompt quotes.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
memories + title suites:  Test Suites: 20 passed, 20 total
                          Tests:     408 passed, 408 total

full test:ci:             298 suites, 7048 passed / 71 skipped, 8 snapshots
```

Only failures are the pre-existing malformed-UUID fixture suites. Nothing new fails. No test makes a real provider call.

### Every fallback path is individually tested

| Failure | Provider called? |
|---|---|
| `memories.aiTitles.enabled` off | **no** — config never even read |
| `ai.features.memories` unset | no |
| Credential missing/disabled | no |
| Unknown provider key | no |
| HTTP/network error | yes, run not stopped |
| 10s hard timeout | yes — asserts `iterator.return()` was invoked |
| Malformed / non-JSON output | yes |
| Empty title / empty stream | yes |
| Fact-lookup DB failure | no |
| 429 / 529 rate limit | one call, then run stops — 2 further `generate` calls make **zero** calls |
| Backfill cap | exactly 100 calls across 105 memories, rest templated |
| Tombstoned memory | no — tombstone outranks titling |

Every fallback test also asserts nothing above `debug` was logged, so degradation is quiet rather than noisy.

`titleSource`/`titleModel` are proven **at the row level** in a DB-gated spec that genuinely ran against live PostgreSQL (9 tests): AI success → `('ai','gpt-test-1')` + narrative; failure → `('template', NULL)` + `narrative NULL`; a &lt;30% refresh keeps the AI title with **no second call**; ≥30% re-titles; and a *failed* re-title after a previous success clears the now-stale `titleModel`/`narrative` rather than leaving them describing content that no longer exists.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

**One accepted risk, flagged rather than buried.** Some newer OpenAI reasoning models reject an explicit `temperature` with a 400, which would silently degrade that model choice to templates permanently. #306 asks for ~0.7 explicitly and the degradation is graceful, so it's implemented as specified and documented as the first entry in spec §5.8 — together with the fact that Doctor currently has no `ai.memories` check that would surface it. Worth a follow-up.

**A failed titling attempt is not retried until the memory next changes materially.** Deliberate: retrying template-titled rows every run would re-call the provider for every memory on a no-provider deployment, which is exactly the case the degradation story exists to make free.

Four pre-existing memories integration specs needed a new constructor argument; they got `neverCalledTitleService()` — a hostile stub that throws if touched — rather than a permissive one, so any suite that starts exercising titling by accident fails loudly instead of silently passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_