### PR TITLE
feat(db): database backup data model, settings namespace &amp; RBAC permissions (#340)

### DIFF
--- a/apps/api/prisma/migrations/20260809150000_add_database_backups/migration.sql
+++ b/apps/api/prisma/migrations/20260809150000_add_database_backups/migration.sql
@@ -1,0 +1,95 @@
+-- PostgreSQL Database Backup & Restore (epic #339, issue #340) — schema-only
+-- foundation. No service/API/CLI logic lands in this migration, mirroring the
+-- precedent set by migration 20260808010000_add_backup_feed_foundations
+-- (issue #310). Adds:
+--   1. DatabaseBackupStatus / DatabaseBackupTrigger enums.
+--   2. database_backup_runs — one row per pg_dump/pg_restore backup attempt
+--      of the application's own PostgreSQL database, with a nullable
+--      "restore-audit" column group on the SAME row for when that backup is
+--      later used to drive a restore (a restore is always defined in terms
+--      of exactly one backup, so a join buys nothing a nullable group
+--      doesn't already give for free).
+--   3. A raw-SQL-only partial unique index enforcing the single-active-run
+--      guard, appended below — not representable in Prisma's schema DSL.
+
+-- -----------------------------------------------------------------------------
+-- Enums
+-- -----------------------------------------------------------------------------
+
+CREATE TYPE "DatabaseBackupStatus" AS ENUM ('pending', 'running', 'completed', 'failed', 'stale');
+
+CREATE TYPE "DatabaseBackupTrigger" AS ENUM ('manual', 'scheduled', 'pre_restore');
+
+-- -----------------------------------------------------------------------------
+-- Table: database_backup_runs
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "database_backup_runs" (
+    "id"                    UUID                     NOT NULL DEFAULT gen_random_uuid(),
+    "status"                "DatabaseBackupStatus"   NOT NULL DEFAULT 'pending',
+    "trigger"               "DatabaseBackupTrigger"  NOT NULL,
+
+    "started_at"            TIMESTAMPTZ(6),
+    "finished_at"           TIMESTAMPTZ(6),
+    "last_heartbeat_at"     TIMESTAMPTZ(6),
+
+    "bytes_written"         BIGINT                   NOT NULL DEFAULT 0,
+    "size_bytes"            BIGINT,
+
+    "storage_provider"      TEXT,
+    "storage_key"           TEXT,
+    "bucket"                TEXT,
+    "format"                TEXT,
+    "checksum_sha256"       TEXT,
+
+    "db_version"            TEXT,
+    "app_version"           TEXT,
+    "migration_name"        TEXT,
+
+    "verified_at"           TIMESTAMPTZ(6),
+    "last_error"            TEXT,
+
+    "created_by_id"         UUID,
+
+    -- Restore-audit fields — populated only once this backup is used to
+    -- drive a restore.
+    "restore_status"        TEXT,
+    "restore_error"         TEXT,
+    "restored_at"           TIMESTAMPTZ(6),
+    "restored_by_id"        UUID,
+    "restore_scratch_db"    TEXT,
+    "restore_old_db"        TEXT,
+    "swapped_at"            TIMESTAMPTZ(6),
+    -- Self-relation: when restoreRollbackMode='pre_restore_dump', a fresh
+    -- safety backup is taken immediately before a restore runs; its row id
+    -- is recorded here on the run being restored FROM.
+    "pre_restore_backup_id" UUID,
+
+    CONSTRAINT "database_backup_runs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "database_backup_runs_created_by_id_fkey"
+        FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE SET NULL,
+    CONSTRAINT "database_backup_runs_restored_by_id_fkey"
+        FOREIGN KEY ("restored_by_id") REFERENCES "users"("id") ON DELETE SET NULL,
+    CONSTRAINT "database_backup_runs_pre_restore_backup_id_fkey"
+        FOREIGN KEY ("pre_restore_backup_id") REFERENCES "database_backup_runs"("id") ON DELETE SET NULL
+);
+
+-- -----------------------------------------------------------------------------
+-- Indexes
+-- -----------------------------------------------------------------------------
+
+CREATE INDEX "database_backup_runs_status_idx" ON "database_backup_runs" ("status");
+
+CREATE INDEX "database_backup_runs_started_at_idx" ON "database_backup_runs" ("started_at" DESC);
+
+-- -----------------------------------------------------------------------------
+-- Single-active-run guard — raw SQL, not representable in Prisma's schema
+-- DSL (same precedent as notifications_review_queue_live_uniq_idx and
+-- media_items_gallery_idx). At most one row may be "pending" or "running"
+-- at a time app-wide, so a scheduled backup can never start while a manual
+-- one (or a pre-restore safety backup) is already in flight, and vice versa.
+-- -----------------------------------------------------------------------------
+
+CREATE UNIQUE INDEX "database_backup_runs_active_uniq_idx"
+    ON "database_backup_runs" ("status")
+    WHERE "status" IN ('pending', 'running');

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -79,6 +79,9 @@ model User {
   notifications               Notification[]              @relation("UserNotifications")
   // Memories relations (epic #300, issue #301)
   memoryUserStates            MemoryUserState[]
+  // PostgreSQL Database Backup & Restore relations (epic #339, issue #340)
+  databaseBackupsCreated      DatabaseBackupRun[]         @relation("DatabaseBackupCreatedBy")
+  databaseBackupsRestored     DatabaseBackupRun[]         @relation("DatabaseBackupRestoredBy")
 
   @@map("users")
 }
@@ -2236,4 +2239,98 @@ model MemoryUserState {
   @@unique([memoryId, userId])
   @@index([userId, favoritedAt])
   @@map("memory_user_state")
+}
+
+// =============================================================================
+// PostgreSQL Database Backup & Restore (epic #339, issue #340)
+// =============================================================================
+//
+// Schema-only foundation for server-managed pg_dump/pg_restore backup and
+// restore of the application's own PostgreSQL database — distinct from both
+// the S3-object `backup:run`/`backup:read` local-drive replication above and
+// the per-node Local Media Backup feature (`node_backup_configs` /
+// `node_backup_runs`), neither of which touches the database itself. No
+// service/API/CLI logic lands in this issue, mirroring the precedent set by
+// migration `20260808010000_add_backup_feed_foundations` (issue #310).
+//
+// One row per backup attempt AND, when that backup is later used to restore,
+// the audit trail of that restore lives on the SAME row rather than a
+// separate table — a restore is defined in terms of exactly one backup, so
+// there is nothing a join buys here that a nullable "restore-audit" column
+// group doesn't already give for free.
+
+enum DatabaseBackupStatus {
+  pending
+  running
+  completed
+  failed
+  stale
+}
+
+enum DatabaseBackupTrigger {
+  manual
+  scheduled
+  pre_restore
+}
+
+// SINGLE-ACTIVE-RUN GUARD — raw SQL, not representable in Prisma's schema
+// DSL (same precedent as `notifications_review_queue_live_uniq_idx` and
+// `media_items_gallery_idx`): a partial unique index on ("status") WHERE
+// status IN ('pending','running') enforces at most one backup run in flight
+// at a time app-wide. See migration `<timestamp>_add_database_backups` for
+// the actual index, named `database_backup_runs_active_uniq_idx`.
+model DatabaseBackupRun {
+  id      String                @id @default(uuid()) @db.Uuid
+  status  DatabaseBackupStatus  @default(pending)
+  trigger DatabaseBackupTrigger
+
+  startedAt       DateTime? @map("started_at") @db.Timestamptz(6)
+  finishedAt      DateTime? @map("finished_at") @db.Timestamptz(6)
+  lastHeartbeatAt DateTime? @map("last_heartbeat_at") @db.Timestamptz(6)
+
+  bytesWritten BigInt  @default(0) @map("bytes_written")
+  sizeBytes    BigInt? @map("size_bytes")
+
+  storageProvider String? @map("storage_provider")
+  storageKey      String? @map("storage_key")
+  bucket          String? @map("bucket")
+  format          String? @map("format")
+  checksumSha256  String? @map("checksum_sha256")
+
+  dbVersion     String? @map("db_version")
+  appVersion    String? @map("app_version")
+  migrationName String? @map("migration_name")
+
+  verifiedAt DateTime? @map("verified_at") @db.Timestamptz(6)
+  lastError  String?   @map("last_error")
+
+  createdById String? @map("created_by_id") @db.Uuid
+
+  // Restore-audit fields — populated only once this backup is used to drive
+  // a restore. Kept on the same row rather than a separate table: a restore
+  // is always defined in terms of exactly one backup, so there is no
+  // one-to-many relationship a join would need to express.
+  restoreStatus      String?   @map("restore_status")
+  restoreError       String?   @map("restore_error")
+  restoredAt         DateTime? @map("restored_at") @db.Timestamptz(6)
+  restoredById       String?   @map("restored_by_id") @db.Uuid
+  restoreScratchDb   String?   @map("restore_scratch_db")
+  restoreOldDb       String?   @map("restore_old_db")
+  swappedAt          DateTime? @map("swapped_at") @db.Timestamptz(6)
+  // Self-relation: when `restoreRollbackMode='pre_restore_dump'`, a fresh
+  // safety backup is taken immediately before a restore runs. That safety
+  // backup's own row id is recorded here on the run being restored FROM, so
+  // the pre-restore snapshot that could undo a bad restore is always
+  // traceable from the run that triggered it.
+  preRestoreBackupId String?   @map("pre_restore_backup_id") @db.Uuid
+
+  // Relations
+  createdBy          User?               @relation("DatabaseBackupCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  restoredBy         User?               @relation("DatabaseBackupRestoredBy", fields: [restoredById], references: [id], onDelete: SetNull)
+  preRestoreBackup   DatabaseBackupRun?  @relation("DatabaseBackupPreRestore", fields: [preRestoreBackupId], references: [id], onDelete: SetNull)
+  preRestoreBackupOf DatabaseBackupRun[] @relation("DatabaseBackupPreRestore")
+
+  @@index([status])
+  @@index([startedAt(sort: Desc)])
+  @@map("database_backup_runs")
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2277,8 +2277,8 @@ enum DatabaseBackupTrigger {
 // DSL (same precedent as `notifications_review_queue_live_uniq_idx` and
 // `media_items_gallery_idx`): a partial unique index on ("status") WHERE
 // status IN ('pending','running') enforces at most one backup run in flight
-// at a time app-wide. See migration `<timestamp>_add_database_backups` for
-// the actual index, named `database_backup_runs_active_uniq_idx`.
+// at a time app-wide. See migration `20260809150000_add_database_backups`
+// for the actual index, named `database_backup_runs_active_uniq_idx`.
 model DatabaseBackupRun {
   id      String                @id @default(uuid()) @db.Uuid
   status  DatabaseBackupStatus  @default(pending)

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -95,6 +95,11 @@ const PERMISSIONS = [
   // Email Provider Settings (Admin only)
   { name: 'email_settings:read', description: 'View email provider configuration and test connectivity' },
   { name: 'email_settings:write', description: 'Configure email provider credentials, set active provider, and send test emails' },
+
+  // PostgreSQL Database Backup & Restore (Admin only, epic #339)
+  { name: 'db_backup:read', description: 'Admin: read database backup run history and status' },
+  { name: 'db_backup:write', description: 'Admin: configure and trigger database backups' },
+  { name: 'db_backup:restore', description: 'Admin: restore the database from a backup' },
 ] as const;
 
 // Role to permissions mapping
@@ -148,6 +153,10 @@ const ROLE_PERMISSIONS: Record<string, string[]> = {
     // Email Provider Settings: admin-only
     'email_settings:read',
     'email_settings:write',
+    // PostgreSQL Database Backup & Restore: admin-only
+    'db_backup:read',
+    'db_backup:write',
+    'db_backup:restore',
   ],
   contributor: [
     'user_settings:read',

--- a/apps/api/src/common/constants/rbac.catalog.ts
+++ b/apps/api/src/common/constants/rbac.catalog.ts
@@ -138,6 +138,11 @@ export const PERMISSION_CATALOG: readonly PermissionDefinition[] = [
     description:
       'Configure email provider credentials, set active provider, and send test emails',
   },
+
+  // PostgreSQL Database Backup & Restore (Admin only, epic #339)
+  { name: PERMISSIONS.DB_BACKUP_READ, description: 'Admin: read database backup run history and status' },
+  { name: PERMISSIONS.DB_BACKUP_WRITE, description: 'Admin: configure and trigger database backups' },
+  { name: PERMISSIONS.DB_BACKUP_RESTORE, description: 'Admin: restore the database from a backup' },
 ];
 
 /**
@@ -198,6 +203,10 @@ export const ROLE_PERMISSION_MATRIX: Record<RoleName, readonly PermissionName[]>
     // Email Provider Settings: admin-only
     PERMISSIONS.EMAIL_SETTINGS_READ,
     PERMISSIONS.EMAIL_SETTINGS_WRITE,
+    // PostgreSQL Database Backup & Restore: admin-only
+    PERMISSIONS.DB_BACKUP_READ,
+    PERMISSIONS.DB_BACKUP_WRITE,
+    PERMISSIONS.DB_BACKUP_RESTORE,
   ],
   [ROLES.CONTRIBUTOR]: [
     PERMISSIONS.USER_SETTINGS_READ,

--- a/apps/api/src/common/constants/roles.constants.ts
+++ b/apps/api/src/common/constants/roles.constants.ts
@@ -86,6 +86,11 @@ export const PERMISSIONS = {
   // Sharing (Admin + Contributor; manage_any = Admin only)
   SHARES_MANAGE: 'shares:manage',
   SHARES_MANAGE_ANY: 'shares:manage_any',
+
+  // PostgreSQL Database Backup & Restore (Admin only, epic #339)
+  DB_BACKUP_READ: 'db_backup:read',
+  DB_BACKUP_WRITE: 'db_backup:write',
+  DB_BACKUP_RESTORE: 'db_backup:restore',
 } as const;
 
 export type PermissionName = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];

--- a/apps/api/src/common/schemas/settings-db-backup.schema.spec.ts
+++ b/apps/api/src/common/schemas/settings-db-backup.schema.spec.ts
@@ -1,0 +1,421 @@
+/**
+ * Unit tests for the `databaseBackup` namespace in the settings schema
+ * (epic #339, issue #340).
+ *
+ * Tests full (PUT) and partial (PATCH) schemas. Mirrors the style of
+ * settings-jobs-stuck-threshold.schema.spec.ts.
+ */
+import {
+  systemSettingsSchema,
+  systemSettingsPatchSchema,
+} from './settings.schema';
+
+// ---------------------------------------------------------------------------
+// Minimal valid full settings for PUT tests
+// ---------------------------------------------------------------------------
+
+function makeFullSettings(databaseBackupOverrides: Record<string, unknown> = {}) {
+  return {
+    ui: { allowUserThemeOverride: true },
+    features: {},
+    ai: {
+      features: {
+        search: { provider: null, model: null },
+        tagging: { provider: null, model: null },
+        embedding: { provider: null, model: null },
+      },
+    },
+    databaseBackup: {
+      enabled: false,
+      frequency: 'daily',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '02:00',
+      timezone: 'UTC',
+      retentionCount: 7,
+      storageProvider: null,
+      runStaleMinutes: 30,
+      compressionLevel: 1,
+      restoreRollbackMode: 'retain_database',
+      oldDatabaseRetentionHours: 168,
+      ...databaseBackupOverrides,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// systemSettingsSchema (PUT — full replace)
+// ---------------------------------------------------------------------------
+
+describe('systemSettingsSchema — databaseBackup', () => {
+  it('accepts the default values', () => {
+    const result = systemSettingsSchema.parse(makeFullSettings());
+    expect(result.databaseBackup).toEqual({
+      enabled: false,
+      frequency: 'daily',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '02:00',
+      timezone: 'UTC',
+      retentionCount: 7,
+      storageProvider: null,
+      runStaleMinutes: 30,
+      compressionLevel: 1,
+      restoreRollbackMode: 'retain_database',
+      oldDatabaseRetentionHours: 168,
+    });
+  });
+
+  it('applies the full default namespace when databaseBackup is omitted', () => {
+    const result = systemSettingsSchema.parse({
+      ui: { allowUserThemeOverride: true },
+      features: {},
+      ai: {
+        features: {
+          search: { provider: null, model: null },
+          tagging: { provider: null, model: null },
+          embedding: { provider: null, model: null },
+        },
+      },
+    });
+    expect(result.databaseBackup?.enabled).toBe(false);
+    expect(result.databaseBackup?.frequency).toBe('daily');
+    expect(result.databaseBackup?.retentionCount).toBe(7);
+    expect(result.databaseBackup?.storageProvider).toBeNull();
+  });
+
+  it('accepts enabled: true', () => {
+    const result = systemSettingsSchema.parse(makeFullSettings({ enabled: true }));
+    expect(result.databaseBackup?.enabled).toBe(true);
+  });
+
+  describe('frequency', () => {
+    it.each(['daily', 'weekly', 'monthly'])('accepts %s', (frequency) => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ frequency }));
+      expect(result.databaseBackup?.frequency).toBe(frequency);
+    });
+
+    it('rejects an unknown frequency', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ frequency: 'hourly' })),
+      ).toThrow();
+    });
+  });
+
+  describe('dayOfWeek (0-6)', () => {
+    it('accepts the minimum valid value of 0', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ dayOfWeek: 0 }));
+      expect(result.databaseBackup?.dayOfWeek).toBe(0);
+    });
+
+    it('accepts the maximum valid value of 6', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ dayOfWeek: 6 }));
+      expect(result.databaseBackup?.dayOfWeek).toBe(6);
+    });
+
+    it('rejects -1 (below minimum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ dayOfWeek: -1 })),
+      ).toThrow();
+    });
+
+    it('rejects 7 (above maximum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ dayOfWeek: 7 })),
+      ).toThrow();
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ dayOfWeek: 2.5 })),
+      ).toThrow();
+    });
+  });
+
+  describe('dayOfMonth (1-28)', () => {
+    it('accepts the minimum valid value of 1', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ dayOfMonth: 1 }));
+      expect(result.databaseBackup?.dayOfMonth).toBe(1);
+    });
+
+    it('accepts the maximum valid value of 28', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ dayOfMonth: 28 }));
+      expect(result.databaseBackup?.dayOfMonth).toBe(28);
+    });
+
+    it('rejects 0 (below minimum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ dayOfMonth: 0 })),
+      ).toThrow();
+    });
+
+    it('rejects 29 (above maximum — no month guarantees a 29th day)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ dayOfMonth: 29 })),
+      ).toThrow();
+    });
+  });
+
+  describe('timeOfDay ("HH:mm")', () => {
+    it('accepts the default 02:00', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ timeOfDay: '02:00' }));
+      expect(result.databaseBackup?.timeOfDay).toBe('02:00');
+    });
+
+    it('accepts 00:00 and 23:59 (boundary times)', () => {
+      expect(
+        systemSettingsSchema.parse(makeFullSettings({ timeOfDay: '00:00' })).databaseBackup
+          ?.timeOfDay,
+      ).toBe('00:00');
+      expect(
+        systemSettingsSchema.parse(makeFullSettings({ timeOfDay: '23:59' })).databaseBackup
+          ?.timeOfDay,
+      ).toBe('23:59');
+    });
+
+    it('rejects an out-of-range hour', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ timeOfDay: '24:00' })),
+      ).toThrow();
+    });
+
+    it('rejects an out-of-range minute', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ timeOfDay: '10:60' })),
+      ).toThrow();
+    });
+
+    it('rejects a malformed string', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ timeOfDay: '2am' })),
+      ).toThrow();
+    });
+  });
+
+  describe('timezone', () => {
+    it('accepts an IANA timezone string', () => {
+      const result = systemSettingsSchema.parse(
+        makeFullSettings({ timezone: 'America/Costa_Rica' }),
+      );
+      expect(result.databaseBackup?.timezone).toBe('America/Costa_Rica');
+    });
+
+    it('rejects an empty string', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ timezone: '' })),
+      ).toThrow();
+    });
+  });
+
+  describe('retentionCount (1-100)', () => {
+    it('accepts the minimum valid value of 1', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ retentionCount: 1 }));
+      expect(result.databaseBackup?.retentionCount).toBe(1);
+    });
+
+    it('accepts the maximum valid value of 100', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ retentionCount: 100 }));
+      expect(result.databaseBackup?.retentionCount).toBe(100);
+    });
+
+    it('rejects 0 (below minimum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ retentionCount: 0 })),
+      ).toThrow();
+    });
+
+    it('rejects 101 (above maximum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ retentionCount: 101 })),
+      ).toThrow();
+    });
+  });
+
+  describe('storageProvider (nullable)', () => {
+    it('accepts null (use the active storage provider)', () => {
+      const result = systemSettingsSchema.parse(
+        makeFullSettings({ storageProvider: null }),
+      );
+      expect(result.databaseBackup?.storageProvider).toBeNull();
+    });
+
+    it('accepts a provider key string', () => {
+      const result = systemSettingsSchema.parse(
+        makeFullSettings({ storageProvider: 's3' }),
+      );
+      expect(result.databaseBackup?.storageProvider).toBe('s3');
+    });
+  });
+
+  describe('runStaleMinutes (5-240)', () => {
+    it('accepts the minimum valid value of 5', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ runStaleMinutes: 5 }));
+      expect(result.databaseBackup?.runStaleMinutes).toBe(5);
+    });
+
+    it('accepts the maximum valid value of 240', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ runStaleMinutes: 240 }));
+      expect(result.databaseBackup?.runStaleMinutes).toBe(240);
+    });
+
+    it('rejects 4 (below minimum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ runStaleMinutes: 4 })),
+      ).toThrow();
+    });
+
+    it('rejects 241 (above maximum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ runStaleMinutes: 241 })),
+      ).toThrow();
+    });
+  });
+
+  describe('compressionLevel (0-9)', () => {
+    it('accepts the minimum valid value of 0', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ compressionLevel: 0 }));
+      expect(result.databaseBackup?.compressionLevel).toBe(0);
+    });
+
+    it('accepts the maximum valid value of 9', () => {
+      const result = systemSettingsSchema.parse(makeFullSettings({ compressionLevel: 9 }));
+      expect(result.databaseBackup?.compressionLevel).toBe(9);
+    });
+
+    it('rejects -1 (below minimum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ compressionLevel: -1 })),
+      ).toThrow();
+    });
+
+    it('rejects 10 (above maximum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ compressionLevel: 10 })),
+      ).toThrow();
+    });
+  });
+
+  describe('restoreRollbackMode', () => {
+    it.each(['retain_database', 'pre_restore_dump'])('accepts %s', (mode) => {
+      const result = systemSettingsSchema.parse(
+        makeFullSettings({ restoreRollbackMode: mode }),
+      );
+      expect(result.databaseBackup?.restoreRollbackMode).toBe(mode);
+    });
+
+    it('rejects an unknown mode', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ restoreRollbackMode: 'discard' })),
+      ).toThrow();
+    });
+  });
+
+  describe('oldDatabaseRetentionHours (1-720)', () => {
+    it('accepts the minimum valid value of 1', () => {
+      const result = systemSettingsSchema.parse(
+        makeFullSettings({ oldDatabaseRetentionHours: 1 }),
+      );
+      expect(result.databaseBackup?.oldDatabaseRetentionHours).toBe(1);
+    });
+
+    it('accepts the maximum valid value of 720', () => {
+      const result = systemSettingsSchema.parse(
+        makeFullSettings({ oldDatabaseRetentionHours: 720 }),
+      );
+      expect(result.databaseBackup?.oldDatabaseRetentionHours).toBe(720);
+    });
+
+    it('rejects 0 (below minimum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ oldDatabaseRetentionHours: 0 })),
+      ).toThrow();
+    });
+
+    it('rejects 721 (above maximum)', () => {
+      expect(() =>
+        systemSettingsSchema.parse(makeFullSettings({ oldDatabaseRetentionHours: 721 })),
+      ).toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// systemSettingsPatchSchema (PATCH — partial update)
+// ---------------------------------------------------------------------------
+
+describe('systemSettingsPatchSchema — databaseBackup', () => {
+  it('accepts empty object (all fields optional)', () => {
+    const result = systemSettingsPatchSchema.parse({});
+    expect(result.databaseBackup).toBeUndefined();
+  });
+
+  it('accepts patch with only databaseBackup.enabled', () => {
+    const result = systemSettingsPatchSchema.parse({
+      databaseBackup: { enabled: true },
+    });
+    expect(result.databaseBackup?.enabled).toBe(true);
+    expect(result.databaseBackup?.frequency).toBeUndefined();
+  });
+
+  it('accepts an empty databaseBackup object (no-op patch)', () => {
+    const result = systemSettingsPatchSchema.parse({ databaseBackup: {} });
+    expect(result.databaseBackup).toEqual({});
+  });
+
+  it('accepts patching multiple fields together', () => {
+    const result = systemSettingsPatchSchema.parse({
+      databaseBackup: {
+        enabled: true,
+        frequency: 'weekly',
+        dayOfWeek: 3,
+        timeOfDay: '03:30',
+        retentionCount: 14,
+      },
+    });
+    expect(result.databaseBackup).toEqual({
+      enabled: true,
+      frequency: 'weekly',
+      dayOfWeek: 3,
+      timeOfDay: '03:30',
+      retentionCount: 14,
+    });
+  });
+
+  it('accepts storageProvider: null explicitly', () => {
+    const result = systemSettingsPatchSchema.parse({
+      databaseBackup: { storageProvider: null },
+    });
+    expect(result.databaseBackup?.storageProvider).toBeNull();
+  });
+
+  it('accepts storageProvider as a string', () => {
+    const result = systemSettingsPatchSchema.parse({
+      databaseBackup: { storageProvider: 'r2' },
+    });
+    expect(result.databaseBackup?.storageProvider).toBe('r2');
+  });
+
+  it('rejects an out-of-range field in a partial patch', () => {
+    expect(() =>
+      systemSettingsPatchSchema.parse({
+        databaseBackup: { dayOfMonth: 29 },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects an invalid enum value in a partial patch', () => {
+    expect(() =>
+      systemSettingsPatchSchema.parse({
+        databaseBackup: { restoreRollbackMode: 'nope' },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a malformed timeOfDay in a partial patch', () => {
+    expect(() =>
+      systemSettingsPatchSchema.parse({
+        databaseBackup: { timeOfDay: '9:00' },
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -579,6 +579,43 @@ export const systemSettingsSchema = z.object({
     yearInReview: { enabled: true, minItems: 15 },
     digest: { enabled: true, frequency: 'weekly', sendHourUtc: 8, imageTokenTtlDays: 30 },
   }),
+  // PostgreSQL Database Backup & Restore (epic #339, issue #340). The full
+  // namespace ships here as a schema-only foundation, mirroring the
+  // `backup` (Local Media Backup) and `memories` precedents above — later
+  // issues in the epic read these through the one cached getSettings() call
+  // with no further schema change.
+  databaseBackup: z.object({
+    enabled: z.boolean().default(false),
+    frequency: z.enum(['daily', 'weekly', 'monthly']).default('daily'),
+    dayOfWeek: z.number().int().min(0).max(6).default(0),
+    dayOfMonth: z.number().int().min(1).max(28).default(1),
+    timeOfDay: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'timeOfDay must be "HH:mm"')
+      .default('02:00'),
+    timezone: z.string().min(1).default('UTC'),
+    retentionCount: z.number().int().min(1).max(100).default(7),
+    storageProvider: z.string().nullable().default(null),
+    runStaleMinutes: z.number().int().min(5).max(240).default(30),
+    compressionLevel: z.number().int().min(0).max(9).default(1),
+    restoreRollbackMode: z
+      .enum(['retain_database', 'pre_restore_dump'])
+      .default('retain_database'),
+    oldDatabaseRetentionHours: z.number().int().min(1).max(720).default(168),
+  }).optional().default({
+    enabled: false,
+    frequency: 'daily',
+    dayOfWeek: 0,
+    dayOfMonth: 1,
+    timeOfDay: '02:00',
+    timezone: 'UTC',
+    retentionCount: 7,
+    storageProvider: null,
+    runStaleMinutes: 30,
+    compressionLevel: 1,
+    restoreRollbackMode: 'retain_database',
+    oldDatabaseRetentionHours: 168,
+  }),
 });
 
 export type SystemSettingsDto = z.infer<typeof systemSettingsSchema>;
@@ -772,5 +809,24 @@ export const systemSettingsPatchSchema = z.object({
       sendHourUtc: z.number().int().min(0).max(23).optional(),
       imageTokenTtlDays: z.number().int().min(7).max(90).optional(),
     }).optional(),
+  }).optional(),
+  // PostgreSQL Database Backup & Restore (epic #339, issue #340) — all-optional
+  // twin of the namespace above.
+  databaseBackup: z.object({
+    enabled: z.boolean().optional(),
+    frequency: z.enum(['daily', 'weekly', 'monthly']).optional(),
+    dayOfWeek: z.number().int().min(0).max(6).optional(),
+    dayOfMonth: z.number().int().min(1).max(28).optional(),
+    timeOfDay: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'timeOfDay must be "HH:mm"')
+      .optional(),
+    timezone: z.string().min(1).optional(),
+    retentionCount: z.number().int().min(1).max(100).optional(),
+    storageProvider: z.string().nullable().optional(),
+    runStaleMinutes: z.number().int().min(5).max(240).optional(),
+    compressionLevel: z.number().int().min(0).max(9).optional(),
+    restoreRollbackMode: z.enum(['retain_database', 'pre_restore_dump']).optional(),
+    oldDatabaseRetentionHours: z.number().int().min(1).max(720).optional(),
   }).optional(),
 });

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -350,6 +350,40 @@ export interface SystemSettingsValue {
    * `generation.intervalHours` (plus the `features.memories` flag).
    */
   memories?: MemoriesSettingsValue;
+  /**
+   * PostgreSQL Database Backup & Restore (epic #339, issue #340). The full
+   * namespace ships here as a schema-only foundation so every later issue in
+   * the epic reads its parameters through the one cached getSettings() call
+   * with no further schema change.
+   */
+  databaseBackup?: DatabaseBackupSettingsValue;
+}
+
+/** The `databaseBackup.*` system-settings namespace (epic #339, issue #340). */
+export interface DatabaseBackupSettingsValue {
+  /** Master switch for the scheduled backup cron. */
+  enabled: boolean;
+  frequency: 'daily' | 'weekly' | 'monthly';
+  /** Day of week (0=Sunday) the weekly schedule fires on. */
+  dayOfWeek: number;
+  /** Day of month (1-28) the monthly schedule fires on. */
+  dayOfMonth: number;
+  /** "HH:mm" local time (in `timezone`) the schedule fires at. */
+  timeOfDay: string;
+  /** IANA timezone name the schedule is evaluated in. */
+  timezone: string;
+  /** How many completed backups to retain before pruning the oldest. */
+  retentionCount: number;
+  /** Storage provider key backups are written to; null = use the active storage provider. */
+  storageProvider: string | null;
+  /** Minutes without a heartbeat before a `running` backup run is marked stale. */
+  runStaleMinutes: number;
+  /** pg_dump custom-format compression level, 0 (none) to 9 (max). */
+  compressionLevel: number;
+  /** How the old database is handled after a restore swap. */
+  restoreRollbackMode: 'retain_database' | 'pre_restore_dump';
+  /** Hours the pre-swap old database is retained before cleanup. */
+  oldDatabaseRetentionHours: number;
 }
 
 /** The `memories.*` system-settings namespace (epic #300, issue #302). */
@@ -642,5 +676,19 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
     seasonal: { enabled: true, minItems: 12 },
     yearInReview: { enabled: true, minItems: 15 },
     digest: { enabled: true, frequency: 'weekly', sendHourUtc: 8, imageTokenTtlDays: 30 },
+  },
+  databaseBackup: {
+    enabled: false,
+    frequency: 'daily',
+    dayOfWeek: 0,
+    dayOfMonth: 1,
+    timeOfDay: '02:00',
+    timezone: 'UTC',
+    retentionCount: 7,
+    storageProvider: null,
+    runStaleMinutes: 30,
+    compressionLevel: 1,
+    restoreRollbackMode: 'retain_database',
+    oldDatabaseRetentionHours: 168,
   },
 };

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -271,6 +271,29 @@ export const patchSystemSettingsSchema = z.object({
         .optional(),
     })
     .optional(),
+  // PostgreSQL Database Backup & Restore (epic #339, issue #340). Same THIRD
+  // hand-maintained copy caveat as the `memories` comment above — a key
+  // missing HERE is silently stripped from the request body before the
+  // service ever sees it.
+  databaseBackup: z
+    .object({
+      enabled: z.boolean().optional(),
+      frequency: z.enum(['daily', 'weekly', 'monthly']).optional(),
+      dayOfWeek: z.number().int().min(0).max(6).optional(),
+      dayOfMonth: z.number().int().min(1).max(28).optional(),
+      timeOfDay: z
+        .string()
+        .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'timeOfDay must be "HH:mm"')
+        .optional(),
+      timezone: z.string().min(1).optional(),
+      retentionCount: z.number().int().min(1).max(100).optional(),
+      storageProvider: z.string().nullable().optional(),
+      runStaleMinutes: z.number().int().min(5).max(240).optional(),
+      compressionLevel: z.number().int().min(0).max(9).optional(),
+      restoreRollbackMode: z.enum(['retain_database', 'pre_restore_dump']).optional(),
+      oldDatabaseRetentionHours: z.number().int().min(1).max(720).optional(),
+    })
+    .optional(),
 }).default({});
 
 export class PatchSystemSettingsDto extends createZodDto(

--- a/apps/api/src/settings/system-settings/system-settings.service.spec.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.spec.ts
@@ -119,12 +119,12 @@ describe('SystemSettingsService', () => {
       // systemSettingsSchema.parse fills in every optional top-level branch
       // with its default when omitted from the DTO — not just `face`. This
       // fixture must mirror ALL of those defaults (face, storage, burst,
-      // dedup, geo, jobs, pictureEnhancement, workflows) or the
-      // toHaveBeenCalledWith assertion below drifts out of sync every time a
-      // new default branch is added to the schema. `ai.features.enhance` and
-      // `ai.features.memories` are also filled with their defaults (null) even
-      // though `ai.features` itself was supplied, since the DTO's `ai.features`
-      // omits both keys.
+      // dedup, geo, jobs, pictureEnhancement, workflows, databaseBackup) or
+      // the toHaveBeenCalledWith assertion below drifts out of sync every
+      // time a new default branch is added to the schema. `ai.features.enhance`
+      // and `ai.features.memories` are also filled with their defaults (null)
+      // even though `ai.features` itself was supplied, since the DTO's
+      // `ai.features` omits both keys.
       const expectedParsed = {
         ...newSettings,
         ai: {
@@ -145,6 +145,7 @@ describe('SystemSettingsService', () => {
         reviewRuns: DEFAULT_SYSTEM_SETTINGS.reviewRuns,
         notifications: DEFAULT_SYSTEM_SETTINGS.notifications,
         memories: DEFAULT_SYSTEM_SETTINGS.memories,
+        databaseBackup: DEFAULT_SYSTEM_SETTINGS.databaseBackup,
       };
 
       mockPrisma.systemSettings.upsert.mockResolvedValue({
@@ -252,6 +253,7 @@ describe('SystemSettingsService', () => {
         reviewRuns: DEFAULT_SYSTEM_SETTINGS.reviewRuns,
         notifications: DEFAULT_SYSTEM_SETTINGS.notifications,
         memories: DEFAULT_SYSTEM_SETTINGS.memories,
+        databaseBackup: DEFAULT_SYSTEM_SETTINGS.databaseBackup,
       };
 
       mockPrisma.systemSettings.upsert.mockResolvedValue({

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -41,6 +41,7 @@ export interface ResolvedSettings {
   backup: SystemSettingsValue['backup'];
   workflows: SystemSettingsValue['workflows'];
   memories: SystemSettingsValue['memories'];
+  databaseBackup: SystemSettingsValue['databaseBackup'];
   updatedAt: Date;
   updatedBy: { id: string; email: string } | null;
   version: number;
@@ -144,6 +145,7 @@ export class SystemSettingsService {
       backup: value.backup,
       workflows: value.workflows,
       memories: value.memories,
+      databaseBackup: value.databaseBackup,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,
@@ -242,6 +244,7 @@ export class SystemSettingsService {
       backup: value.backup,
       workflows: value.workflows,
       memories: value.memories,
+      databaseBackup: value.databaseBackup,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,
@@ -718,6 +721,60 @@ export class SystemSettingsService {
             30,
         },
       },
+      // PostgreSQL Database Backup & Restore (epic #339, issue #340).
+      databaseBackup: {
+        enabled:
+          (dto as any).databaseBackup?.enabled ??
+          (current as any).databaseBackup?.enabled ??
+          false,
+        frequency:
+          (dto as any).databaseBackup?.frequency ??
+          (current as any).databaseBackup?.frequency ??
+          'daily',
+        dayOfWeek:
+          (dto as any).databaseBackup?.dayOfWeek ??
+          (current as any).databaseBackup?.dayOfWeek ??
+          0,
+        dayOfMonth:
+          (dto as any).databaseBackup?.dayOfMonth ??
+          (current as any).databaseBackup?.dayOfMonth ??
+          1,
+        timeOfDay:
+          (dto as any).databaseBackup?.timeOfDay ??
+          (current as any).databaseBackup?.timeOfDay ??
+          '02:00',
+        timezone:
+          (dto as any).databaseBackup?.timezone ??
+          (current as any).databaseBackup?.timezone ??
+          'UTC',
+        retentionCount:
+          (dto as any).databaseBackup?.retentionCount ??
+          (current as any).databaseBackup?.retentionCount ??
+          7,
+        // Nullable: null is meaningful ("use the active storage provider"),
+        // so use !== undefined rather than ?? to distinguish "not sent" from
+        // "explicitly cleared to null".
+        storageProvider:
+          (dto as any).databaseBackup?.storageProvider !== undefined
+            ? (dto as any).databaseBackup?.storageProvider
+            : ((current as any).databaseBackup?.storageProvider ?? null),
+        runStaleMinutes:
+          (dto as any).databaseBackup?.runStaleMinutes ??
+          (current as any).databaseBackup?.runStaleMinutes ??
+          30,
+        compressionLevel:
+          (dto as any).databaseBackup?.compressionLevel ??
+          (current as any).databaseBackup?.compressionLevel ??
+          1,
+        restoreRollbackMode:
+          (dto as any).databaseBackup?.restoreRollbackMode ??
+          (current as any).databaseBackup?.restoreRollbackMode ??
+          'retain_database',
+        oldDatabaseRetentionHours:
+          (dto as any).databaseBackup?.oldDatabaseRetentionHours ??
+          (current as any).databaseBackup?.oldDatabaseRetentionHours ??
+          168,
+      },
     };
 
     // Validate merged result
@@ -769,6 +826,7 @@ export class SystemSettingsService {
       backup: value.backup,
       workflows: value.workflows,
       memories: value.memories,
+      databaseBackup: value.databaseBackup,
       updatedAt: settings.updatedAt,
       updatedBy: settings.updatedByUser,
       version: settings.version,


### PR DESCRIPTION
## Summary

Schema-only foundation for the PostgreSQL Database Backup &amp; Restore epic: the `DatabaseBackupRun` model and its migration, the `databaseBackup.*` settings namespace, and three Admin-only RBAC permissions. No service, API, or CLI logic lands here — this mirrors the precedent set by `20260808010000_add_backup_feed_foundations`.

The run table is not just a history log: it **is** the concurrency guard and liveness mechanism for a long-running operation, which is why its shape is settled up front.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #340
Part of epic #339

## Changes Made

- **`DatabaseBackupRun` model + `DatabaseBackupStatus`/`DatabaseBackupTrigger` enums** — one row per backup attempt, with the restore-audit column group (`restoreScratchDb`, `restoreOldDb`, `swappedAt`, `preRestoreBackupId` self-FK) on the *same* row, since a restore is 1:1 with the backup it restores from.
- **Migration `20260809150000_add_database_backups`** — hand-authored, including the raw-SQL partial unique index `database_backup_runs_active_uniq_idx ON (status) WHERE status IN ('pending','running')`. This is the single-active-run guard: a concurrent start hits P2002 rather than relying on an in-process boolean, so it is multi-replica-safe by construction. Not representable in Prisma's DSL, so it is documented as intentional schema drift above the model — same precedent as `notifications_review_queue_live_uniq_idx` and `media_items_gallery_idx`.
- **`databaseBackup` settings namespace** in `systemSettingsSchema` and its all-`.optional()` PATCH twin, plus `SystemSettingsValue` / `DEFAULT_SYSTEM_SETTINGS` and the explicit field-by-field merge block in `patchSettings` (nullable `storageProvider` uses `!== undefined`, since `null` is meaningful there).
- **Three Admin-only permissions** — `db_backup:read`, `db_backup:write`, `db_backup:restore` — added identically to all three catalog copies (`roles.constants.ts`, `rbac.catalog.ts`, `seed.ts`), which `rbac.catalog.spec.ts` enforces.
- **53 new schema tests** covering defaults, every bound at min/max and just outside, enum values, the `timeOfDay` regex, nullable `storageProvider`, and PATCH partial-update semantics.

### Note on a change beyond the stated scope

`apps/api/src/settings/dto/update-system-settings.dto.ts` holds a **third** hand-maintained copy of the settings shape, and its own comment warns that a namespace missing there is silently stripped from PATCH before the service ever sees it. `databaseBackup` was added there too — without it, the "PATCH of a single field leaves the others intact" acceptance criterion would have failed at runtime while unit tests still passed.

## Testing

- [x] Unit tests pass — full API suite: **291 suites, 7054 tests passed, 0 failed**
- [x] Type checks pass — `npx tsc --noEmit` clean
- [ ] E2E tests pass (not run)
- [ ] Manual testing completed (see limitation below)

Commands were run directly (`npx jest ...` / `npx tsc --noEmit`) rather than through `npm test` / `npm run typecheck`, whose pre-hooks trigger a workspace install that cannot complete in this sandbox.

Adding the namespace initially broke two pre-existing tests in `system-settings.service.spec.ts`, whose `expectedParsed` fixture hand-enumerates every default branch the schema fills in. Fixed by adding the new namespace to that fixture — the drift the fixture's own comment warns about.

### Not verified — requires a live database

There is no Docker or PostgreSQL in the environment this was developed in, so:

- **The migration was never applied against real Postgres.** The SQL is hand-authored to match the schema, with conventions checked against recent migrations (`TIMESTAMPTZ(6)`, `gen_random_uuid()` defaults, `&lt;table&gt;_&lt;column&gt;_fkey` naming, no auto-index on nullable FK columns). `prisma validate` and `prisma generate` both pass, but `prisma migrate diff` against a live database is the strongest confirmation and should be run before merge-to-deploy.
- **The partial unique index guard was not exercised** (i.e. two concurrent `status='running'` inserts → second fails). Worth confirming once a database is available, as the entire concurrency model depends on it.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (schema/migration comments; user-facing CLAUDE.md docs land in #346 per the epic's plan)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Blocks every other issue in epic #339. Next: #341 (pg_dump engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HS1v19WgTyEnUvsw8ECEYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HS1v19WgTyEnUvsw8ECEYM)_