### PR TITLE
feat(api,web): Memories admin settings page &amp; sharded library backfill (#315)

### DIFF
--- a/apps/api/src/memories/admin/admin-memories.controller.spec.ts
+++ b/apps/api/src/memories/admin/admin-memories.controller.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for AdminMemoriesController (epic #300, issue #315).
+ *
+ * The controller is deliberately thin, so exactly two things are worth testing:
+ * the feature gate (400 before anything is enqueued, folding in the
+ * MEMORIES_ENABLED env kill-switch) and the `{ data: … }` envelope the sibling
+ * admin backfills use.
+ *
+ * The guard matrix itself (Admin role + system_settings:write) is enforced by
+ * the shared @Auth decorator and asserted at the metadata level below rather
+ * than by standing up the whole Nest HTTP stack — the same approach the other
+ * admin controllers' specs take.
+ */
+
+import { BadRequestException } from '@nestjs/common';
+import { AdminMemoriesController } from './admin-memories.controller';
+import { MemoryBackfillService } from './memory-backfill.service';
+import { SystemSettingsService } from '../../settings/system-settings/system-settings.service';
+import { PERMISSIONS, ROLES } from '../../common/constants/roles.constants';
+
+describe('AdminMemoriesController', () => {
+  let controller: AdminMemoriesController;
+  let backfill: { backfillLibrary: jest.Mock };
+  let settings: { getSettings: jest.Mock };
+
+  const originalEnv = process.env['MEMORIES_ENABLED'];
+
+  beforeEach(async () => {
+    backfill = {
+      backfillLibrary: jest.fn().mockResolvedValue({ enqueued: 18, circles: 1, skipped: 0 }),
+    };
+    settings = {
+      getSettings: jest.fn().mockResolvedValue({ features: { memories: true } }),
+    };
+    delete process.env['MEMORIES_ENABLED'];
+
+    // Constructed directly rather than through Test.createTestingModule: the
+    // class carries @Auth, whose guards Nest would try to instantiate (and
+    // whose own dependency graph reaches the whole auth module) for a
+    // controller whose logic is two awaits. The guard wiring is asserted at the
+    // metadata level below instead.
+    controller = new AdminMemoriesController(
+      backfill as unknown as MemoryBackfillService,
+      settings as unknown as SystemSettingsService,
+    );
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['MEMORIES_ENABLED'];
+    else process.env['MEMORIES_ENABLED'] = originalEnv;
+  });
+
+  // -------------------------------------------------------------------------
+  describe('feature gate', () => {
+    it('400s and enqueues nothing when features.memories is off', async () => {
+      settings.getSettings.mockResolvedValue({ features: { memories: false } });
+
+      await expect(controller.backfill({} as never)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(backfill.backfillLibrary).not.toHaveBeenCalled();
+    });
+
+    it('400s when the settings flag is on but MEMORIES_ENABLED=false', async () => {
+      process.env['MEMORIES_ENABLED'] = 'false';
+
+      await expect(controller.backfill({} as never)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(backfill.backfillLibrary).not.toHaveBeenCalled();
+    });
+
+    it('400s when the features record is absent entirely', async () => {
+      settings.getSettings.mockResolvedValue({});
+
+      await expect(controller.backfill({} as never)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('enqueue', () => {
+    it('sweeps every circle when no circleId is given', async () => {
+      const response = await controller.backfill({} as never);
+
+      expect(backfill.backfillLibrary).toHaveBeenCalledWith({});
+      expect(response).toEqual({ data: { enqueued: 18, circles: 1, skipped: 0 } });
+    });
+
+    it('scopes the sweep to one circle when circleId is given', async () => {
+      await controller.backfill({ circleId: 'circle-a' } as never);
+
+      expect(backfill.backfillLibrary).toHaveBeenCalledWith({ circleId: 'circle-a' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('RBAC metadata', () => {
+    it('requires the Admin role and system_settings:write', () => {
+      const handler = AdminMemoriesController.prototype.backfill;
+      const roles = Reflect.getMetadata('roles', handler);
+      const permissions = Reflect.getMetadata('permissions', handler);
+
+      expect(roles).toEqual([ROLES.ADMIN]);
+      expect(permissions).toEqual([PERMISSIONS.SYSTEM_SETTINGS_WRITE]);
+    });
+  });
+});

--- a/apps/api/src/memories/admin/admin-memories.controller.ts
+++ b/apps/api/src/memories/admin/admin-memories.controller.ts
@@ -1,0 +1,87 @@
+// =============================================================================
+// Memories — admin library backfill endpoint (epic #300, issue #315)
+// =============================================================================
+//
+// `POST /api/admin/memories/backfill` — the one write the admin settings page
+// makes that is not a settings save.
+//
+// Guard style, response envelope and flag-off status code are copied verbatim
+// from the sibling global backfills (`POST /api/admin/bursts/backfill`,
+// `.../location-inference/backfill`): Admin role + `system_settings:write`,
+// 400 when the feature is globally disabled, `{ data: … }` envelope, 201.
+// =============================================================================
+
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { Auth } from '../../auth/decorators/auth.decorator';
+import { PERMISSIONS, ROLES } from '../../common/constants/roles.constants';
+import { isMemoriesEnabled } from '../../common/types/settings.types';
+import { SystemSettingsService } from '../../settings/system-settings/system-settings.service';
+import { MemoryBackfillService } from './memory-backfill.service';
+import { MEMORY_BACKFILL_SHARDS } from './memory-backfill.shards';
+
+const adminMemoriesBackfillSchema = z
+  .object({
+    /** Omit to sweep every circle in the deployment. */
+    circleId: z.string().uuid().optional(),
+    // .prefault({}) so a bodyless POST parses exactly like {} — see issue #289
+    // (app.module.ts) and admin-metadata.controller.ts.
+  })
+  .prefault({});
+class AdminMemoriesBackfillDto extends createZodDto(adminMemoriesBackfillSchema) {}
+
+@ApiTags('Admin — Memories')
+@ApiBearerAuth('JWT-auth')
+@Controller('admin/memories')
+export class AdminMemoriesController {
+  constructor(
+    private readonly backfillService: MemoryBackfillService,
+    private readonly systemSettingsService: SystemSettingsService,
+  ) {}
+
+  @Post('backfill')
+  @Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.SYSTEM_SETTINGS_WRITE] })
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Generate memories from the existing library (Admin)',
+    description:
+      'Enqueues the sharded `memory_generation` backfill plan for one circle ' +
+      `(\`circleId\`) or for every circle when omitted — ${MEMORY_BACKFILL_SHARDS.length} ` +
+      'background-priority jobs per circle, so no single job can approach the ' +
+      "worker's execution timeout on a large library. Circles that already have " +
+      'a `memory_generation` job pending or running are skipped and counted in ' +
+      '`skipped`. Idempotent and safe to re-run: every curator write is an ' +
+      'upsert keyed on (circleId, type, periodKey, subjectKey), and a memory a ' +
+      'user has deleted is never resurrected. Progress is observable in ' +
+      '/admin/settings/jobs under type=memory_generation.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Backfill jobs enqueued — `{ enqueued, circles, skipped }`',
+  })
+  @ApiResponse({ status: 400, description: 'Memories is disabled globally' })
+  @ApiResponse({ status: 404, description: 'The requested circle does not exist' })
+  async backfill(@Body() dto: AdminMemoriesBackfillDto) {
+    // isMemoriesEnabled(), not isFeatureEnabled('memories'): it folds in the
+    // MEMORIES_ENABLED env kill-switch, so a deployment that has hard-disabled
+    // the feature cannot be made to enqueue jobs its handler would no-op.
+    const settings = await this.systemSettingsService.getSettings();
+    if (!isMemoriesEnabled(settings)) {
+      throw new BadRequestException('Memories is disabled globally');
+    }
+
+    const result = await this.backfillService.backfillLibrary({
+      ...(dto.circleId ? { circleId: dto.circleId } : {}),
+    });
+    return { data: result };
+  }
+}

--- a/apps/api/src/memories/admin/memory-backfill.service.spec.ts
+++ b/apps/api/src/memories/admin/memory-backfill.service.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for MemoryBackfillService (epic #300, issue #315).
+ *
+ * The three properties worth pinning down here are the ones an admin actually
+ * depends on, and none of them is a curator's behaviour:
+ *
+ *  1. CHUNKING. A backfill must enqueue the whole shard plan per circle — one
+ *     job per On This Day month plus one per remaining curator — because a
+ *     single unsharded job can approach ENRICHMENT_JOB_TIMEOUT_MS on a 70k-item
+ *     library. Every row must carry `backfill: true`, background priority 100,
+ *     `skipDedup: true` and a divided AI-title cap.
+ *  2. IN-FLIGHT SKIPPING. A circle already generating is skipped and counted,
+ *     so the button is safe to double-click.
+ *  3. IT NEVER PARTIALLY FAILS THE SWEEP. One bad enqueue is logged and the
+ *     rest of the deployment still gets its backfill.
+ *
+ * No database: PrismaService and EnrichmentJobService are fully mocked, the
+ * same shape as MemoriesGenerationTask's spec.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { JobReason, JobStatus } from '@prisma/client';
+import { EnrichmentJobService } from '../../enrichment/enrichment-job.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MEMORY_GENERATION_JOB_TYPE } from '../memories-generation.task';
+import { MemoryBackfillService } from './memory-backfill.service';
+import {
+  MEMORY_BACKFILL_AI_TITLE_CAP_PER_SHARD,
+  MEMORY_BACKFILL_SHARDS,
+} from './memory-backfill.shards';
+
+const SHARDS = MEMORY_BACKFILL_SHARDS.length;
+
+describe('MemoryBackfillService', () => {
+  let service: MemoryBackfillService;
+  let prisma: {
+    circle: { findMany: jest.Mock; findUnique: jest.Mock };
+    enrichmentJob: { findMany: jest.Mock };
+  };
+  let enrichment: { enqueue: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      circle: {
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      enrichmentJob: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    enrichment = { enqueue: jest.fn().mockResolvedValue({ id: 'job-1' }) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemoryBackfillService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EnrichmentJobService, useValue: enrichment },
+      ],
+    }).compile();
+    module.useLogger(false);
+
+    service = module.get(MemoryBackfillService);
+  });
+
+  // -------------------------------------------------------------------------
+  describe('the shard plan', () => {
+    it('covers all twelve calendar months for on_this_day', () => {
+      const months = MEMORY_BACKFILL_SHARDS.filter((s) =>
+        s.curators.includes('on_this_day'),
+      ).flatMap((s) => [...(s.anchorMonths ?? [])]);
+
+      expect([...months].sort((a, b) => a - b)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+      ]);
+    });
+
+    it('gives every other curator exactly one shard and no month filter', () => {
+      const others = MEMORY_BACKFILL_SHARDS.filter((s) => !s.curators.includes('on_this_day'));
+
+      expect(others.map((s) => s.curators).flat().sort()).toEqual([
+        'person_highlights',
+        'person_over_years',
+        'seasonal',
+        'theme',
+        'trip',
+        'year_in_review',
+      ]);
+      expect(others.every((s) => s.anchorMonths === undefined)).toBe(true);
+    });
+
+    it('divides the AI-title budget rather than multiplying it', () => {
+      // The whole point of the division: a sharded backfill must not cost N x
+      // the per-job cap #306 chose.
+      expect(MEMORY_BACKFILL_AI_TITLE_CAP_PER_SHARD).toBeGreaterThanOrEqual(1);
+      expect(MEMORY_BACKFILL_AI_TITLE_CAP_PER_SHARD * SHARDS).toBeLessThanOrEqual(100);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('all circles', () => {
+    it('enqueues the whole shard plan for every circle', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'c1' }, { id: 'c2' }]);
+
+      const result = await service.backfillLibrary();
+
+      expect(result).toEqual({ enqueued: SHARDS * 2, circles: 2, skipped: 0 });
+      expect(enrichment.enqueue).toHaveBeenCalledTimes(SHARDS * 2);
+    });
+
+    it('enqueues background-priority, dedup-skipping backfill jobs', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'c1' }]);
+
+      await service.backfillLibrary();
+
+      for (const call of enrichment.enqueue.mock.calls) {
+        expect(call[0]).toMatchObject({
+          type: MEMORY_GENERATION_JOB_TYPE,
+          mediaItemId: null,
+          circleId: 'c1',
+          reason: JobReason.backfill,
+          priority: 100,
+          skipDedup: true,
+        });
+        expect(call[0].payload).toMatchObject({
+          backfill: true,
+          aiTitleCap: MEMORY_BACKFILL_AI_TITLE_CAP_PER_SHARD,
+        });
+        expect(Array.isArray(call[0].payload.curators)).toBe(true);
+      }
+    });
+
+    it('produces one on_this_day job per month', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'c1' }]);
+
+      await service.backfillLibrary();
+
+      const months = enrichment.enqueue.mock.calls
+        .map((call) => call[0].payload)
+        .filter((p: { curators: string[] }) => p.curators.includes('on_this_day'))
+        .flatMap((p: { anchorMonths?: number[] }) => p.anchorMonths ?? []);
+
+      expect(months).toHaveLength(12);
+      expect(new Set(months).size).toBe(12);
+    });
+
+    it('pages through circles with a keyset cursor', async () => {
+      // 100 is the page size — a full page must trigger a second read.
+      const page1 = Array.from({ length: 100 }, (_u, i) => ({ id: `c${i}` }));
+      prisma.circle.findMany
+        .mockResolvedValueOnce(page1)
+        .mockResolvedValueOnce([{ id: 'last' }]);
+
+      const result = await service.backfillLibrary();
+
+      expect(prisma.circle.findMany).toHaveBeenCalledTimes(2);
+      expect(prisma.circle.findMany.mock.calls[1]![0]).toMatchObject({
+        cursor: { id: 'c99' },
+        skip: 1,
+      });
+      expect(result.circles).toBe(101);
+    });
+
+    it('returns zeroes when there are no circles', async () => {
+      const result = await service.backfillLibrary();
+
+      expect(result).toEqual({ enqueued: 0, circles: 0, skipped: 0 });
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('in-flight skipping', () => {
+    it('skips a circle that already has a generation job pending or running', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'busy' }, { id: 'free' }]);
+      prisma.enrichmentJob.findMany.mockResolvedValueOnce([{ circleId: 'busy' }]);
+
+      const result = await service.backfillLibrary();
+
+      expect(result).toEqual({ enqueued: SHARDS, circles: 1, skipped: 1 });
+      expect(
+        enrichment.enqueue.mock.calls.every((call) => call[0].circleId === 'free'),
+      ).toBe(true);
+    });
+
+    it('checks in-flight jobs once per page, not once per circle', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }]);
+
+      await service.backfillLibrary();
+
+      expect(prisma.enrichmentJob.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.enrichmentJob.findMany.mock.calls[0]![0]).toMatchObject({
+        where: {
+          type: MEMORY_GENERATION_JOB_TYPE,
+          circleId: { in: ['c1', 'c2', 'c3'] },
+          status: { in: [JobStatus.pending, JobStatus.running] },
+        },
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('single circle', () => {
+    it('enqueues only that circle and never pages', async () => {
+      prisma.circle.findUnique.mockResolvedValueOnce({ id: 'c9' });
+
+      const result = await service.backfillLibrary({ circleId: 'c9' });
+
+      expect(result).toEqual({ enqueued: SHARDS, circles: 1, skipped: 0 });
+      expect(prisma.circle.findMany).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound for an unknown circle rather than reporting success', async () => {
+      prisma.circle.findUnique.mockResolvedValueOnce(null);
+
+      await expect(service.backfillLibrary({ circleId: 'nope' })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(enrichment.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('still honours the in-flight skip', async () => {
+      prisma.circle.findUnique.mockResolvedValueOnce({ id: 'c9' });
+      prisma.enrichmentJob.findMany.mockResolvedValueOnce([{ circleId: 'c9' }]);
+
+      const result = await service.backfillLibrary({ circleId: 'c9' });
+
+      expect(result).toEqual({ enqueued: 0, circles: 0, skipped: 1 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('failure isolation', () => {
+    it('keeps going when one shard enqueue throws', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'c1' }]);
+      enrichment.enqueue
+        .mockRejectedValueOnce(new Error('deadlock'))
+        .mockResolvedValue({ id: 'job' });
+
+      const result = await service.backfillLibrary();
+
+      expect(result).toEqual({ enqueued: SHARDS - 1, circles: 1, skipped: 0 });
+    });
+
+    it('does not count a circle whose every shard failed', async () => {
+      prisma.circle.findMany.mockResolvedValueOnce([{ id: 'c1' }]);
+      enrichment.enqueue.mockRejectedValue(new Error('down'));
+
+      const result = await service.backfillLibrary();
+
+      expect(result).toEqual({ enqueued: 0, circles: 0, skipped: 0 });
+    });
+  });
+});

--- a/apps/api/src/memories/admin/memory-backfill.service.ts
+++ b/apps/api/src/memories/admin/memory-backfill.service.ts
@@ -1,0 +1,180 @@
+// =============================================================================
+// Memories — admin library backfill (epic #300, issue #315)
+// =============================================================================
+//
+// Sweeps the EXISTING library so an admin who has just switched Memories on
+// gets years of memories immediately instead of waiting for the hourly cron to
+// trickle "today + tomorrow" in one day at a time.
+//
+// This service only ENQUEUES. Backfill semantics — every curator's widened
+// horizon — live in the curators themselves (#303–#305), keyed off
+// `payload.backfill`, so there is exactly one implementation of "what backfill
+// means" and this endpoint cannot drift from it.
+//
+// WHY IT IS NOT `MemoriesGenerationTask.sweep()`
+// ---------------------------------------------
+// The cron's sweep exists to enforce an INTERVAL ("has this circle generated in
+// the last N hours?"). A backfill is an explicit human instruction that must
+// run now regardless of when the circle last generated, and it enqueues a
+// sharded plan rather than one bare job. Reusing `sweep()` would have meant
+// threading two mutually exclusive modes through it; the two share the circle
+// paging shape and the per-circle in-flight guard, which is where the real
+// logic is, and nothing else.
+//
+// THREE PROPERTIES THIS SWEEP HAS TO KEEP
+// ---------------------------------------
+//  1. It never starves upload enrichment. Every row is priority 100 — the same
+//     background priority as the cron's — so face detection and auto-tagging
+//     (priority 0/10) are always claimed first, even mid-backfill.
+//  2. It is memory-safe on a large deployment: circles are keyset-paged 100 at
+//     a time and the in-flight check is one batched query per page, so a
+//     500-circle install costs a bounded number of round trips and never loads
+//     every circle at once.
+//  3. It is safe to re-run. A circle with a `memory_generation` job already
+//     pending or running is SKIPPED, not double-queued, so a double-clicked
+//     button does not enqueue 36 rows; and even if it did, every curator write
+//     is an idempotent upsert.
+// =============================================================================
+
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { JobReason, JobStatus } from '@prisma/client';
+import { EnrichmentJobService } from '../../enrichment/enrichment-job.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MEMORY_GENERATION_JOB_TYPE } from '../memories-generation.task';
+import { MEMORY_BACKFILL_SHARDS, memoryBackfillPayload } from './memory-backfill.shards';
+
+/** Circles fetched per keyset page — the sweep never loads them all at once. */
+const CIRCLE_PAGE_SIZE = 100;
+
+/** Background priority: never starve upload enrichment (rerun=0, upload=10). */
+const MEMORY_BACKFILL_PRIORITY = 100;
+
+/** Response body of `POST /api/admin/memories/backfill`. */
+export interface MemoryBackfillResult {
+  /**
+   * Job ROWS created. One circle contributes `MEMORY_BACKFILL_SHARDS.length`
+   * rows, not one — see `memory-backfill.shards.ts` for why the work is split.
+   */
+  enqueued: number;
+  /** Circles the backfill enqueued jobs for. */
+  circles: number;
+  /** Circles skipped because a `memory_generation` job was already in flight. */
+  skipped: number;
+}
+
+@Injectable()
+export class MemoryBackfillService {
+  private readonly logger = new Logger(MemoryBackfillService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly enrichmentJobService: EnrichmentJobService,
+  ) {}
+
+  /**
+   * Enqueue the sharded backfill plan for one circle, or for every circle when
+   * `circleId` is omitted.
+   *
+   * The caller (AdminMemoriesController) has already rejected the request when
+   * the feature is disabled — this method assumes the gate passed, exactly like
+   * the sibling admin backfill services.
+   */
+  async backfillLibrary(opts: { circleId?: string } = {}): Promise<MemoryBackfillResult> {
+    const result: MemoryBackfillResult = { enqueued: 0, circles: 0, skipped: 0 };
+
+    if (opts.circleId) {
+      const circle = await this.prisma.circle.findUnique({
+        where: { id: opts.circleId },
+        select: { id: true },
+      });
+      // 404 rather than a silent no-op: an admin who mistypes a circle id must
+      // not get back a cheerful `{ enqueued: 0 }` that reads like success.
+      if (!circle) {
+        throw new NotFoundException(`Circle ${opts.circleId} not found`);
+      }
+      await this.processPage([circle.id], result);
+    } else {
+      let cursor: string | undefined;
+      for (;;) {
+        const circles = await this.prisma.circle.findMany({
+          select: { id: true },
+          orderBy: { id: 'asc' },
+          take: CIRCLE_PAGE_SIZE,
+          ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+        });
+        if (circles.length === 0) break;
+
+        const circleIds = circles.map((c) => c.id);
+        await this.processPage(circleIds, result);
+
+        if (circles.length < CIRCLE_PAGE_SIZE) break;
+        cursor = circleIds[circleIds.length - 1]!;
+      }
+    }
+
+    this.logger.log(
+      `Memories library backfill: ${result.enqueued} job(s) enqueued across ` +
+        `${result.circles} circle(s), ${result.skipped} skipped (already in flight)`,
+    );
+    return result;
+  }
+
+  /** Enqueue the shard plan for every non-busy circle in one keyset page. */
+  private async processPage(circleIds: string[], result: MemoryBackfillResult): Promise<void> {
+    // ONE batched read per page rather than one per circle. This is the same
+    // guard the cron uses, and it is what makes the endpoint safe to double-
+    // click: a circle already being generated is left alone.
+    const inFlight = await this.prisma.enrichmentJob.findMany({
+      where: {
+        type: MEMORY_GENERATION_JOB_TYPE,
+        circleId: { in: circleIds },
+        status: { in: [JobStatus.pending, JobStatus.running] },
+      },
+      select: { circleId: true },
+    });
+    const busy = new Set(
+      inFlight.map((job) => job.circleId).filter((id): id is string => !!id),
+    );
+
+    for (const circleId of circleIds) {
+      if (busy.has(circleId)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      let enqueuedForCircle = 0;
+      for (const shard of MEMORY_BACKFILL_SHARDS) {
+        try {
+          await this.enrichmentJobService.enqueue({
+            type: MEMORY_GENERATION_JOB_TYPE,
+            mediaItemId: null,
+            circleId,
+            reason: JobReason.backfill,
+            priority: MEMORY_BACKFILL_PRIORITY,
+            payload: memoryBackfillPayload(shard),
+            // MANDATORY, and for two reasons here. Global-job dedup keys on
+            // `(type, mediaItemId IS NULL)` SYSTEM-WIDE, so without it the very
+            // first shard would swallow the other 17 — and every other circle's
+            // as well. The correctly-scoped replacement is the per-circle
+            // in-flight check above.
+            skipDedup: true,
+          });
+          enqueuedForCircle += 1;
+        } catch (err) {
+          // A per-shard failure is logged and skipped, never fatal: one bad
+          // insert must not cost the rest of the deployment its backfill, and
+          // the shards that did land are independently useful.
+          this.logger.warn(
+            `memory_generation backfill enqueue failed for circle ${circleId} ` +
+              `shard "${shard.label}": ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      if (enqueuedForCircle > 0) {
+        result.circles += 1;
+        result.enqueued += enqueuedForCircle;
+      }
+    }
+  }
+}

--- a/apps/api/src/memories/admin/memory-backfill.shards.ts
+++ b/apps/api/src/memories/admin/memory-backfill.shards.ts
@@ -1,0 +1,130 @@
+// =============================================================================
+// Memories — library backfill shard plan (epic #300, issue #315)
+// =============================================================================
+//
+// WHY A BACKFILL IS SHARDED AT ALL
+// --------------------------------
+// A scheduled `memory_generation` job is small by construction: On This Day
+// curates two anchor days, Trips looks back `lookbackMonths`, the people/theme
+// curators only touch the current and previous year. A BACKFILL deliberately
+// removes every one of those horizons — that is what makes a 70k-item library
+// light up with years of memories on day one — and the result is a single job
+// whose work is proportional to the whole library.
+//
+// The worst offender is On This Day: up to 366 anchor days × `lookbackYears`
+// curations, each a query plus a scored selection plus an upsert. #303 shipped
+// that as ONE job and explicitly deferred chunking here, noting it can approach
+// `ENRICHMENT_JOB_TIMEOUT_MS` (10 minutes by default). A job killed by that
+// timeout is not just slow — it burns an attempt, and after
+// `ENRICHMENT_MAX_ATTEMPTS` the backfill fails permanently having produced only
+// whatever the first few minutes managed each time.
+//
+// So the backfill is split into bounded units, following the precedent set by
+// `duplicate_detection_batch` (100 media items per job, chosen specifically to
+// stay under the worker's stuck-job reset threshold). Every shard is a normal
+// `memory_generation` row: retryable, observable in /admin/settings/jobs,
+// claimable by any worker slot, and idempotent — a shard that fails and retries
+// re-does only its own slice, because every curator write is an upsert keyed on
+// `(circleId, type, periodKey, subjectKey)`.
+//
+// THE SHARD AXES, AND WHY THEY DIFFER PER CURATOR
+// -----------------------------------------------
+//  • On This Day is sharded BY CALENDAR MONTH (12 shards). Its cost scales with
+//    the number of distinct (month, day) pairs the circle has photos on, and a
+//    month is the natural bounded slice of that: at most 31 anchors × the
+//    lookback years per shard. Nothing else needs an intra-curator split.
+//  • Every other curator gets ITS OWN shard. Their backfills are bounded by
+//    period count (years, seasons) or subject count (people, tags) rather than
+//    by 366 calendar days, and one job each already bounds them well below the
+//    timeout while buying per-type error isolation and letting several worker
+//    slots run different types in parallel.
+//
+// Deliberately NOT sharded further by year/person/tag: that would multiply job
+// rows for slices whose individual cost is already small, and each extra shard
+// re-pays that curator's census query. Month-per-shard is the one place the
+// arithmetic actually demanded it.
+//
+// WHY THE AI-TITLE BUDGET IS DIVIDED
+// ----------------------------------
+// #306's `BACKFILL_AI_TITLE_CAP` is a per-JOB ceiling, so N shards would
+// silently become an N× larger bill for one admin click. The planner hands each
+// shard `cap / shards` instead, keeping a sharded backfill's provider spend at
+// roughly the unsharded figure the cap was chosen for. Every scheduled run
+// afterwards gets a fresh, uncapped budget, so the library still converges on
+// AI titles over time — which is exactly the convergence #306 designed for.
+// =============================================================================
+
+import { BACKFILL_AI_TITLE_CAP } from '../titles/memory-title.service';
+import { MemoryGenerationPayload } from '../memory-generation.payload';
+
+/** One bounded unit of a circle's library backfill. */
+export interface MemoryBackfillShard {
+  /** Stable identifier, used only in logs. */
+  readonly label: string;
+  /** Curator names this shard runs. */
+  readonly curators: readonly string[];
+  /** On This Day only: the calendar months this shard's anchors come from. */
+  readonly anchorMonths?: readonly number[];
+}
+
+/** Curators that are cheap enough to backfill in one shard each. */
+const SINGLE_SHARD_CURATORS = [
+  'trip',
+  'person_highlights',
+  'person_over_years',
+  'theme',
+  'seasonal',
+  'year_in_review',
+] as const;
+
+/**
+ * The full shard plan for ONE circle: 12 On This Day months + one shard per
+ * remaining curator = 18 `memory_generation` rows.
+ *
+ * Order matters — it is the order the rows are created in, and the queue claims
+ * equal-priority jobs oldest-first, so the calendar months (the content users
+ * see on Home first) run before the long-tail types.
+ */
+export const MEMORY_BACKFILL_SHARDS: readonly MemoryBackfillShard[] = [
+  ...Array.from({ length: 12 }, (_unused, index): MemoryBackfillShard => {
+    const month = index + 1;
+    return {
+      label: `on_this_day:month-${month}`,
+      curators: ['on_this_day'],
+      anchorMonths: [month],
+    };
+  }),
+  ...SINGLE_SHARD_CURATORS.map((name): MemoryBackfillShard => ({
+    label: name,
+    curators: [name],
+  })),
+];
+
+/**
+ * Per-shard slice of #306's backfill AI-titling budget.
+ *
+ * Floored at 1 so a plan with more shards than the cap still lets every shard
+ * title at least one memory rather than silently disabling AI titles wholesale.
+ */
+export const MEMORY_BACKFILL_AI_TITLE_CAP_PER_SHARD = Math.max(
+  1,
+  Math.floor(BACKFILL_AI_TITLE_CAP / MEMORY_BACKFILL_SHARDS.length),
+);
+
+/**
+ * The payload for one shard, ready to hand to `EnrichmentJobService.enqueue`.
+ *
+ * Returned as `MemoryGenerationPayload & Record<string, unknown>` because
+ * `enqueue()` types `payload` as an open record (it is JSONB) while the shape
+ * above is a closed interface, which TypeScript will not widen on its own.
+ */
+export function memoryBackfillPayload(
+  shard: MemoryBackfillShard,
+): MemoryGenerationPayload & Record<string, unknown> {
+  return {
+    backfill: true,
+    curators: [...shard.curators],
+    ...(shard.anchorMonths ? { anchorMonths: [...shard.anchorMonths] } : {}),
+    aiTitleCap: MEMORY_BACKFILL_AI_TITLE_CAP_PER_SHARD,
+  };
+}

--- a/apps/api/src/memories/curators/memory-curator.interface.ts
+++ b/apps/api/src/memories/curators/memory-curator.interface.ts
@@ -41,6 +41,18 @@ export interface MemoryCuratorContext {
    */
   backfill: boolean;
   /**
+   * #315 backfill sharding: restrict the On This Day curator's anchor set to
+   * these calendar months (1–12).
+   *
+   * Absent means "every month", which is what a scheduled run and an unsharded
+   * backfill both do. It lives on the shared context rather than on a curator-
+   * specific options object because the context is already the one channel
+   * from `job.payload` to a curator, and only one curator reads it — inventing
+   * a per-curator payload envelope for a single field would cost more than it
+   * bought. A curator that does not shard by month simply ignores it.
+   */
+  anchorMonths?: number[];
+  /**
    * The run's AI-titling budget and circuit breaker (#306), created ONCE by the
    * handler and shared by every curator so a provider rate limit stops the
    * whole job's titling and a backfill's 100-call cap is job-wide rather than

--- a/apps/api/src/memories/curators/memory-curators.provider.spec.ts
+++ b/apps/api/src/memories/curators/memory-curators.provider.spec.ts
@@ -10,6 +10,7 @@
  * decides what a timed-out job has produced) is the intended one.
  */
 
+import { MEMORY_BACKFILL_SHARDS } from '../admin/memory-backfill.shards';
 import { MEMORY_CURATORS } from './memory-curator.interface';
 import { memoryCuratorsProvider } from './memory-curators.provider';
 import { OnThisDayCurator } from './on-this-day.curator';
@@ -62,5 +63,44 @@ describe('memoryCuratorsProvider', () => {
       YearInReviewCurator,
     ]);
     expect(memoryCuratorsProvider.provide).toBe(MEMORY_CURATORS);
+  });
+
+  // #315: the backfill shard plan names curators as STRINGS in a job payload,
+  // and the handler treats an unknown name as a no-op (a payload from another
+  // release must not poison the queue). That safety valve is also a silent
+  // failure: renaming a curator would leave its shard enqueuing a job that
+  // curates nothing, forever, with only a log line to show for it. Pinning the
+  // two together here is the only place that would notice.
+  it('covers every registered curator exactly once across the backfill shard plan', () => {
+    const registered = memoryCuratorsProvider
+      .useFactory(
+        stub('on_this_day') as never,
+        stub('trip') as never,
+        stub('person_highlights') as never,
+        stub('person_over_years') as never,
+        stub('theme') as never,
+        stub('seasonal') as never,
+        stub('year_in_review') as never,
+      )
+      .map((c) => c.name);
+
+    const sharded = MEMORY_BACKFILL_SHARDS.flatMap((shard) => [...shard.curators]);
+
+    // Every curator is reachable from a backfill...
+    expect(new Set(sharded)).toEqual(new Set(registered));
+    // ...and no shard names a curator that does not exist.
+    for (const name of sharded) {
+      expect(registered).toContain(name);
+    }
+    // On This Day is the only type split across shards (by calendar month);
+    // every other type appears exactly once.
+    const counts = sharded.reduce<Record<string, number>>((acc, name) => {
+      acc[name] = (acc[name] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(counts['on_this_day']).toBe(12);
+    for (const name of registered.filter((n) => n !== 'on_this_day')) {
+      expect(counts[name]).toBe(1);
+    }
   });
 });

--- a/apps/api/src/memories/curators/on-this-day-anchors.spec.ts
+++ b/apps/api/src/memories/curators/on-this-day-anchors.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for OnThisDayCurator's anchor resolution (epic #300, issue #315).
+ *
+ * Anchor selection is the axis a library backfill is sharded along, so it is
+ * worth pinning down directly:
+ *
+ *  • a SCHEDULED run resolves today + tomorrow and never touches the DISTINCT
+ *    scan, so nothing about sharding leaks into the hourly cron;
+ *  • a full backfill scans every month;
+ *  • a SHARDED backfill pushes its month filter into SQL rather than filtering
+ *    the result set, which is what stops twelve shards from each scanning the
+ *    whole circle.
+ *
+ * PrismaService and MemoryCurationService are mocked — this asserts the query
+ * that is built and the anchors that come out of it, not the database.
+ */
+
+import { Prisma } from '@prisma/client';
+import { MemoryCurationService } from '../curation/memory-curation.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { DEFAULT_SYSTEM_SETTINGS, MemoriesSettingsValue } from '../../common/types/settings.types';
+import { OnThisDayCurator } from './on-this-day.curator';
+import { MemoryCuratorContext } from './memory-curator.interface';
+
+const SETTINGS = DEFAULT_SYSTEM_SETTINGS.memories as MemoriesSettingsValue;
+
+function makeContext(over: Partial<MemoryCuratorContext> = {}): MemoryCuratorContext {
+  return {
+    circleId: '11111111-1111-1111-1111-111111111111',
+    settings: SETTINGS,
+    now: new Date('2026-08-09T12:00:00.000Z'),
+    backfill: false,
+    ...over,
+  };
+}
+
+describe('OnThisDayCurator — anchor resolution', () => {
+  let curator: OnThisDayCurator;
+  let queryRaw: jest.Mock;
+
+  /** The anchor `periodKey`s the curator ended up curating, in order. */
+  let curatedPeriodKeys: string[];
+
+  beforeEach(() => {
+    curatedPeriodKeys = [];
+    queryRaw = jest.fn();
+
+    const prisma = { $queryRaw: queryRaw } as unknown as PrismaService;
+    const curation = {
+      // Every anchor's per-year query returns nothing, so `curateAnchor` exits
+      // early — the anchor SET is what this spec is about.
+      curate: jest.fn(),
+      upsertMemory: jest.fn(),
+    } as unknown as MemoryCurationService;
+
+    curator = new OnThisDayCurator(prisma, curation);
+
+    // First call per anchor is the DISTINCT month/day scan (backfill only);
+    // every subsequent one is that anchor's per-year id query.
+    queryRaw.mockImplementation((sql: Prisma.Sql) => {
+      const text = sql.text ?? '';
+      if (text.includes('SELECT DISTINCT')) return Promise.resolve([]);
+      curatedPeriodKeys.push('anchor');
+      return Promise.resolve([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  it('SCHEDULED: resolves today + tomorrow without the DISTINCT scan', async () => {
+    await curator.run(makeContext());
+
+    const statements = queryRaw.mock.calls.map((call) => (call[0] as Prisma.Sql).text ?? '');
+    expect(statements.some((s) => s.includes('SELECT DISTINCT'))).toBe(false);
+    // One per-anchor query for today, one for tomorrow.
+    expect(statements).toHaveLength(2);
+  });
+
+  // -------------------------------------------------------------------------
+  it('BACKFILL: scans every month when no shard filter is present', async () => {
+    queryRaw.mockImplementationOnce(() => Promise.resolve([{ month: 3, day: 14 }]));
+
+    await curator.run(makeContext({ backfill: true }));
+
+    const distinct = queryRaw.mock.calls[0]![0] as Prisma.Sql;
+    expect(distinct.text).toContain('SELECT DISTINCT');
+    expect(distinct.text).not.toContain('IN (');
+    // Only the circle id is bound — no month parameters.
+    expect(distinct.values).toEqual(['11111111-1111-1111-1111-111111111111']);
+  });
+
+  // -------------------------------------------------------------------------
+  it('SHARDED BACKFILL: pushes the month filter into SQL', async () => {
+    queryRaw.mockImplementationOnce(() => Promise.resolve([{ month: 7, day: 4 }]));
+
+    await curator.run(makeContext({ backfill: true, anchorMonths: [7] }));
+
+    const distinct = queryRaw.mock.calls[0]![0] as Prisma.Sql;
+    expect(distinct.text).toContain('EXTRACT(MONTH');
+    expect(distinct.text).toContain('IN (');
+    // Bound as a parameter, not interpolated — the month reaches SQL as data.
+    expect(distinct.values).toContain(7);
+  });
+
+  // -------------------------------------------------------------------------
+  it('SHARDED BACKFILL: an empty month list means "no restriction"', async () => {
+    queryRaw.mockImplementationOnce(() => Promise.resolve([]));
+
+    await curator.run(makeContext({ backfill: true, anchorMonths: [] }));
+
+    const distinct = queryRaw.mock.calls[0]![0] as Prisma.Sql;
+    expect(distinct.text).not.toContain('IN (');
+  });
+
+  // -------------------------------------------------------------------------
+  it('BACKFILL: maps each (month, day) to its NEXT occurrence, deduplicated', async () => {
+    // March 14 is behind "now" (2026-08-09) and must roll to 2027; August 9 is
+    // today and must stay. A day listed twice must not produce two anchors.
+    queryRaw.mockImplementationOnce(() =>
+      Promise.resolve([
+        { month: 3, day: 14 },
+        { month: 8, day: 9 },
+        { month: 3, day: 14 },
+      ]),
+    );
+
+    await curator.run(makeContext({ backfill: true }));
+
+    // One DISTINCT scan + one per-anchor query per unique anchor.
+    expect(queryRaw).toHaveBeenCalledTimes(3);
+    const perAnchor = queryRaw.mock.calls.slice(1).map((call) => call[0] as Prisma.Sql);
+    // Anchors are sorted ascending, so 2026-08-09 precedes 2027-03-14.
+    expect(perAnchor[0]!.values).toContain(8);
+    expect(perAnchor[1]!.values).toContain(3);
+  });
+
+  // -------------------------------------------------------------------------
+  it('BACKFILL: an empty library produces no anchors and no further queries', async () => {
+    queryRaw.mockImplementationOnce(() => Promise.resolve([]));
+
+    const result = await curator.run(makeContext({ backfill: true }));
+
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ created: 0, refreshed: 0, skipped: 0, tombstoned: 0 });
+  });
+});

--- a/apps/api/src/memories/curators/on-this-day.curator.ts
+++ b/apps/api/src/memories/curators/on-this-day.curator.ts
@@ -140,6 +140,12 @@ export class OnThisDayCurator implements MemoryCurator {
    * backfilled memory's `periodKey` and `expiresAt` describe a day that is still
    * ahead, rather than a day that has already passed (which would make the row
    * born expired and immediately purge-eligible).
+   *
+   * `ctx.anchorMonths` narrows that backfill set to one calendar month, which
+   * is the axis #315 shards a library backfill along — see
+   * `admin/memory-backfill.shards.ts`. The filter is pushed into SQL rather
+   * than applied to the result set so each shard's DISTINCT scan reads only its
+   * own month instead of the whole circle twelve times over.
    */
   private async resolveAnchors(ctx: MemoryCuratorContext): Promise<Date[]> {
     if (!ctx.backfill) {
@@ -147,7 +153,13 @@ export class OnThisDayCurator implements MemoryCurator {
       return [today, new Date(today.getTime() + MS_PER_DAY)];
     }
 
-    // At most 366 rows — one per calendar day the circle has any candidate on.
+    const months = ctx.anchorMonths?.length ? ctx.anchorMonths : null;
+    const monthFilter = months
+      ? Prisma.sql`AND EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC'))::int IN (${Prisma.join(months)})`
+      : Prisma.empty;
+
+    // At most 366 rows — one per calendar day the circle has any candidate on
+    // (at most 31 when this is one shard of a sharded backfill).
     const pairs = await this.prisma.$queryRaw<Array<{ month: number; day: number }>>(Prisma.sql`
       SELECT DISTINCT
         EXTRACT(MONTH FROM ("captured_at" AT TIME ZONE 'UTC'))::int AS month,
@@ -158,6 +170,7 @@ export class OnThisDayCurator implements MemoryCurator {
         AND "archived_at" IS NULL
         AND "captured_at" IS NOT NULL
         AND "social_media_source" IS NULL
+        ${monthFilter}
     `);
 
     const byKey = new Map<string, Date>();

--- a/apps/api/src/memories/memories.module.ts
+++ b/apps/api/src/memories/memories.module.ts
@@ -33,6 +33,8 @@ import { MemoryDigestService } from './digest/memory-digest.service';
 import { MemoryDigestHandler } from './digest/memory-digest.handler';
 import { MemoryDigestTask } from './digest/memory-digest.task';
 import { PublicMemoryDigestController } from './digest/public-memory-digest.controller';
+import { AdminMemoriesController } from './admin/admin-memories.controller';
+import { MemoryBackfillService } from './admin/memory-backfill.service';
 import { MemoriesController } from './api/memories.controller';
 import { MemoriesService } from './api/memories.service';
 import { MemoryTitleService } from './titles/memory-title.service';
@@ -83,9 +85,15 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
     EmailModule,
     StorageProvidersModule,
   ],
-  controllers: [MemoriesController, PublicMemoryDigestController],
+  // #315's AdminMemoriesController is mounted here rather than in a separate
+  // admin module: it needs MemoryBackfillService and MEMORY_GENERATION_JOB_TYPE,
+  // both of which live in this module, and every other feature's admin backfill
+  // controller (AdminBurstController, AdminLocationInferenceController) sits in
+  // its own feature module for the same reason.
+  controllers: [MemoriesController, AdminMemoriesController, PublicMemoryDigestController],
   providers: [
     MemoriesService,
+    MemoryBackfillService,
     MemoriesNotificationService,
     MemoryDigestService,
     MemoryDigestHandler,
@@ -105,6 +113,7 @@ import { memoryCuratorsProvider } from './curators/memory-curators.provider';
   ],
   exports: [
     MemoriesGenerationTask,
+    MemoryBackfillService,
     MemoryCurationService,
     MemoriesService,
     MemoryDigestTask,

--- a/apps/api/src/memories/memory-generation.handler.spec.ts
+++ b/apps/api/src/memories/memory-generation.handler.spec.ts
@@ -276,6 +276,89 @@ describe('MemoryGenerationHandler', () => {
     expect(titles.beginRun).toHaveBeenCalledWith({ backfill: true, aiTitlesEnabled: true });
   });
 
+  // --- #315: backfill sharding ----------------------------------------------
+  //
+  // A library backfill is split into bounded jobs so no single one approaches
+  // ENRICHMENT_JOB_TIMEOUT_MS. The handler's half of that contract is honouring
+  // the shard descriptor in the payload — and, just as importantly, behaving
+  // exactly as before when there isn't one.
+
+  it('SHARDING: runs only the curators named in the payload', async () => {
+    const otd = fakeCurator('on_this_day');
+    const trip = fakeCurator('trip');
+    const theme = fakeCurator('theme');
+    await build([otd, trip, theme]);
+
+    await handler.process(
+      makeJob({ payload: { backfill: true, curators: ['on_this_day', 'theme'] } as never }),
+    );
+
+    expect(otd.run).toHaveBeenCalled();
+    expect(theme.run).toHaveBeenCalled();
+    expect(trip.run).not.toHaveBeenCalled();
+    // A curator outside the shard must not even have its retention tail run —
+    // another shard owns that type entirely.
+    expect(trip.purge).not.toHaveBeenCalled();
+  });
+
+  it('SHARDING: an absent curator list still runs the whole registry', async () => {
+    const a = fakeCurator('a');
+    const b = fakeCurator('b');
+    await build([a, b]);
+
+    await handler.process(makeJob());
+
+    expect(a.run).toHaveBeenCalled();
+    expect(b.run).toHaveBeenCalled();
+  });
+
+  it('SHARDING: an unknown curator name is a logged no-op, not a failure', async () => {
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
+
+    // A payload written by another release must never poison the queue.
+    await expect(
+      handler.process(makeJob({ payload: { backfill: true, curators: ['nope'] } as never })),
+    ).resolves.toBeUndefined();
+    expect(curator.run).not.toHaveBeenCalled();
+  });
+
+  it('SHARDING: passes anchorMonths through to the curator context', async () => {
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
+
+    await handler.process(
+      makeJob({
+        payload: { backfill: true, curators: ['on_this_day'], anchorMonths: [7] } as never,
+      }),
+    );
+
+    expect(curator.run.mock.calls[0]![0].anchorMonths).toEqual([7]);
+  });
+
+  it('SHARDING: a scheduled run carries no anchorMonths at all', async () => {
+    const curator = fakeCurator('on_this_day');
+    await build([curator]);
+
+    await handler.process(makeJob());
+
+    expect(curator.run.mock.calls[0]![0].anchorMonths).toBeUndefined();
+  });
+
+  it('SHARDING: forwards the shard AI-title cap to beginRun', async () => {
+    const curator = fakeCurator('a');
+    await build([curator]);
+
+    await handler.process(makeJob({ payload: { backfill: true, aiTitleCap: 5 } as never }));
+
+    // Divided, not multiplied: N shards must not cost N x #306's per-job cap.
+    expect(titles.beginRun).toHaveBeenCalledWith({
+      backfill: true,
+      aiTitlesEnabled: true,
+      maxAiCalls: 5,
+    });
+  });
+
   // --- #311: the memories_ready notification hook ---------------------------
 
   it('NOTIFY: fires memories_ready once with the run-wide created total', async () => {

--- a/apps/api/src/memories/memory-generation.handler.ts
+++ b/apps/api/src/memories/memory-generation.handler.ts
@@ -31,6 +31,7 @@ import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.regi
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { isMemoriesEnabled } from '../common/types/settings.types';
 import { resolveMemoriesSettings } from './memories-settings.util';
+import { parseMemoryGenerationPayload } from './memory-generation.payload';
 import { MemoriesNotificationService } from './notifications/memories-notification.service';
 import { MemoryTitleService } from './titles/memory-title.service';
 import {
@@ -38,12 +39,6 @@ import {
   MemoryCurator,
   MemoryCuratorContext,
 } from './curators/memory-curator.interface';
-
-/** Payload shape for a `memory_generation` job. */
-interface MemoryGenerationPayload {
-  /** Admin library backfill (#315): widen curators past "what matters today". */
-  backfill?: boolean;
-}
 
 @Injectable()
 export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit {
@@ -87,16 +82,20 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
       return;
     }
 
-    const payload = (job.payload as unknown as MemoryGenerationPayload | null) ?? {};
+    const payload = parseMemoryGenerationPayload(job.payload);
     const memoriesSettings = resolveMemoriesSettings(settings.memories);
     // ONE titling budget for the whole job (#306), shared by every curator: a
     // provider rate limit must stop titling for the rest of the run, and a
-    // backfill's 100-call cap is job-wide, not per curator. It is created here
+    // backfill's call cap is job-wide, not per curator. It is created here
     // rather than held on MemoryTitleService because that service is a
     // singleton and several `memory_generation` jobs can run concurrently.
+    //
+    // `payload.aiTitleCap` is #315's shard slice of that cap: a backfill split
+    // across N jobs would otherwise multiply the per-job ceiling by N.
     const titling = this.titles.beginRun({
       backfill: payload.backfill === true,
       aiTitlesEnabled: memoriesSettings.aiTitles.enabled,
+      ...(payload.aiTitleCap !== undefined ? { maxAiCalls: payload.aiTitleCap } : {}),
     });
     const ctx: MemoryCuratorContext = {
       circleId: job.circleId,
@@ -106,7 +105,24 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
       // not have curator A anchoring on today and curator B on tomorrow.
       now: new Date(),
       backfill: payload.backfill === true,
+      ...(payload.anchorMonths ? { anchorMonths: payload.anchorMonths } : {}),
     };
+
+    // #315 sharding: a backfill is split into bounded jobs, each naming the
+    // curators it owns. An absent/empty list means "every enabled curator",
+    // which is what every scheduled run does. An unknown name matches nothing
+    // and is logged rather than thrown — a payload written by another release
+    // must never poison the queue.
+    const selected = payload.curators
+      ? this.curators.filter((curator) => payload.curators!.includes(curator.name))
+      : this.curators;
+    if (payload.curators && selected.length === 0) {
+      this.logger.warn(
+        `memory_generation job ${job.id} names no known curator ` +
+          `(${payload.curators.join(', ')}); nothing to run`,
+      );
+      return;
+    }
 
     let created = 0;
     let refreshed = 0;
@@ -114,7 +130,7 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
     let purged = 0;
     let failed = 0;
 
-    for (const curator of this.curators) {
+    for (const curator of selected) {
       if (!curator.isEnabled(ctx.settings)) continue;
 
       try {
@@ -178,6 +194,10 @@ export class MemoryGenerationHandler implements EnrichmentHandler, OnModuleInit 
       jobId: job.id,
       circleId: ctx.circleId,
       backfill: ctx.backfill,
+      // #315: which shard of a sharded backfill this row was. Absent on a
+      // scheduled run, which always runs the whole registry.
+      curators: payload.curators ?? null,
+      anchorMonths: payload.anchorMonths ?? null,
       created,
       refreshed,
       tombstoned,

--- a/apps/api/src/memories/memory-generation.payload.spec.ts
+++ b/apps/api/src/memories/memory-generation.payload.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for parseMemoryGenerationPayload (epic #300, issue #315).
+ *
+ * `EnrichmentJob.payload` is JSONB: it can be null (every scheduled run), hand-
+ * edited from /admin/settings/jobs, or written by a different release. The
+ * parser's whole contract is that NOTHING in it throws and every malformed
+ * field degrades to "absent" — which means the full, unsharded behaviour, i.e.
+ * doing more work rather than less. That is the safe direction: a job that runs
+ * every curator is merely slower, whereas one that silently runs none would
+ * leave an admin's backfill looking complete while producing nothing.
+ */
+
+import { parseMemoryGenerationPayload } from './memory-generation.payload';
+
+describe('parseMemoryGenerationPayload', () => {
+  it.each([null, undefined, 'string', 42, [], true])(
+    'treats a non-object payload (%p) as a scheduled, unsharded run',
+    (raw) => {
+      expect(parseMemoryGenerationPayload(raw)).toEqual({});
+    },
+  );
+
+  it('reports backfill: false for an object payload that omits it', () => {
+    expect(parseMemoryGenerationPayload({})).toEqual({ backfill: false });
+  });
+
+  it('reads a full shard payload', () => {
+    expect(
+      parseMemoryGenerationPayload({
+        backfill: true,
+        curators: ['on_this_day'],
+        anchorMonths: [3],
+        aiTitleCap: 5,
+      }),
+    ).toEqual({
+      backfill: true,
+      curators: ['on_this_day'],
+      anchorMonths: [3],
+      aiTitleCap: 5,
+    });
+  });
+
+  it('requires backfill to be literally true', () => {
+    expect(parseMemoryGenerationPayload({ backfill: 'yes' }).backfill).toBe(false);
+    expect(parseMemoryGenerationPayload({ backfill: 1 }).backfill).toBe(false);
+  });
+
+  it('drops non-string curator names and an empty list', () => {
+    expect(parseMemoryGenerationPayload({ curators: [1, null, 'trip'] }).curators).toEqual([
+      'trip',
+    ]);
+    // Empty means "no restriction", not "run nothing".
+    expect(parseMemoryGenerationPayload({ curators: [] }).curators).toBeUndefined();
+    expect(parseMemoryGenerationPayload({ curators: 'trip' }).curators).toBeUndefined();
+  });
+
+  it('drops out-of-range and non-integer months', () => {
+    expect(
+      parseMemoryGenerationPayload({ anchorMonths: [0, 1, 12, 13, 6.5, '3'] }).anchorMonths,
+    ).toEqual([1, 12]);
+    expect(parseMemoryGenerationPayload({ anchorMonths: [99] }).anchorMonths).toBeUndefined();
+  });
+
+  it('floors a fractional AI cap and rejects a negative or non-numeric one', () => {
+    expect(parseMemoryGenerationPayload({ aiTitleCap: 5.9 }).aiTitleCap).toBe(5);
+    expect(parseMemoryGenerationPayload({ aiTitleCap: 0 }).aiTitleCap).toBe(0);
+    expect(parseMemoryGenerationPayload({ aiTitleCap: -1 }).aiTitleCap).toBeUndefined();
+    expect(parseMemoryGenerationPayload({ aiTitleCap: 'lots' }).aiTitleCap).toBeUndefined();
+  });
+});

--- a/apps/api/src/memories/memory-generation.payload.ts
+++ b/apps/api/src/memories/memory-generation.payload.ts
@@ -1,0 +1,93 @@
+// =============================================================================
+// Memories — the `memory_generation` job payload (epic #300, issues #302 + #315)
+// =============================================================================
+//
+// Kept in its own dependency-free module so the admin backfill planner (which
+// WRITES payloads) and the generation handler (which READS them) agree on one
+// shape without either importing the other.
+//
+// A scheduled run writes NO payload at all: every field here is optional and
+// every absent field means "the whole, unsharded, non-backfill behaviour". The
+// hourly cron therefore keeps enqueuing bare rows exactly as it did in #302 and
+// nothing about the sharding below leaks into it.
+// =============================================================================
+
+/** Payload shape for a `memory_generation` enrichment job. */
+export interface MemoryGenerationPayload {
+  /**
+   * Admin library backfill (#315): widen every curator from "what matters
+   * today" to "everything this circle's library supports". Scheduled runs never
+   * set it.
+   */
+  backfill?: boolean;
+  /**
+   * Restrict this job to these curator names (#315 sharding). Absent or empty
+   * means "run every enabled curator", which is what a scheduled run does.
+   *
+   * Names are `MemoryCurator.name` values (`on_this_day`, `trip`,
+   * `person_highlights`, `person_over_years`, `theme`, `seasonal`,
+   * `year_in_review`). An unknown name simply matches nothing — the handler
+   * logs it rather than failing, so a payload written by an older release can
+   * never poison the queue.
+   */
+  curators?: string[];
+  /**
+   * Restrict the On This Day curator's BACKFILL anchor set to these calendar
+   * months (1–12). Absent means every month the circle has photos in.
+   *
+   * This is the axis a full-library backfill is sharded along — see
+   * `admin/memory-backfill.shards.ts` for why On This Day is the one curator
+   * that needs an intra-curator split.
+   */
+  anchorMonths?: number[];
+  /**
+   * This shard's slice of the run-wide AI-titling budget (#306's
+   * `BACKFILL_AI_TITLE_CAP`).
+   *
+   * Sharding a backfill into N jobs would otherwise multiply that cap by N,
+   * since the budget is per JOB. The planner divides it instead, so a sharded
+   * backfill costs about the same number of provider calls as the single
+   * unsharded job it replaced.
+   */
+  aiTitleCap?: number;
+}
+
+/** Months are 1-based calendar months; anything else is ignored. */
+function isCalendarMonth(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 12;
+}
+
+/**
+ * Coerce an untrusted `EnrichmentJob.payload` (JSONB, hand-editable from
+ * `/admin/settings/jobs`, and possibly written by another release) into the
+ * shape above.
+ *
+ * Every malformed field degrades to "absent", i.e. to the full unsharded
+ * behaviour, rather than throwing: a payload problem must never cost a job its
+ * retry budget over what is, in the worst case, doing MORE work than asked.
+ */
+export function parseMemoryGenerationPayload(raw: unknown): MemoryGenerationPayload {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const source = raw as Record<string, unknown>;
+
+  const curators = Array.isArray(source['curators'])
+    ? source['curators'].filter((name): name is string => typeof name === 'string' && name.length > 0)
+    : undefined;
+
+  const anchorMonths = Array.isArray(source['anchorMonths'])
+    ? source['anchorMonths'].filter(isCalendarMonth)
+    : undefined;
+
+  const rawCap = source['aiTitleCap'];
+  const aiTitleCap =
+    typeof rawCap === 'number' && Number.isFinite(rawCap) && rawCap >= 0
+      ? Math.floor(rawCap)
+      : undefined;
+
+  return {
+    backfill: source['backfill'] === true,
+    ...(curators && curators.length > 0 ? { curators } : {}),
+    ...(anchorMonths && anchorMonths.length > 0 ? { anchorMonths } : {}),
+    ...(aiTitleCap !== undefined ? { aiTitleCap } : {}),
+  };
+}

--- a/apps/api/src/memories/titles/memory-title.service.spec.ts
+++ b/apps/api/src/memories/titles/memory-title.service.spec.ts
@@ -146,6 +146,27 @@ describe('MemoryTitleService', () => {
         BACKFILL_AI_TITLE_CAP,
       );
     });
+
+    // #315: a library backfill is sharded, and the cap is per JOB — so the
+    // planner divides it across shards. beginRun accepts that slice.
+    it('accepts a lower per-shard cap for a sharded backfill', () => {
+      expect(
+        service.beginRun({ backfill: true, aiTitlesEnabled: true, maxAiCalls: 5 }).maxAiCalls,
+      ).toBe(5);
+    });
+
+    it('never lets a payload RAISE the backfill cap', () => {
+      expect(
+        service.beginRun({ backfill: true, aiTitlesEnabled: true, maxAiCalls: 10_000 })
+          .maxAiCalls,
+      ).toBe(BACKFILL_AI_TITLE_CAP);
+    });
+
+    it('ignores the override outside a backfill, where the budget is unbounded', () => {
+      expect(
+        service.beginRun({ backfill: false, aiTitlesEnabled: true, maxAiCalls: 5 }).maxAiCalls,
+      ).toBe(Number.POSITIVE_INFINITY);
+    });
   });
 
   // --- success --------------------------------------------------------------

--- a/apps/api/src/memories/titles/memory-title.service.ts
+++ b/apps/api/src/memories/titles/memory-title.service.ts
@@ -194,11 +194,24 @@ export class MemoryTitleService {
    * the run, so a disabled feature costs neither a settings read nor a provider
    * call per memory.
    */
-  beginRun(options: { backfill: boolean; aiTitlesEnabled: boolean }): MemoryTitleRun {
+  beginRun(options: {
+    backfill: boolean;
+    aiTitlesEnabled: boolean;
+    /**
+     * Override for the backfill ceiling (#315). A sharded library backfill
+     * divides `BACKFILL_AI_TITLE_CAP` across its shards, because the cap is
+     * per JOB and N shards would otherwise multiply the bill by N. Ignored
+     * outside backfill, where the budget is deliberately unbounded, and capped
+     * at `BACKFILL_AI_TITLE_CAP` so a payload can only ever lower it.
+     */
+    maxAiCalls?: number;
+  }): MemoryTitleRun {
     return {
       enabled: options.aiTitlesEnabled,
       backfill: options.backfill,
-      maxAiCalls: options.backfill ? BACKFILL_AI_TITLE_CAP : Number.POSITIVE_INFINITY,
+      maxAiCalls: options.backfill
+        ? Math.min(options.maxAiCalls ?? BACKFILL_AI_TITLE_CAP, BACKFILL_AI_TITLE_CAP)
+        : Number.POSITIVE_INFINITY,
       aiCalls: 0,
       stopped: false,
       stopReason: null,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,6 +42,7 @@ const BurstsSettingsPage = lazy(() => import('./pages/Admin/BurstsSettingsPage')
 const DuplicatesSettingsPage = lazy(() => import('./pages/Admin/DuplicatesSettingsPage'));
 const SocialMediaSettingsPage = lazy(() => import('./pages/Admin/SocialMediaSettingsPage'));
 const EnhancerSettingsPage = lazy(() => import('./pages/Admin/EnhancerSettingsPage'));
+const MemoriesSettingsPage = lazy(() => import('./pages/Admin/MemoriesSettingsPage'));
 const LocationInferenceSettingsPage = lazy(() => import('./pages/Admin/LocationInferenceSettingsPage'));
 const ArchivingSettingsPage = lazy(() => import('./pages/Admin/ArchivingSettingsPage'));
 const SearchPage = lazy(() => import('./pages/SearchPage'));
@@ -119,6 +120,7 @@ function AppRoutes() {
                 <Route path="/admin/settings/duplicates" element={<DuplicatesSettingsPage />} />
                 <Route path="/admin/settings/social-media" element={<SocialMediaSettingsPage />} />
                 <Route path="/admin/settings/enhancer" element={<EnhancerSettingsPage />} />
+                <Route path="/admin/settings/memories" element={<MemoriesSettingsPage />} />
                 <Route path="/admin/settings/location-inference" element={<LocationInferenceSettingsPage />} />
                 <Route path="/admin/settings/archiving" element={<ArchivingSettingsPage />} />
                 <Route path="/admin/settings/geo" element={<GeoSettingsPage />} />

--- a/apps/web/src/__tests__/pages/AiSettingsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/AiSettingsPage.test.tsx
@@ -78,6 +78,7 @@ function defaultSettingsMock() {
     testEmbedding: vi.fn().mockResolvedValue({ ok: true, provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 }),
     saveEnhanceFeature: vi.fn().mockResolvedValue(undefined),
     getImageModels: vi.fn().mockResolvedValue(['gpt-image-1']),
+    saveMemoriesFeature: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/apps/web/src/__tests__/pages/AiSettingsPageExtended.test.tsx
+++ b/apps/web/src/__tests__/pages/AiSettingsPageExtended.test.tsx
@@ -91,6 +91,7 @@ function defaultSettingsMock() {
     testEmbedding: vi.fn().mockResolvedValue({ ok: true, provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 }),
     saveEnhanceFeature: vi.fn().mockResolvedValue(undefined),
     getImageModels: vi.fn().mockResolvedValue(['gpt-image-1']),
+    saveMemoriesFeature: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/apps/web/src/__tests__/pages/MemoriesSettingsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/MemoriesSettingsPage.test.tsx
@@ -1,0 +1,645 @@
+/**
+ * Unit tests for MemoriesSettingsPage (epic #300, issue #315).
+ *
+ * Mocking strategy mirrors BurstsSettingsPage.test.tsx: usePermissions and
+ * useSystemSettings are module-mocked to drive admin state and the settings
+ * payload, and every service the page calls is mocked so nothing hits the
+ * network.
+ *
+ * What is actually worth asserting here, per the issue's acceptance criteria:
+ *   - admin gating;
+ *   - the feature toggle MERGES the features record rather than replacing it
+ *     (the documented footgun — replacing it clears every other flag);
+ *   - `memories.*` round-trips with the stored values and with defaults when
+ *     the namespace is absent, which is its normal state;
+ *   - the AI provider/model picker persists through PUT /api/ai/features/memories
+ *     and warns when the provider has no enabled credential;
+ *   - the digest section warns when no email provider is configured;
+ *   - the backfill button is gated on the feature flag, passes the selected
+ *     circle, and reports enqueued/skipped.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, mockAdminUser } from '../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../../hooks/useSystemSettings', () => ({
+  useSystemSettings: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAiSettings', () => ({
+  useAiSettings: vi.fn(),
+}));
+
+vi.mock('../../services/email', () => ({
+  getEmailSettings: vi.fn(),
+}));
+
+vi.mock('../../services/circles', () => ({
+  listCircles: vi.fn(),
+}));
+
+vi.mock('../../services/adminMemories', () => ({
+  runMemoriesBackfill: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import MemoriesSettingsPage from '../../pages/Admin/MemoriesSettingsPage';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useAiSettings } from '../../hooks/useAiSettings';
+import { getEmailSettings } from '../../services/email';
+import { listCircles } from '../../services/circles';
+import { runMemoriesBackfill } from '../../services/adminMemories';
+
+const mockUsePermissions = vi.mocked(usePermissions);
+const mockUseSystemSettings = vi.mocked(useSystemSettings);
+const mockUseAiSettings = vi.mocked(useAiSettings);
+const mockGetEmailSettings = vi.mocked(getEmailSettings);
+const mockListCircles = vi.mocked(listCircles);
+const mockRunBackfill = vi.mocked(runMemoriesBackfill);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminPermissions(canWrite = true) {
+  return {
+    isAdmin: true,
+    permissions: new Set(['system_settings:read', 'system_settings:write']),
+    roles: new Set(['admin']),
+    hasPermission: vi.fn().mockReturnValue(canWrite),
+    hasAnyPermission: vi.fn().mockReturnValue(true),
+    hasAllPermissions: vi.fn().mockReturnValue(true),
+    hasRole: vi.fn().mockReturnValue(true),
+    hasAnyRole: vi.fn().mockReturnValue(true),
+  };
+}
+
+function nonAdminPermissions() {
+  return {
+    isAdmin: false,
+    permissions: new Set<string>(),
+    roles: new Set<string>(),
+    hasPermission: vi.fn().mockReturnValue(false),
+    hasAnyPermission: vi.fn().mockReturnValue(false),
+    hasAllPermissions: vi.fn().mockReturnValue(false),
+    hasRole: vi.fn().mockReturnValue(false),
+    hasAnyRole: vi.fn().mockReturnValue(false),
+  };
+}
+
+function makeSystemSettingsMock(options: {
+  memoriesEnabled?: boolean;
+  memories?: Record<string, unknown>;
+} = {}) {
+  const updateSettings = vi.fn().mockResolvedValue(undefined);
+  return {
+    settings: {
+      // Two OTHER flags, so a toggle that replaces the record instead of
+      // merging it is visible as a regression.
+      features: {
+        autoTagging: true,
+        faceRecognition: true,
+        memories: options.memoriesEnabled ?? false,
+      },
+      ...(options.memories ? { memories: options.memories } : {}),
+      ui: { allowUserThemeOverride: true },
+      updatedAt: new Date().toISOString(),
+      updatedBy: null,
+      version: 1,
+    },
+    isLoading: false,
+    isSaving: false,
+    error: null,
+    updateSettings,
+    replaceSettings: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeAiSettingsMock(
+  over: {
+    provider?: string | null;
+    model?: string | null;
+    credentialEnabled?: boolean;
+  } = {},
+) {
+  const saveMemoriesFeature = vi.fn().mockResolvedValue(undefined);
+  return {
+    settings: {
+      providers: [
+        {
+          provider: 'openai',
+          configured: true,
+          enabled: over.credentialEnabled ?? true,
+          last4: 'abcd',
+          baseUrl: null,
+        },
+      ],
+      knownProviders: [
+        { provider: 'anthropic', configured: false, enabled: false, last4: null, baseUrl: null },
+      ],
+      features: {
+        search: null,
+        tagging: null,
+        embedding: null,
+        memories:
+          over.provider === undefined
+            ? null
+            : { provider: over.provider, model: over.model ?? null },
+      },
+      conversations: { archiveAfterDays: 30, deleteAfterArchiveDays: 30 },
+    },
+    loading: false,
+    error: null,
+    fetchSettings: vi.fn().mockResolvedValue(undefined),
+    saveCredentials: vi.fn(),
+    removeCredentials: vi.fn(),
+    testProvider: vi.fn(),
+    getModels: vi.fn().mockResolvedValue(['gpt-4o-mini', 'gpt-4o']),
+    saveSearchFeature: vi.fn(),
+    saveTaggingFeature: vi.fn(),
+    saveEmbeddingFeature: vi.fn(),
+    getEmbeddingModels: vi.fn().mockResolvedValue([]),
+    testEmbedding: vi.fn(),
+    saveEnhanceFeature: vi.fn(),
+    getImageModels: vi.fn().mockResolvedValue([]),
+    saveMemoriesFeature,
+  };
+}
+
+function switchFor(labelText: RegExp): HTMLInputElement {
+  const label = screen.getByText(labelText);
+  return label
+    .closest('.MuiFormControlLabel-root')!
+    .querySelector('input[type="checkbox"]') as HTMLInputElement;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MemoriesSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePermissions.mockReturnValue(adminPermissions() as never);
+    mockUseSystemSettings.mockReturnValue(makeSystemSettingsMock() as never);
+    mockUseAiSettings.mockReturnValue(makeAiSettingsMock() as never);
+    mockGetEmailSettings.mockResolvedValue({
+      provider: 'smtp',
+      enabled: true,
+      fromAddress: 'a@b.c',
+      fromName: null,
+      sesRegion: null,
+      sesCredentialAvailable: false,
+      smtp: {
+        host: 'smtp.example.com',
+        port: 587,
+        useTls: true,
+        username: null,
+        passwordConfigured: true,
+        passwordLast4: null,
+      },
+      credentialSource: 'smtp:inline',
+    });
+    mockListCircles.mockResolvedValue({
+      items: [{ id: 'circle-1', name: 'Marin Family' }] as never,
+      total: 1,
+      page: 1,
+      pageSize: 1,
+      totalPages: 1,
+    });
+    mockRunBackfill.mockResolvedValue({ enqueued: 18, circles: 1, skipped: 0 });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('access control', () => {
+    it('redirects non-admin users', () => {
+      mockUsePermissions.mockReturnValue(nonAdminPermissions() as never);
+
+      render(<MemoriesSettingsPage />);
+
+      expect(screen.queryByRole('heading', { name: /^memories$/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('page structure', () => {
+    beforeEach(() => {
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+    });
+
+    it('renders the page heading and back link', () => {
+      expect(screen.getByRole('heading', { name: /^memories$/i })).toBeInTheDocument();
+      expect(screen.getByText(/back to settings/i)).toBeInTheDocument();
+    });
+
+    it('renders every section', () => {
+      expect(screen.getByText('Global Settings')).toBeInTheDocument();
+      expect(screen.getByText('AI Titles')).toBeInTheDocument();
+      expect(screen.getByText('Generation')).toBeInTheDocument();
+      expect(screen.getByText('Memory Types')).toBeInTheDocument();
+      expect(screen.getByText('Email Digest')).toBeInTheDocument();
+      expect(
+        screen.getByText(/generate memories from the existing library/i),
+      ).toBeInTheDocument();
+    });
+
+    it('names the MEMORIES_ENABLED env kill-switch', () => {
+      expect(screen.getByText(/MEMORIES_ENABLED=false/)).toBeInTheDocument();
+    });
+
+    it('offers a switch for each of the six memory types', () => {
+      for (const label of [
+        /^On This Day$/,
+        /^Trips$/,
+        /^People$/,
+        /^Themes$/,
+        /^Seasonal$/,
+        /^Year in Review$/,
+      ]) {
+        expect(switchFor(label)).toBeTruthy();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('global feature toggle', () => {
+    it('reflects features.memories', () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({ memoriesEnabled: true }) as never,
+      );
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(switchFor(/enable memories globally/i).checked).toBe(true);
+    });
+
+    it('MERGES the features record instead of replacing it', async () => {
+      const mock = makeSystemSettingsMock();
+      mockUseSystemSettings.mockReturnValue(mock as never);
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(switchFor(/enable memories globally/i));
+
+      await waitFor(() => {
+        expect(mock.updateSettings).toHaveBeenCalledWith({
+          features: { autoTagging: true, faceRecognition: true, memories: true },
+        });
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('memories.* round-trip', () => {
+    it('falls back to defaults when the namespace is absent', () => {
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(
+        (screen.getByLabelText(/generation interval/i) as HTMLInputElement).value,
+      ).toBe('24');
+      expect(
+        (screen.getByLabelText(/max items per memory/i) as HTMLInputElement).value,
+      ).toBe('30');
+    });
+
+    it('pre-fills from stored settings', () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({
+          memories: {
+            generation: { intervalHours: 6 },
+            maxItemsPerMemory: 40,
+            onThisDay: { enabled: false, lookbackYears: 3, minItems: 5 },
+          },
+        }) as never,
+      );
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(
+        (screen.getByLabelText(/generation interval/i) as HTMLInputElement).value,
+      ).toBe('6');
+      expect(
+        (screen.getByLabelText(/max items per memory/i) as HTMLInputElement).value,
+      ).toBe('40');
+      expect(switchFor(/^On This Day$/).checked).toBe(false);
+    });
+
+    it('enforces the server bounds on the number inputs', () => {
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const interval = screen.getByLabelText(/generation interval/i);
+      expect(interval).toHaveAttribute('min', '1');
+      expect(interval).toHaveAttribute('max', '168');
+
+      const maxItems = screen.getByLabelText(/max items per memory/i);
+      expect(maxItems).toHaveAttribute('min', '5');
+      expect(maxItems).toHaveAttribute('max', '100');
+    });
+
+    it('saves the whole namespace in one call', async () => {
+      const mock = makeSystemSettingsMock({ memoriesEnabled: true });
+      mockUseSystemSettings.mockReturnValue(mock as never);
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(screen.getByRole('button', { name: /save memories settings/i }));
+
+      await waitFor(() => {
+        expect(mock.updateSettings).toHaveBeenCalledWith({
+          memories: expect.objectContaining({
+            generation: { intervalHours: 24 },
+            maxItemsPerMemory: 30,
+            aiTitles: { enabled: true },
+            onThisDay: expect.objectContaining({ enabled: true, lookbackYears: 10 }),
+            trips: expect.objectContaining({ minDistanceKm: 50 }),
+            people: expect.objectContaining({ favoritesOnly: true }),
+            themes: expect.objectContaining({ maxPerPeriod: 3 }),
+            seasonal: expect.objectContaining({ minItems: 12 }),
+            yearInReview: expect.objectContaining({ minItems: 15 }),
+            digest: expect.objectContaining({ frequency: 'weekly', sendHourUtc: 8 }),
+          }),
+        });
+      });
+    });
+
+    it('saves an edited value', async () => {
+      const mock = makeSystemSettingsMock({ memoriesEnabled: true });
+      mockUseSystemSettings.mockReturnValue(mock as never);
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const interval = screen.getByLabelText(/generation interval/i);
+      await user.clear(interval);
+      await user.type(interval, '12');
+      await user.click(screen.getByRole('button', { name: /save memories settings/i }));
+
+      await waitFor(() => {
+        expect(mock.updateSettings).toHaveBeenCalledWith(
+          expect.objectContaining({
+            memories: expect.objectContaining({ generation: { intervalHours: 12 } }),
+          }),
+        );
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('AI model picker', () => {
+    it('reflects the configured ai.features.memories selection', async () => {
+      mockUseAiSettings.mockReturnValue(
+        makeAiSettingsMock({ provider: 'openai', model: 'gpt-4o' }) as never,
+      );
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/ai provider/i)).toHaveTextContent('openai');
+      });
+      expect(screen.getByLabelText(/^model$/i)).toHaveTextContent('gpt-4o');
+    });
+
+    it('persists the selection through saveMemoriesFeature', async () => {
+      const ai = makeAiSettingsMock({ provider: 'openai', model: 'gpt-4o' });
+      mockUseAiSettings.mockReturnValue(ai as never);
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(screen.getByRole('button', { name: /save ai model/i }));
+
+      await waitFor(() => {
+        expect(ai.saveMemoriesFeature).toHaveBeenCalledWith('openai', 'gpt-4o');
+      });
+    });
+
+    it('clears the selection with nulls when no provider is chosen', async () => {
+      const ai = makeAiSettingsMock();
+      mockUseAiSettings.mockReturnValue(ai as never);
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(screen.getByRole('button', { name: /save ai model/i }));
+
+      await waitFor(() => {
+        expect(ai.saveMemoriesFeature).toHaveBeenCalledWith(null, null);
+      });
+    });
+
+    it('warns when the selected provider has no enabled credential', async () => {
+      mockUseAiSettings.mockReturnValue(
+        makeAiSettingsMock({
+          provider: 'openai',
+          model: 'gpt-4o',
+          credentialEnabled: false,
+        }) as never,
+      );
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/no credential for openai/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows no credential warning when one is configured', async () => {
+      mockUseAiSettings.mockReturnValue(
+        makeAiSettingsMock({ provider: 'openai', model: 'gpt-4o' }) as never,
+      );
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/ai provider/i)).toHaveTextContent('openai');
+      });
+      expect(screen.queryByText(/no credential for/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('email digest', () => {
+    it('warns when no email provider is configured', async () => {
+      mockGetEmailSettings.mockResolvedValue({
+        provider: null,
+        enabled: false,
+        fromAddress: null,
+        fromName: null,
+        sesRegion: null,
+        sesCredentialAvailable: false,
+        smtp: {
+          host: null,
+          port: 587,
+          useTls: true,
+          username: null,
+          passwordConfigured: false,
+          passwordLast4: null,
+        },
+        credentialSource: null,
+      });
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/email not configured/i)).toBeInTheDocument();
+      });
+    });
+
+    it('does not warn when email is configured and enabled', async () => {
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => expect(mockGetEmailSettings).toHaveBeenCalled());
+      expect(screen.queryByText(/email not configured/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('library backfill', () => {
+    it('is disabled while the feature is off', () => {
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(
+        screen.getByRole('button', { name: /generate memories from existing library/i }),
+      ).toBeDisabled();
+    });
+
+    it('is enabled once the feature is on', () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({ memoriesEnabled: true }) as never,
+      );
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(
+        screen.getByRole('button', { name: /generate memories from existing library/i }),
+      ).not.toBeDisabled();
+    });
+
+    it('sweeps every circle by default', async () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({ memoriesEnabled: true }) as never,
+      );
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(
+        screen.getByRole('button', { name: /generate memories from existing library/i }),
+      );
+
+      await waitFor(() => expect(mockRunBackfill).toHaveBeenCalledWith({}));
+    });
+
+    it('passes the selected circle', async () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({ memoriesEnabled: true }) as never,
+      );
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => expect(mockListCircles).toHaveBeenCalledWith(true));
+      await user.click(screen.getByLabelText(/^circle$/i));
+      await user.click(await screen.findByRole('option', { name: 'Marin Family' }));
+      await user.click(
+        screen.getByRole('button', { name: /generate memories from existing library/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockRunBackfill).toHaveBeenCalledWith({ circleId: 'circle-1' }),
+      );
+    });
+
+    it('reports enqueued and skipped counts with a link to the job queue', async () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({ memoriesEnabled: true }) as never,
+      );
+      mockRunBackfill.mockResolvedValue({ enqueued: 36, circles: 2, skipped: 1 });
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(
+        screen.getByRole('button', { name: /generate memories from existing library/i }),
+      );
+
+      const alert = await screen.findByText(/36 job\(s\) queued across 2 circle/i);
+      expect(alert).toBeInTheDocument();
+      expect(screen.getByText(/1 skipped \(already generating\)/i)).toBeInTheDocument();
+      expect(
+        within(alert.closest('.MuiAlert-root') as HTMLElement).getByRole('link', {
+          name: /watch progress/i,
+        }),
+      ).toHaveAttribute('href', '/admin/settings/jobs?type=memory_generation');
+    });
+
+    it('surfaces the flag-off 400 from the API', async () => {
+      mockUseSystemSettings.mockReturnValue(
+        makeSystemSettingsMock({ memoriesEnabled: true }) as never,
+      );
+      mockRunBackfill.mockRejectedValue(new Error('Memories is disabled globally'));
+
+      const user = userEvent.setup();
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.click(
+        screen.getByRole('button', { name: /generate memories from existing library/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/memories is disabled globally/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('loading and error states', () => {
+    it('shows a spinner while settings load', () => {
+      mockUseSystemSettings.mockReturnValue({
+        settings: null,
+        isLoading: true,
+        isSaving: false,
+        error: null,
+        updateSettings: vi.fn(),
+        replaceSettings: vi.fn(),
+        refresh: vi.fn(),
+      } as never);
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('shows an error alert when settings fail to load', () => {
+      mockUseSystemSettings.mockReturnValue({
+        settings: null,
+        isLoading: false,
+        isSaving: false,
+        error: 'Failed to load settings',
+        updateSettings: vi.fn(),
+        replaceSettings: vi.fn(),
+        refresh: vi.fn(),
+      } as never);
+
+      render(<MemoriesSettingsPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText(/failed to load settings/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/hooks/useAiSettings.ts
+++ b/apps/web/src/hooks/useAiSettings.ts
@@ -11,6 +11,7 @@ import {
   getAiEmbeddingModels,
   testAiEmbedding,
   putAiEnhanceFeature,
+  putAiMemoriesFeature,
   getAiImageModels,
 } from '../services/ai';
 import { useIsMounted } from './useIsMounted';
@@ -105,6 +106,17 @@ export function useAiSettings() {
     return getAiImageModels(provider);
   }, []);
 
+  /**
+   * Memories title/subtitle/narrative model (epic #300). Nulls clear the
+   * selection, which drops memories back to deterministic template titles.
+   */
+  const saveMemoriesFeature = useCallback(
+    async (provider: string | null, model: string | null) => {
+      await putAiMemoriesFeature({ provider, model });
+    },
+    [],
+  );
+
   return {
     settings,
     loading,
@@ -121,5 +133,6 @@ export function useAiSettings() {
     testEmbedding,
     saveEnhanceFeature,
     getImageModels,
+    saveMemoriesFeature,
   };
 }

--- a/apps/web/src/pages/Admin/MemoriesSettingsPage.tsx
+++ b/apps/web/src/pages/Admin/MemoriesSettingsPage.tsx
@@ -1,0 +1,1053 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Navigate, Link as RouterLink } from 'react-router-dom';
+import {
+  Container,
+  Box,
+  Typography,
+  Paper,
+  Stack,
+  TextField,
+  Button,
+  Switch,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  Select,
+  MenuItem,
+  Chip,
+  CircularProgress,
+  Alert,
+  AlertTitle,
+  Snackbar,
+  Link,
+  Divider,
+} from '@mui/material';
+import { AutoAwesomeMotion as AutoAwesomeMotionIcon } from '@mui/icons-material';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useAiSettings } from '../../hooks/useAiSettings';
+import { getEmailSettings } from '../../services/email';
+import { listCircles } from '../../services/circles';
+import { runMemoriesBackfill } from '../../services/adminMemories';
+import type { MemoriesBackfillResult } from '../../services/adminMemories';
+
+type DigestFrequency = 'off' | 'daily' | 'weekly' | 'monthly';
+
+// ---------------------------------------------------------------------------
+// Bounds
+//
+// Every pair below mirrors the zod schema in
+// apps/api/src/common/schemas/settings.schema.ts. They are duplicated here on
+// purpose — the alternative is a page that lets an admin type a value the API
+// rejects with an opaque 400 — but they are the THIRD hand-maintained copy of
+// this namespace (see docs/specs/memories.md §9.3), so a bound changed on the
+// server has to be changed here too.
+// ---------------------------------------------------------------------------
+const BOUNDS = {
+  intervalHours: [1, 168],
+  maxItemsPerMemory: [5, 100],
+  onThisDayLookbackYears: [1, 50],
+  onThisDayMinItems: [1, 20],
+  tripsMinDays: [1, 14],
+  tripsMinItems: [3, 100],
+  tripsMinDistanceKm: [5, 500],
+  tripsLookbackMonths: [1, 240],
+  peopleMinItems: [3, 50],
+  themesMinItems: [3, 50],
+  themesMaxPerPeriod: [1, 10],
+  seasonalMinItems: [5, 100],
+  yearInReviewMinItems: [5, 100],
+  imageTokenTtlDays: [7, 90],
+} as const;
+
+/** Defaults mirror DEFAULT_SYSTEM_SETTINGS.memories. */
+const DEFAULTS = {
+  intervalHours: 24,
+  maxItemsPerMemory: 30,
+  aiTitles: true,
+  onThisDay: { enabled: true, lookbackYears: 10, minItems: 3 },
+  trips: { enabled: true, minDays: 2, minItems: 10, minDistanceKm: 50, lookbackMonths: 18 },
+  people: { enabled: true, favoritesOnly: true, minItems: 8 },
+  themes: { enabled: true, minItems: 8, maxPerPeriod: 3 },
+  seasonal: { enabled: true, minItems: 12 },
+  yearInReview: { enabled: true, minItems: 15 },
+  digest: {
+    enabled: true,
+    frequency: 'weekly' as DigestFrequency,
+    sendHourUtc: 8,
+    imageTokenTtlDays: 30,
+  },
+};
+
+/** `00:00 UTC` … `23:00 UTC`. */
+const SEND_HOURS = Array.from({ length: 24 }, (_unused, hour) => hour);
+
+function MemoriesSettingsContent() {
+  const { settings, isSaving, updateSettings, error } = useSystemSettings();
+  const { hasPermission } = usePermissions();
+  const canManage = hasPermission('system_settings:write');
+
+  const {
+    settings: aiSettings,
+    fetchSettings: fetchAiSettings,
+    getModels,
+    saveMemoriesFeature,
+  } = useAiSettings();
+
+  // --- memories.* local state ----------------------------------------------
+  const [intervalHours, setIntervalHours] = useState(String(DEFAULTS.intervalHours));
+  const [maxItemsPerMemory, setMaxItemsPerMemory] = useState(
+    String(DEFAULTS.maxItemsPerMemory),
+  );
+  const [aiTitlesEnabled, setAiTitlesEnabled] = useState(DEFAULTS.aiTitles);
+
+  const [onThisDay, setOnThisDay] = useState(DEFAULTS.onThisDay);
+  const [trips, setTrips] = useState(DEFAULTS.trips);
+  const [people, setPeople] = useState(DEFAULTS.people);
+  const [themes, setThemes] = useState(DEFAULTS.themes);
+  const [seasonal, setSeasonal] = useState(DEFAULTS.seasonal);
+  const [yearInReview, setYearInReview] = useState(DEFAULTS.yearInReview);
+  const [digest, setDigest] = useState(DEFAULTS.digest);
+  const [paramSaving, setParamSaving] = useState(false);
+
+  // --- ai.features.memories -------------------------------------------------
+  const [aiProvider, setAiProvider] = useState('');
+  const [aiModel, setAiModel] = useState('');
+  const [aiModels, setAiModels] = useState<string[]>([]);
+  const [aiModelsLoading, setAiModelsLoading] = useState(false);
+  const [aiSaving, setAiSaving] = useState(false);
+
+  // --- email readiness ------------------------------------------------------
+  const [emailProvider, setEmailProvider] = useState<string | null>(null);
+  const [emailEnabled, setEmailEnabled] = useState<boolean | null>(null);
+  const [emailChecked, setEmailChecked] = useState(false);
+
+  // --- backfill -------------------------------------------------------------
+  const [backfillCircleId, setBackfillCircleId] = useState('');
+  const [circles, setCircles] = useState<Array<{ id: string; name: string }>>([]);
+  const [backfillLoading, setBackfillLoading] = useState(false);
+  const [backfillResult, setBackfillResult] = useState<MemoriesBackfillResult | null>(null);
+  const [backfillError, setBackfillError] = useState<string | null>(null);
+
+  // --- feedback -------------------------------------------------------------
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const featureEnabled = settings?.features?.memories ?? false;
+
+  // Sync every field from settings. `?? default` throughout: the whole
+  // `memories` namespace is legitimately absent until it is first saved.
+  useEffect(() => {
+    if (!settings) return;
+    const m = settings.memories;
+    setIntervalHours(String(m?.generation?.intervalHours ?? DEFAULTS.intervalHours));
+    setMaxItemsPerMemory(String(m?.maxItemsPerMemory ?? DEFAULTS.maxItemsPerMemory));
+    setAiTitlesEnabled(m?.aiTitles?.enabled ?? DEFAULTS.aiTitles);
+    setOnThisDay({
+      enabled: m?.onThisDay?.enabled ?? DEFAULTS.onThisDay.enabled,
+      lookbackYears: m?.onThisDay?.lookbackYears ?? DEFAULTS.onThisDay.lookbackYears,
+      minItems: m?.onThisDay?.minItems ?? DEFAULTS.onThisDay.minItems,
+    });
+    setTrips({
+      enabled: m?.trips?.enabled ?? DEFAULTS.trips.enabled,
+      minDays: m?.trips?.minDays ?? DEFAULTS.trips.minDays,
+      minItems: m?.trips?.minItems ?? DEFAULTS.trips.minItems,
+      minDistanceKm: m?.trips?.minDistanceKm ?? DEFAULTS.trips.minDistanceKm,
+      lookbackMonths: m?.trips?.lookbackMonths ?? DEFAULTS.trips.lookbackMonths,
+    });
+    setPeople({
+      enabled: m?.people?.enabled ?? DEFAULTS.people.enabled,
+      favoritesOnly: m?.people?.favoritesOnly ?? DEFAULTS.people.favoritesOnly,
+      minItems: m?.people?.minItems ?? DEFAULTS.people.minItems,
+    });
+    setThemes({
+      enabled: m?.themes?.enabled ?? DEFAULTS.themes.enabled,
+      minItems: m?.themes?.minItems ?? DEFAULTS.themes.minItems,
+      maxPerPeriod: m?.themes?.maxPerPeriod ?? DEFAULTS.themes.maxPerPeriod,
+    });
+    setSeasonal({
+      enabled: m?.seasonal?.enabled ?? DEFAULTS.seasonal.enabled,
+      minItems: m?.seasonal?.minItems ?? DEFAULTS.seasonal.minItems,
+    });
+    setYearInReview({
+      enabled: m?.yearInReview?.enabled ?? DEFAULTS.yearInReview.enabled,
+      minItems: m?.yearInReview?.minItems ?? DEFAULTS.yearInReview.minItems,
+    });
+    setDigest({
+      enabled: m?.digest?.enabled ?? DEFAULTS.digest.enabled,
+      frequency: m?.digest?.frequency ?? DEFAULTS.digest.frequency,
+      sendHourUtc: m?.digest?.sendHourUtc ?? DEFAULTS.digest.sendHourUtc,
+      imageTokenTtlDays: m?.digest?.imageTokenTtlDays ?? DEFAULTS.digest.imageTokenTtlDays,
+    });
+  }, [settings]);
+
+  useEffect(() => {
+    void fetchAiSettings();
+  }, [fetchAiSettings]);
+
+  // Reflect the CURRENT ai.features.memories selection on load.
+  useEffect(() => {
+    if (!aiSettings) return;
+    setAiProvider(aiSettings.features?.memories?.provider ?? '');
+    setAiModel(aiSettings.features?.memories?.model ?? '');
+  }, [aiSettings]);
+
+  // Chat models for whichever provider is selected.
+  useEffect(() => {
+    if (!aiProvider) {
+      setAiModels([]);
+      return;
+    }
+    setAiModelsLoading(true);
+    getModels(aiProvider)
+      .then(setAiModels)
+      .catch(() => setAiModels([]))
+      .finally(() => setAiModelsLoading(false));
+  }, [aiProvider, getModels]);
+
+  // Email readiness for the digest section. Permission-guarded on the server,
+  // and an admin holds it — a failure is treated as "unknown" rather than an
+  // error, since the digest section is informational.
+  useEffect(() => {
+    getEmailSettings()
+      .then((email) => {
+        setEmailProvider(email.provider);
+        setEmailEnabled(email.enabled);
+      })
+      .catch(() => {
+        setEmailProvider(null);
+        setEmailEnabled(null);
+      })
+      .finally(() => setEmailChecked(true));
+  }, []);
+
+  // Circle list for the backfill selector. `all=true` needs circles:manage_any,
+  // which an Admin has; anything else degrades to "All circles" only.
+  useEffect(() => {
+    listCircles(true)
+      .then((res) => setCircles(res.items.map((c) => ({ id: c.id, name: c.name }))))
+      .catch(() => setCircles([]));
+  }, []);
+
+  /**
+   * Whether the selected AI provider actually has an enabled credential.
+   * Without one, titling silently falls back to templates — worth saying out
+   * loud rather than letting an admin believe AI titles are live.
+   */
+  const aiCredentialReady = useMemo(() => {
+    if (!aiProvider || !aiSettings) return false;
+    return (aiSettings.providers ?? []).some(
+      (p) => p.provider === aiProvider && p.configured && p.enabled,
+    );
+  }, [aiProvider, aiSettings]);
+
+  const providerOptions = useMemo(() => {
+    if (!aiSettings) return [] as Array<{ provider: string; configured: boolean }>;
+    return [...(aiSettings.providers ?? []), ...(aiSettings.knownProviders ?? [])].map((p) => ({
+      provider: p.provider,
+      configured: p.configured && p.enabled,
+    }));
+  }, [aiSettings]);
+
+  const handleGlobalToggle = (checked: boolean) => {
+    // Merge-spread, never replace: the features record holds every other
+    // feature flag, and assigning a fresh object would clear them all.
+    void updateSettings({
+      features: { ...(settings?.features ?? {}), memories: checked },
+    }).catch((err: unknown) => {
+      setLocalError(err instanceof Error ? err.message : 'Failed to save settings');
+    });
+  };
+
+  // One Save for the whole `memories` namespace — simplest, and it keeps the
+  // per-type parameters consistent with each other on every write.
+  const handleSaveMemories = () => {
+    setParamSaving(true);
+    updateSettings({
+      memories: {
+        generation: { intervalHours: Number(intervalHours) },
+        maxItemsPerMemory: Number(maxItemsPerMemory),
+        aiTitles: { enabled: aiTitlesEnabled },
+        onThisDay,
+        trips,
+        people,
+        themes,
+        seasonal,
+        yearInReview,
+        digest,
+      },
+    })
+      .then(() => setSuccessMessage('Memories settings saved'))
+      .catch((err: unknown) => {
+        setLocalError(err instanceof Error ? err.message : 'Failed to save settings');
+      })
+      .finally(() => setParamSaving(false));
+  };
+
+  const handleSaveAiModel = () => {
+    setAiSaving(true);
+    // Both nulls clear the selection, which is the documented way back to
+    // deterministic template titles.
+    saveMemoriesFeature(aiProvider || null, aiModel || null)
+      .then(() => {
+        setSuccessMessage(
+          aiProvider && aiModel
+            ? `Memories will be titled by ${aiModel}`
+            : 'Memory titles reset to templates',
+        );
+        return fetchAiSettings();
+      })
+      .catch((err: unknown) => {
+        setLocalError(err instanceof Error ? err.message : 'Failed to save the model');
+      })
+      .finally(() => setAiSaving(false));
+  };
+
+  const handleRunBackfill = useCallback(() => {
+    setBackfillLoading(true);
+    setBackfillResult(null);
+    setBackfillError(null);
+    runMemoriesBackfill(backfillCircleId ? { circleId: backfillCircleId } : {})
+      .then(setBackfillResult)
+      .catch((err: unknown) => {
+        setBackfillError(err instanceof Error ? err.message : 'Backfill failed');
+      })
+      .finally(() => setBackfillLoading(false));
+  }, [backfillCircleId]);
+
+  if (!settings && !error) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error && !settings) {
+    return (
+      <Alert severity="error" sx={{ m: 3 }}>
+        {error}
+      </Alert>
+    );
+  }
+
+  const emailUnconfigured = emailChecked && (!emailProvider || emailEnabled === false);
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ py: 4 }}>
+        <Link
+          component={RouterLink}
+          to="/admin/settings"
+          underline="hover"
+          variant="body2"
+          sx={{ display: 'inline-block', mb: 2 }}
+        >
+          &larr; Back to Settings
+        </Link>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <AutoAwesomeMotionIcon color="primary" />
+          <Typography variant="h4" component="h1">
+            Memories
+          </Typography>
+        </Box>
+        <Typography color="text.secondary" sx={{ mb: 3 }}>
+          Automatic memory curation, story feed, and email digests.
+        </Typography>
+
+        {/* ---- Section 1: global toggle ------------------------------------ */}
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Global Settings
+          </Typography>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={featureEnabled}
+                onChange={(e) => handleGlobalToggle(e.target.checked)}
+                disabled={isSaving || !settings || !canManage}
+              />
+            }
+            label="Enable Memories globally"
+            sx={{ mb: 1, display: 'block' }}
+          />
+          <Typography variant="body2" color="text.secondary">
+            Curates &ldquo;On this day&rdquo;, trips, people, themes, seasons and year-in-review
+            collections from every circle&rsquo;s library and surfaces them on Home, in the
+            Memories hub, through the notification bell and by email. Off by default &mdash;
+            with it off, no background work runs at all and every Memories endpoint returns
+            an empty list. The <code>MEMORIES_ENABLED=false</code> environment variable
+            overrides this switch and hard-disables the feature regardless of what is saved
+            here.
+          </Typography>
+        </Paper>
+
+        {/* ---- Section 2: AI titles ---------------------------------------- */}
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            AI Titles
+          </Typography>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={aiTitlesEnabled}
+                onChange={(e) => setAiTitlesEnabled(e.target.checked)}
+                disabled={!canManage}
+              />
+            }
+            label="Let an AI model write memory titles"
+            sx={{ mb: 1, display: 'block' }}
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Writes a warm title, subtitle and short narrative for each memory. When this is
+            off &mdash; or the model call fails, times out, or hits a rate limit &mdash;
+            memories fall back to deterministic template titles, which is a supported
+            configuration, not a broken one.
+          </Typography>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2 }}>
+            <FormControl size="small" sx={{ flex: 1 }} disabled={!canManage}>
+              <InputLabel id="memories-ai-provider-label">AI provider</InputLabel>
+              <Select
+                labelId="memories-ai-provider-label"
+                label="AI provider"
+                value={aiProvider}
+                onChange={(e) => {
+                  setAiProvider(e.target.value);
+                  setAiModel('');
+                }}
+              >
+                <MenuItem value="">
+                  <em>None (template titles)</em>
+                </MenuItem>
+                {providerOptions.map((p) => (
+                  <MenuItem key={p.provider} value={p.provider}>
+                    {p.provider}
+                    {p.configured ? '' : ' (no credential)'}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl
+              size="small"
+              sx={{ flex: 1 }}
+              disabled={!canManage || !aiProvider || aiModelsLoading}
+            >
+              <InputLabel id="memories-ai-model-label">Model</InputLabel>
+              <Select
+                labelId="memories-ai-model-label"
+                label="Model"
+                value={aiModel}
+                onChange={(e) => setAiModel(e.target.value)}
+              >
+                {aiModelsLoading ? (
+                  <MenuItem value="">Loading&hellip;</MenuItem>
+                ) : aiModels.length === 0 ? (
+                  <MenuItem value="">No models available</MenuItem>
+                ) : (
+                  aiModels.map((model) => (
+                    <MenuItem key={model} value={model}>
+                      {model}
+                    </MenuItem>
+                  ))
+                )}
+              </Select>
+            </FormControl>
+          </Stack>
+
+          {aiProvider && !aiCredentialReady && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              <AlertTitle>No credential for {aiProvider}</AlertTitle>
+              Memory titles will keep using templates until an enabled credential exists. Add
+              one under{' '}
+              <Link component={RouterLink} to="/admin/settings/ai" underline="hover">
+                AI Providers
+              </Link>
+              .
+            </Alert>
+          )}
+
+          <Button
+            variant="outlined"
+            disabled={!canManage || aiSaving}
+            startIcon={aiSaving ? <CircularProgress size={16} /> : undefined}
+            onClick={handleSaveAiModel}
+          >
+            Save AI Model
+          </Button>
+        </Paper>
+
+        {/* ---- Section 3: generation --------------------------------------- */}
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Generation
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              label="Generation interval (hours)"
+              type="number"
+              size="small"
+              value={intervalHours}
+              onChange={(e) => setIntervalHours(e.target.value)}
+              helperText={`How often each circle is re-curated. ${BOUNDS.intervalHours[0]}-${BOUNDS.intervalHours[1]}.`}
+              slotProps={{
+                htmlInput: {
+                  min: BOUNDS.intervalHours[0],
+                  max: BOUNDS.intervalHours[1],
+                },
+              }}
+              disabled={!canManage}
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              label="Max items per memory"
+              type="number"
+              size="small"
+              value={maxItemsPerMemory}
+              onChange={(e) => setMaxItemsPerMemory(e.target.value)}
+              helperText={`Photos and videos in one memory. ${BOUNDS.maxItemsPerMemory[0]}-${BOUNDS.maxItemsPerMemory[1]}.`}
+              slotProps={{
+                htmlInput: {
+                  min: BOUNDS.maxItemsPerMemory[0],
+                  max: BOUNDS.maxItemsPerMemory[1],
+                },
+              }}
+              disabled={!canManage}
+              sx={{ flex: 1 }}
+            />
+          </Stack>
+        </Paper>
+
+        {/* ---- Section 4: memory types ------------------------------------- */}
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Memory Types
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Each type is generated independently &mdash; turning one off never affects the
+            others, and a type with too little material simply produces nothing.
+          </Typography>
+
+          {/* On This Day */}
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={onThisDay.enabled}
+                  onChange={(e) =>
+                    setOnThisDay((prev) => ({ ...prev, enabled: e.target.checked }))
+                  }
+                  disabled={!canManage}
+                />
+              }
+              label="On This Day"
+              sx={{ display: 'block' }}
+            />
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 1 }}>
+              <TextField
+                label="Lookback years"
+                type="number"
+                size="small"
+                value={onThisDay.lookbackYears}
+                onChange={(e) =>
+                  setOnThisDay((prev) => ({ ...prev, lookbackYears: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.onThisDayLookbackYears[0]}-${BOUNDS.onThisDayLookbackYears[1]}`}
+                slotProps={{
+                  htmlInput: {
+                    min: BOUNDS.onThisDayLookbackYears[0],
+                    max: BOUNDS.onThisDayLookbackYears[1],
+                  },
+                }}
+                disabled={!canManage || !onThisDay.enabled}
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                label="Minimum items"
+                type="number"
+                size="small"
+                value={onThisDay.minItems}
+                onChange={(e) =>
+                  setOnThisDay((prev) => ({ ...prev, minItems: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.onThisDayMinItems[0]}-${BOUNDS.onThisDayMinItems[1]}`}
+                slotProps={{
+                  htmlInput: {
+                    min: BOUNDS.onThisDayMinItems[0],
+                    max: BOUNDS.onThisDayMinItems[1],
+                  },
+                }}
+                disabled={!canManage || !onThisDay.enabled}
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          {/* Trips */}
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={trips.enabled}
+                  onChange={(e) => setTrips((prev) => ({ ...prev, enabled: e.target.checked }))}
+                  disabled={!canManage}
+                />
+              }
+              label="Trips"
+              sx={{ display: 'block' }}
+            />
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 1 }}>
+              <TextField
+                label="Minimum days"
+                type="number"
+                size="small"
+                value={trips.minDays}
+                onChange={(e) =>
+                  setTrips((prev) => ({ ...prev, minDays: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.tripsMinDays[0]}-${BOUNDS.tripsMinDays[1]}`}
+                slotProps={{
+                  htmlInput: { min: BOUNDS.tripsMinDays[0], max: BOUNDS.tripsMinDays[1] },
+                }}
+                disabled={!canManage || !trips.enabled}
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                label="Minimum items"
+                type="number"
+                size="small"
+                value={trips.minItems}
+                onChange={(e) =>
+                  setTrips((prev) => ({ ...prev, minItems: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.tripsMinItems[0]}-${BOUNDS.tripsMinItems[1]}`}
+                slotProps={{
+                  htmlInput: { min: BOUNDS.tripsMinItems[0], max: BOUNDS.tripsMinItems[1] },
+                }}
+                disabled={!canManage || !trips.enabled}
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                label="Minimum distance (km)"
+                type="number"
+                size="small"
+                value={trips.minDistanceKm}
+                onChange={(e) =>
+                  setTrips((prev) => ({ ...prev, minDistanceKm: Number(e.target.value) }))
+                }
+                helperText={`From home. ${BOUNDS.tripsMinDistanceKm[0]}-${BOUNDS.tripsMinDistanceKm[1]}`}
+                slotProps={{
+                  htmlInput: {
+                    min: BOUNDS.tripsMinDistanceKm[0],
+                    max: BOUNDS.tripsMinDistanceKm[1],
+                  },
+                }}
+                disabled={!canManage || !trips.enabled}
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                label="Lookback months"
+                type="number"
+                size="small"
+                value={trips.lookbackMonths}
+                onChange={(e) =>
+                  setTrips((prev) => ({ ...prev, lookbackMonths: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.tripsLookbackMonths[0]}-${BOUNDS.tripsLookbackMonths[1]}`}
+                slotProps={{
+                  htmlInput: {
+                    min: BOUNDS.tripsLookbackMonths[0],
+                    max: BOUNDS.tripsLookbackMonths[1],
+                  },
+                }}
+                disabled={!canManage || !trips.enabled}
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          {/* People */}
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={people.enabled}
+                  onChange={(e) => setPeople((prev) => ({ ...prev, enabled: e.target.checked }))}
+                  disabled={!canManage}
+                />
+              }
+              label="People"
+              sx={{ display: 'block' }}
+            />
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={2}
+              sx={{ mt: 1, alignItems: { sm: 'center' } }}
+            >
+              <TextField
+                label="Minimum items"
+                type="number"
+                size="small"
+                value={people.minItems}
+                onChange={(e) =>
+                  setPeople((prev) => ({ ...prev, minItems: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.peopleMinItems[0]}-${BOUNDS.peopleMinItems[1]}`}
+                slotProps={{
+                  htmlInput: { min: BOUNDS.peopleMinItems[0], max: BOUNDS.peopleMinItems[1] },
+                }}
+                disabled={!canManage || !people.enabled}
+                sx={{ flex: 1 }}
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={people.favoritesOnly}
+                    onChange={(e) =>
+                      setPeople((prev) => ({ ...prev, favoritesOnly: e.target.checked }))
+                    }
+                    disabled={!canManage || !people.enabled}
+                  />
+                }
+                label="Favorites only"
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          {/* Themes */}
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={themes.enabled}
+                  onChange={(e) => setThemes((prev) => ({ ...prev, enabled: e.target.checked }))}
+                  disabled={!canManage}
+                />
+              }
+              label="Themes"
+              sx={{ display: 'block' }}
+            />
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 1 }}>
+              <TextField
+                label="Minimum items"
+                type="number"
+                size="small"
+                value={themes.minItems}
+                onChange={(e) =>
+                  setThemes((prev) => ({ ...prev, minItems: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.themesMinItems[0]}-${BOUNDS.themesMinItems[1]}`}
+                slotProps={{
+                  htmlInput: { min: BOUNDS.themesMinItems[0], max: BOUNDS.themesMinItems[1] },
+                }}
+                disabled={!canManage || !themes.enabled}
+                sx={{ flex: 1 }}
+              />
+              <TextField
+                label="Max themes per period"
+                type="number"
+                size="small"
+                value={themes.maxPerPeriod}
+                onChange={(e) =>
+                  setThemes((prev) => ({ ...prev, maxPerPeriod: Number(e.target.value) }))
+                }
+                helperText={`${BOUNDS.themesMaxPerPeriod[0]}-${BOUNDS.themesMaxPerPeriod[1]}`}
+                slotProps={{
+                  htmlInput: {
+                    min: BOUNDS.themesMaxPerPeriod[0],
+                    max: BOUNDS.themesMaxPerPeriod[1],
+                  },
+                }}
+                disabled={!canManage || !themes.enabled}
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          {/* Seasonal */}
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={seasonal.enabled}
+                  onChange={(e) =>
+                    setSeasonal((prev) => ({ ...prev, enabled: e.target.checked }))
+                  }
+                  disabled={!canManage}
+                />
+              }
+              label="Seasonal"
+              sx={{ display: 'block' }}
+            />
+            <TextField
+              label="Minimum items"
+              type="number"
+              size="small"
+              value={seasonal.minItems}
+              onChange={(e) =>
+                setSeasonal((prev) => ({ ...prev, minItems: Number(e.target.value) }))
+              }
+              helperText={`${BOUNDS.seasonalMinItems[0]}-${BOUNDS.seasonalMinItems[1]}`}
+              slotProps={{
+                htmlInput: {
+                  min: BOUNDS.seasonalMinItems[0],
+                  max: BOUNDS.seasonalMinItems[1],
+                },
+              }}
+              disabled={!canManage || !seasonal.enabled}
+              sx={{ mt: 1, maxWidth: 260 }}
+            />
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          {/* Year in Review */}
+          <Box>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={yearInReview.enabled}
+                  onChange={(e) =>
+                    setYearInReview((prev) => ({ ...prev, enabled: e.target.checked }))
+                  }
+                  disabled={!canManage}
+                />
+              }
+              label="Year in Review"
+              sx={{ display: 'block' }}
+            />
+            <TextField
+              label="Minimum items"
+              type="number"
+              size="small"
+              value={yearInReview.minItems}
+              onChange={(e) =>
+                setYearInReview((prev) => ({ ...prev, minItems: Number(e.target.value) }))
+              }
+              helperText={`${BOUNDS.yearInReviewMinItems[0]}-${BOUNDS.yearInReviewMinItems[1]}`}
+              slotProps={{
+                htmlInput: {
+                  min: BOUNDS.yearInReviewMinItems[0],
+                  max: BOUNDS.yearInReviewMinItems[1],
+                },
+              }}
+              disabled={!canManage || !yearInReview.enabled}
+              sx={{ mt: 1, maxWidth: 260 }}
+            />
+          </Box>
+        </Paper>
+
+        {/* ---- Section 5: email digest ------------------------------------- */}
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Email Digest
+          </Typography>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={digest.enabled}
+                onChange={(e) => setDigest((prev) => ({ ...prev, enabled: e.target.checked }))}
+                disabled={!canManage}
+              />
+            }
+            label="Send the memories digest by email"
+            sx={{ mb: 1, display: 'block' }}
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            This switch is global. Each member can still opt out individually in their own
+            settings, and the digest is only sent when there is genuinely new content.
+          </Typography>
+
+          {emailUnconfigured && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              <Chip size="small" color="warning" label="Email not configured" sx={{ mr: 1 }} />
+              No outbound email provider is enabled, so no digest can be delivered. Set one up
+              under{' '}
+              <Link component={RouterLink} to="/admin/settings/email" underline="hover">
+                Email
+              </Link>
+              .
+            </Alert>
+          )}
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <FormControl size="small" sx={{ flex: 1 }} disabled={!canManage || !digest.enabled}>
+              <InputLabel id="memories-digest-frequency-label">Frequency</InputLabel>
+              <Select
+                labelId="memories-digest-frequency-label"
+                label="Frequency"
+                value={digest.frequency}
+                onChange={(e) =>
+                  setDigest((prev) => ({
+                    ...prev,
+                    frequency: e.target.value as DigestFrequency,
+                  }))
+                }
+              >
+                <MenuItem value="off">Off</MenuItem>
+                <MenuItem value="daily">Daily</MenuItem>
+                <MenuItem value="weekly">Weekly</MenuItem>
+                <MenuItem value="monthly">Monthly</MenuItem>
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ flex: 1 }} disabled={!canManage || !digest.enabled}>
+              <InputLabel id="memories-digest-hour-label">Send hour (UTC)</InputLabel>
+              <Select
+                labelId="memories-digest-hour-label"
+                label="Send hour (UTC)"
+                value={digest.sendHourUtc}
+                onChange={(e) =>
+                  setDigest((prev) => ({ ...prev, sendHourUtc: Number(e.target.value) }))
+                }
+              >
+                {SEND_HOURS.map((hour) => (
+                  <MenuItem key={hour} value={hour}>
+                    {String(hour).padStart(2, '0')}:00 UTC
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              label="Image link lifetime (days)"
+              type="number"
+              size="small"
+              value={digest.imageTokenTtlDays}
+              onChange={(e) =>
+                setDigest((prev) => ({ ...prev, imageTokenTtlDays: Number(e.target.value) }))
+              }
+              helperText={`How long a sent email's thumbnails keep working. ${BOUNDS.imageTokenTtlDays[0]}-${BOUNDS.imageTokenTtlDays[1]}.`}
+              slotProps={{
+                htmlInput: {
+                  min: BOUNDS.imageTokenTtlDays[0],
+                  max: BOUNDS.imageTokenTtlDays[1],
+                },
+              }}
+              disabled={!canManage || !digest.enabled}
+              sx={{ flex: 1 }}
+            />
+          </Stack>
+        </Paper>
+
+        {/* ---- Save the whole namespace ------------------------------------ */}
+        <Box sx={{ mb: 3 }}>
+          <Button
+            variant="contained"
+            disabled={isSaving || paramSaving || !settings || !canManage}
+            startIcon={paramSaving ? <CircularProgress size={16} /> : undefined}
+            onClick={handleSaveMemories}
+          >
+            Save Memories Settings
+          </Button>
+        </Box>
+
+        {/* ---- Section 6: backfill ----------------------------------------- */}
+        <Paper variant="outlined" sx={{ p: 3, mb: 2, borderColor: 'warning.main' }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Generate Memories From the Existing Library
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Sweeps everything already uploaded, rather than waiting for the schedule to pick
+            up today&rsquo;s anniversaries one day at a time. It is idempotent and safe to
+            re-run: memories are refreshed in place, per-user state is preserved, and a memory
+            someone has deleted is never resurrected. The work is split into several
+            background-priority jobs per circle, so it can never starve uploads or time out on
+            a large library, and AI titles are capped for the run &mdash; later scheduled runs
+            fill the rest in.
+          </Typography>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2 }}>
+            <FormControl size="small" sx={{ flex: 1, maxWidth: 360 }} disabled={!canManage}>
+              <InputLabel id="memories-backfill-circle-label">Circle</InputLabel>
+              <Select
+                labelId="memories-backfill-circle-label"
+                label="Circle"
+                value={backfillCircleId}
+                onChange={(e) => setBackfillCircleId(e.target.value)}
+              >
+                <MenuItem value="">All circles</MenuItem>
+                {circles.map((circle) => (
+                  <MenuItem key={circle.id} value={circle.id}>
+                    {circle.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+
+          {backfillResult && (
+            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setBackfillResult(null)}>
+              {backfillResult.enqueued} job(s) queued across {backfillResult.circles} circle(s)
+              {backfillResult.skipped > 0
+                ? `, ${backfillResult.skipped} skipped (already generating)`
+                : ''}
+              .{' '}
+              <Link
+                component={RouterLink}
+                to="/admin/settings/jobs?type=memory_generation"
+                underline="hover"
+              >
+                Watch progress
+              </Link>
+            </Alert>
+          )}
+          {backfillError && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setBackfillError(null)}>
+              {backfillError}
+            </Alert>
+          )}
+
+          <Button
+            variant="contained"
+            color="warning"
+            disabled={!featureEnabled || !canManage || backfillLoading}
+            startIcon={backfillLoading ? <CircularProgress size={16} /> : undefined}
+            onClick={handleRunBackfill}
+          >
+            Generate Memories From Existing Library
+          </Button>
+          {!featureEnabled && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Turn Memories on above before running a backfill.
+            </Typography>
+          )}
+        </Paper>
+      </Box>
+
+      <Snackbar
+        open={!!successMessage}
+        autoHideDuration={3000}
+        onClose={() => setSuccessMessage(null)}
+        message={successMessage}
+      />
+
+      <Snackbar open={!!localError} autoHideDuration={5000} onClose={() => setLocalError(null)}>
+        <Alert severity="error" onClose={() => setLocalError(null)}>
+          {localError}
+        </Alert>
+      </Snackbar>
+    </Container>
+  );
+}
+
+export default function MemoriesSettingsPage() {
+  const { isAdmin, hasPermission } = usePermissions();
+
+  if (!isAdmin || !hasPermission('system_settings:read')) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <MemoriesSettingsContent />;
+}

--- a/apps/web/src/pages/Admin/SettingsHubPage.tsx
+++ b/apps/web/src/pages/Admin/SettingsHubPage.tsx
@@ -31,6 +31,7 @@ import {
   Email as EmailIcon,
   AccountTree as AccountTreeIcon,
   AutoFixHigh as AutoFixHighIcon,
+  AutoAwesomeMotion as AutoAwesomeMotionIcon,
 } from '@mui/icons-material';
 import { usePermissions } from '../../hooks/usePermissions';
 
@@ -135,6 +136,13 @@ export default function SettingsHubPage() {
             'Enable AI photo enhancement and set the quality, strength, and review presets.',
           icon: <AutoFixHighIcon sx={{ fontSize: 40 }} color="primary" />,
           path: '/admin/settings/enhancer',
+          permission: 'system_settings:read',
+        },
+        {
+          title: 'Memories',
+          description: 'Automatic memory curation, story feed, and email digests.',
+          icon: <AutoAwesomeMotionIcon sx={{ fontSize: 40 }} color="primary" />,
+          path: '/admin/settings/memories',
           permission: 'system_settings:read',
         },
         {

--- a/apps/web/src/services/adminMemories.ts
+++ b/apps/web/src/services/adminMemories.ts
@@ -1,0 +1,23 @@
+import { api } from './api';
+
+/**
+ * Result of `POST /api/admin/memories/backfill` (epic #300, issue #315).
+ *
+ * `enqueued` counts job ROWS, not circles: a library backfill is sharded into
+ * several `memory_generation` jobs per circle so no single job can approach the
+ * worker's execution timeout on a large library. `circles` is how many circles
+ * got jobs, and `skipped` how many were left alone because a generation job was
+ * already pending or running for them.
+ */
+export interface MemoriesBackfillResult {
+  enqueued: number;
+  circles: number;
+  skipped: number;
+}
+
+/** Sweep the existing library. Omit `circleId` to cover every circle. */
+export async function runMemoriesBackfill(body?: {
+  circleId?: string;
+}): Promise<MemoriesBackfillResult> {
+  return api.post<MemoriesBackfillResult>('/admin/memories/backfill', body ?? {});
+}

--- a/apps/web/src/services/ai.ts
+++ b/apps/web/src/services/ai.ts
@@ -20,6 +20,8 @@ export interface AiSettingsResponse {
     tagging: { provider: string | null; model: string | null } | null;
     embedding: { provider: string | null; model: string | null } | null;
     enhance?: { provider: string | null; model: string | null } | null;
+    /** Memories title/subtitle/narrative model (epic #300). */
+    memories?: { provider: string | null; model: string | null } | null;
   };
   conversations: {
     archiveAfterDays: number;
@@ -103,6 +105,18 @@ export async function putAiEnhanceFeature(body: {
   model: string;
 }): Promise<void> {
   await api.put<void>('/ai/features/enhance', body);
+}
+
+/**
+ * Set the chat-capable provider/model that writes memory titles, subtitles and
+ * narratives (epic #300). Passing nulls clears the selection, in which case
+ * memories fall back to deterministic template titles.
+ */
+export async function putAiMemoriesFeature(body: {
+  provider: string | null;
+  model: string | null;
+}): Promise<void> {
+  await api.put<void>('/ai/features/memories', body);
 }
 
 export async function getAiImageModels(provider: string): Promise<string[]> {

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -180,6 +180,38 @@ export interface SystemSettings {
     };
     scheduleMinIntervalMinutes?: number;
   };
+  /**
+   * Memories (epic #300). Mirrors the `memories` namespace in
+   * `apps/api/src/common/schemas/settings.schema.ts` — every bound quoted in
+   * `/admin/settings/memories`'s number fields comes from there.
+   *
+   * Every key is optional because the namespace is genuinely absent on any
+   * deployment that has never saved it; the admin page reads each value with a
+   * `?? default` fallback rather than assuming presence.
+   */
+  memories?: {
+    generation?: { intervalHours?: number };
+    maxItemsPerMemory?: number;
+    aiTitles?: { enabled?: boolean };
+    onThisDay?: { enabled?: boolean; lookbackYears?: number; minItems?: number };
+    trips?: {
+      enabled?: boolean;
+      minDays?: number;
+      minItems?: number;
+      minDistanceKm?: number;
+      lookbackMonths?: number;
+    };
+    people?: { enabled?: boolean; favoritesOnly?: boolean; minItems?: number };
+    themes?: { enabled?: boolean; minItems?: number; maxPerPeriod?: number };
+    seasonal?: { enabled?: boolean; minItems?: number };
+    yearInReview?: { enabled?: boolean; minItems?: number };
+    digest?: {
+      enabled?: boolean;
+      frequency?: 'off' | 'daily' | 'weekly' | 'monthly';
+      sendHourUtc?: number;
+      imageTokenTtlDays?: number;
+    };
+  };
   updatedAt: string;
   updatedBy: { id: string; email: string } | null;
   version: number;

--- a/docs/specs/memories.md
+++ b/docs/specs/memories.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.8 (data model + generation plumbing + curation engine; all seven curators; AI titles; read/act API + per-user preferences; web Home carousel & hub; notifications & email digest) |
+| **Version** | 1.0 (complete: data model + generation plumbing + curation engine; all seven curators; AI titles; read/act API + per-user preferences; web Home carousel, hub & story player; notifications & email digest; admin settings page & sharded library backfill) |
 | **Last Updated** | August 2026 |
-| **Status** | Partial — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305), AI titles / subtitles / narratives (#306), API / per-user state / delete / save-as-album / preferences (#307), web Home carousel & `/memories` hub (#309), Notification Center integration & HTML email digest (#311), story player / save-as-album / share / preferences UI (#313); the admin settings page + library backfill (#315) is still outstanding |
+| **Status** | Implemented — Data Model (#301), Generation plumbing & Settings (#302), Curation engine / On This Day / template titles (#303), Trips curator (#304), People / Theme / Seasonal / Year-in-Review curators (#305), AI titles / subtitles / narratives (#306), API / per-user state / delete / save-as-album / preferences (#307), web Home carousel & `/memories` hub (#309), Notification Center integration & HTML email digest (#311), story player / save-as-album / share / preferences UI (#313), admin settings page & sharded library backfill (#315). The epic's remaining issue (#317) is documentation only |
 
 ---
 
@@ -34,7 +34,7 @@ Seven memory types ship across the epic (see [§2.1](#21-memorytype-enum)): `on_
 
 The epic is delivered incrementally, and this document grows with it. Implemented so far: the database foundation — the `MemoryType` enum and the `Memory` / `MemoryItem` / `MemoryUserState` models ([#301](https://github.com/marinoscar/MemoriaHub/issues/301), §2) — and the configuration surface plus generation plumbing: the `features.memories` flag, the `memories.*` namespace, `ai.features.memories`, and an hourly per-circle `memory_generation` job whose handler is still a deliberate **no-op** ([#302](https://github.com/marinoscar/MemoriaHub/issues/302), §3 and §9). Every later issue builds on the #301 schema without altering it.
 
-With #313 landed, an enabled deployment now curates all seven memory types, serves them over the API and the web hub, announces them through the Notification Center bell, mails them out as an HTML digest, plays a memory back as a full-screen story, saves and shares one as an album, and lets each user hide the people and dates they never want resurfaced. What remains of the epic is administration: #315's admin settings page and library backfill.
+With #315 landed, an enabled deployment curates all seven memory types, serves them over the API and the web hub, announces them through the Notification Center bell, mails them out as an HTML digest, plays a memory back as a full-screen story, saves and shares one as an album, lets each user hide the people and dates they never want resurfaced, and gives an admin one page to turn the feature on, tune every parameter, pick the titling model, and sweep the existing library in bounded background jobs. The epic's remaining issue is documentation.
 
 ## 2. Data Model
 
@@ -228,6 +228,33 @@ v1's body is a log line and a return. That log line is the observability hook pr
 ### 3.4 Job-type labels
 
 `JOB_TYPE_LABELS` (`apps/api/src/enrichment/job-type-labels.ts`) gains `memory_generation: 'Memory generation'` so the type renders with a friendly name in `/admin/settings/jobs`. `memory_digest: 'Memory email digest'` sits alongside it ([§7.2](#72-digest-architecture)); both are server-only global jobs, one per circle — generation curates, digest mails the result out.
+
+### 3.5 The library backfill, and why it is sharded
+
+`POST /api/admin/memories/backfill` (issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315), Admin + `system_settings:write`, body `{ circleId? }`) sweeps the **existing** library so a deployment that has just switched Memories on lights up with years of memories immediately, instead of the hourly cron trickling in today's anniversaries one day at a time.
+
+It **only enqueues**. What "backfill" means — every curator's widened horizon (§4.7's every-`(month, day)` anchor set, §4.8's whole-geo-history trip scan, §4.9's all-years person census, §4.10–§4.11's all-history periods) — lives in the curators, keyed off `payload.backfill`, so there is exactly one implementation of it and this endpoint cannot drift from the scheduled path.
+
+**Why it is not one job per circle.** A scheduled run is small by construction: two anchor days, a bounded lookback, the current and previous year. A backfill deliberately removes every one of those horizons, and the result is a job whose work is proportional to the whole library. On This Day is the worst case — up to 366 anchor days × `lookbackYears` curations, each a query plus a scored selection plus an upsert — which #303 shipped as one job while explicitly noting it can approach `ENRICHMENT_JOB_TIMEOUT_MS` (10 minutes by default). A job killed by that timeout is not merely slow: `attempts` is charged at *claim* time, so each kill burns an attempt, and after `ENRICHMENT_MAX_ATTEMPTS` the backfill fails permanently having produced only whatever the first few minutes managed each time.
+
+So the plan is split into bounded units (`apps/api/src/memories/admin/memory-backfill.shards.ts`), following the precedent `duplicate_detection_batch` set with its 100-items-per-job chunking chosen to stay under the worker's stuck-job threshold:
+
+| Shard | Count per circle | Bound |
+|---|---|---|
+| On This Day, one calendar month each | 12 | ≤ 31 anchors × `lookbackYears` |
+| Trip / People highlights / People over years / Theme / Seasonal / Year in Review | 1 each (6) | Bounded by period or subject count, not by 366 days |
+
+**18 rows per circle.** The axes differ per curator on purpose: only On This Day's cost scales with distinct calendar days, and a month is the natural bounded slice of that. Nothing is sharded further by year, person or tag — that would multiply job rows for slices whose individual cost is already small, and each extra shard re-pays that curator's census query.
+
+Each shard is an ordinary `memory_generation` row: background priority 100 (so it can never starve upload enrichment), `skipDedup: true`, `reason: 'backfill'`, and a payload naming its slice — `{ backfill: true, curators: [...], anchorMonths?: [...], aiTitleCap }`. Being ordinary rows is the point: they are retryable, claimable by any worker slot, visible in `/admin/settings/jobs` under `type=memory_generation`, and individually idempotent, because every curator write is an upsert keyed on `(circleId, type, periodKey, subjectKey)`. A shard that fails and retries re-does only its own slice.
+
+**The payload contract is total.** `parseMemoryGenerationPayload` (`memory-generation.payload.ts`) coerces the untrusted JSONB — hand-editable from the jobs dashboard, and possibly written by a different release — and every malformed field degrades to *absent*, i.e. to the full unsharded behaviour. That direction is deliberate: a job that runs every curator is merely slower, whereas one that silently runs none would leave an admin's backfill looking complete while producing nothing. A `curators` list naming nothing the registry knows is logged and no-ops rather than throwing.
+
+**The AI-title budget is divided, not multiplied.** #306's `BACKFILL_AI_TITLE_CAP` is a per-**job** ceiling, so N shards would silently turn one admin click into an N× larger provider bill. The planner hands each shard `cap / shards` via `payload.aiTitleCap`, and `beginRun` clamps that to the cap so a payload can only ever *lower* it. Subsequent scheduled runs get a fresh, uncapped budget, so the library still converges on AI titles over time — exactly the convergence §5.5 designed for.
+
+**Skipping, not double-queueing.** Circles are keyset-paged 100 at a time with **one** batched in-flight query per page; a circle that already has a `memory_generation` job pending or running is skipped and counted in `skipped`, which is what makes a double-clicked button harmless. The response is `{ enqueued, circles, skipped }`, where `enqueued` counts job **rows** (18 per circle) rather than circles. A per-shard enqueue failure is logged and skipped — one bad insert must not cost the rest of the deployment its backfill.
+
+Gating matches the sibling global backfills exactly: `isMemoriesEnabled(settings)` — folding in the `MEMORIES_ENABLED` kill-switch, so a hard-disabled deployment cannot be made to enqueue jobs its handler would no-op — returning **400** when off, and **404** for an unknown `circleId` rather than a cheerful `{ enqueued: 0 }` that reads like success.
 
 ## 4. Curation Engine
 
@@ -612,7 +639,7 @@ One wall clock (`ctx.now`) is captured once by the handler and shared by every c
 ### 4.15 Known gaps
 
 - **A period that falls below `minItems` after items are removed keeps its existing memory.** Curators only upsert periods that still qualify; they do not delete a memory whose material has since been trashed. Its `MemoryItem` rows for hard-deleted media cascade away and `itemCount` is corrected on the next refresh, but a memory whose items were all *soft*-deleted lingers until read-time filtering ([#307](https://github.com/marinoscar/MemoriaHub/issues/307)) hides it. Deleting it automatically was rejected for v1: a curator silently destroying a memory a user may have favorited is a worse failure than a stale one.
-- **Backfill is unchunked.** A full On This Day backfill for a dense circle is up to 366 anchors × `lookbackYears` curations in one job, which can approach `ENRICHMENT_JOB_TIMEOUT_MS`. It is memory-safe (nothing accumulates across anchors) and restartable (every write is idempotent), but chunking the admin backfill into multiple jobs belongs to #315.
+- ~~**Backfill is unchunked.**~~ **Resolved by [#315](https://github.com/marinoscar/MemoriaHub/issues/315)** — the admin backfill now enqueues 18 bounded shards per circle (On This Day split by calendar month, one shard per other curator) rather than one job whose On This Day pass alone could reach 366 anchors × `lookbackYears`. See [§3.5](#35-the-library-backfill-and-why-it-is-sharded). The *scheduled* path is unchanged and was never at risk: it curates two anchor days.
 - **Truncation is chronologically biased.** When `DEFAULT_MAX_CANDIDATES` is hit the scan keeps the earliest candidates. See §4.2 for why that is accepted as a crash guard rather than solved.
 - **`person_highlights` never writes `periodKey = 'all'`,** although the `MemoryType` enum reserves it. An all-time view of a person is what `person_over_years` already is, and generating both would produce two near-identical memories for the same subject. The key shape is kept available for a future variant.
 - **`themes.minItems` / `seasonal.minItems` / `yearInReview.minItems` above `maxItemsPerMemory`** can never be satisfied, since curation caps the selection first — the same un-cross-validated combination already noted for `trips.minItems` in §4.8.
@@ -752,7 +779,7 @@ Introduced by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307).
 | `POST /api/memories/:id/save-album` | `media:write` + **collaborator** | Creates an album from the memory's items — `201 { albumId }` |
 | `DELETE /api/memories/:id` | `media:write` + **collaborator** | Circle-level tombstone (§2.5) + a `memory:deleted` audit event — 204 |
 
-`POST /api/admin/memories/backfill` belongs to this API map but is implemented by issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315), not here.
+`POST /api/admin/memories/backfill` (Admin + `system_settings:write`) belongs to this API map but lives in `AdminMemoriesController`, not this controller — it is an administration action over the generation pipeline rather than a circle-scoped read. See [§3.5](#35-the-library-backfill-and-why-it-is-sharded).
 
 Per-user preferences are **not** endpoints of this controller at all — see §6.7.
 
@@ -1299,9 +1326,34 @@ Three controls:
 
 The section is gated strict-true on `useMemoriesEnabled()` and threads that into `usePeople` (`enabled ? circleId : null`), so with the flag off it renders nothing **and** fires no people request — the same standard as the carousel (§8.3).
 
+### 8.18 The admin settings page
+
+`apps/web/src/pages/Admin/MemoriesSettingsPage.tsx` (`/admin/settings/memories`, issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315)) is the deployment-wide counterpart to §8.17's per-user preferences, and the two are deliberately different surfaces: one decides what the *feature* does, the other what one *person* sees. It follows `BurstsSettingsPage`/`EnhancerSettingsPage` exactly — admin gate → `Navigate`, `useSystemSettings()`, local state synced with `?? default`, `Paper` sections, snackbars — plus a route in `App.tsx` and a tile in `SettingsHubPage` (AI & Enrichment group, `AutoAwesomeMotion`).
+
+Six sections:
+
+1. **Feature toggle** — `features.memories`, plus prose on the default-off posture and the `MEMORIES_ENABLED` env kill-switch that overrides it.
+2. **AI titles** — the `memories.aiTitles.enabled` switch, and the provider/model picker for `ai.features.memories` (§9.4).
+3. **Generation** — `generation.intervalHours`, `maxItemsPerMemory`.
+4. **Memory types** — a switch plus that type's parameters for each of the six curator families.
+5. **Email digest** — `digest.*`, with a warning when no email provider is configured.
+6. **Backfill** — the circle selector and the button described in §3.5.
+
+Five things about it are load-bearing rather than cosmetic:
+
+**The feature toggle merge-spreads.** `features` is one open `Record<string, boolean>` holding every flag in the deployment, so `updateSettings({ features: { memories: checked } })` would clear auto-tagging, face recognition and the rest. The page writes `{ ...(settings?.features ?? {}), memories: checked }`, and a test asserts the two unrelated flags survive — this is the documented footgun of the settings shape, not a hypothetical.
+
+**One Save for the whole `memories` namespace.** Per-section saves would let an admin persist a `minItems` above `maxItemsPerMemory` in two steps without ever seeing them side by side. A single `updateSettings({ memories: { … } })` writes the namespace as one consistent document, matching how the curators read it (§4.14). The AI model is the one exception — it is not in this namespace at all, and saves separately through `PUT /api/ai/features/memories`.
+
+**Every bound is duplicated from the zod schema, on purpose.** The `BOUNDS` table at the top of the file mirrors §9.2 so a number field rejects out-of-range input in the browser instead of surfacing an opaque 400. That makes the page a **fourth** hand-maintained copy of this namespace on top of the three §9.3 already warns about — the tradeoff was taken because the alternative is a form that lets an admin type a value the API silently refuses, but a bound changed on the server has to be changed here too.
+
+**The credential warning exists because the failure is invisible.** Selecting a provider with no enabled credential is not an error anywhere: titling just returns `null` and every memory gets a template title (§5.1), which is *correct* behaviour and therefore indistinguishable from working. The page cross-checks the selection against `GET /api/ai/settings`'s provider list and says so out loud, linking to `/admin/settings/ai` — the same reasoning behind `EnhancerSettingsPage`'s readiness panel. The same logic drives the digest section's "Email not configured" chip: `digest.enabled` with no email provider is a switch that does nothing.
+
+**The backfill button is gated on the feature flag client-side and the API 400s anyway.** Both, deliberately: the client gate is the affordance (with a caption saying why it is disabled), the server gate is the guarantee — and only the server sees `MEMORIES_ENABLED`. On success the alert reports `enqueued`/`skipped` and links to `/admin/settings/jobs?type=memory_generation`, because a backfill's real progress lives in the job queue, not on this page; the caption states up front that it is idempotent, background-priority, and AI-title-capped, so nobody has to read §3.5 to know it is safe to press twice.
+
 ## 9. Settings
 
-Introduced by issue [#302](https://github.com/marinoscar/MemoriaHub/issues/302). The admin page that edits these (`/admin/settings/memories`) arrives with issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315); until then every key below is reachable through the generic `PUT`/`PATCH /api/system-settings` (Admin + `system_settings:write`).
+Introduced by issue [#302](https://github.com/marinoscar/MemoriaHub/issues/302) and edited by the `/admin/settings/memories` admin page ([§8.18](#818-the-admin-settings-page)) since issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315). Every key below also remains reachable through the generic `PUT`/`PATCH /api/system-settings` (Admin + `system_settings:write`), which is what the page itself uses.
 
 The **full** namespace ships now, not just the keys #302 reads, so every later issue in the epic consumes its parameters through the one cached `SystemSettingsService.getSettings()` call with no further schema change. Issue #302 itself actively reads only `memories.generation.intervalHours` (plus the feature flag).
 
@@ -1372,7 +1424,7 @@ Consumed by `MemoryTitleService` in [#306](https://github.com/marinoscar/Memoria
 
 ## 10. RBAC
 
-Filled in by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307) for the user-facing API; the admin surface (`/admin/settings/memories`, the library backfill) arrives with issue [#315](https://github.com/marinoscar/MemoriaHub/issues/315) and reuses `system_settings:read`/`system_settings:write` like every other admin settings page.
+Filled in by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307) for the user-facing API. The admin surface — `/admin/settings/memories` and the library backfill ([#315](https://github.com/marinoscar/MemoriaHub/issues/315)) — reuses `system_settings:read`/`system_settings:write` like every other admin settings page, and the AI model picker on that page reuses `ai_settings:write` because it writes `ai.features.memories` through the existing `PUT /api/ai/features/memories`.
 
 **No new permission was introduced, and none should be.** A memory is a *derived view* over media the caller can already see — it grants access to nothing they could not reach through `GET /api/media`. `media:read` / `media:write` plus the per-circle roles express the intent exactly, so a `memories:*` permission would add a second thing to keep in sync with the media permissions for zero additional expressiveness. That was the epic's explicit decision, and it follows the precedent set by Workflows (which reuses `media:read`/`media:write`/`media:delete` + per-circle roles) and Notifications (authentication only, because every route is already user-scoped).
 
@@ -1382,6 +1434,9 @@ Filled in by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307) f
 | Mark seen / hide / un-hide / favorite / un-favorite | `media:read` | **viewer** | Scoped to the JWT's `userId` and touching no circle content, so membership is the real gate; `media:read` rides along because it is what the whole surface is gated on and a caller without it has no business reading the memory the state refers to |
 | Save as album | `media:write` | **collaborator** | Same bar as `POST /api/media/albums`, whose service path this reuses |
 | Delete (tombstone) | `media:write` | **collaborator** | Mutates circle content for every member; a viewer's equivalent is the personal hide |
+| View / edit `/admin/settings/memories` | `system_settings:read` / `system_settings:write` (+ **Admin** role) | — | Not circle-scoped: these are deployment-wide settings |
+| Run the library backfill | `system_settings:write` (+ **Admin** role) | — | Same guard as `POST /api/admin/bursts/backfill` and every other global backfill |
+| Choose the memory-titling model | `ai_settings:write` (+ **Admin** role) | — | Written through the existing `PUT /api/ai/features/memories`; the page adds no endpoint of its own |
 
 **Super-admin bypass.** A user holding `circles:manage_any`, `media:write_any` or `media:read_any` bypasses the per-circle role check entirely, exactly as `CircleMembershipService.assertCircleAccess` does elsewhere — `loadAccessibleMemory` reproduces that bypass rather than inventing a second policy. This is what lets a system Admin moderate a circle they do not belong to.
 
@@ -1408,6 +1463,7 @@ Filled in by issue [#307](https://github.com/marinoscar/MemoriaHub/issues/307) f
 
 | Version | Date | Author | Changes |
 |---|---|---|---|
+| 1.0 | August 2026 | AI Assistant | Issue #315: added §3.5 (the library backfill — why it enqueues rather than implements backfill semantics, why one job per circle could not hold On This Day's 366-anchor pass under `ENRICHMENT_JOB_TIMEOUT_MS` and what a claim-time-charged attempt makes that cost, the 12-months + 6-curators shard plan and why only On This Day needed an intra-curator axis, the total payload parser and its degrade-to-more-work direction, the divided-not-multiplied AI-title budget, and the per-page batched in-flight skip with its 400/404 gating) and §8.18 (the admin settings page — its six sections, the merge-spread feature toggle, the one-Save-per-namespace decision, the bounds table as a knowingly-fourth hand-maintained copy, and why the missing-credential and unconfigured-email warnings exist at all: both failures are silent by design). Marked §4.15's "backfill is unchunked" gap resolved, pointed §6.1's backfill row at `AdminMemoriesController`, and extended §9's lead-in and §10's RBAC table with the admin surface.  |
 | 0.9 | August 2026 | AI Assistant | Issue #313: completed §8 (Web UI) — §8.10 rewritten from "what #309 stops at" to a record of where the seam fell, plus new §8.12 (why the story player is a dedicated component rather than `MediaLightbox` with a `storyMode` flag, and what is reused instead), §8.13 (the timing table; the two-clock model with JS owning advance correctness and CSS owning smoothness, and why driving the advance off `animationend` would break under reduced motion or a background tab; pause as a derived value that banks its remainder; the step-index reset key, the item-id-tagged video measurement, and the 1,500 ms short-clip floor as the one deliberate deviation from the issue text; on-demand full-media resolution with opacity-0 neighbour mounting), §8.14 (what `prefers-reduced-motion` turns off, and why the progress fill is deliberately not one of them), §8.15 (tap zones / hold-to-pause / swipe and the engaged-hold rule; the window-bound keyboard map and its interactive-target `Space` guard; one progressbar rather than a dozen unlabelled meters, the polite live region as the only position channel for a screen reader, and the accessible name belonging on the Paper; safe-area insets; muted video autoplay with a real unmute control), §8.16 (save-as-album naming, and sharing as album chaining with the honesty requirement, the shared three-call-site component, and the flow-keyed effect that prevents duplicate albums), and §8.17 (the preferences UI and the absent-key contract it must not break — derive-never-mirror, one-key deltas, `null`-to-delete; unresolvable person ids preserved rather than dropped; native date inputs and why; why only the date ranges have a Save button). Updated the status line, §1, the file map, and the §6.7 / §7.8 pointers to the in-app digest toggle. §8 is now complete; only #315's admin page remains outstanding for the epic. |
 | 0.8 | August 2026 | AI Assistant | Issue #309: filled in §8 (Web UI — the file map; the strict-true `useMemoriesEnabled()` gate, its three consumers, why the flag is threaded INTO the feed hook rather than wrapped around the component, and the deliberately unfolded `MEMORIES_ENABLED` env kill-switch; the carousel's self-hiding contract including the failed-request case and why Home carries no empty state or poll; the one-card/two-sizes anatomy, the gradient-padding-box unseen ring, the fan's DTO-driven absence on the hub, and the two literal-rgba exceptions; motion as opt-out with pointer-only hover and ungated focus; the ≥90%-for-1s seen dwell and its module-scoped cross-surface dedup; the merge-not-replace and index-preserving-restore rollback rules; the hub's URL-coerced filters, the single People chip narrowing, the auto-fill grid with `md`-only wide spans, `generatedAt` month grouping, dual kebab/long-press action entry, omitted-not-disabled Delete, and the two distinct empty states; the delete dialog's permanence copy and in-dialog hide alternative; the #313 seam; and the retired dashboard components). §7 remains a placeholder. |
 | 0.7 | August 2026 | AI Assistant | Issue #307: filled in §6 (API — the endpoint catalogue with its permission/role column; the three read invariants and why per-user hide is deliberately not the tombstone; the flag-checked-before-any-query ordering that makes the default-off state cost zero queries and return empty lists rather than errors; keyset-only pagination, the `year` range-overlap compilation, and why `nextCursor` must come from the RAW page; the feed's two bounded reads, exact-`periodKey` anchor match and 60-row candidate window; the 404-not-403 `loadAccessibleMemory` policy and why it does not call `assertCircleAccess`; the `user_settings.memories` namespace with its absent-means-default rule, field-wise merge, overlap-not-containment date filtering and the read-time-never-generation-input rationale; COALESCE state writes and why clearing never upserts; the tombstone write and its audit event; save-as-album's reuse of the album service path plus its trashed-item and non-idempotence decisions; the one-batched-call thumbnail rule; serialization; and six known gaps) and §10 (RBAC — the no-new-permission decision, the capability table, super-admin bypass, the two status-code rules, and why preferences carry no permission). §7 and §8 remain placeholders. |


### PR DESCRIPTION
## Summary

The `/admin/settings/memories` admin page and `POST /api/admin/memories/backfill`, which sweeps an entire library into memories. This also closes the unchunked-backfill gap #303 explicitly deferred.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #300
Fixes #315

## Changes Made

### Backend — `POST /api/admin/memories/backfill`

Admin + `system_settings:write`, 201, `{ data: { enqueued, circles, skipped } }`.

Gates on `isMemoriesEnabled(settings)` rather than a bare `isFeatureEnabled`, so the `MEMORIES_ENABLED` env kill-switch is honoured too → **400, nothing enqueued**. An unknown `circleId` returns 404 rather than a misleading `{ enqueued: 0 }`.

`memory-backfill.service.ts` keyset-pages circles 100 at a time with one batched in-flight query per page, skips circles that already have a `memory_generation` job pending/running, and isolates per-shard failures. `memory-generation.payload.ts` is a total parser for the untrusted JSONB payload — every malformed field degrades to *absent* (= full unsharded behaviour) rather than throwing.

### Chunking — the gap #303 deferred

A backfill removes every curator's horizon, so one job per circle is proportional to the *whole library*. On This Day alone is up to 366 anchors × `lookbackYears`, which can exceed `ENRICHMENT_JOB_TIMEOUT_MS` — and because `attempts` is charged at **claim** time, each timeout burns an attempt, so a too-large job doesn't just fail slowly, it exhausts its retry budget.

The plan is **18 shards per circle**: On This Day split by calendar month (12 shards, ≤31 anchors each, with the month filter pushed into SQL so shards don't each rescan the circle), plus one shard per remaining curator. Every shard is an ordinary `memory_generation` row — priority **100**, `skipDedup: true`, `reason: 'backfill'` — so all of it stays retryable, idempotent, and visible in `/admin/settings/jobs?type=memory_generation`.

**#306's `BACKFILL_AI_TITLE_CAP` is divided across shards** (and `beginRun` clamps so a payload can only ever lower it), so sharding into 18 jobs doesn't multiply the AI provider bill 18×.

### Frontend — `/admin/settings/memories`

Six sections: global toggle (**merge-spread**, with a test asserting the other feature flags survive the write); AI titles switch + `ai.features.memories` provider/model picker with a missing-credential warning; generation params; per-type switches and parameters for all six curator families; email digest with an "Email not configured" warning driven by `GET /api/email-settings`; and the backfill card (all-circles/specific selector, flag-gated button, enqueued/skipped alert linking to the job queue). One Save writes the whole namespace; every number field's min/max mirrors the server zod bounds.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

```
api typecheck: clean          web typecheck: clean
api test:ci:   7357 passed    web test:run: 214/214 files, 4425/4425 tests passed
memories-only: 33 suites / 628 tests green (incl. DB-gated integration specs)
```

Only failures are the two known pre-existing malformed-UUID fixture suites. The `WorkflowRunPage` timing flake passed in this run.

New coverage: shard plan, in-flight skip, keyset paging, 404, failure isolation, flag/env gate, envelope + RBAC metadata, payload parsing, On This Day anchors, handler sharding, title-cap division, a shard-plan↔curator-registry drift guard, and 27 web tests.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

- **Two pre-existing web fixtures needed updating.** `AiSettingsPage.test.tsx` / `AiSettingsPageExtended.test.tsx` assert that their `useAiSettings` mock's key set matches the real hook's — adding `saveMemoriesFeature` tripped that guard *by design*, so the key was added to both.
- **No migration needed.** The whole `memories.*` namespace and all three schema copies already existed from #302, and no new settings key was added — so the three-copies wire-DTO trap wasn't in play here.
- **A knowing tradeoff, recorded in the spec:** the admin page's `BOUNDS` table is a **fourth** hand-maintained copy of the namespace (§9.3 warns about three). The alternative is a form that lets an admin type a value the API then rejects with an opaque 400, which seemed worse — but it is drift surface and is documented as such.
- CLAUDE.md is untouched even though the issue text asks for the `/admin/settings/*` list entry — #317 owns that file, and it's the next and final issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrMQjVv3op565kvui3cWkP)_