### PR TITLE
feat(api): Memories API — list/feed/detail, per-user state, delete, save-as-album &amp; preferences (#307)

### DIFF
--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -155,6 +155,97 @@ export type NotificationPreferencesPatch = z.infer<
 >;
 
 // =============================================================================
+// Per-user Memories preferences (issue #307, epic #300)
+// =============================================================================
+//
+// Stored inside the existing `user_settings` JSONB blob — no new table, no new
+// endpoint, no migration, no new RBAC permission. Read/written exclusively
+// through GET/PATCH/PUT /api/user-settings, exactly like `dataTables` and
+// `notifications` above.
+//
+// ABSENT-KEY RULE (load-bearing — same contract as the two namespaces above):
+//   Every field is `.optional()` with NO `.default()`, and `memories` itself is
+//   optional. An absent key means "no preference": nobody is hidden, no date
+//   range is sensitive, and the digest is NOT opted out of. That is what lets
+//   the namespace ship without a data migration, and it means a future field
+//   added here is opt-IN rather than silently applied to everyone who ever
+//   saved a preference. Do NOT add `.default()` to anything in this block —
+//   a `.default([])` on `hiddenPersonIds` would pin a stored blob to "no
+//   people hidden" and make it indistinguishable from "never expressed one".
+
+/** Max hidden person ids one user may persist. */
+export const MEMORIES_MAX_HIDDEN_PERSON_IDS = 200;
+/** Max sensitive date ranges one user may persist. */
+export const MEMORIES_MAX_HIDDEN_DATE_RANGES = 50;
+
+/** Calendar-day key, `YYYY-MM-DD`. */
+export const MEMORIES_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * A `YYYY-MM-DD` string that names a REAL calendar day. The regex alone accepts
+ * `2026-02-31`; the round-trip check rejects it, because a range whose bound
+ * silently rolls into the next month would filter days the user never named.
+ */
+const memoriesDateSchema = z
+  .string()
+  .regex(MEMORIES_DATE_PATTERN, 'Date must be formatted YYYY-MM-DD')
+  .refine((v) => {
+    const parsed = new Date(`${v}T00:00:00.000Z`);
+    return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === v;
+  }, 'Date must be a real calendar day');
+
+/** One inclusive sensitive-date window. `.strict()` — unknown keys rejected. */
+export const memoriesHiddenDateRangeSchema = z
+  .object({
+    from: memoriesDateSchema,
+    to: memoriesDateSchema,
+  })
+  .strict()
+  .refine((v) => v.from <= v.to, {
+    message: 'hiddenDateRanges entries require from <= to',
+  });
+
+/** The `memories` namespace as accepted by PUT and stored at rest. */
+export const memoriesPreferencesSchema = z
+  .object({
+    hiddenPersonIds: z
+      .array(z.string().uuid())
+      .max(MEMORIES_MAX_HIDDEN_PERSON_IDS)
+      .optional(),
+    hiddenDateRanges: z
+      .array(memoriesHiddenDateRangeSchema)
+      .max(MEMORIES_MAX_HIDDEN_DATE_RANGES)
+      .optional(),
+    emailDigestOptOut: z.boolean().optional(),
+  })
+  .strict();
+
+/**
+ * The `memories` namespace as accepted by PATCH. Identical, except any field
+ * may be set to `null` to DELETE it (JSON Merge Patch), resetting it to its
+ * absent default rather than pinning an explicit empty list / `false` that
+ * would survive a future default change.
+ */
+export const memoriesPreferencesPatchSchema = z
+  .object({
+    hiddenPersonIds: z
+      .array(z.string().uuid())
+      .max(MEMORIES_MAX_HIDDEN_PERSON_IDS)
+      .nullable()
+      .optional(),
+    hiddenDateRanges: z
+      .array(memoriesHiddenDateRangeSchema)
+      .max(MEMORIES_MAX_HIDDEN_DATE_RANGES)
+      .nullable()
+      .optional(),
+    emailDigestOptOut: z.boolean().nullable().optional(),
+  })
+  .strict();
+
+export type MemoriesPreferencesSettings = z.infer<typeof memoriesPreferencesSchema>;
+export type MemoriesPreferencesPatch = z.infer<typeof memoriesPreferencesPatchSchema>;
+
+// =============================================================================
 // User Settings Schema
 // =============================================================================
 
@@ -170,6 +261,7 @@ export const userSettingsSchema = z.object({
   }).optional(),
   dataTables: dataTablesSchema.optional(),
   notifications: notificationPreferencesSchema.optional(),
+  memories: memoriesPreferencesSchema.optional(),
 });
 
 export type UserSettingsDto = z.infer<typeof userSettingsSchema>;
@@ -189,6 +281,10 @@ export const userSettingsPatchSchema = z.object({
   // `null` clears the whole namespace back to defaults (everything enabled,
   // micro-runs off) — JSON Merge Patch, mirroring dataTables' per-entry null.
   notifications: notificationPreferencesPatchSchema.nullable().optional(),
+  // Merged field-wise (see UserSettingsService.mergeMemories): a listed field
+  // replaces, an unlisted one is untouched, `null` clears that field, and
+  // `memories: null` clears the whole namespace.
+  memories: memoriesPreferencesPatchSchema.nullable().optional(),
 });
 
 // =============================================================================

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -45,6 +45,33 @@ export interface NotificationPreferencesValue {
   workflowMicroRuns?: boolean;
 }
 
+/** One inclusive `YYYY-MM-DD` date window a user never wants resurfaced. */
+export interface MemoriesHiddenDateRangeValue {
+  from: string;
+  to: string;
+}
+
+/**
+ * Per-user Memories preferences (epic #300, issue #307).
+ *
+ * EVERY field is optional and is NEVER filled in server-side. An absent key
+ * means "no preference" — no person is hidden, no date range is sensitive, and
+ * the digest is NOT opted out of. Same absent-key contract as `dataTables` and
+ * `notifications` above, and the same reason it needs no data migration: every
+ * existing row simply has no namespace.
+ *
+ * `hiddenPersonIds` / `hiddenDateRanges` filter READ paths only (see
+ * MemoriesService) — generation is circle-scoped and cannot be personalised.
+ */
+export interface MemoriesPreferencesValue {
+  /** Memories whose `personId` is listed are dropped from list + feed. */
+  hiddenPersonIds?: string[];
+  /** Memories whose `[periodStart, periodEnd]` overlaps a range are dropped. */
+  hiddenDateRanges?: MemoriesHiddenDateRangeValue[];
+  /** Absent = false, i.e. the user receives the circle's memory digest. */
+  emailDigestOptOut?: boolean;
+}
+
 /**
  * User settings schema - stored in user_settings.value JSONB
  */
@@ -70,6 +97,12 @@ export interface UserSettingsValue {
    * namespace needed no data migration. Absent ⇒ everything enabled.
    */
   notifications?: NotificationPreferencesValue;
+  /**
+   * Per-user Memories preferences (issue #307). Absent for any user who has
+   * never hidden a person or a date range — the normal state, and why this
+   * namespace needed no data migration. Absent ⇒ nothing filtered.
+   */
+  memories?: MemoriesPreferencesValue;
 }
 
 /**

--- a/apps/api/src/memories/api/dto/memory-query.dto.ts
+++ b/apps/api/src/memories/api/dto/memory-query.dto.ts
@@ -1,0 +1,39 @@
+import { MemoryType } from '@prisma/client';
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+/**
+ * Query for `GET /api/memories` (epic #300, issue #307).
+ *
+ * KEYSET ONLY — there is deliberately no `page` escape hatch the way
+ * `GET /api/media` has one. That endpoint's offset mode exists purely for
+ * legacy clients (the Android app, the CLI) that predate keyset; nothing has
+ * ever consumed memories, so the dual-mode complexity and its `COUNT(*)` are
+ * not inherited.
+ *
+ * `year` is not a column — a memory covers a RANGE. It is compiled to an
+ * overlap test against that calendar year in UTC (see MemoriesService), so a
+ * trip spanning New Year's Eve appears under BOTH years, which is what a user
+ * filtering "2023" expects of a photo taken on 2023-12-31.
+ */
+export const memoryListQuerySchema = z.object({
+  circleId: z.string().uuid(),
+  type: z.nativeEnum(MemoryType).optional(),
+  year: z.coerce.number().int().min(1900).max(3000).optional(),
+  /** `true` narrows to the caller's own favorites; anything else is ignored. */
+  favorite: z
+    .string()
+    .optional()
+    .transform((v) => (v === 'true' ? true : v === 'false' ? false : undefined)),
+  cursor: z.string().uuid().optional(),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export class MemoryListQueryDto extends createZodDto(memoryListQuerySchema) {}
+
+/** Query for `GET /api/memories/feed` — circle scope only; the cap is fixed. */
+export const memoryFeedQuerySchema = z.object({
+  circleId: z.string().uuid(),
+});
+
+export class MemoryFeedQueryDto extends createZodDto(memoryFeedQuerySchema) {}

--- a/apps/api/src/memories/api/dto/memory-response.dto.ts
+++ b/apps/api/src/memories/api/dto/memory-response.dto.ts
@@ -1,0 +1,127 @@
+import { MemoryType } from '@prisma/client';
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+/**
+ * Response shapes for the Memories API (epic #300, issue #307).
+ *
+ * NOTE: these describe the HANDLER's return value, not the wire format. The
+ * global TransformInterceptor wraps every one of them as
+ * `{ data: <this>, meta: { timestamp } }`, so a list's own pagination meta
+ * lands at `data.meta` — the same shape `GET /api/media` and
+ * `GET /api/notifications` already produce.
+ *
+ * Every timestamp is an ISO 8601 STRING, and there is no BigInt anywhere in
+ * these payloads (the repo's BigInt-serialization gotcha): the only BigInt
+ * column near this feature is `storage_objects.size`, which nothing here
+ * selects, and `MediaItem.durationMs` is a plain `Int?`.
+ */
+
+const memoryTypeSchema = z.nativeEnum(MemoryType);
+
+/**
+ * The caller's OWN state on a memory — never another user's.
+ *
+ * The CARD form carries `seen` + `favorited` only: `hidden` would be constant
+ * `false` there, since a hidden memory is filtered out of the list and the feed
+ * in SQL. Detail adds it, because detail deliberately still resolves a hidden
+ * memory (a direct link must work) and the UI needs to offer "unhide".
+ */
+export const memoryMyStateSchema = z.object({
+  seen: z.boolean(),
+  favorited: z.boolean(),
+});
+
+export const memoryDetailMyStateSchema = memoryMyStateSchema.extend({
+  hidden: z.boolean(),
+});
+
+/** Card projection used by both the list and the feed. */
+export const memoryCardSchema = z.object({
+  id: z.string().uuid(),
+  type: memoryTypeSchema,
+  title: z.string(),
+  subtitle: z.string().nullable(),
+  itemCount: z.number().int(),
+  periodStart: z.string(),
+  periodEnd: z.string(),
+  coverMediaItemId: z.string().uuid().nullable(),
+  coverThumbnailUrl: z.string().nullable(),
+  meta: z.unknown().nullable(),
+  myState: memoryMyStateSchema,
+  generatedAt: z.string(),
+});
+
+export class MemoryCardDto extends createZodDto(memoryCardSchema) {}
+
+/**
+ * Feed card = the list card plus the first few item thumbnails, which the Home
+ * carousel fans out behind the cover.
+ */
+export const memoryFeedCardSchema = memoryCardSchema.extend({
+  itemThumbnailUrls: z.array(z.string()),
+});
+
+export class MemoryFeedCardDto extends createZodDto(memoryFeedCardSchema) {}
+
+/** Keyset envelope for `GET /api/memories` — no COUNT, so no totals. */
+export const memoryListSchema = z.object({
+  items: z.array(memoryCardSchema),
+  meta: z.object({
+    pageSize: z.number().int(),
+    nextCursor: z.string().nullable(),
+    hasMore: z.boolean(),
+  }),
+});
+
+export class MemoryListDto extends createZodDto(memoryListSchema) {}
+
+/** Envelope for `GET /api/memories/feed` — a fixed, capped, uncursored list. */
+export const memoryFeedSchema = z.object({
+  items: z.array(memoryFeedCardSchema),
+});
+
+export class MemoryFeedDto extends createZodDto(memoryFeedSchema) {}
+
+/** One ordered photo/video inside a memory. */
+export const memoryDetailItemSchema = z.object({
+  id: z.string().uuid(),
+  mediaItemId: z.string().uuid(),
+  position: z.number().int(),
+  mediaType: z.string(),
+  width: z.number().int().nullable(),
+  height: z.number().int().nullable(),
+  durationMs: z.number().int().nullable(),
+  capturedAt: z.string().nullable(),
+  thumbnailUrl: z.string().nullable(),
+});
+
+export class MemoryDetailItemDto extends createZodDto(memoryDetailItemSchema) {}
+
+/**
+ * Full detail for `GET /api/memories/:id`. Items are returned in full — a
+ * memory holds at most `memories.maxItemsPerMemory` (bounded 5–100) rows, so
+ * there is nothing to paginate.
+ */
+export const memoryDetailSchema = memoryCardSchema.extend({
+  circleId: z.string().uuid(),
+  myState: memoryDetailMyStateSchema,
+  narrative: z.string().nullable(),
+  titleSource: z.string(),
+  titleModel: z.string().nullable(),
+  personId: z.string().uuid().nullable(),
+  refreshedAt: z.string(),
+  expiresAt: z.string().nullable(),
+  items: z.array(memoryDetailItemSchema),
+});
+
+export class MemoryDetailDto extends createZodDto(memoryDetailSchema) {}
+
+/** Response for `POST /api/memories/:id/save-album`. */
+export const saveMemoryAlbumResultSchema = z.object({
+  albumId: z.string().uuid(),
+});
+
+export class SaveMemoryAlbumResultDto extends createZodDto(
+  saveMemoryAlbumResultSchema,
+) {}

--- a/apps/api/src/memories/api/dto/save-memory-album.dto.ts
+++ b/apps/api/src/memories/api/dto/save-memory-album.dto.ts
@@ -1,0 +1,22 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+/**
+ * Body for `POST /api/memories/:id/save-album`.
+ *
+ * `name` is optional — omitted means "use the memory's own title", which is
+ * already the string the user is looking at. The 256 cap matches
+ * `createAlbumSchema` exactly, because this path creates the album through
+ * `MediaService.createAlbum` rather than a parallel mutation; a longer default
+ * derived from a title is truncated server-side rather than rejected.
+ *
+ * `.default({})` so a bodyless POST parses as `{}` — same reason
+ * `patchUserSettingsSchema` carries one (issue #289).
+ */
+export const saveMemoryAlbumSchema = z
+  .object({
+    name: z.string().min(1).max(256).optional(),
+  })
+  .default({});
+
+export class SaveMemoryAlbumDto extends createZodDto(saveMemoryAlbumSchema) {}

--- a/apps/api/src/memories/api/memories.controller.ts
+++ b/apps/api/src/memories/api/memories.controller.ts
@@ -1,0 +1,291 @@
+// =============================================================================
+// Memories — HTTP surface (epic #300, issue #307)
+// =============================================================================
+//
+// RBAC, in one place (see docs/specs/memories.md §10):
+//
+//   - Reads and per-user state  : `media:read`  + per-circle **viewer**
+//   - Delete and save-as-album  : `media:write` + per-circle **collaborator**
+//
+// NO new permission was introduced. A memory is a derived view over media the
+// caller can already see, so `media:read`/`media:write` plus the per-circle
+// roles express the intent exactly — the same decision Workflows made, and the
+// epic's stated tie-breaker.
+//
+// Per-user state (`seen`/`hide`/`favorite`) is scoped to the JWT's `userId` and
+// touches no circle content, so it needs membership only; it still carries
+// `media:read` because that is the permission the whole surface is gated on and
+// a caller without it has no business reading the memory it refers to.
+//
+// EVERY `:id` route resolves through `MemoriesService.loadAccessibleMemory`,
+// which returns **404 (not 403)** for a memory in a circle the caller is not a
+// member of — enumeration-resistant, matching the notifications `:id` policy.
+//
+// The static `/feed` route is declared BEFORE `:id` so it is not shadowed.
+// =============================================================================
+
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { RequestUser } from '../../auth/interfaces/authenticated-user.interface';
+import { PERMISSIONS } from '../../common/constants/roles.constants';
+import { MemoryFeedQueryDto, MemoryListQueryDto } from './dto/memory-query.dto';
+import {
+  MemoryDetailDto,
+  MemoryFeedDto,
+  MemoryListDto,
+  SaveMemoryAlbumResultDto,
+} from './dto/memory-response.dto';
+import { SaveMemoryAlbumDto } from './dto/save-memory-album.dto';
+import { MemoriesService } from './memories.service';
+
+@ApiTags('Memories')
+@ApiBearerAuth('JWT-auth')
+@Controller('memories')
+export class MemoriesController {
+  constructor(private readonly memoriesService: MemoriesService) {}
+
+  // ---------------------------------------------------------------------------
+  // GET /api/memories
+  // ---------------------------------------------------------------------------
+
+  @Get()
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({
+    summary: "Browse a circle's memories (keyset paginated, newest first)",
+    description:
+      'Excludes deleted (tombstoned) memories, expired memories, memories the ' +
+      'caller has hidden, and memories filtered by the caller\'s ' +
+      '`user_settings.memories` preferences. Returns an EMPTY page — never an ' +
+      'error — when `features.memories` is off.',
+  })
+  @ApiQuery({ name: 'circleId', required: true, type: String, format: 'uuid' })
+  @ApiQuery({
+    name: 'type',
+    required: false,
+    enum: [
+      'on_this_day',
+      'trip',
+      'person_highlights',
+      'person_over_years',
+      'theme',
+      'seasonal',
+      'year_in_review',
+    ],
+  })
+  @ApiQuery({
+    name: 'year',
+    required: false,
+    type: Number,
+    description: 'Keeps memories whose covered period overlaps that UTC year.',
+  })
+  @ApiQuery({
+    name: 'favorite',
+    required: false,
+    type: Boolean,
+    description: "`true` narrows to the caller's own favorites.",
+  })
+  @ApiQuery({ name: 'cursor', required: false, type: String, format: 'uuid' })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number, description: 'Max 100.' })
+  @ApiResponse({ status: 200, description: 'Keyset page of memory cards', type: MemoryListDto })
+  async list(
+    @Query() query: MemoryListQueryDto,
+    @CurrentUser() user: RequestUser,
+  ): Promise<MemoryListDto> {
+    return this.memoriesService.list(query, user.id, user.permissions);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /api/memories/feed   (before :id — static routes must not be shadowed)
+  // ---------------------------------------------------------------------------
+
+  @Get('feed')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({
+    summary: 'Home carousel feed (max 10 cards)',
+    description:
+      "Ordered: today's On This Day memories (closest year first), then the " +
+      'newest unseen, then the newest seen. Each card carries up to four item ' +
+      'thumbnails for the fan effect. Empty when `features.memories` is off.',
+  })
+  @ApiQuery({ name: 'circleId', required: true, type: String, format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Feed cards', type: MemoryFeedDto })
+  async feed(
+    @Query() query: MemoryFeedQueryDto,
+    @CurrentUser() user: RequestUser,
+  ): Promise<MemoryFeedDto> {
+    return this.memoriesService.feed(query, user.id, user.permissions);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /api/memories/:id
+  // ---------------------------------------------------------------------------
+
+  @Get(':id')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({
+    summary: 'Full memory detail with its ordered items',
+    description:
+      'Preference filters are intentionally NOT applied here so a direct link ' +
+      'always resolves; hide and delete are the tools on this page. A memory ' +
+      'in a circle the caller does not belong to returns 404, not 403.',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Memory detail', type: MemoryDetailDto })
+  @ApiResponse({ status: 404, description: 'Not found, deleted, expired, or not accessible' })
+  async detail(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<MemoryDetailDto> {
+    return this.memoriesService.detail(id, user.id, user.permissions);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-user state — membership only, scoped to the JWT user
+  // ---------------------------------------------------------------------------
+
+  @Post(':id/seen')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Mark a memory seen by the current user',
+    description:
+      'Idempotent: `seenAt` is preserved once set, so it always names the ' +
+      'FIRST view (same contract as marking a notification read).',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Marked seen' })
+  async markSeen(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.memoriesService.markSeen(id, user.id, user.permissions);
+  }
+
+  @Post(':id/hide')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Hide a memory for the current user only',
+    description:
+      'Personal and reversible — it does NOT delete the memory and does not ' +
+      'affect any other circle member. Use DELETE /api/memories/:id for that.',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Hidden' })
+  async hide(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.memoriesService.hide(id, user.id, user.permissions);
+  }
+
+  @Delete(':id/hide')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Un-hide a memory for the current user' })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Un-hidden' })
+  async unhide(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.memoriesService.unhide(id, user.id, user.permissions);
+  }
+
+  @Post(':id/favorite')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Favorite a memory for the current user' })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Favorited' })
+  async favorite(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.memoriesService.favorite(id, user.id, user.permissions);
+  }
+
+  @Delete(':id/favorite')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Un-favorite a memory for the current user' })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Un-favorited' })
+  async unfavorite(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.memoriesService.unfavorite(id, user.id, user.permissions);
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /api/memories/:id/save-album
+  // ---------------------------------------------------------------------------
+
+  @Post(':id/save-album')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Save a memory's items as a new album",
+    description:
+      "Creates an album (default name = the memory's title) containing the " +
+      "memory's live items in position order, with the memory's cover as the " +
+      'album cover. Deliberately NOT idempotent — saving twice yields two ' +
+      'albums. Requires media:write + the collaborator circle role.',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 201, description: 'Album created', type: SaveMemoryAlbumResultDto })
+  async saveAsAlbum(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: SaveMemoryAlbumDto,
+    @CurrentUser() user: RequestUser,
+  ): Promise<SaveMemoryAlbumResultDto> {
+    return this.memoriesService.saveAsAlbum(id, dto, user.id, user.permissions);
+  }
+
+  // ---------------------------------------------------------------------------
+  // DELETE /api/memories/:id — circle-level tombstone
+  // ---------------------------------------------------------------------------
+
+  @Delete(':id')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete a memory for the whole circle (tombstone)',
+    description:
+      'Sets `deletedAt`. The memory disappears for every member and can never ' +
+      'be regenerated — the natural-key unique index spans tombstoned rows, so ' +
+      'curation recognises and skips it. Writes a `memory:deleted` audit event. ' +
+      'Requires media:write + the collaborator circle role.',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Deleted' })
+  @ApiResponse({ status: 403, description: 'Member without the collaborator role' })
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: RequestUser,
+  ): Promise<void> {
+    await this.memoriesService.remove(id, user.id, user.permissions);
+  }
+}

--- a/apps/api/src/memories/api/memories.service.ts
+++ b/apps/api/src/memories/api/memories.service.ts
@@ -1,0 +1,834 @@
+// =============================================================================
+// Memories — read/act API service (epic #300, issue #307)
+// =============================================================================
+//
+// Serves every user-facing Memories surface: the browsable history
+// (`GET /api/memories`), the Home carousel (`/feed`), full detail, the per-user
+// seen/hide/favorite state, the circle-level tombstone delete, and
+// save-as-album.
+//
+// THREE INVARIANTS RUN THROUGH EVERY METHOD HERE:
+//
+//   1. THE TOMBSTONE (docs/specs/memories.md §2.5). `deletedAt IS NOT NULL` is
+//      excluded from EVERY read without exception. Delete is circle-level and
+//      permanent in effect: the natural-key unique index spans tombstoned rows,
+//      so regeneration can never resurrect one. Per-user `hiddenAt` is a
+//      DIFFERENT, personal thing and is deliberately not conflated with it — a
+//      hidden memory is still there for everyone else, and still reachable by
+//      its own id for the user who hid it.
+//
+//   2. THE ACTIVE FILTER. `expiresAt IS NULL OR expiresAt > now()`. Only
+//      `on_this_day` sets an expiry (start of the day after its anchor), so
+//      this is what stops yesterday's "6 years ago" card from lingering.
+//
+//   3. THE FEATURE FLAG IS CHECKED FIRST, BEFORE ANY QUERY. With
+//      `features.memories` off — the default — the list and feed return an
+//      empty page and the per-id routes 404, having issued exactly ZERO
+//      database queries beyond the cached settings read. "Zero cost when off"
+//      is a stated epic success criterion, not a nicety; putting the gate after
+//      the circle-access check would already have cost two queries.
+//
+// Thumbnails on every payload are signed through
+// `MediaThumbnailService.signThumbsBatched` — ONE `storageObject.findMany` per
+// response, never a per-item lookup. A per-item N+1 here would re-introduce
+// exactly the regression documented in docs/audits/search-audit.md.
+// =============================================================================
+
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { CircleRole, MemoryType, Prisma } from '@prisma/client';
+
+import { CircleMembershipService } from '../../circles/circle-membership.service';
+import { PERMISSIONS } from '../../common/constants/roles.constants';
+import {
+  MemoriesPreferencesValue,
+  UserSettingsValue,
+  isMemoriesEnabled,
+} from '../../common/types/settings.types';
+import { MediaThumbnailService } from '../../media/media-thumbnail.service';
+import { MediaService } from '../../media/media.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { SystemSettingsService } from '../../settings/system-settings/system-settings.service';
+import {
+  MemoryCardDto,
+  MemoryDetailDto,
+  MemoryDetailItemDto,
+  MemoryFeedCardDto,
+  MemoryFeedDto,
+  MemoryListDto,
+  SaveMemoryAlbumResultDto,
+} from './dto/memory-response.dto';
+import { MemoryFeedQueryDto, MemoryListQueryDto } from './dto/memory-query.dto';
+import { SaveMemoryAlbumDto } from './dto/save-memory-album.dto';
+import {
+  ResolvedMemoryPreferences,
+  isMemoryHiddenByPreferences,
+  preferencesAreEmpty,
+  resolveMemoryPreferences,
+} from './memory-preferences';
+
+/** Hard cap on feed cards, per the epic. */
+const FEED_LIMIT = 10;
+
+/**
+ * How many non-`on_this_day` rows the feed reads before ranking. Larger than
+ * FEED_LIMIT on purpose: per-user hidden rows are excluded in SQL, but the
+ * preference filter runs in memory afterwards, so a user with several hidden
+ * people would otherwise see a short feed. One bounded read, no second query.
+ */
+const FEED_CANDIDATE_LIMIT = 60;
+
+/** Item thumbnails returned per feed card for the fan effect. */
+const FEED_ITEM_THUMBS = 4;
+
+/** Album names are capped at 256 by createAlbumSchema; a title may be longer. */
+const ALBUM_NAME_MAX = 256;
+
+/** Selection shared by the list and feed card projections. */
+const CARD_SELECT = {
+  id: true,
+  type: true,
+  title: true,
+  subtitle: true,
+  itemCount: true,
+  periodStart: true,
+  periodEnd: true,
+  coverMediaItemId: true,
+  meta: true,
+  generatedAt: true,
+  personId: true,
+  coverMediaItem: { select: { id: true, metadata: true } },
+} satisfies Prisma.MemorySelect;
+
+type CardRow = Prisma.MemoryGetPayload<{ select: typeof CARD_SELECT }> & {
+  userStates: Array<{
+    seenAt: Date | null;
+    hiddenAt: Date | null;
+    favoritedAt: Date | null;
+  }>;
+};
+
+type FeedRow = CardRow & {
+  items: Array<{ mediaItem: { metadata: Prisma.JsonValue | null } }>;
+};
+
+@Injectable()
+export class MemoriesService {
+  private readonly logger = new Logger(MemoriesService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly circleMembership: CircleMembershipService,
+    private readonly thumbnails: MediaThumbnailService,
+    private readonly systemSettings: SystemSettingsService,
+    private readonly mediaService: MediaService,
+  ) {}
+
+  // ===========================================================================
+  // Gates
+  // ===========================================================================
+
+  /**
+   * The single feature gate. Reads through `SystemSettingsService.getSettings()`
+   * (5 s in-process cache) and folds in the `MEMORIES_ENABLED` env kill-switch
+   * via the shared `isMemoriesEnabled()` helper, so this surface can never
+   * disagree with the generation cron or the handler about what "enabled" means.
+   */
+  private async featureEnabled(): Promise<boolean> {
+    const settings = await this.systemSettings.getSettings();
+    return isMemoriesEnabled(settings as { features?: Record<string, boolean> });
+  }
+
+  /**
+   * `WHERE` fragment shared by every read: circle scope, tombstone exclusion
+   * and the active-expiry filter. Nothing in this service builds a memory query
+   * without it.
+   */
+  private activeWhere(circleId: string): Prisma.MemoryWhereInput {
+    return {
+      circleId,
+      deletedAt: null,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    };
+  }
+
+  /**
+   * Load one memory by id and prove the caller may act on it at `required` rank.
+   *
+   * Deliberately NOT `assertCircleAccess`: a non-member must get **404, not
+   * 403**, so a stranger cannot use the status code to confirm that a memory id
+   * exists (the same enumeration-resistant policy as the notifications `:id`
+   * routes and public shares). A member who simply lacks the RANK — a viewer
+   * trying to delete — does get a 403, because their membership is not a secret
+   * and the distinction is actionable to them.
+   */
+  private async loadAccessibleMemory(
+    id: string,
+    userId: string,
+    permissions: string[],
+    required: CircleRole,
+  ) {
+    const memory = await this.prisma.memory.findFirst({
+      where: {
+        id,
+        deletedAt: null,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+    });
+    if (!memory) {
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+
+    // Super-admins moderate any circle without being a member — the same bypass
+    // CircleMembershipService.assertCircleAccess applies.
+    const isSuperAdmin =
+      permissions.includes(PERMISSIONS.CIRCLES_MANAGE_ANY) ||
+      permissions.includes(PERMISSIONS.MEDIA_WRITE_ANY) ||
+      permissions.includes(PERMISSIONS.MEDIA_READ_ANY);
+    if (isSuperAdmin) return memory;
+
+    const role = await this.circleMembership.resolveRole(userId, memory.circleId);
+    if (role === null) {
+      // Not a member: indistinguishable from "no such memory".
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+    const rank: Record<CircleRole, number> = {
+      viewer: 1,
+      collaborator: 2,
+      circle_admin: 3,
+    };
+    if (rank[role] < rank[required]) {
+      throw new ForbiddenException(`This action requires ${required} role or higher`);
+    }
+    return memory;
+  }
+
+  /**
+   * Read this user's `user_settings.memories` namespace and compile it.
+   *
+   * Absent namespace / absent row ⇒ no filtering, which is the normal state
+   * (nothing is ever populated server-side). A read failure degrades to "no
+   * preference" with a warning rather than failing the list — over-showing is
+   * strictly better than a 500 on a browse surface.
+   */
+  private async loadPreferences(userId: string): Promise<ResolvedMemoryPreferences> {
+    try {
+      const row = await this.prisma.userSettings.findUnique({
+        where: { userId },
+        select: { value: true },
+      });
+      const value = row?.value as unknown as UserSettingsValue | undefined;
+      return resolveMemoryPreferences(
+        value?.memories as MemoriesPreferencesValue | undefined,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Failed to read memory preferences for user ${userId}: ${msg}`);
+      return resolveMemoryPreferences(null);
+    }
+  }
+
+  // ===========================================================================
+  // GET /api/memories
+  // ===========================================================================
+
+  async list(
+    query: MemoryListQueryDto,
+    userId: string,
+    permissions: string[],
+  ): Promise<MemoryListDto> {
+    const { circleId, type, year, favorite, cursor, pageSize } = query;
+
+    // Gate FIRST — see invariant 3 in the file header.
+    if (!(await this.featureEnabled())) {
+      return { items: [], meta: { pageSize, nextCursor: null, hasMore: false } };
+    }
+
+    await this.circleMembership.assertCircleAccess(
+      userId,
+      circleId,
+      permissions,
+      'viewer' as CircleRole,
+    );
+
+    const where: Prisma.MemoryWhereInput = {
+      ...this.activeWhere(circleId),
+      ...(type ? { type } : {}),
+      ...(year ? this.yearOverlapWhere(year) : {}),
+      // Per-user hide is excluded in SQL (unlike the preference filter, which
+      // cannot be — see below), so a user who hid most of a circle's memories
+      // still gets full pages.
+      NOT: { userStates: { some: { userId, hiddenAt: { not: null } } } },
+      ...(favorite === true
+        ? { userStates: { some: { userId, favoritedAt: { not: null } } } }
+        : {}),
+    };
+
+    const rawRows = await this.prisma.memory.findMany({
+      where,
+      select: {
+        ...CARD_SELECT,
+        userStates: {
+          where: { userId },
+          select: { seenAt: true, hiddenAt: true, favoritedAt: true },
+        },
+      },
+      // `id` DESC is the tiebreak that makes the keyset deterministic when two
+      // memories share a `generatedAt` — which they routinely do, since one
+      // generation run writes a whole batch.
+      orderBy: [{ generatedAt: 'desc' }, { id: 'desc' }],
+      take: pageSize + 1,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+    const rows = rawRows as unknown as CardRow[];
+
+    const hasMore = rows.length > pageSize;
+    const page = hasMore ? rows.slice(0, pageSize) : rows;
+    // The cursor is derived from the RAW page, before preference filtering.
+    // Deriving it from the filtered list would make a page whose every row was
+    // preference-hidden return `nextCursor: null` and silently truncate the
+    // history at the first fully-hidden page.
+    const nextCursor = hasMore && page.length > 0 ? page[page.length - 1].id : null;
+
+    const prefs = await this.loadPreferences(userId);
+    const visible = preferencesAreEmpty(prefs)
+      ? page
+      : page.filter((row) => !isMemoryHiddenByPreferences(row, prefs));
+
+    const items = await this.toCards(visible);
+    return { items, meta: { pageSize, nextCursor, hasMore } };
+  }
+
+  /**
+   * `year` compiled to a range OVERLAP, because a memory covers a period rather
+   * than sitting on a date: keep rows whose `[periodStart, periodEnd]` window
+   * intersects that calendar year in UTC.
+   */
+  private yearOverlapWhere(year: number): Prisma.MemoryWhereInput {
+    const start = new Date(Date.UTC(year, 0, 1));
+    const endExclusive = new Date(Date.UTC(year + 1, 0, 1));
+    return {
+      periodStart: { lt: endExclusive },
+      periodEnd: { gte: start },
+    };
+  }
+
+  // ===========================================================================
+  // GET /api/memories/feed
+  // ===========================================================================
+
+  /**
+   * The Home carousel: today's `on_this_day` first (closest year first), then
+   * the newest unseen, then the newest seen, capped at 10.
+   *
+   * Two bounded reads rather than one: today's anchor memories must appear even
+   * when they are not among the newest rows overall (a backfill can generate a
+   * pile of trips after them), and ranking them by `meta.yearsAgo` is a JSONB
+   * sort SQL would do badly and an in-memory sort does trivially.
+   */
+  async feed(
+    query: MemoryFeedQueryDto,
+    userId: string,
+    permissions: string[],
+  ): Promise<MemoryFeedDto> {
+    const { circleId } = query;
+
+    if (!(await this.featureEnabled())) {
+      return { items: [] };
+    }
+
+    await this.circleMembership.assertCircleAccess(
+      userId,
+      circleId,
+      permissions,
+      'viewer' as CircleRole,
+    );
+
+    const notHidden: Prisma.MemoryWhereInput = {
+      NOT: { userStates: { some: { userId, hiddenAt: { not: null } } } },
+    };
+    const feedSelect = {
+      ...CARD_SELECT,
+      userStates: {
+        where: { userId },
+        select: { seenAt: true, hiddenAt: true, favoritedAt: true },
+      },
+      items: {
+        orderBy: { position: 'asc' as const },
+        take: FEED_ITEM_THUMBS,
+        select: { mediaItem: { select: { metadata: true } } },
+      },
+    };
+
+    // `periodKey` for an `on_this_day` memory IS the anchor day in UTC
+    // (`toIsoDateKey`), so "today's" is an exact string match rather than a
+    // range scan — see on-this-day.curator.ts.
+    const todayKey = new Date().toISOString().slice(0, 10);
+
+    const [todayRaw, recentRaw] = await Promise.all([
+      this.prisma.memory.findMany({
+        where: {
+          ...this.activeWhere(circleId),
+          ...notHidden,
+          type: MemoryType.on_this_day,
+          periodKey: todayKey,
+        },
+        select: feedSelect,
+        take: FEED_LIMIT,
+      }),
+      this.prisma.memory.findMany({
+        where: {
+          ...this.activeWhere(circleId),
+          ...notHidden,
+          NOT: [
+            { AND: [{ type: MemoryType.on_this_day }, { periodKey: todayKey }] },
+          ],
+        },
+        select: feedSelect,
+        orderBy: [{ generatedAt: 'desc' }, { id: 'desc' }],
+        take: FEED_CANDIDATE_LIMIT,
+      }),
+    ]);
+    const todayRows = todayRaw as unknown as FeedRow[];
+    const recentRows = recentRaw as unknown as FeedRow[];
+
+    const prefs = await this.loadPreferences(userId);
+    const keep = (row: FeedRow) =>
+      preferencesAreEmpty(prefs) || !isMemoryHiddenByPreferences(row, prefs);
+
+    // Closest year first: "1 year ago" before "9 years ago".
+    const today = todayRows
+      .filter(keep)
+      .sort((a, b) => this.yearsAgo(a) - this.yearsAgo(b));
+
+    const rest = recentRows.filter(keep);
+    const unseen = rest.filter((row) => !row.userStates[0]?.seenAt);
+    const seen = rest.filter((row) => row.userStates[0]?.seenAt);
+
+    const ordered = [...today, ...unseen, ...seen].slice(0, FEED_LIMIT);
+    return { items: await this.toFeedCards(ordered) };
+  }
+
+  /** `meta.yearsAgo` written by the On This Day curator; unknown sorts last. */
+  private yearsAgo(row: CardRow): number {
+    const meta = row.meta;
+    if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+      const value = (meta as Record<string, unknown>)['yearsAgo'];
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+    }
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  // ===========================================================================
+  // GET /api/memories/:id
+  // ===========================================================================
+
+  /**
+   * Full detail. Applies the tombstone and active filters (invariants 1 and 2)
+   * but deliberately NOT the per-user preference filter and NOT the per-user
+   * hide: a direct link — from the story player, a notification, an email
+   * digest, or the user's own hidden list — must still resolve. Hiding and
+   * deleting are the tools for making a memory go away, and both remain
+   * available from this page.
+   */
+  async detail(
+    id: string,
+    userId: string,
+    permissions: string[],
+  ): Promise<MemoryDetailDto> {
+    if (!(await this.featureEnabled())) {
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+
+    await this.loadAccessibleMemory(id, userId, permissions, 'viewer' as CircleRole);
+
+    const memory = await this.prisma.memory.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        coverMediaItem: { select: { id: true, metadata: true } },
+        userStates: {
+          where: { userId },
+          select: { seenAt: true, hiddenAt: true, favoritedAt: true },
+        },
+        items: {
+          orderBy: { position: 'asc' },
+          select: {
+            id: true,
+            mediaItemId: true,
+            position: true,
+            mediaItem: {
+              select: {
+                type: true,
+                width: true,
+                height: true,
+                durationMs: true,
+                capturedAt: true,
+                metadata: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!memory) {
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+
+    // ONE batched signing call covering the cover AND every item.
+    const coverKey = this.thumbnails.extractThumbKey(
+      memory.coverMediaItem?.metadata ?? null,
+    );
+    const itemKeys = memory.items.map((item) =>
+      this.thumbnails.extractThumbKey(item.mediaItem.metadata),
+    );
+    const signed = await this.thumbnails.signThumbsBatched(
+      [coverKey, ...itemKeys].filter((k): k is string => k !== null),
+    );
+
+    const items: MemoryDetailItemDto[] = memory.items.map((item, i) => {
+      const key = itemKeys[i];
+      return {
+        id: item.id,
+        mediaItemId: item.mediaItemId,
+        position: item.position,
+        mediaType: item.mediaItem.type,
+        width: item.mediaItem.width,
+        height: item.mediaItem.height,
+        durationMs: item.mediaItem.durationMs,
+        capturedAt: item.mediaItem.capturedAt?.toISOString() ?? null,
+        thumbnailUrl: key ? signed.get(key) ?? null : null,
+      };
+    });
+
+    const state = memory.userStates[0];
+    return {
+      id: memory.id,
+      circleId: memory.circleId,
+      type: memory.type,
+      title: memory.title,
+      subtitle: memory.subtitle,
+      narrative: memory.narrative,
+      titleSource: memory.titleSource,
+      titleModel: memory.titleModel,
+      personId: memory.personId,
+      itemCount: memory.itemCount,
+      periodStart: memory.periodStart.toISOString(),
+      periodEnd: memory.periodEnd.toISOString(),
+      coverMediaItemId: memory.coverMediaItemId,
+      coverThumbnailUrl: coverKey ? signed.get(coverKey) ?? null : null,
+      meta: memory.meta,
+      myState: {
+        seen: Boolean(state?.seenAt),
+        hidden: Boolean(state?.hiddenAt),
+        favorited: Boolean(state?.favoritedAt),
+      },
+      generatedAt: memory.generatedAt.toISOString(),
+      refreshedAt: memory.refreshedAt.toISOString(),
+      expiresAt: memory.expiresAt?.toISOString() ?? null,
+      items,
+    };
+  }
+
+  // ===========================================================================
+  // Per-user state
+  // ===========================================================================
+
+  /** `seenAt = COALESCE(seenAt, now())` — idempotent, first view wins. */
+  async markSeen(id: string, userId: string, permissions: string[]): Promise<void> {
+    await this.requireMemberMemory(id, userId, permissions);
+    await this.setUserStateTimestamp(id, userId, 'seenAt');
+  }
+
+  async hide(id: string, userId: string, permissions: string[]): Promise<void> {
+    await this.requireMemberMemory(id, userId, permissions);
+    await this.setUserStateTimestamp(id, userId, 'hiddenAt');
+  }
+
+  async unhide(id: string, userId: string, permissions: string[]): Promise<void> {
+    await this.requireMemberMemory(id, userId, permissions);
+    await this.clearUserStateTimestamp(id, userId, 'hiddenAt');
+  }
+
+  async favorite(id: string, userId: string, permissions: string[]): Promise<void> {
+    await this.requireMemberMemory(id, userId, permissions);
+    await this.setUserStateTimestamp(id, userId, 'favoritedAt');
+  }
+
+  async unfavorite(id: string, userId: string, permissions: string[]): Promise<void> {
+    await this.requireMemberMemory(id, userId, permissions);
+    await this.clearUserStateTimestamp(id, userId, 'favoritedAt');
+  }
+
+  /** State writes need membership only — viewer rank, no elevated permission. */
+  private async requireMemberMemory(
+    id: string,
+    userId: string,
+    permissions: string[],
+  ) {
+    if (!(await this.featureEnabled())) {
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+    return this.loadAccessibleMemory(id, userId, permissions, 'viewer' as CircleRole);
+  }
+
+  /**
+   * Set one `MemoryUserState` timestamp with COALESCE semantics.
+   *
+   * Two statements rather than one because that is what COALESCE-on-upsert
+   * costs in Prisma: the `upsert` covers "no row yet", and the guarded
+   * `updateMany` covers "a row exists because the user favorited it earlier but
+   * this particular column is still null". Re-running never moves an existing
+   * timestamp, so `seenAt` keeps naming the FIRST view — the same idempotency
+   * contract as `POST /api/notifications/:id/read`.
+   */
+  private async setUserStateTimestamp(
+    memoryId: string,
+    userId: string,
+    field: 'seenAt' | 'hiddenAt' | 'favoritedAt',
+  ): Promise<void> {
+    const now = new Date();
+    await this.prisma.memoryUserState.upsert({
+      where: { memoryId_userId: { memoryId, userId } },
+      create: { memoryId, userId, [field]: now },
+      update: {},
+    });
+    await this.prisma.memoryUserState.updateMany({
+      where: { memoryId, userId, [field]: null },
+      data: { [field]: now },
+    });
+  }
+
+  /**
+   * Clear one timestamp. `updateMany`, never an upsert: un-hiding a memory the
+   * user never hid is a no-op, and creating an all-null state row to record
+   * that nothing happened would be pure garbage.
+   */
+  private async clearUserStateTimestamp(
+    memoryId: string,
+    userId: string,
+    field: 'hiddenAt' | 'favoritedAt',
+  ): Promise<void> {
+    await this.prisma.memoryUserState.updateMany({
+      where: { memoryId, userId },
+      data: { [field]: null },
+    });
+  }
+
+  // ===========================================================================
+  // DELETE /api/memories/:id — the tombstone
+  // ===========================================================================
+
+  /**
+   * Circle-level delete. Sets `deletedAt`, which removes the memory for EVERY
+   * member and — because the `(circleId, type, periodKey, subjectKey)` unique
+   * index spans tombstoned rows — permanently: `upsertMemory` sees the row,
+   * recognises the tombstone and skips it, so no future generation run can
+   * recreate it (docs/specs/memories.md §2.5).
+   *
+   * Requires `media:write` + collaborator, the same bar as any other mutation
+   * of circle content. A viewer who merely wants it out of their own way has
+   * `POST /:id/hide`.
+   */
+  async remove(id: string, userId: string, permissions: string[]): Promise<void> {
+    if (!(await this.featureEnabled())) {
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+    const memory = await this.loadAccessibleMemory(
+      id,
+      userId,
+      permissions,
+      'collaborator' as CircleRole,
+    );
+
+    await this.prisma.memory.update({
+      where: { id: memory.id },
+      data: { deletedAt: new Date() },
+    });
+
+    await this.prisma.auditEvent.create({
+      data: {
+        actorUserId: userId,
+        action: 'memory:deleted',
+        targetType: 'memory',
+        targetId: memory.id,
+        meta: {
+          circleId: memory.circleId,
+          type: memory.type,
+          periodKey: memory.periodKey,
+          subjectKey: memory.subjectKey,
+          title: memory.title,
+        } as Prisma.InputJsonValue,
+      },
+    });
+
+    this.logger.log(
+      `Memory ${memory.id} (${memory.type}) tombstoned in circle ${memory.circleId} by user ${userId}`,
+    );
+  }
+
+  // ===========================================================================
+  // POST /api/memories/:id/save-album
+  // ===========================================================================
+
+  /**
+   * Materialise a memory as a real album.
+   *
+   * Every mutation goes through the EXISTING album service path
+   * (`MediaService.createAlbum` / `addAlbumItems` / `updateAlbum`) rather than
+   * writing `Album`/`AlbumItem` rows directly, so this inherits their circle
+   * checks, their `MediaTouchService` backup-feed bookkeeping and their cover
+   * validation for free, and cannot drift from them.
+   *
+   * NOT idempotent by design (per issue #307): saving the same memory twice
+   * yields two albums, because a user may genuinely want a second copy to edit.
+   *
+   * Item order is the memory's `position` order. Soft-deleted items are dropped
+   * first: `addAlbumItems` rejects the whole batch if any id is trashed, and a
+   * memory generated before a photo was trashed would otherwise be unsaveable.
+   */
+  async saveAsAlbum(
+    id: string,
+    dto: SaveMemoryAlbumDto,
+    userId: string,
+    permissions: string[],
+  ): Promise<SaveMemoryAlbumResultDto> {
+    if (!(await this.featureEnabled())) {
+      throw new NotFoundException(`Memory ${id} not found`);
+    }
+    const memory = await this.loadAccessibleMemory(
+      id,
+      userId,
+      permissions,
+      'collaborator' as CircleRole,
+    );
+
+    const memoryItems = await this.prisma.memoryItem.findMany({
+      where: { memoryId: memory.id },
+      orderBy: { position: 'asc' },
+      select: { mediaItemId: true },
+    });
+
+    const live = await this.prisma.mediaItem.findMany({
+      where: {
+        id: { in: memoryItems.map((item) => item.mediaItemId) },
+        circleId: memory.circleId,
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+    const liveIds = new Set(live.map((row) => row.id));
+    const orderedIds = memoryItems
+      .map((item) => item.mediaItemId)
+      .filter((mediaItemId) => liveIds.has(mediaItemId));
+
+    const name = (dto?.name ?? memory.title).slice(0, ALBUM_NAME_MAX).trim();
+    if (!name) {
+      throw new BadRequestException('Album name cannot be empty');
+    }
+
+    const album = await this.mediaService.createAlbum(
+      { circleId: memory.circleId, name },
+      userId,
+      permissions,
+    );
+
+    if (orderedIds.length > 0) {
+      // Sequential inserts inside addAlbumItems preserve `addedAt` order, which
+      // is the order `GET /api/media/albums/:id` reads items back in.
+      await this.mediaService.addAlbumItems(
+        album.id,
+        { mediaItemIds: orderedIds },
+        userId,
+        permissions,
+      );
+    }
+
+    // The cover only survives if it is actually a member — updateAlbum enforces
+    // that, and a memory whose cover photo was trashed must not 400 the save.
+    if (memory.coverMediaItemId && liveIds.has(memory.coverMediaItemId)) {
+      await this.mediaService.updateAlbum(
+        album.id,
+        { coverMediaItemId: memory.coverMediaItemId },
+        userId,
+        permissions,
+      );
+    }
+
+    this.logger.log(
+      `Memory ${memory.id} saved as album ${album.id} (${orderedIds.length} item(s)) by user ${userId}`,
+    );
+
+    return { albumId: album.id };
+  }
+
+  // ===========================================================================
+  // Projections
+  // ===========================================================================
+
+  /** Card projection with ONE batched signing call for the whole page. */
+  private async toCards(rows: CardRow[]): Promise<MemoryCardDto[]> {
+    const coverKeys = rows.map((row) =>
+      this.thumbnails.extractThumbKey(row.coverMediaItem?.metadata ?? null),
+    );
+    const signed = await this.thumbnails.signThumbsBatched(
+      coverKeys.filter((k): k is string => k !== null),
+    );
+    return rows.map((row, i) => this.toCard(row, coverKeys[i], signed));
+  }
+
+  /**
+   * Feed projection. Signs cover AND item thumbnails for every card in ONE
+   * batched call — the fan effect needs 4 extra thumbnails per card, which is
+   * exactly the shape that becomes an N+1 if signed per item.
+   */
+  private async toFeedCards(rows: FeedRow[]): Promise<MemoryFeedCardDto[]> {
+    const coverKeys = rows.map((row) =>
+      this.thumbnails.extractThumbKey(row.coverMediaItem?.metadata ?? null),
+    );
+    const itemKeys = rows.map((row) =>
+      row.items.map((item) =>
+        this.thumbnails.extractThumbKey(item.mediaItem.metadata),
+      ),
+    );
+    const signed = await this.thumbnails.signThumbsBatched(
+      [...coverKeys, ...itemKeys.flat()].filter((k): k is string => k !== null),
+    );
+
+    return rows.map((row, i) => ({
+      ...this.toCard(row, coverKeys[i], signed),
+      itemThumbnailUrls: itemKeys[i]
+        .map((key) => (key ? signed.get(key) ?? null : null))
+        .filter((url): url is string => url !== null),
+    }));
+  }
+
+  private toCard(
+    row: CardRow,
+    coverKey: string | null,
+    signed: Map<string, string | null>,
+  ): MemoryCardDto {
+    const state = row.userStates[0];
+    return {
+      id: row.id,
+      type: row.type,
+      title: row.title,
+      subtitle: row.subtitle,
+      itemCount: row.itemCount,
+      periodStart: row.periodStart.toISOString(),
+      periodEnd: row.periodEnd.toISOString(),
+      coverMediaItemId: row.coverMediaItemId,
+      coverThumbnailUrl: coverKey ? signed.get(coverKey) ?? null : null,
+      meta: row.meta,
+      myState: {
+        seen: Boolean(state?.seenAt),
+        favorited: Boolean(state?.favoritedAt),
+      },
+      generatedAt: row.generatedAt.toISOString(),
+    };
+  }
+}

--- a/apps/api/src/memories/api/memory-preferences.spec.ts
+++ b/apps/api/src/memories/api/memory-preferences.spec.ts
@@ -1,0 +1,111 @@
+import {
+  isMemoryHiddenByPreferences,
+  preferencesAreEmpty,
+  resolveMemoryPreferences,
+} from './memory-preferences';
+
+function memory(start: string, end: string, personId: string | null = null) {
+  return {
+    personId,
+    periodStart: new Date(start),
+    periodEnd: new Date(end),
+  };
+}
+
+describe('resolveMemoryPreferences', () => {
+  it('treats an absent namespace as "no preference"', () => {
+    for (const input of [undefined, null, {}]) {
+      const prefs = resolveMemoryPreferences(input as never);
+      expect(preferencesAreEmpty(prefs)).toBe(true);
+      expect(prefs.emailDigestOptOut).toBe(false);
+    }
+  });
+
+  it('compiles person ids into a Set', () => {
+    const prefs = resolveMemoryPreferences({
+      hiddenPersonIds: ['a', 'b', 'a'],
+    });
+    expect(prefs.hiddenPersonIds.size).toBe(2);
+    expect(prefs.hiddenPersonIds.has('a')).toBe(true);
+  });
+
+  it('expands an inclusive `to` day to the next UTC midnight', () => {
+    const prefs = resolveMemoryPreferences({
+      hiddenDateRanges: [{ from: '2024-05-10', to: '2024-05-10' }],
+    });
+    expect(prefs.hiddenRanges).toEqual([
+      {
+        startMs: Date.parse('2024-05-10T00:00:00.000Z'),
+        endExclusiveMs: Date.parse('2024-05-11T00:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('skips malformed entries rather than throwing', () => {
+    // Simulates a hand-edited / legacy JSONB blob: the schema validates on
+    // WRITE, but a read must degrade to "no filter", never 500 a browse page.
+    const prefs = resolveMemoryPreferences({
+      hiddenPersonIds: [null, 42, 'ok'],
+      hiddenDateRanges: [
+        null,
+        { from: 'nonsense', to: 'nonsense' },
+        { from: '2024-01-02', to: '2024-01-01' }, // inverted
+        { from: '2024-03-01', to: '2024-03-02' },
+      ],
+    } as never);
+    expect([...prefs.hiddenPersonIds]).toEqual(['ok']);
+    expect(prefs.hiddenRanges).toHaveLength(1);
+  });
+
+  it('reads emailDigestOptOut strictly as true', () => {
+    expect(resolveMemoryPreferences({ emailDigestOptOut: true }).emailDigestOptOut).toBe(true);
+    expect(resolveMemoryPreferences({ emailDigestOptOut: false }).emailDigestOptOut).toBe(false);
+    expect(resolveMemoryPreferences({}).emailDigestOptOut).toBe(false);
+  });
+});
+
+describe('isMemoryHiddenByPreferences', () => {
+  it('hides a memory keyed to a hidden person', () => {
+    const prefs = resolveMemoryPreferences({ hiddenPersonIds: ['p1'] });
+    expect(
+      isMemoryHiddenByPreferences(memory('2024-01-01', '2024-01-02', 'p1'), prefs),
+    ).toBe(true);
+    expect(
+      isMemoryHiddenByPreferences(memory('2024-01-01', '2024-01-02', 'p2'), prefs),
+    ).toBe(false);
+    // A memory with no person is never hidden by a person preference.
+    expect(
+      isMemoryHiddenByPreferences(memory('2024-01-01', '2024-01-02'), prefs),
+    ).toBe(false);
+  });
+
+  describe('date-range OVERLAP (not containment)', () => {
+    const prefs = resolveMemoryPreferences({
+      hiddenDateRanges: [{ from: '2024-06-10', to: '2024-06-20' }],
+    });
+
+    it.each([
+      ['fully inside', '2024-06-12', '2024-06-15', true],
+      ['straddling the start', '2024-06-01', '2024-06-11', true],
+      ['straddling the end', '2024-06-19', '2024-07-05', true],
+      ['fully containing', '2024-01-01', '2024-12-31', true],
+      ['touching the first day', '2024-06-10T00:00:00Z', '2024-06-10T00:00:00Z', true],
+      ['touching the last day', '2024-06-20T23:59:59Z', '2024-06-20T23:59:59Z', true],
+      ['entirely before', '2024-05-01', '2024-06-09T23:00:00Z', false],
+      ['entirely after', '2024-06-21T00:00:01Z', '2024-07-01', false],
+    ])('%s → %s', (_label, start, end, expected) => {
+      expect(isMemoryHiddenByPreferences(memory(start, end), prefs)).toBe(expected);
+    });
+  });
+
+  it('hides when ANY of several ranges overlaps', () => {
+    const prefs = resolveMemoryPreferences({
+      hiddenDateRanges: [
+        { from: '2020-01-01', to: '2020-01-05' },
+        { from: '2024-06-10', to: '2024-06-20' },
+      ],
+    });
+    expect(isMemoryHiddenByPreferences(memory('2024-06-15', '2024-06-16'), prefs)).toBe(true);
+    expect(isMemoryHiddenByPreferences(memory('2022-01-01', '2022-01-02'), prefs)).toBe(false);
+  });
+});

--- a/apps/api/src/memories/api/memory-preferences.ts
+++ b/apps/api/src/memories/api/memory-preferences.ts
@@ -1,0 +1,121 @@
+// =============================================================================
+// Memories — per-user read-time preference filtering (epic #300, issue #307)
+// =============================================================================
+//
+// The `user_settings.memories` namespace (hidden people, sensitive date ranges)
+// is a READ-TIME filter, never a generation input. Generation is circle-scoped:
+// one `Memory` row is shared by every member, so a personal preference cannot
+// influence what gets curated without leaking one member's preferences into
+// another member's feed. That is why the curators deliberately ignore this
+// namespace (docs/specs/memories.md §4.9) and why the filtering lives here.
+//
+// V1 LIMITATION (epic #300, deliberate): a memory is dropped WHOLE. A hidden
+// person removes `person_highlights` / `person_over_years` memories keyed to
+// them, but a trip or theme memory that merely CONTAINS that person among many
+// faces is not scrubbed at the item level.
+// =============================================================================
+
+import { MemoriesPreferencesValue } from '../../common/types/settings.types';
+
+/** Just enough of a Memory row to decide whether a preference hides it. */
+export interface PreferenceFilterableMemory {
+  personId: string | null;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+/**
+ * A user's preferences pre-compiled into the exact shapes the per-row check
+ * needs, so a page of 20 rows does not re-parse the same date strings 20 times.
+ *
+ * `hiddenPersonIds` becomes a Set (membership, not scan) and each date range
+ * becomes a half-open `[startMs, endExclusiveMs)` millisecond interval.
+ */
+export interface ResolvedMemoryPreferences {
+  hiddenPersonIds: Set<string>;
+  hiddenRanges: Array<{ startMs: number; endExclusiveMs: number }>;
+  emailDigestOptOut: boolean;
+}
+
+/** The identity value: nothing hidden. Shared, never mutated. */
+export const NO_MEMORY_PREFERENCES: ResolvedMemoryPreferences = {
+  hiddenPersonIds: new Set<string>(),
+  hiddenRanges: [],
+  emailDigestOptOut: false,
+};
+
+/** True when the resolved preferences cannot filter anything out. */
+export function preferencesAreEmpty(prefs: ResolvedMemoryPreferences): boolean {
+  return prefs.hiddenPersonIds.size === 0 && prefs.hiddenRanges.length === 0;
+}
+
+/**
+ * Compile a stored `user_settings.memories` blob into the resolved form.
+ *
+ * Defensive by construction: this reads a JSONB blob that the schema validated
+ * when it was WRITTEN, but an older row (or a hand-edited one) can hold
+ * anything, and a malformed preference must degrade to "no filter" rather than
+ * throw inside a list request. Every non-string / unparseable entry is skipped.
+ *
+ * A `YYYY-MM-DD` range is inclusive of both endpoints, so `to` is expanded to
+ * the START of the following day and the comparison is half-open — the same
+ * trick `expiresAt` uses for an anchor day (see on-this-day.curator.ts).
+ */
+export function resolveMemoryPreferences(
+  stored: MemoriesPreferencesValue | undefined | null,
+): ResolvedMemoryPreferences {
+  if (!stored || typeof stored !== 'object') return NO_MEMORY_PREFERENCES;
+
+  const hiddenPersonIds = new Set<string>();
+  if (Array.isArray(stored.hiddenPersonIds)) {
+    for (const id of stored.hiddenPersonIds) {
+      if (typeof id === 'string' && id) hiddenPersonIds.add(id);
+    }
+  }
+
+  const hiddenRanges: Array<{ startMs: number; endExclusiveMs: number }> = [];
+  if (Array.isArray(stored.hiddenDateRanges)) {
+    for (const range of stored.hiddenDateRanges) {
+      if (!range || typeof range !== 'object') continue;
+      const startMs = Date.parse(`${range.from}T00:00:00.000Z`);
+      const endMs = Date.parse(`${range.to}T00:00:00.000Z`);
+      if (Number.isNaN(startMs) || Number.isNaN(endMs)) continue;
+      // `to` is INCLUSIVE, so the exclusive bound is the next UTC midnight.
+      const endExclusiveMs = endMs + 24 * 60 * 60 * 1000;
+      if (endExclusiveMs <= startMs) continue;
+      hiddenRanges.push({ startMs, endExclusiveMs });
+    }
+  }
+
+  return {
+    hiddenPersonIds,
+    hiddenRanges,
+    emailDigestOptOut: stored.emailDigestOptOut === true,
+  };
+}
+
+/**
+ * True when this memory must be withheld from THIS user's list/feed.
+ *
+ * Two independent rules, OR-combined:
+ *   1. the memory is keyed to a hidden person (`personId` match), or
+ *   2. its covered capture window OVERLAPS a sensitive range. Overlap, not
+ *      containment: a trip that merely crosses a hidden anniversary is exactly
+ *      the case the user is trying not to be shown, so a partial hit counts.
+ */
+export function isMemoryHiddenByPreferences(
+  memory: PreferenceFilterableMemory,
+  prefs: ResolvedMemoryPreferences,
+): boolean {
+  if (memory.personId && prefs.hiddenPersonIds.has(memory.personId)) {
+    return true;
+  }
+  if (prefs.hiddenRanges.length === 0) return false;
+
+  const startMs = memory.periodStart.getTime();
+  const endMs = memory.periodEnd.getTime();
+  for (const range of prefs.hiddenRanges) {
+    if (startMs < range.endExclusiveMs && endMs >= range.startMs) return true;
+  }
+  return false;
+}

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -5,7 +5,8 @@
 // Owns the Memories generation plumbing: the hourly per-circle scheduling cron,
 // the `memory_generation` enrichment handler, the shared curation engine and the
 // curator registry. Later issues in the epic add more curators (#304–#305), AI
-// titles (#306), the read API (#307) and the email digest (#311) here.
+// titles (#306) and the email digest (#311) here. Issue #307 added the read/act
+// HTTP surface (MemoriesController + MemoriesService) under `api/`.
 //
 // Minimal-template module (mirrors InsightsModule): PrismaModule for DB access,
 // SettingsModule for the cached feature-flag/settings reads, EnrichmentModule
@@ -22,6 +23,10 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { SettingsModule } from '../settings/settings.module';
 import { EnrichmentModule } from '../enrichment/enrichment.module';
 import { AiModule } from '../ai/ai.module';
+import { CirclesModule } from '../circles/circles.module';
+import { MediaModule } from '../media/media.module';
+import { MemoriesController } from './api/memories.controller';
+import { MemoriesService } from './api/memories.service';
 import { MemoryTitleService } from './titles/memory-title.service';
 import { MemoriesGenerationTask } from './memories-generation.task';
 import { MemoryGenerationHandler } from './memory-generation.handler';
@@ -40,8 +45,23 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
   // credential) and AiProviderRegistry to MemoryTitleService (#306). The edge
   // points one way only — AiModule imports SettingsModule and nothing else —
   // so there is no cycle to break.
-  imports: [PrismaModule, SettingsModule, EnrichmentModule, AiModule],
+  //
+  // #307's API layer adds two edges: CirclesModule (CircleMembershipService,
+  // the per-circle role checks) and MediaModule (MediaThumbnailService for
+  // batched signing, MediaService for the album path save-as-album reuses
+  // rather than duplicating). Both point one way — neither imports
+  // MemoriesModule — so there is no cycle and no forwardRef.
+  imports: [
+    PrismaModule,
+    SettingsModule,
+    EnrichmentModule,
+    AiModule,
+    CirclesModule,
+    MediaModule,
+  ],
+  controllers: [MemoriesController],
   providers: [
+    MemoriesService,
     MemoriesGenerationTask,
     MemoryGenerationHandler,
     MemoryCurationService,
@@ -55,6 +75,6 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
     YearInReviewCurator,
     memoryCuratorsProvider,
   ],
-  exports: [MemoriesGenerationTask, MemoryCurationService],
+  exports: [MemoriesGenerationTask, MemoryCurationService, MemoriesService],
 })
 export class MemoriesModule {}

--- a/apps/api/src/settings/dto/update-user-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-user-settings.dto.ts
@@ -5,6 +5,8 @@ import {
   dataTablesPatchSchema,
   notificationPreferencesSchema,
   notificationPreferencesPatchSchema,
+  memoriesPreferencesSchema,
+  memoriesPreferencesPatchSchema,
 } from '../../common/schemas/settings.schema';
 
 // Full replacement (PUT)
@@ -26,6 +28,9 @@ export const updateUserSettingsSchema = z.object({
   // an absent namespace / field / type key means ENABLED. See
   // settings.schema.ts for the absent-key rule.
   notifications: notificationPreferencesSchema.optional(),
+  // Per-user Memories preferences (issue #307). Optional with NO default: an
+  // absent namespace / field means "no preference". See settings.schema.ts.
+  memories: memoriesPreferencesSchema.optional(),
 });
 
 export class UpdateUserSettingsDto extends createZodDto(
@@ -56,6 +61,10 @@ export const patchUserSettingsSchema = z.object({
   // another's stored value; a `null` type entry resets that type to its
   // default, and `notifications: null` clears the whole namespace.
   notifications: notificationPreferencesPatchSchema.nullable().optional(),
+  // Merged field-wise (see UserSettingsService.mergeMemories): a listed field
+  // replaces, an unlisted one is untouched, a `null` field clears it, and
+  // `memories: null` clears the whole namespace.
+  memories: memoriesPreferencesPatchSchema.nullable().optional(),
 }).default({});
 
 export class PatchUserSettingsDto extends createZodDto(

--- a/apps/api/src/settings/user-settings/user-settings.service.spec.ts
+++ b/apps/api/src/settings/user-settings/user-settings.service.spec.ts
@@ -16,6 +16,10 @@ import {
 
 const ALL_NOTIFICATION_TYPES = Object.values(NotificationType) as NotificationType[];
 
+/** Fixture person ids for the #307 `memories` preference namespace. */
+const PERSON_A = '11111111-1111-4111-8111-111111111111';
+const PERSON_B = '22222222-2222-4222-8222-222222222222';
+
 /**
  * Wires $transaction so `cb(tx)` runs against the same mock — mirrors
  * production tx semantics and the identical helper in
@@ -871,6 +875,144 @@ describe('UserSettingsService', () => {
       } as any);
 
       expect(result.dataTables).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // Per-user Memories preferences (issue #307, epic #300)
+  // ===========================================================================
+
+  describe('patchSettings (PATCH) — memories', () => {
+    const persistedValue = (): UserSettingsValue =>
+      (mockPrisma.userSettings.update.mock.calls[0][0] as any).data
+        .value as UserSettingsValue;
+
+    const seed = (memories?: Record<string, unknown>) => {
+      const stored: UserSettingsValue = {
+        ...DEFAULT_USER_SETTINGS,
+        ...(memories ? { memories: memories as any } : {}),
+      };
+      mockPrisma.userSettings.findUnique.mockResolvedValue({
+        ...mockUserSettings,
+        value: stored as any,
+      } as any);
+      mockPrisma.userSettings.update.mockImplementation((async (args: any) => ({
+        ...mockUserSettings,
+        value: args.data.value,
+        version: 2,
+      })) as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+    };
+
+    it('leaves the namespace absent when absent and unpatched (absent = default)', async () => {
+      seed();
+
+      const result = await service.patchSettings(mockUserId, { theme: 'dark' });
+
+      expect(result.memories).toBeUndefined();
+      expect(persistedValue().memories).toBeUndefined();
+    });
+
+    it('persists a new namespace', async () => {
+      seed();
+
+      const result = await service.patchSettings(mockUserId, {
+        memories: { hiddenPersonIds: [PERSON_A] },
+      });
+
+      expect(result.memories).toEqual({ hiddenPersonIds: [PERSON_A] });
+    });
+
+    it('merges FIELD-WISE — an unlisted field is untouched', async () => {
+      seed({ hiddenPersonIds: [PERSON_A], emailDigestOptOut: true });
+
+      const result = await service.patchSettings(mockUserId, {
+        memories: { hiddenDateRanges: [{ from: '2024-01-01', to: '2024-01-05' }] },
+      });
+
+      expect(result.memories).toEqual({
+        hiddenPersonIds: [PERSON_A],
+        emailDigestOptOut: true,
+        hiddenDateRanges: [{ from: '2024-01-01', to: '2024-01-05' }],
+      });
+    });
+
+    it('REPLACES a listed list rather than appending — which is how un-hiding works', async () => {
+      seed({ hiddenPersonIds: [PERSON_A, PERSON_B] });
+
+      const result = await service.patchSettings(mockUserId, {
+        memories: { hiddenPersonIds: [PERSON_A] },
+      });
+
+      expect(result.memories!.hiddenPersonIds).toEqual([PERSON_A]);
+    });
+
+    it('deletes a field set to null, resetting it to its absent default', async () => {
+      seed({ hiddenPersonIds: [PERSON_A], emailDigestOptOut: true });
+
+      const result = await service.patchSettings(mockUserId, {
+        memories: { emailDigestOptOut: null },
+      });
+
+      expect(result.memories).toEqual({ hiddenPersonIds: [PERSON_A] });
+      expect('emailDigestOptOut' in result.memories!).toBe(false);
+    });
+
+    it('clears the whole namespace on `memories: null`', async () => {
+      seed({ hiddenPersonIds: [PERSON_A] });
+
+      const result = await service.patchSettings(mockUserId, { memories: null });
+
+      expect(result.memories).toBeUndefined();
+      expect(persistedValue().memories).toBeUndefined();
+    });
+
+    it('collapses an emptied namespace back to undefined rather than storing {}', async () => {
+      seed({ hiddenPersonIds: [PERSON_A] });
+
+      const result = await service.patchSettings(mockUserId, {
+        memories: { hiddenPersonIds: null },
+      });
+
+      expect(result.memories).toBeUndefined();
+    });
+
+    it('rejects an inverted date range', async () => {
+      seed();
+
+      await expect(
+        service.patchSettings(mockUserId, {
+          memories: {
+            hiddenDateRanges: [{ from: '2024-02-10', to: '2024-02-01' }],
+          },
+        } as any),
+      ).rejects.toThrow();
+    });
+
+    it('rejects a date that is not a real calendar day', async () => {
+      seed();
+
+      await expect(
+        service.patchSettings(mockUserId, {
+          memories: {
+            hiddenDateRanges: [{ from: '2024-02-31', to: '2024-03-01' }],
+          },
+        } as any),
+      ).rejects.toThrow();
+    });
+
+    it('never persists an unknown key', async () => {
+      // `.strict()` rejects one at the HTTP boundary (the zod DTO pipe); the
+      // merge is the second line of defence — it copies only known fields, so
+      // an unknown key cannot reach the stored blob even on a direct call.
+      seed();
+
+      const result = await service.patchSettings(mockUserId, {
+        memories: { hiddenPetIds: ['x'] },
+      } as any);
+
+      expect(result.memories).toBeUndefined();
+      expect(persistedValue().memories).toBeUndefined();
     });
   });
 

--- a/apps/api/src/settings/user-settings/user-settings.service.ts
+++ b/apps/api/src/settings/user-settings/user-settings.service.ts
@@ -12,11 +12,13 @@ import { PatchUserSettingsDto } from '../dto/update-user-settings.dto';
 import {
   DEFAULT_USER_SETTINGS,
   DataTableLayoutValue,
+  MemoriesPreferencesValue,
   NotificationPreferencesValue,
   UserSettingsValue,
 } from '../../common/types/settings.types';
 import {
   DATA_TABLE_MAX_TABLES,
+  MemoriesPreferencesPatch,
   NotificationPreferencesPatch,
   userSettingsSchema,
 } from '../../common/schemas/settings.schema';
@@ -64,6 +66,9 @@ export class UserSettingsService {
       // Same contract: absent namespace / field / type key means ENABLED (with
       // `workflowMicroRuns` the one inverted default). Never materialized here.
       notifications: value.notifications,
+      // Same contract again: absent namespace / field means "no preference"
+      // (nothing hidden, digest not opted out). Never materialized here.
+      memories: value.memories,
       updatedAt: settings.updatedAt,
       version: settings.version,
     };
@@ -107,6 +112,9 @@ export class UserSettingsService {
       // namespace/entry/field against the column contract's defaults.
       dataTables: value.dataTables,
       notifications: value.notifications,
+      // Same contract again: absent namespace / field means "no preference"
+      // (nothing hidden, digest not opted out). Never materialized here.
+      memories: value.memories,
       updatedAt: settings.updatedAt,
       version: settings.version,
     };
@@ -156,6 +164,7 @@ export class UserSettingsService {
         current.notifications,
         dto.notifications,
       ),
+      memories: this.mergeMemories(current.memories, dto.memories),
     };
 
     // The per-table-id merge above can push the namespace past its cap even
@@ -198,6 +207,9 @@ export class UserSettingsService {
       // namespace/entry/field against the column contract's defaults.
       dataTables: value.dataTables,
       notifications: value.notifications,
+      // Same contract again: absent namespace / field means "no preference"
+      // (nothing hidden, digest not opted out). Never materialized here.
+      memories: value.memories,
       updatedAt: settings.updatedAt,
       version: settings.version,
     };
@@ -306,6 +318,50 @@ export class UserSettingsService {
     if (microRuns !== undefined) merged.workflowMicroRuns = microRuns;
 
     if (Object.keys(types).length > 0) merged.types = types;
+
+    return Object.keys(merged).length > 0 ? merged : undefined;
+  }
+
+  /**
+   * Merge a PATCH's `memories` payload into the stored namespace (issue #307).
+   *
+   * FIELD-WISE, one level deep — the same shape as mergeNotifications():
+   *   - `memories` absent from the patch  → stored namespace untouched;
+   *   - `memories: null`                  → namespace DELETED, i.e. reset to
+   *     defaults (nothing hidden, digest not opted out) rather than pinned to
+   *     an explicit empty blob;
+   *   - a field present                   → replaced wholesale. The two list
+   *     fields are replace-not-append deliberately: "hide this person" and
+   *     "un-hide this person" are the same PATCH from the client's point of
+   *     view, and an append-only merge would make removal inexpressible;
+   *   - a field set to `null`             → DELETED (JSON Merge Patch), which
+   *     resets it to its absent default instead of writing `[]` / `false` that
+   *     would survive a future default change.
+   *
+   * An empty result collapses back to `undefined` — the absent namespace IS
+   * the canonical "nothing persisted" state, and storing `{}` is only noise.
+   */
+  private mergeMemories(
+    current: MemoriesPreferencesValue | undefined,
+    patch: MemoriesPreferencesPatch | null | undefined,
+  ): MemoriesPreferencesValue | undefined {
+    if (patch === undefined) return current;
+    if (patch === null) return undefined;
+
+    const merged: MemoriesPreferencesValue = { ...(current ?? {}) };
+
+    if (patch.hiddenPersonIds !== undefined) {
+      if (patch.hiddenPersonIds === null) delete merged.hiddenPersonIds;
+      else merged.hiddenPersonIds = patch.hiddenPersonIds;
+    }
+    if (patch.hiddenDateRanges !== undefined) {
+      if (patch.hiddenDateRanges === null) delete merged.hiddenDateRanges;
+      else merged.hiddenDateRanges = patch.hiddenDateRanges;
+    }
+    if (patch.emailDigestOptOut !== undefined) {
+      if (patch.emailDigestOptOut === null) delete merged.emailDigestOptOut;
+      else merged.emailDigestOptOut = patch.emailDigestOptOut;
+    }
 
     return Object.keys(merged).length > 0 ? merged : undefined;
   }

--- a/apps/api/test/memories/memories-api.integration.spec.ts
+++ b/apps/api/test/memories/memories-api.integration.spec.ts
@@ -1,0 +1,1160 @@
+/**
+ * Memories API integration (epic #300, issue #307)
+ *
+ * Boots the REAL AppModule over a mocked PrismaService
+ * (`createTestApp({ useMockDatabase: true })`), which is the right harness for
+ * what this suite is about: routing, guards, the RBAC matrix, status codes and
+ * the projection/ordering logic the service performs in memory. None of that
+ * needs real SQL, and every assertion here runs in CI without a database.
+ *
+ * The DB-level guarantees this feature leans on — the natural-key unique index
+ * spanning tombstoned rows, the cascades — are already covered by the DB-gated
+ * `test/memories/memories.integration.spec.ts` from issue #301.
+ *
+ * What is proven here:
+ *   - the feature flag OFF (the default) returns EMPTY lists, not errors, and
+ *     404s the per-id routes — the epic's "zero cost when off" criterion;
+ *   - the RBAC matrix: viewer reads and writes state but cannot delete or
+ *     save-as-album; collaborator can; a non-member gets 404, never 403;
+ *   - keyset pagination shape and the raw-page cursor rule;
+ *   - the tombstone and active-expiry filters reach every query;
+ *   - per-user preference filtering (hidden person + overlapping date range);
+ *   - feed ordering: today's on_this_day → unseen → seen, capped at 10;
+ *   - save-as-album reuses the album service path, in memory order, with cover.
+ */
+
+import request from 'supertest';
+import { randomUUID } from 'crypto';
+
+import {
+  TestContext,
+  createTestApp,
+  closeTestApp,
+} from '../helpers/test-app.helper';
+import { resetPrismaMock } from '../mocks/prisma.mock';
+import {
+  setupBaseMocks,
+  setupMockUserSettings,
+} from '../fixtures/mock-setup.helper';
+import {
+  createMockContributorUser,
+  createMockViewerUser,
+  authHeader,
+} from '../helpers/auth-mock.helper';
+import { DEFAULT_SYSTEM_SETTINGS } from '../../src/common/types/settings.types';
+import { SystemSettingsService } from '../../src/settings/system-settings/system-settings.service';
+import { MediaThumbnailService } from '../../src/media/media-thumbnail.service';
+
+const CIRCLE_ID = '5c1c1e00-0000-4000-8000-000000000001';
+const OTHER_CIRCLE_ID = '5c1c1e00-0000-4000-8000-000000000002';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupCircleMocks(
+  context: TestContext,
+  userId: string,
+  circleId: string,
+  role: string,
+): void {
+  context.prismaMock.circle.findUnique.mockResolvedValue({ id: circleId });
+  context.prismaMock.circleMember.findUnique.mockImplementation(
+    async ({ where }: any) =>
+      where?.circleId_userId?.circleId === circleId &&
+      where?.circleId_userId?.userId === userId
+        ? { circleId, userId, role, joinedAt: new Date() }
+        : null,
+  );
+}
+
+/** Enable features.memories and bust the SystemSettingsService 5 s cache. */
+function enableMemories(context: TestContext): void {
+  context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+    id: 'settings-1',
+    key: 'global',
+    value: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      features: { ...DEFAULT_SYSTEM_SETTINGS.features, memories: true },
+    },
+    version: 1,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    updatedByUser: null,
+  } as any);
+  (context.module.get(SystemSettingsService) as any).settingsCache = null;
+}
+
+/** The default: the flag is off. */
+function disableMemories(context: TestContext): void {
+  context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+    id: 'settings-1',
+    key: 'global',
+    value: { ...DEFAULT_SYSTEM_SETTINGS },
+    version: 1,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    updatedByUser: null,
+  } as any);
+  (context.module.get(SystemSettingsService) as any).settingsCache = null;
+}
+
+function makeMemoryRow(overrides: Record<string, any> = {}) {
+  const now = new Date();
+  return {
+    id: randomUUID(),
+    circleId: CIRCLE_ID,
+    type: 'trip',
+    periodKey: '2023-03-12',
+    subjectKey: 'guanacaste',
+    personId: null,
+    title: 'Trip to Guanacaste',
+    subtitle: 'March 2023',
+    narrative: null,
+    titleSource: 'template',
+    titleModel: null,
+    coverMediaItemId: null,
+    periodStart: new Date('2023-03-12T00:00:00.000Z'),
+    periodEnd: new Date('2023-03-16T00:00:00.000Z'),
+    itemCount: 12,
+    meta: null,
+    generatedAt: now,
+    refreshedAt: now,
+    expiresAt: null,
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    // Relation payloads the card projection selects.
+    coverMediaItem: null,
+    userStates: [],
+    items: [],
+    ...overrides,
+  };
+}
+
+describe('Memories API (issue #307)', () => {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    context = await createTestApp({ useMockDatabase: true });
+  });
+
+  afterAll(async () => {
+    await closeTestApp(context);
+  });
+
+  beforeEach(() => {
+    resetPrismaMock();
+    setupBaseMocks();
+    jest.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Feature flag — the default-off contract
+  // =========================================================================
+
+  describe('feature flag off (default)', () => {
+    it('GET /api/memories returns an empty page, not an error', async () => {
+      disableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items).toEqual([]);
+      expect(res.body.data.meta).toEqual({
+        pageSize: 20,
+        nextCursor: null,
+        hasMore: false,
+      });
+    });
+
+    it('costs ZERO memory queries when off', async () => {
+      disableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(context.prismaMock.memory.findMany).not.toHaveBeenCalled();
+      // The gate is checked BEFORE the circle-access check, so not even the
+      // membership lookups run.
+      expect(context.prismaMock.circleMember.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('GET /api/memories/feed returns an empty list', async () => {
+      disableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories/feed?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items).toEqual([]);
+      expect(context.prismaMock.memory.findMany).not.toHaveBeenCalled();
+    });
+
+    it('GET /api/memories/:id 404s while the feature is off', async () => {
+      disableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories/${randomUUID()}`)
+        .set(authHeader(user.accessToken))
+        .expect(404);
+
+      expect(context.prismaMock.memory.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Auth
+  // =========================================================================
+
+  describe('authentication', () => {
+    it('401s without a token', async () => {
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .expect(401);
+    });
+
+    it('400s on a non-uuid circleId', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .get('/api/memories?circleId=not-a-uuid')
+        .set(authHeader(user.accessToken))
+        .expect(400);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/memories — filters, keyset, tombstone
+  // =========================================================================
+
+  describe('GET /api/memories', () => {
+    it('excludes tombstoned, expired and per-user hidden rows in SQL', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      const where = context.prismaMock.memory.findMany.mock.calls[0][0].where;
+      expect(where.circleId).toBe(CIRCLE_ID);
+      expect(where.deletedAt).toBeNull();
+      // Active filter: expiresAt IS NULL OR expiresAt > now()
+      expect(where.OR).toEqual([
+        { expiresAt: null },
+        { expiresAt: { gt: expect.any(Date) } },
+      ]);
+      expect(where.NOT).toEqual({
+        userStates: { some: { userId: user.id, hiddenAt: { not: null } } },
+      });
+    });
+
+    it('orders by (generatedAt DESC, id DESC) and takes pageSize + 1', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&pageSize=5`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      const args = context.prismaMock.memory.findMany.mock.calls[0][0];
+      expect(args.orderBy).toEqual([{ generatedAt: 'desc' }, { id: 'desc' }]);
+      expect(args.take).toBe(6);
+      expect(args.cursor).toBeUndefined();
+    });
+
+    it('applies the cursor with skip: 1', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+      const cursor = randomUUID();
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&cursor=${cursor}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      const args = context.prismaMock.memory.findMany.mock.calls[0][0];
+      expect(args.cursor).toEqual({ id: cursor });
+      expect(args.skip).toBe(1);
+    });
+
+    it('returns hasMore + nextCursor from the last row of the page', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      const rows = [makeMemoryRow(), makeMemoryRow(), makeMemoryRow()];
+      context.prismaMock.memory.findMany.mockResolvedValue(rows);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&pageSize=2`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items).toHaveLength(2);
+      expect(res.body.data.meta.hasMore).toBe(true);
+      expect(res.body.data.meta.nextCursor).toBe(rows[1].id);
+      // No COUNT anywhere in keyset mode.
+      expect(context.prismaMock.memory.count).not.toHaveBeenCalled();
+    });
+
+    it('keeps nextCursor from the RAW page even when every row is preference-hidden', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      const personId = randomUUID();
+      setupMockUserSettings(user.id, {
+        theme: 'system',
+        profile: { useProviderImage: true },
+        memories: { hiddenPersonIds: [personId] },
+      });
+
+      const rows = [
+        makeMemoryRow({ type: 'person_highlights', personId }),
+        makeMemoryRow({ type: 'person_highlights', personId }),
+        makeMemoryRow({ type: 'person_highlights', personId }),
+      ];
+      context.prismaMock.memory.findMany.mockResolvedValue(rows);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&pageSize=2`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      // Everything filtered out of THIS page...
+      expect(res.body.data.items).toEqual([]);
+      // ...but pagination can still continue past it.
+      expect(res.body.data.meta.hasMore).toBe(true);
+      expect(res.body.data.meta.nextCursor).toBe(rows[1].id);
+    });
+
+    it('compiles ?year= to a period-range overlap', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&year=2023`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      const where = context.prismaMock.memory.findMany.mock.calls[0][0].where;
+      expect(where.periodStart).toEqual({ lt: new Date('2024-01-01T00:00:00.000Z') });
+      expect(where.periodEnd).toEqual({ gte: new Date('2023-01-01T00:00:00.000Z') });
+    });
+
+    it('narrows to the caller\'s own favorites with ?favorite=true', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&favorite=true`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      const where = context.prismaMock.memory.findMany.mock.calls[0][0].where;
+      expect(where.userStates).toEqual({
+        some: { userId: user.id, favoritedAt: { not: null } },
+      });
+    });
+
+    it('passes ?type= straight through', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&type=year_in_review`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(
+        context.prismaMock.memory.findMany.mock.calls[0][0].where.type,
+      ).toBe('year_in_review');
+    });
+
+    it('400s on an unknown type', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}&type=not_a_type`)
+        .set(authHeader(user.accessToken))
+        .expect(400);
+    });
+
+    it('403s a non-member (a circle-scoped list is not enumeration-sensitive)', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      context.prismaMock.circle.findUnique.mockResolvedValue({ id: CIRCLE_ID });
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(403);
+    });
+
+    it('signs cover thumbnails with ONE batched storageObject query', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      const rows = [1, 2, 3].map((n) =>
+        makeMemoryRow({
+          coverMediaItemId: randomUUID(),
+          coverMediaItem: {
+            id: randomUUID(),
+            metadata: { thumbnailStorageKey: `thumbnails/cover-${n}.jpg` },
+          },
+        }),
+      );
+      context.prismaMock.memory.findMany.mockResolvedValue(rows);
+      context.prismaMock.storageObject.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      // Batched: one findMany for three covers, and never a per-item findUnique.
+      expect(context.prismaMock.storageObject.findMany).toHaveBeenCalledTimes(1);
+      expect(
+        context.prismaMock.storageObject.findMany.mock.calls[0][0].where
+          .storageKey.in,
+      ).toHaveLength(3);
+      expect(context.prismaMock.storageObject.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Preference filtering
+  // =========================================================================
+
+  describe('per-user preference filtering', () => {
+    it('drops memories keyed to a hidden person', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      const hidden = randomUUID();
+      setupMockUserSettings(user.id, {
+        theme: 'system',
+        profile: { useProviderImage: true },
+        memories: { hiddenPersonIds: [hidden] },
+      });
+
+      const kept = makeMemoryRow({ title: 'Kept' });
+      context.prismaMock.memory.findMany.mockResolvedValue([
+        makeMemoryRow({ type: 'person_highlights', personId: hidden, title: 'Dropped' }),
+        kept,
+      ]);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items.map((m: any) => m.title)).toEqual(['Kept']);
+    });
+
+    it('drops memories whose period OVERLAPS a sensitive range (partial hit counts)', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      setupMockUserSettings(user.id, {
+        theme: 'system',
+        profile: { useProviderImage: true },
+        memories: {
+          hiddenDateRanges: [{ from: '2023-03-15', to: '2023-03-20' }],
+        },
+      });
+
+      context.prismaMock.memory.findMany.mockResolvedValue([
+        // 2023-03-12 .. 2023-03-16 — overlaps the range only at its tail.
+        makeMemoryRow({ title: 'Overlapping' }),
+        makeMemoryRow({
+          title: 'Before',
+          periodStart: new Date('2023-01-01T00:00:00.000Z'),
+          periodEnd: new Date('2023-01-05T00:00:00.000Z'),
+        }),
+      ]);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items.map((m: any) => m.title)).toEqual(['Before']);
+    });
+
+    it('treats a hidden range as INCLUSIVE of its `to` day', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      setupMockUserSettings(user.id, {
+        theme: 'system',
+        profile: { useProviderImage: true },
+        memories: {
+          hiddenDateRanges: [{ from: '2023-06-01', to: '2023-06-01' }],
+        },
+      });
+
+      context.prismaMock.memory.findMany.mockResolvedValue([
+        makeMemoryRow({
+          title: 'On the single hidden day',
+          periodStart: new Date('2023-06-01T18:00:00.000Z'),
+          periodEnd: new Date('2023-06-01T22:00:00.000Z'),
+        }),
+      ]);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items).toEqual([]);
+    });
+
+    it('filters ONLY that user — another member still sees the memory', async () => {
+      enableMemories(context);
+      const other = await createMockViewerUser(context, 'other@example.test');
+      setupCircleMocks(context, other.id, CIRCLE_ID, 'viewer');
+      // No `memories` namespace for this user: absent means no preference.
+      context.prismaMock.memory.findMany.mockResolvedValue([
+        makeMemoryRow({ type: 'person_highlights', personId: randomUUID() }),
+      ]);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories?circleId=${CIRCLE_ID}`)
+        .set(authHeader(other.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items).toHaveLength(1);
+    });
+
+    it('does NOT apply preference filters to detail (direct links keep working)', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      const hidden = randomUUID();
+      setupMockUserSettings(user.id, {
+        theme: 'system',
+        profile: { useProviderImage: true },
+        memories: { hiddenPersonIds: [hidden] },
+      });
+
+      const row = makeMemoryRow({ type: 'person_highlights', personId: hidden });
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories/${row.id}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.id).toBe(row.id);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/memories/feed
+  // =========================================================================
+
+  describe('GET /api/memories/feed', () => {
+    it("orders today's on_this_day (closest year first) → unseen → seen, capped at 10", async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      const today = [
+        makeMemoryRow({ title: 'otd-9', type: 'on_this_day', meta: { yearsAgo: 9 } }),
+        makeMemoryRow({ title: 'otd-1', type: 'on_this_day', meta: { yearsAgo: 1 } }),
+      ];
+      const rest = [
+        makeMemoryRow({ title: 'seen-a', userStates: [{ seenAt: new Date(), hiddenAt: null, favoritedAt: null }] }),
+        makeMemoryRow({ title: 'unseen-a' }),
+        makeMemoryRow({ title: 'unseen-b' }),
+      ];
+      context.prismaMock.memory.findMany
+        .mockResolvedValueOnce(today)
+        .mockResolvedValueOnce(rest);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories/feed?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items.map((m: any) => m.title)).toEqual([
+        'otd-1',
+        'otd-9',
+        'unseen-a',
+        'unseen-b',
+        'seen-a',
+      ]);
+    });
+
+    it('caps the feed at 10 cards', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      context.prismaMock.memory.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(
+          Array.from({ length: 25 }, (_, i) => makeMemoryRow({ title: `m-${i}` })),
+        );
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories/feed?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items).toHaveLength(10);
+    });
+
+    it('returns up to four item thumbnails per card, signed in ONE batched call', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      // Stub the signer rather than the storage layer: this suite's app boots
+      // with the REAL storage provider (unconfigured), so a genuine signing
+      // attempt resolves to null and would hide the batching contract being
+      // asserted here.
+      const thumbs = context.module.get(MediaThumbnailService);
+      const signSpy = jest
+        .spyOn(thumbs, 'signThumbsBatched')
+        .mockImplementation(async (keys: string[]) =>
+          new Map(keys.map((k) => [k, `https://signed.test/${k}`])),
+        );
+
+      const withItems = makeMemoryRow({
+        coverMediaItemId: randomUUID(),
+        coverMediaItem: {
+          id: randomUUID(),
+          metadata: { thumbnailStorageKey: 'thumbnails/cover.jpg' },
+        },
+        items: [1, 2, 3, 4].map((n) => ({
+          mediaItem: { metadata: { thumbnailStorageKey: `thumbnails/i-${n}.jpg` } },
+        })),
+      });
+      context.prismaMock.memory.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([withItems]);
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories/feed?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.items[0].coverThumbnailUrl).toBe(
+        'https://signed.test/thumbnails/cover.jpg',
+      );
+      expect(res.body.data.items[0].itemThumbnailUrls).toEqual([
+        'https://signed.test/thumbnails/i-1.jpg',
+        'https://signed.test/thumbnails/i-2.jpg',
+        'https://signed.test/thumbnails/i-3.jpg',
+        'https://signed.test/thumbnails/i-4.jpg',
+      ]);
+
+      // THE contract: cover + every item thumbnail signed in a SINGLE call.
+      expect(signSpy).toHaveBeenCalledTimes(1);
+      expect(signSpy.mock.calls[0][0]).toHaveLength(5);
+
+      // The DB is asked for exactly four, so the fan never over-fetches.
+      const itemsArg = context.prismaMock.memory.findMany.mock.calls[1][0].select.items;
+      expect(itemsArg.take).toBe(4);
+      expect(itemsArg.orderBy).toEqual({ position: 'asc' });
+
+      signSpy.mockRestore();
+    });
+
+    it("excludes today's on_this_day rows from the 'rest' query so they cannot double-appear", async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findMany.mockResolvedValue([]);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories/feed?circleId=${CIRCLE_ID}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      const todayKey = new Date().toISOString().slice(0, 10);
+      const todayWhere = context.prismaMock.memory.findMany.mock.calls[0][0].where;
+      expect(todayWhere.type).toBe('on_this_day');
+      expect(todayWhere.periodKey).toBe(todayKey);
+
+      const restWhere = context.prismaMock.memory.findMany.mock.calls[1][0].where;
+      expect(restWhere.NOT).toEqual([
+        { AND: [{ type: 'on_this_day' }, { periodKey: todayKey }] },
+      ]);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/memories/:id
+  // =========================================================================
+
+  describe('GET /api/memories/:id', () => {
+    it('returns detail with ordered items and myState', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+
+      const row = makeMemoryRow({ narrative: 'Four days on the Pacific coast.' });
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memory.findFirst.mockResolvedValueOnce(row);
+      const mediaItemId = randomUUID();
+      context.prismaMock.memory.findFirst.mockResolvedValue({
+        ...row,
+        userStates: [{ seenAt: new Date(), hiddenAt: null, favoritedAt: new Date() }],
+        items: [
+          {
+            id: randomUUID(),
+            mediaItemId,
+            position: 0,
+            mediaItem: {
+              type: 'photo',
+              width: 4032,
+              height: 3024,
+              durationMs: null,
+              capturedAt: new Date('2023-03-12T10:00:00.000Z'),
+              metadata: null,
+            },
+          },
+        ],
+      });
+
+      const res = await request(context.app.getHttpServer())
+        .get(`/api/memories/${row.id}`)
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.narrative).toBe('Four days on the Pacific coast.');
+      expect(res.body.data.myState).toEqual({
+        seen: true,
+        hidden: false,
+        favorited: true,
+      });
+      expect(res.body.data.items).toHaveLength(1);
+      expect(res.body.data.items[0]).toMatchObject({
+        mediaItemId,
+        position: 0,
+        mediaType: 'photo',
+        width: 4032,
+        thumbnailUrl: null,
+      });
+      const itemsArg =
+        context.prismaMock.memory.findFirst.mock.calls.at(-1)[0].include.items;
+      expect(itemsArg.orderBy).toEqual({ position: 'asc' });
+    });
+
+    it('404s a tombstoned memory (the query filters deletedAt)', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      // The service filters deletedAt IS NULL, so the DB returns nothing.
+      context.prismaMock.memory.findFirst.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories/${randomUUID()}`)
+        .set(authHeader(user.accessToken))
+        .expect(404);
+
+      const where = context.prismaMock.memory.findFirst.mock.calls[0][0].where;
+      expect(where.deletedAt).toBeNull();
+      expect(where.OR).toEqual([
+        { expiresAt: null },
+        { expiresAt: { gt: expect.any(Date) } },
+      ]);
+    });
+
+    it('404s — NOT 403 — for a memory in a circle the caller is not a member of', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      const row = makeMemoryRow({ circleId: OTHER_CIRCLE_ID });
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .get(`/api/memories/${row.id}`)
+        .set(authHeader(user.accessToken))
+        .expect(404);
+    });
+  });
+
+  // =========================================================================
+  // Per-user state
+  // =========================================================================
+
+  describe('per-user state', () => {
+    it('POST /:id/seen upserts and preserves an existing seenAt (COALESCE)', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryUserState.upsert.mockResolvedValue({});
+      context.prismaMock.memoryUserState.updateMany.mockResolvedValue({ count: 0 });
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/seen`)
+        .set(authHeader(user.accessToken))
+        .expect(204);
+
+      expect(context.prismaMock.memoryUserState.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { memoryId_userId: { memoryId: row.id, userId: user.id } },
+          update: {},
+        }),
+      );
+      // The guarded second statement only fills a still-null column.
+      expect(
+        context.prismaMock.memoryUserState.updateMany.mock.calls[0][0].where,
+      ).toEqual({ memoryId: row.id, userId: user.id, seenAt: null });
+    });
+
+    it('POST/DELETE /:id/hide set and clear hiddenAt', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryUserState.upsert.mockResolvedValue({});
+      context.prismaMock.memoryUserState.updateMany.mockResolvedValue({ count: 1 });
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/hide`)
+        .set(authHeader(user.accessToken))
+        .expect(204);
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/memories/${row.id}/hide`)
+        .set(authHeader(user.accessToken))
+        .expect(204);
+
+      const clear = context.prismaMock.memoryUserState.updateMany.mock.calls.at(-1)[0];
+      expect(clear).toEqual({
+        where: { memoryId: row.id, userId: user.id },
+        data: { hiddenAt: null },
+      });
+      // Clearing never creates a state row.
+      expect(context.prismaMock.memoryUserState.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('POST/DELETE /:id/favorite set and clear favoritedAt', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      setupCircleMocks(context, user.id, CIRCLE_ID, 'viewer');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryUserState.upsert.mockResolvedValue({});
+      context.prismaMock.memoryUserState.updateMany.mockResolvedValue({ count: 1 });
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/favorite`)
+        .set(authHeader(user.accessToken))
+        .expect(204);
+      await request(context.app.getHttpServer())
+        .delete(`/api/memories/${row.id}/favorite`)
+        .set(authHeader(user.accessToken))
+        .expect(204);
+
+      expect(
+        context.prismaMock.memoryUserState.updateMany.mock.calls.at(-1)[0].data,
+      ).toEqual({ favoritedAt: null });
+    });
+
+    it('a viewer CAN write their own state (membership only)', async () => {
+      enableMemories(context);
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryUserState.upsert.mockResolvedValue({});
+      context.prismaMock.memoryUserState.updateMany.mockResolvedValue({ count: 0 });
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/seen`)
+        .set(authHeader(viewer.accessToken))
+        .expect(204);
+    });
+
+    it('404s state writes for a non-member', async () => {
+      enableMemories(context);
+      const user = await createMockViewerUser(context);
+      const row = makeMemoryRow({ circleId: OTHER_CIRCLE_ID });
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/seen`)
+        .set(authHeader(user.accessToken))
+        .expect(404);
+    });
+  });
+
+  // =========================================================================
+  // DELETE /api/memories/:id — the tombstone
+  // =========================================================================
+
+  describe('DELETE /api/memories/:id', () => {
+    it('403s a viewer holding media:read but not media:write', async () => {
+      enableMemories(context);
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/memories/${randomUUID()}`)
+        .set(authHeader(viewer.accessToken))
+        .expect(403);
+    });
+
+    it('403s a member with media:write but only the viewer circle role', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'viewer');
+      context.prismaMock.memory.findFirst.mockResolvedValue(makeMemoryRow());
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/memories/${randomUUID()}`)
+        .set(authHeader(contributor.accessToken))
+        .expect(403);
+
+      expect(context.prismaMock.memory.update).not.toHaveBeenCalled();
+    });
+
+    it('tombstones for a collaborator and writes a memory:deleted audit event', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memory.update.mockResolvedValue({ ...row, deletedAt: new Date() });
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/memories/${row.id}`)
+        .set(authHeader(contributor.accessToken))
+        .expect(204);
+
+      const update = context.prismaMock.memory.update.mock.calls[0][0];
+      expect(update.where).toEqual({ id: row.id });
+      expect(update.data.deletedAt).toBeInstanceOf(Date);
+
+      const audit = context.prismaMock.auditEvent.create.mock.calls.at(-1)[0].data;
+      expect(audit).toMatchObject({
+        actorUserId: contributor.id,
+        action: 'memory:deleted',
+        targetType: 'memory',
+        targetId: row.id,
+      });
+    });
+
+    it('404s — not 403 — for a non-member collaborator elsewhere', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      context.prismaMock.memory.findFirst.mockResolvedValue(
+        makeMemoryRow({ circleId: OTHER_CIRCLE_ID }),
+      );
+      context.prismaMock.circleMember.findUnique.mockResolvedValue(null);
+
+      await request(context.app.getHttpServer())
+        .delete(`/api/memories/${randomUUID()}`)
+        .set(authHeader(contributor.accessToken))
+        .expect(404);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/memories/:id/save-album
+  // =========================================================================
+
+  describe('POST /api/memories/:id/save-album', () => {
+    function setupAlbumMocks(context: TestContext, albumId: string) {
+      context.prismaMock.album.create.mockResolvedValue({
+        id: albumId,
+        circleId: CIRCLE_ID,
+        name: 'x',
+        description: null,
+        coverMediaItemId: null,
+      });
+      context.prismaMock.album.findUnique.mockResolvedValue({
+        id: albumId,
+        circleId: CIRCLE_ID,
+        name: 'x',
+        coverMediaItemId: null,
+      });
+      context.prismaMock.album.update.mockResolvedValue({ id: albumId });
+      context.prismaMock.albumItem.upsert.mockImplementation(async ({ create }: any) => ({
+        id: randomUUID(),
+        ...create,
+        addedAt: new Date(),
+      }));
+      context.prismaMock.albumItem.findFirst.mockResolvedValue({ id: randomUUID() });
+      context.prismaMock.mediaItem.updateMany.mockResolvedValue({ count: 0 });
+    }
+
+    it('403s a viewer (no media:write)', async () => {
+      enableMemories(context);
+      const viewer = await createMockViewerUser(context);
+      setupCircleMocks(context, viewer.id, CIRCLE_ID, 'viewer');
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${randomUUID()}/save-album`)
+        .set(authHeader(viewer.accessToken))
+        .send({})
+        .expect(403);
+    });
+
+    it('creates an album from the memory in position order with the cover set', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+
+      const coverId = randomUUID();
+      const secondId = randomUUID();
+      const row = makeMemoryRow({ title: 'Trip to Guanacaste', coverMediaItemId: coverId });
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryItem.findMany.mockResolvedValue([
+        { mediaItemId: coverId },
+        { mediaItemId: secondId },
+      ]);
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([
+        { id: coverId },
+        { id: secondId },
+      ]);
+      const albumId = randomUUID();
+      setupAlbumMocks(context, albumId);
+
+      const res = await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/save-album`)
+        .set(authHeader(contributor.accessToken))
+        .send({})
+        .expect(201);
+
+      expect(res.body.data.albumId).toBe(albumId);
+      // Default name = the memory's title.
+      expect(context.prismaMock.album.create.mock.calls[0][0].data.name).toBe(
+        'Trip to Guanacaste',
+      );
+      // Items in memory position order.
+      expect(
+        context.prismaMock.albumItem.upsert.mock.calls.map(
+          (c: any) => c[0].create.mediaItemId,
+        ),
+      ).toEqual([coverId, secondId]);
+      // The memory's cover becomes the album's cover.
+      expect(context.prismaMock.album.update.mock.calls[0][0].data).toEqual({
+        coverMediaItemId: coverId,
+      });
+      // The memoryItem read is ordered by position, not insertion.
+      expect(
+        context.prismaMock.memoryItem.findMany.mock.calls[0][0].orderBy,
+      ).toEqual({ position: 'asc' });
+    });
+
+    it('honors an explicit album name', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryItem.findMany.mockResolvedValue([]);
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([]);
+      setupAlbumMocks(context, randomUUID());
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/save-album`)
+        .set(authHeader(contributor.accessToken))
+        .send({ name: 'Costa Rica 2023' })
+        .expect(201);
+
+      expect(context.prismaMock.album.create.mock.calls[0][0].data.name).toBe(
+        'Costa Rica 2023',
+      );
+    });
+
+    it('drops trashed items rather than failing the whole save', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+
+      const liveId = randomUUID();
+      const trashedId = randomUUID();
+      const row = makeMemoryRow({ coverMediaItemId: trashedId });
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryItem.findMany.mockResolvedValue([
+        { mediaItemId: trashedId },
+        { mediaItemId: liveId },
+      ]);
+      // Only the live one comes back from the deletedAt: null lookup.
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([{ id: liveId }]);
+      setupAlbumMocks(context, randomUUID());
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/save-album`)
+        .set(authHeader(contributor.accessToken))
+        .send({})
+        .expect(201);
+
+      expect(
+        context.prismaMock.albumItem.upsert.mock.calls.map(
+          (c: any) => c[0].create.mediaItemId,
+        ),
+      ).toEqual([liveId]);
+      // A trashed cover is not carried over.
+      expect(context.prismaMock.album.update).not.toHaveBeenCalled();
+    });
+
+    it('is NOT idempotent — a second save creates a second album', async () => {
+      enableMemories(context);
+      const contributor = await createMockContributorUser(context);
+      setupCircleMocks(context, contributor.id, CIRCLE_ID, 'collaborator');
+      const row = makeMemoryRow();
+      context.prismaMock.memory.findFirst.mockResolvedValue(row);
+      context.prismaMock.memoryItem.findMany.mockResolvedValue([]);
+      context.prismaMock.mediaItem.findMany.mockResolvedValue([]);
+      setupAlbumMocks(context, randomUUID());
+
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/save-album`)
+        .set(authHeader(contributor.accessToken))
+        .send({})
+        .expect(201);
+      await request(context.app.getHttpServer())
+        .post(`/api/memories/${row.id}/save-album`)
+        .set(authHeader(contributor.accessToken))
+        .send({})
+        .expect(201);
+
+      expect(context.prismaMock.album.create).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/api/test/settings/user-settings.integration.spec.ts
+++ b/apps/api/test/settings/user-settings.integration.spec.ts
@@ -1016,4 +1016,120 @@ describe('User Settings Integration', () => {
       );
     });
   });
+  // ===========================================================================
+  // memories — per-user Memories preferences (issue #307, epic #300)
+  // ===========================================================================
+
+  describe('memories preference namespace', () => {
+    const settingsRow = (value: UserSettingsValue, version = 1) => ({
+      id: 'settings-1',
+      userId: 'user-1',
+      value: value as any,
+      version,
+      updatedAt: new Date(),
+    });
+
+    const seedStored = (memories?: Record<string, any>) => {
+      const stored: UserSettingsValue = {
+        ...DEFAULT_USER_SETTINGS,
+        ...(memories ? { memories: memories as any } : {}),
+      };
+      context.prismaMock.userSettings.findUnique.mockResolvedValue(
+        settingsRow(stored),
+      );
+      context.prismaMock.userSettings.update.mockImplementation(
+        async ({ data }: any) => settingsRow(data.value, 2),
+      );
+      context.prismaMock.userSettings.upsert.mockImplementation(
+        async ({ create, update }: any) =>
+          settingsRow((update?.value ?? create?.value) as UserSettingsValue, 2),
+      );
+      context.prismaMock.user.update.mockResolvedValue({} as any);
+    };
+
+    const PERSON = '11111111-1111-4111-8111-111111111111';
+
+    it('omits the namespace entirely when nothing is stored (absent = default)', async () => {
+      const user = await createMockTestUser(context);
+      seedStored();
+
+      const res = await request(context.app.getHttpServer())
+        .get('/api/user-settings')
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(res.body.data.memories).toBeUndefined();
+    });
+
+    it('round-trips a namespace through PATCH', async () => {
+      const user = await createMockTestUser(context);
+      seedStored();
+
+      const res = await request(context.app.getHttpServer())
+        .patch('/api/user-settings')
+        .set(authHeader(user.accessToken))
+        .send({
+          memories: {
+            hiddenPersonIds: [PERSON],
+            hiddenDateRanges: [{ from: '2024-06-10', to: '2024-06-20' }],
+            emailDigestOptOut: true,
+          },
+        })
+        .expect(200);
+
+      expect(res.body.data.memories).toEqual({
+        hiddenPersonIds: [PERSON],
+        hiddenDateRanges: [{ from: '2024-06-10', to: '2024-06-20' }],
+        emailDigestOptOut: true,
+      });
+    });
+
+    it('rejects an unknown key with 400 (.strict() at the HTTP boundary)', async () => {
+      const user = await createMockTestUser(context);
+      seedStored();
+
+      await request(context.app.getHttpServer())
+        .patch('/api/user-settings')
+        .set(authHeader(user.accessToken))
+        .send({ memories: { hiddenPetIds: ['x'] } })
+        .expect(400);
+    });
+
+    it('rejects an inverted date range with 400', async () => {
+      const user = await createMockTestUser(context);
+      seedStored();
+
+      await request(context.app.getHttpServer())
+        .patch('/api/user-settings')
+        .set(authHeader(user.accessToken))
+        .send({
+          memories: { hiddenDateRanges: [{ from: '2024-02-10', to: '2024-02-01' }] },
+        })
+        .expect(400);
+    });
+
+    it('rejects a non-uuid person id with 400', async () => {
+      const user = await createMockTestUser(context);
+      seedStored();
+
+      await request(context.app.getHttpServer())
+        .patch('/api/user-settings')
+        .set(authHeader(user.accessToken))
+        .send({ memories: { hiddenPersonIds: ['not-a-uuid'] } })
+        .expect(400);
+    });
+
+    it('clears the namespace on `memories: null`', async () => {
+      const user = await createMockTestUser(context);
+      seedStored({ hiddenPersonIds: [PERSON] });
+
+      const res = await request(context.app.getHttpServer())
+        .patch('/api/user-settings')
+        .set(authHeader(user.accessToken))
+        .send({ memories: null })
+        .expect(200);
+
+      expect(res.body.data.memories).toBeUndefined();
+    });
+  });
 });

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.6 (data model + generation plumbing + curation engine; all seven curators; AI titles) |
+| **Version** | 0.7 (data model + generation plumbing + curation engine; all seven curators; AI titles; read/act API + per-user preferences) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305), AI titles / subtitles / narratives (#306); §6–§8 and §10 are placeholders for later issues in epic #300 |
+| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305), AI titles / subtitles / narratives (#306), API / per-user state / delete / save-as-album / preferences (#307); §7 and §8 are placeholders for later issues in epic #300 |
 
 ---
 
@@ -737,7 +737,156 @@ No test in this feature can reach a network. The service suite drives a hand-wri
 
 ## 6. API
 
-Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307). Expected to define: list/feed/detail endpoints, per-user state (seen/hide/favorite via `MemoryUserState`), delete (the tombstone write, §2.5), save-as-album, and per-user preferences (hidden people, sensitive date ranges, digest opt-out).
+Introduced by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307). Everything lives in `apps/api/src/memories/api/` — `MemoriesController`, `MemoriesService`, the query/response DTOs, and `memory-preferences.ts` (the read-time preference compiler). The module edges this adds are `MemoriesModule → CirclesModule` (per-circle role checks) and `MemoriesModule → MediaModule` (batched thumbnail signing plus the album service that save-as-album reuses); neither points back, so there is no cycle and no `forwardRef`.
+
+### 6.1 Endpoint catalogue
+
+| Method & path | Permission + circle role | Behavior |
+|---|---|---|
+| `GET /api/memories?circleId=&type=&year=&favorite=&cursor=&pageSize=` | `media:read` + **viewer** | Keyset page of memory cards, `(generatedAt DESC, id DESC)`, no `COUNT(*)` |
+| `GET /api/memories/feed?circleId=` | `media:read` + **viewer** | Home carousel: today's `on_this_day` first, then newest unseen, then newest seen; hard cap 10 |
+| `GET /api/memories/:id` | `media:read` + **viewer** | Full detail + `narrative` + the ordered item list |
+| `POST /api/memories/:id/seen` | `media:read` + **viewer** | Idempotent `seenAt` — 204 |
+| `POST` / `DELETE /api/memories/:id/hide` | `media:read` + **viewer** | Per-user hide / un-hide — 204 |
+| `POST` / `DELETE /api/memories/:id/favorite` | `media:read` + **viewer** | Per-user favorite / un-favorite — 204 |
+| `POST /api/memories/:id/save-album` | `media:write` + **collaborator** | Creates an album from the memory's items — `201 { albumId }` |
+| `DELETE /api/memories/:id` | `media:write` + **collaborator** | Circle-level tombstone (§2.5) + a `memory:deleted` audit event — 204 |
+
+`POST /api/admin/memories/backfill` belongs to this API map but is implemented by issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315), not here.
+
+Per-user preferences are **not** endpoints of this controller at all — see §6.7.
+
+### 6.2 Three invariants every read obeys
+
+Stated once here because they are asserted in every method of `MemoriesService` and are the things a future change is most likely to break.
+
+**The tombstone.** `deletedAt IS NOT NULL` is excluded from *every* read without exception — list, feed, detail, and the `:id` lookup behind every state write and every mutation. Prisma has no global scope (§2.5), so this is application discipline; in this service it is centralised in one `activeWhere()` helper plus the identical predicate inside `loadAccessibleMemory()`, so there are exactly two places to audit rather than nine.
+
+**The active filter.** `expiresAt IS NULL OR expiresAt > now()`. Only `on_this_day` sets an expiry (start of the day after its anchor, §4.7), so this is what retires yesterday's "6 years ago" card. It applies to detail as well as to the lists: an expired anchor-day memory is genuinely over, and the `on_this_day` retention tail hard-deletes it shortly afterwards anyway, so serving it from a stale link would only produce a card that vanishes moments later.
+
+**Per-user hide is a different thing from the tombstone, and is deliberately not conflated with it.** `MemoryUserState.hiddenAt` is personal and reversible: the memory stays visible to every other member, and it stays reachable *by its own id* for the user who hid it (so the detail page can offer "un-hide"). Only the circle-level tombstone removes it for everyone, and only that is permanent.
+
+### 6.3 The feature flag is checked BEFORE any query
+
+With `features.memories` off — the default — `GET /api/memories` returns `{ items: [], meta: { pageSize, nextCursor: null, hasMore: false } }`, `GET /api/memories/feed` returns `{ items: [] }`, and every `:id` route returns **404**. Not an error, not a 403: a disabled feature is invisible, not broken, so a client that has not yet been taught about the flag degrades to an empty surface rather than an error toast.
+
+The gate runs as the *first statement* of every handler, ahead of the circle-access check. That ordering is the point: "no cron work, no jobs, no nav entry, endpoints return empty — **zero cost**" is a stated epic success criterion, and checking membership first would already have cost two queries per request on a deployment that has the feature switched off. The only work a gated-off request performs is the cached `SystemSettingsService.getSettings()` read (5 s TTL, usually a cache hit). It resolves through the shared `isMemoriesEnabled()` helper, which folds in the `MEMORIES_ENABLED` env kill-switch, so this surface can never disagree with the generation cron about what "enabled" means (§9.1).
+
+A side effect worth naming: while the flag is off, a non-member also gets an empty list rather than a 403. That is strictly less information disclosure, not more.
+
+### 6.4 `GET /api/memories` — keyset, and why the cursor comes from the raw page
+
+Keyset only. There is deliberately **no** `page` escape hatch of the kind `GET /api/media` carries: that endpoint's offset mode exists purely for legacy clients (the Android app, the CLI) that predate keyset, and nothing has ever consumed memories, so neither the dual-mode branch nor its `COUNT(*)` is inherited. Ordering is `(generatedAt DESC, id DESC)`; the `id` tiebreak is not decorative — one generation run writes a whole batch of rows with near-identical `generatedAt`, so without it the keyset would be non-deterministic exactly where it is used most.
+
+Filters:
+
+- `type` — a `MemoryType` value, passed straight through.
+- `year` — **not a column**: a memory covers a *range*, so this compiles to an overlap test against that UTC calendar year (`periodStart < Jan 1 of year+1 AND periodEnd >= Jan 1 of year`). A trip spanning New Year's Eve therefore appears under both years, which is what a user filtering "2023" expects of a photo taken on 2023‑12‑31.
+- `favorite=true` — narrows to the caller's own favorites via `userStates: { some: { userId, favoritedAt: { not: null } } }`.
+
+Per-user hidden rows are excluded **in SQL** (`NOT: { userStates: { some: { userId, hiddenAt: { not: null } } } }`), so a user who has hidden a lot still gets full pages.
+
+The preference filter (§6.7) cannot be, and runs in memory over the fetched page. That creates one subtle trap, which the implementation avoids explicitly: **`nextCursor` and `hasMore` are derived from the RAW page, before preference filtering.** Deriving them from the filtered list would make a page whose every row was preference-hidden report `nextCursor: null`, silently truncating the browsable history at the first fully-hidden page. The visible consequence is that a page may return fewer than `pageSize` items while still reporting `hasMore: true` — correct, and the standard behaviour of any post-filtered keyset.
+
+Card DTO: `{ id, type, title, subtitle, itemCount, periodStart, periodEnd, coverMediaItemId, coverThumbnailUrl, meta, myState: { seen, favorited }, generatedAt }`. `myState` on a *card* carries no `hidden`, because it would be a constant `false` there — hidden rows never reach a list. Detail's `myState` adds it.
+
+### 6.5 `GET /api/memories/feed`
+
+Ordering is: today's `on_this_day` memories with the **closest year first** ("1 year ago" before "9 years ago"), then the newest unseen, then the newest seen, capped at 10.
+
+Two bounded reads rather than one, for two independent reasons. Today's anchor memories must appear *even when they are not among the newest rows overall* — a backfill can generate a pile of trips after them — so they cannot be found by taking the newest N. And ranking them needs `meta.yearsAgo`, a JSONB field that SQL would sort badly and an in-memory sort handles trivially. `periodKey` for an `on_this_day` memory *is* the anchor day in UTC (`toIsoDateKey`, §4.7), so "today's" is an exact string match, not a range scan. The second query excludes that same `(type, periodKey)` pair so a memory can never appear twice in one feed.
+
+The non-anchor read takes `FEED_CANDIDATE_LIMIT = 60` rather than 10: hidden rows are already gone in SQL, but the preference filter runs afterwards in memory, so a user with several hidden people would otherwise get a short feed. Still one bounded read, no second round-trip.
+
+Feed cards extend the list card with `itemThumbnailUrls` — up to the first four items by `position`, for the fan effect behind the cover.
+
+### 6.6 `GET /api/memories/:id`
+
+Applies the tombstone and active filters (§6.2) but **not** the per-user preference filter and **not** the per-user hide: a direct link — from the story player, a notification, the email digest, or the user's own hidden list — must resolve. Hiding and deleting are the tools on that page, and both are offered there.
+
+A memory whose circle the caller does not belong to returns **404, not 403**, so a stranger cannot use the status code to confirm that a memory id exists. This is the same enumeration-resistant policy as the notifications `:id` routes and public shares. A *member* who merely lacks the rank — a viewer attempting a delete — does get a 403, because their membership is not a secret and the distinction is actionable to them. The whole rule lives in one helper, `MemoriesService.loadAccessibleMemory(id, userId, permissions, requiredRole)`, which deliberately does **not** call `assertCircleAccess` (that one throws 403 for a non-member, which is exactly the leak being avoided) but does reproduce its super-admin bypass.
+
+Item DTO: `{ id, mediaItemId, position, mediaType, width, height, durationMs, capturedAt, thumbnailUrl }`, ordered by `position`. There is no item pagination: a memory holds at most `memories.maxItemsPerMemory` (bounded 5–100) rows.
+
+### 6.7 Per-user preferences — the `user_settings.memories` namespace
+
+Read and written **only** through the existing `GET`/`PATCH`/`PUT /api/user-settings`. No new endpoint, no new table, no migration, no new permission — the same model as `user_settings.dataTables` (#255) and `user_settings.notifications` (#251), and the canonical schema sits beside theirs in `apps/api/src/common/schemas/settings.schema.ts`.
+
+```
+memories: {
+  hiddenPersonIds:   string uuid[]                         (<= 200),
+  hiddenDateRanges:  [{ from: 'YYYY-MM-DD', to: 'YYYY-MM-DD' }]  (<= 50, from <= to),
+  emailDigestOptOut: boolean,
+}
+```
+
+**Absent means default**, and that rule is load-bearing exactly as it is for the other two namespaces: every field is `.optional()` with **no** `.default()` anywhere, and nothing is ever populated server-side. An absent namespace / field means "no preference" — nobody hidden, no date sensitive, digest not opted out. That is what lets the namespace ship with no data migration (every existing row simply has no namespace), and it makes any field added here later opt-**in** rather than silently applied to everyone who once saved a preference. A `.default([])` on `hiddenPersonIds` would pin a stored blob to "nothing hidden" and make it indistinguishable from "never expressed a preference".
+
+Both date bounds are validated as **real calendar days**, not just `\d{4}-\d{2}-\d{2}`: the regex alone accepts `2026-02-31`, and a bound that silently rolled into the next month would filter days the user never named.
+
+PATCH merges **field-wise**, one level deep (`UserSettingsService.mergeMemories`, shaped exactly like `mergeNotifications`): an unlisted field is untouched, a listed field is **replaced wholesale**, a field set to `null` is deleted (resetting it to its absent default rather than pinning `[]` / `false`), and `memories: null` clears the namespace. An emptied namespace collapses back to `undefined`, because the absent namespace *is* the canonical "nothing persisted" state and storing `{}` would only be noise. The lists are replace-not-append deliberately: "hide this person" and "un-hide this person" are the same PATCH from the client's point of view, and an append-only merge would leave removal inexpressible.
+
+**Read-time filtering** applies to `GET /api/memories` and `GET /api/memories/feed`, in memory, after the page is fetched — both rules are cheap column comparisons over at most 60 rows:
+
+- **hidden person** — drop memories whose `personId` is listed;
+- **sensitive dates** — drop memories whose `[periodStart, periodEnd]` **overlaps** any hidden range. Overlap, not containment: a trip that merely crosses a hidden anniversary is precisely the case the user is trying not to be shown. A range is inclusive of both endpoints, so `to` is expanded to the following UTC midnight and compared half-open.
+
+`resolveMemoryPreferences()` compiles the stored blob once per request into a `Set` of ids plus millisecond intervals, so a page of 20 rows does not re-parse the same date strings 20 times. It is deliberately defensive: the schema validates on *write*, but an older or hand-edited JSONB blob can hold anything, and a malformed preference degrades to "no filter" with a logged warning rather than 500-ing a browse page. A failed settings read degrades the same way — over-showing beats an error on a browse surface.
+
+Filtering is read-time and **never** a generation input. Generation is circle-scoped: one `Memory` row is shared by every member, so a personal preference cannot influence what gets curated without leaking one member's preferences into another member's feed. That is why the People curators ignore this namespace entirely (§4.9).
+
+**V1 limitation (from the epic, deliberate):** a memory is dropped **whole**. A hidden person removes the `person_highlights` / `person_over_years` memories keyed to them, but a trip or theme memory that merely *contains* that person among several faces is **not** scrubbed at the item level. Item-level scrubbing is listed in §11.
+
+`emailDigestOptOut` is stored and validated here; it is consumed by the digest producer in issue [#311](https://github.com/marinoscar/MemoriaHub/issues/311).
+
+### 6.8 Per-user state writes
+
+`POST /:id/seen`, `POST`/`DELETE /:id/hide`, `POST`/`DELETE /:id/favorite` — all 204, all scoped to the JWT's `userId`, all requiring circle membership only.
+
+Setting a timestamp is `COALESCE(field, now())`: re-running never moves an existing value, so `seenAt` always names the **first** view — the same idempotency contract as `POST /api/notifications/:id/read`. In Prisma that costs two statements, and both are needed: the `upsert` covers "no state row yet", and a guarded `updateMany ... WHERE field IS NULL` covers "a row already exists because the user favorited it earlier, but *this* column is still null".
+
+Clearing is `updateMany` and never an upsert: un-hiding a memory the user never hid is a no-op, and creating an all-null state row to record that nothing happened would be pure garbage.
+
+### 6.9 `DELETE /api/memories/:id` — the tombstone write
+
+Sets `deletedAt = now()`. The memory disappears for **every** member, and permanently: because `@@unique([circleId, type, periodKey, subjectKey])` spans tombstoned rows (§2.5), the next generation run's `upsertMemory` finds the tombstone and skips that natural key instead of resurrecting or duplicating it. The underlying photos are untouched — delete removes the curated collection, never the media.
+
+Writes an `audit_events` row (`action: 'memory:deleted'`, `targetType: 'memory'`) carrying the circle, type, natural key and title, so a "why did that memory vanish" question is answerable after the fact.
+
+Requires `media:write` + **collaborator**, the same bar as any other mutation of circle content. A viewer who simply wants it out of their own way has `POST /:id/hide`. A repeat delete returns 404, since the first one made the row invisible to every read — including this route's own lookup.
+
+### 6.10 `POST /api/memories/:id/save-album`
+
+Body `{ name? }`; omitted means "use the memory's title" (truncated to the 256-char album-name cap). Returns `201 { albumId }`.
+
+Every mutation goes through the **existing** album service path — `MediaService.createAlbum` → `addAlbumItems` → `updateAlbum` for the cover — rather than writing `Album`/`AlbumItem` rows directly. That is deliberate: it inherits their circle checks, their `MediaTouchService` backup-feed bookkeeping (issue #310) and their cover-membership validation for free, and it cannot drift from them. Items are added in the memory's `position` order, which `addAlbumItems`' sequential inserts preserve as `addedAt` order — the order `GET /api/media/albums/:id` reads them back in.
+
+Two details worth stating:
+
+- **Soft-deleted items are dropped first.** `addAlbumItems` rejects the *whole* batch if any id is trashed, so a memory generated before one of its photos was trashed would otherwise be permanently unsaveable. The same check governs the cover: a trashed cover is simply not carried over rather than 400-ing the save.
+- **Not idempotent, by design** (per #307): saving the same memory twice yields two albums, because a user may genuinely want a second copy to edit.
+
+This is also how v1 *shares* a memory: save it as an album, then use the existing album share flow. A native memory share target is explicitly deferred (§11).
+
+### 6.11 Thumbnail signing
+
+Every payload that carries a thumbnail — list cards, feed cards (cover **plus** up to four item thumbnails each), and detail (cover plus every item) — is signed through `MediaThumbnailService.signThumbsBatched`, in **one** call per response covering every key at once. That means a single `storageObject.findMany`, each distinct `(provider, bucket)` resolved once, and each distinct key signed once.
+
+This is a hard repo rule, not a preference: the per-item `findUnique`-per-thumbnail pattern is exactly the N+1 that caused multi-second loads and 502s on large circles, documented in `docs/audits/search-audit.md`. The feed is the most exposed surface here — ten cards times five thumbnails is fifty keys — which is why the fan's item thumbnails are folded into the same batched call as the covers rather than signed per card.
+
+### 6.12 Serialization
+
+Every timestamp is emitted as an ISO 8601 **string**, and no payload in this API contains a `BigInt` (the repo's `JSON.stringify` gotcha): the only `BigInt` column anywhere near this feature is `storage_objects.size`, which nothing here selects, and `MediaItem.durationMs` is a plain `Int?`.
+
+Handler return values are wrapped by the global `TransformInterceptor`, so a list's own pagination meta lands at `data.meta` — the same shape `GET /api/media` and `GET /api/notifications` already produce.
+
+### 6.13 Known gaps
+
+- **Preference filtering shortens pages.** Because it runs after the fetch (as specified by #307), a page can return fewer than `pageSize` items. Pushing `hiddenPersonIds` into the SQL `WHERE` as `personId: { notIn }` would fix it for the person rule; the date-range rule would still need the in-memory pass, so the asymmetry was not worth two filtering paths in v1.
+- **No item-level scrubbing** of hidden people inside mixed memories (§6.7, §11).
+- **`emailDigestOptOut` is stored but unread** until issue #311 lands the digest producer.
+- **Expired memories 404 on detail.** A user who opens an `on_this_day` story a minute before midnight will find the link dead a minute later. The alternative — serving expired memories by id — was rejected because the `on_this_day` retention tail hard-deletes them shortly afterwards anyway, so the link would break regardless, just less predictably.
+- **No cross-circle "all my memories" view.** Every read is scoped to one `circleId`, matching the rest of the media surface.
 
 ## 7. Notification Center Integration & Email Digest
 
@@ -820,7 +969,22 @@ Consumed by `MemoryTitleService` in [#306](https://github.com/marinoscar/Memoria
 
 ## 10. RBAC
 
-Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307) and issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315). No new permission has been introduced by issue #301 — the data model alone grants no access; every read/write path a later issue adds is expected to reuse the existing `media:read`/`media:write`/`media:delete` permissions plus per-circle `viewer`/`collaborator` roles, following the precedent set by Workflows and Notifications (see CLAUDE.md's RBAC Model section).
+Filled in by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307) for the user-facing API; the admin surface (`/admin/settings/memories`, the library backfill) arrives with issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315) and reuses `system_settings:read`/`system_settings:write` like every other admin settings page.
+
+**No new permission was introduced, and none should be.** A memory is a *derived view* over media the caller can already see — it grants access to nothing they could not reach through `GET /api/media`. `media:read` / `media:write` plus the per-circle roles express the intent exactly, so a `memories:*` permission would add a second thing to keep in sync with the media permissions for zero additional expressiveness. That was the epic's explicit decision, and it follows the precedent set by Workflows (which reuses `media:read`/`media:write`/`media:delete` + per-circle roles) and Notifications (authentication only, because every route is already user-scoped).
+
+| Capability | System permission | Per-circle role | Notes |
+|---|---|---|---|
+| List, feed, detail | `media:read` | **viewer** | Circle-scoped list/feed use `assertCircleAccess`; `:id` routes use the 404-not-403 path (§6.6) |
+| Mark seen / hide / un-hide / favorite / un-favorite | `media:read` | **viewer** | Scoped to the JWT's `userId` and touching no circle content, so membership is the real gate; `media:read` rides along because it is what the whole surface is gated on and a caller without it has no business reading the memory the state refers to |
+| Save as album | `media:write` | **collaborator** | Same bar as `POST /api/media/albums`, whose service path this reuses |
+| Delete (tombstone) | `media:write` | **collaborator** | Mutates circle content for every member; a viewer's equivalent is the personal hide |
+
+**Super-admin bypass.** A user holding `circles:manage_any`, `media:write_any` or `media:read_any` bypasses the per-circle role check entirely, exactly as `CircleMembershipService.assertCircleAccess` does elsewhere — `loadAccessibleMemory` reproduces that bypass rather than inventing a second policy. This is what lets a system Admin moderate a circle they do not belong to.
+
+**Two status-code rules.** A memory in a circle the caller is not a member of is **404** (enumeration-resistant — the caller must not be able to confirm the id exists), while a member who lacks the *rank* gets **403** (their membership is not a secret and the distinction is actionable). See §6.6.
+
+**Preferences carry no permission at all.** The `user_settings.memories` namespace (§6.7) is read and written through the existing `GET`/`PATCH`/`PUT /api/user-settings`, which is already scoped to the calling user — there is nothing an additional permission would protect, the same rationale that kept `notifications` and `dataTables` permission-free.
 
 ## 11. Future Work
 
@@ -839,6 +1003,7 @@ Placeholder. Covered by issue [#307](https://github.com/marinoscar/MemoriaHub/is
 
 | Version | Date | Author | Changes |
 |---|---|---|---|
+| 0.7 | August 2026 | AI Assistant | Issue #307: filled in §6 (API — the endpoint catalogue with its permission/role column; the three read invariants and why per-user hide is deliberately not the tombstone; the flag-checked-before-any-query ordering that makes the default-off state cost zero queries and return empty lists rather than errors; keyset-only pagination, the `year` range-overlap compilation, and why `nextCursor` must come from the RAW page; the feed's two bounded reads, exact-`periodKey` anchor match and 60-row candidate window; the 404-not-403 `loadAccessibleMemory` policy and why it does not call `assertCircleAccess`; the `user_settings.memories` namespace with its absent-means-default rule, field-wise merge, overlap-not-containment date filtering and the read-time-never-generation-input rationale; COALESCE state writes and why clearing never upserts; the tombstone write and its audit event; save-as-album's reuse of the album service path plus its trashed-item and non-idempotence decisions; the one-batched-call thumbnail rule; serialization; and six known gaps) and §10 (RBAC — the no-new-permission decision, the capability table, super-admin bypass, the two status-code rules, and why preferences carry no permission). §7 and §8 remain placeholders. |
 | 0.6 | August 2026 | AI Assistant | Issue #306: filled in §5 (AI Titles, Subtitles & Narratives — the total `generate()` contract and the complete failure table with which entries avoid a provider call at all, the metadata-only prompt payload and the absent-by-construction privacy list, the one-file prompt with its per-type snapshots and the strict-JSON/length-cap contract shared between the system prompt and the parser, the 10s whole-stream timeout with its remaining-budget race and fire-and-forget iterator close plus the new optional `ChatRequest.temperature`, the per-job `MemoryTitleRun` budget and why it is a passed object rather than service state, the rate-limit stop-the-run rule and the 100-call backfill cap, the two `upsertMemory` branches that call titling and the tombstone/outside-the-transaction ordering, the no-network test strategy, and five known gaps). §6–§8 and §10 remain placeholders. |
 | 0.1 | August 2026 | AI Assistant | Initial specification for issue #301: the `MemoryType` enum, the `Memory`/`MemoryItem`/`MemoryUserState` data model, the `periodKey`/`subjectKey` semantics, the tombstone contract, cascade summary, and alternatives considered. Sections 3–10 are placeholders for later issues in epic #300. |
 | 0.5 | August 2026 | AI Assistant | Issue #305: added §4.9 (the People curators — the one shared eligibility rule and why per-user hidden people are deliberately excluded from generation, the archived-face exclusion, the grouped `(person, year)` census and why over-counting makes the pre-filter sound, the year-bucketed diversity policy and the >=3-year floor that separates the two types, the highest-confidence cover override, and the Cascade-FK delete/merge story), §4.10 (the Theme curator — the tag-vocabulary-over-clustering rationale, the three filters `source='ai'` / enabled label / denylist, ranking by distinct qualifying items with the exact per-year sum behind the all-history period, walking past a short tag under a bounded attempt cap, and why a tombstoned theme consumes its slot), and §4.11 (Seasonal & Year-in-Review — the shared per-month census, completed-seasons-only and the season-year fold with its spring-first ordinal, and the December/January window plus month bucketing). Extended §4.5 with the opt-in `selectByBuckets` calendar policy, rewrote §4.13's registry paragraph for the full seven, and added five known gaps to §4.15. Renumbered the former §4.9–§4.12 to §4.12–§4.15 so the curator sections stay together. §5–§8 and §10 remain placeholders. |


### PR DESCRIPTION
## Summary

The Memories HTTP API — list/feed/detail, per-user seen/hide/favorite, circle-level delete, save-as-album, and per-user memory preferences. This is what the web UI (#309/#313) consumes.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #300
Fixes #307

## Changes Made

| Method &amp; path | Permission | Circle role |
|---|---|---|
| `GET /api/memories?circleId=&amp;type=&amp;year=&amp;favorite=&amp;cursor=&amp;pageSize=` | `media:read` | viewer |
| `GET /api/memories/feed?circleId=` | `media:read` | viewer |
| `GET /api/memories/:id` | `media:read` | viewer |
| `POST /api/memories/:id/seen` → 204 | `media:read` | viewer |
| `POST` / `DELETE /api/memories/:id/hide` → 204 | `media:read` | viewer |
| `POST` / `DELETE /api/memories/:id/favorite` → 204 | `media:read` | viewer |
| `POST /api/memories/:id/save-album` → 201 `{albumId}` | `media:write` | collaborator |
| `DELETE /api/memories/:id` → 204 (tombstone + `memory:deleted` audit event) | `media:write` | collaborator |

**No new RBAC permission.** Preferences add **no endpoint** — they ride the existing `GET`/`PATCH`/`PUT /api/user-settings` under a `memories` namespace, following the `notifications`/`dataTables` absent-means-default rule. No table, no migration.

Save-as-album goes through `MediaService.createAlbum` / `addAlbumItems` / `updateAlbum` — no parallel mutation path.

### Thumbnail signing

Every payload signs through `MediaThumbnailService.signThumbsBatched`, **exactly one call per response**. The feed folds cover keys *and* every card's ≤4 item thumbnails into the **same** call — 10 cards × 5 keys becomes one `storageObject.findMany`. A test asserts `storageObject.findUnique` is never called and that `signThumbsBatched` fires exactly once with all 5 keys, so the N+1 documented in the search audit cannot regress here.

### Per-user filtering — two deliberately separate layers

- **In SQL:** per-user `hiddenAt` (`NOT: { userStates: { some: { userId, hiddenAt: { not: null } } } }`), so hiding many memories never shortens pages.
- **In memory, post-fetch** (as the issue specifies): `hiddenPersonIds` (`personId` match) and `hiddenDateRanges` (period **overlap**, `to` inclusive), compiled once per request into a Set + ms intervals. Malformed blobs or a failed settings read degrade to "no filter", never a 500.

**`nextCursor`/`hasMore` are computed from the RAW page, before preference filtering.** Otherwise a page whose every row was filtered out would report `nextCursor: null` and silently truncate the user's entire memory history.

### Correctness invariants

`deletedAt IS NULL` **and** `expiresAt IS NULL OR expiresAt > now()` on every read, via one `activeWhere()` helper. The feature flag is checked as the **first statement** of every handler — a test asserts that with the flag off, `memory.findMany` *and* `circleMember.findUnique` are never called, so "off" really is zero cost rather than merely empty output.

**404 vs 403 is deliberate:** `loadAccessibleMemory` does *not* call `assertCircleAccess`, because that throws 403 for a non-member and would confirm the memory exists. Non-member → 404; member lacking rank → 403. Super-admin bypass reproduced.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
memories + settings suites:  Test Suites: 25 passed, 25 total
                             Tests:     8 skipped, 651 passed, 659 total

full test:ci:                300 of 301 suites, 7122 passed
```

Only failures are the pre-existing malformed-UUID fixture suites. New coverage: 43 API integration tests, 15 preference-resolution tests, 9 user-settings service tests, 6 settings integration tests.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

- **Card `myState` is `{seen, favorited}`; detail's is `{seen, hidden, favorited}`.** `hidden` on a card would be a constant `false` (hidden rows never reach a list), while detail needs it to offer "unhide".
- **Detail applies the active-expiry filter, not just the tombstone.** The issue only stated that *preference* filters are skipped there, but the epic lists the active filter as a hard requirement. Consequence documented as a known gap in spec §6.13: an `on_this_day` deep link goes dead at midnight — though the retention tail hard-deletes that row shortly afterwards anyway.
- Documented v1 limitations: no item-level scrubbing of hidden people inside mixed memories (matches the epic's explicit out-of-scope note); preference filtering can shorten a page; `emailDigestOptOut` is stored and validated but unread until #311.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_