### PR TITLE
feat(api): database backup scheduling, staleness release &amp; retention pruning (#342)

### DIFF
--- a/apps/api/src/db-backup/database-backup-retention.service.spec.ts
+++ b/apps/api/src/db-backup/database-backup-retention.service.spec.ts
@@ -1,0 +1,331 @@
+import { Logger } from '@nestjs/common';
+
+import { DatabaseBackupRetentionService } from './database-backup-retention.service';
+
+interface StoredRun {
+  id: string;
+  status: string;
+  trigger: string;
+  startedAt: Date;
+  storageProvider: string | null;
+  storageKey: string | null;
+  bucket: string | null;
+}
+
+function run(
+  id: string,
+  startedAt: string,
+  over: Partial<StoredRun> = {},
+): StoredRun {
+  return {
+    id,
+    status: 'completed',
+    trigger: 'scheduled',
+    startedAt: new Date(startedAt),
+    storageProvider: 's3',
+    storageKey: `db-backups/${id}.dump`,
+    bucket: 'memoria',
+    ...over,
+  };
+}
+
+const DEFAULT_SETTINGS = { retentionCount: 2, oldDatabaseRetentionHours: 168 };
+
+describe('DatabaseBackupRetentionService (issue #342)', () => {
+  let rows: StoredRun[];
+  let prisma: any;
+  let systemSettings: any;
+  let providerResolver: any;
+  let provider: any;
+  let service: DatabaseBackupRetentionService;
+  /** Interleaved audit trail of every object delete and every row delete. */
+  let order: string[];
+
+  function build(settingsOverride: Record<string, unknown> = {}) {
+    order = [];
+
+    prisma = {
+      databaseBackupRun: {
+        findMany: jest.fn(async ({ where, orderBy }: any) => {
+          let out = rows.filter((r) => r.status === where.status);
+          if (where.trigger?.not) out = out.filter((r) => r.trigger !== where.trigger.not);
+          else if (typeof where.trigger === 'string') {
+            out = out.filter((r) => r.trigger === where.trigger);
+          }
+          if (where.startedAt?.lt) {
+            out = out.filter((r) => r.startedAt.getTime() < where.startedAt.lt.getTime());
+          }
+          const dir = orderBy?.startedAt === 'asc' ? 1 : -1;
+          return [...out]
+            .sort((a, b) => dir * (a.startedAt.getTime() - b.startedAt.getTime()))
+            .map((r) => ({
+              id: r.id,
+              storageProvider: r.storageProvider,
+              storageKey: r.storageKey,
+              bucket: r.bucket,
+            }));
+        }),
+        delete: jest.fn(async ({ where }: any) => {
+          order.push(`row:${where.id}`);
+          rows = rows.filter((r) => r.id !== where.id);
+          return {};
+        }),
+      },
+    };
+
+    systemSettings = {
+      getSettings: jest.fn(async () => ({
+        databaseBackup: { ...DEFAULT_SETTINGS, ...settingsOverride },
+      })),
+    };
+
+    provider = {
+      delete: jest.fn(async (key: string) => {
+        order.push(`object:${key}`);
+      }),
+    };
+    providerResolver = { getProviderFor: jest.fn(async () => provider) };
+
+    service = new DatabaseBackupRetentionService(prisma, systemSettings, providerResolver);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-03-10T03:00:00.000Z'));
+    rows = [];
+    build();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Count-based pruning
+  // ---------------------------------------------------------------------------
+
+  describe('count-based pruning', () => {
+    it('keeps the newest retentionCount runs and prunes the rest', async () => {
+      rows = [
+        run('oldest', '2026-03-07T02:00:00.000Z'),
+        run('older', '2026-03-08T02:00:00.000Z'),
+        run('newer', '2026-03-09T02:00:00.000Z'),
+        run('newest', '2026-03-10T02:00:00.000Z'),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByCount).toBe(2);
+      expect(rows.map((r) => r.id).sort()).toEqual(['newer', 'newest']);
+    });
+
+    it('prunes oldest-first', async () => {
+      rows = [
+        run('a', '2026-03-06T02:00:00.000Z'),
+        run('b', '2026-03-07T02:00:00.000Z'),
+        run('c', '2026-03-08T02:00:00.000Z'),
+        run('d', '2026-03-09T02:00:00.000Z'),
+        run('e', '2026-03-10T02:00:00.000Z'),
+      ];
+
+      await service.pruneAfterSuccessfulRun();
+
+      const rowDeletes = order.filter((o) => o.startsWith('row:'));
+      expect(rowDeletes).toEqual(['row:a', 'row:b', 'row:c']);
+    });
+
+    it('deletes the storage object BEFORE the DB row', async () => {
+      rows = [
+        run('victim', '2026-03-01T02:00:00.000Z'),
+        run('keep1', '2026-03-09T02:00:00.000Z'),
+        run('keep2', '2026-03-10T02:00:00.000Z'),
+      ];
+
+      await service.pruneAfterSuccessfulRun();
+
+      expect(order).toEqual(['object:db-backups/victim.dump', 'row:victim']);
+      expect(providerResolver.getProviderFor).toHaveBeenCalledWith('s3', 'memoria');
+    });
+
+    it('keeps the row (visible, fixable) when its object cannot be deleted', async () => {
+      rows = [
+        run('victim', '2026-03-01T02:00:00.000Z'),
+        run('keep1', '2026-03-09T02:00:00.000Z'),
+        run('keep2', '2026-03-10T02:00:00.000Z'),
+      ];
+      provider.delete.mockRejectedValue(new Error('S3 denied'));
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(prisma.databaseBackupRun.delete).not.toHaveBeenCalled();
+      expect(result.prunedByCount).toBe(0);
+      expect(result.errors).toBeGreaterThan(0);
+      expect(rows.map((r) => r.id)).toContain('victim');
+    });
+
+    it('prunes a row that never named a storage key without touching storage', async () => {
+      rows = [
+        run('nokey', '2026-03-01T02:00:00.000Z', { storageProvider: null, storageKey: null }),
+        run('keep1', '2026-03-09T02:00:00.000Z'),
+        run('keep2', '2026-03-10T02:00:00.000Z'),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByCount).toBe(1);
+      expect(providerResolver.getProviderFor).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the number of completed runs is within retention', async () => {
+      rows = [run('a', '2026-03-09T02:00:00.000Z'), run('b', '2026-03-10T02:00:00.000Z')];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByCount).toBe(0);
+      expect(prisma.databaseBackupRun.delete).not.toHaveBeenCalled();
+    });
+
+    it('never prunes a non-completed run by count', async () => {
+      rows = [
+        run('failed-old', '2026-03-01T02:00:00.000Z', { status: 'failed' }),
+        run('stale-old', '2026-03-02T02:00:00.000Z', { status: 'stale' }),
+        run('a', '2026-03-09T02:00:00.000Z'),
+        run('b', '2026-03-10T02:00:00.000Z'),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByCount).toBe(0);
+      expect(rows.map((r) => r.id).sort()).toEqual(['a', 'b', 'failed-old', 'stale-old']);
+    });
+
+    it('counts manual runs alongside scheduled ones', async () => {
+      rows = [
+        run('sched-old', '2026-03-01T02:00:00.000Z'),
+        run('manual', '2026-03-09T02:00:00.000Z', { trigger: 'manual' }),
+        run('sched-new', '2026-03-10T02:00:00.000Z'),
+      ];
+
+      await service.pruneAfterSuccessfulRun();
+
+      expect(rows.map((r) => r.id).sort()).toEqual(['manual', 'sched-new']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // pre_restore exemption — the load-bearing rule
+  // ---------------------------------------------------------------------------
+
+  describe('pre_restore exemption', () => {
+    it('NEVER prunes a pre_restore run by count, however many backups came after it', async () => {
+      rows = [
+        run('rollback', '2026-03-10T01:00:00.000Z', { trigger: 'pre_restore' }),
+        run('n1', '2026-03-10T01:10:00.000Z'),
+        run('n2', '2026-03-10T01:20:00.000Z'),
+        run('n3', '2026-03-10T01:30:00.000Z'),
+        run('n4', '2026-03-10T01:40:00.000Z'),
+        run('n5', '2026-03-10T01:50:00.000Z'),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      // retentionCount=2 → n1..n3 pruned, n4/n5 kept, rollback untouched.
+      expect(rows.map((r) => r.id).sort()).toEqual(['n4', 'n5', 'rollback']);
+      expect(result.prunedByAge).toBe(0);
+    });
+
+    it('does not let a pre_restore run consume a retention slot', async () => {
+      rows = [
+        run('rollback', '2026-03-10T01:00:00.000Z', { trigger: 'pre_restore' }),
+        run('a', '2026-03-10T01:10:00.000Z'),
+        run('b', '2026-03-10T01:20:00.000Z'),
+      ];
+
+      await service.pruneAfterSuccessfulRun();
+
+      // Both routine backups survive: the exempt row was never counted.
+      expect(rows.map((r) => r.id).sort()).toEqual(['a', 'b', 'rollback']);
+    });
+
+    it('prunes a pre_restore run once it exceeds oldDatabaseRetentionHours', async () => {
+      // Now = 2026-03-10T03:00Z, retention 168h → cutoff 2026-03-03T03:00Z.
+      rows = [
+        run('expired', '2026-03-01T02:00:00.000Z', { trigger: 'pre_restore' }),
+        run('fresh', '2026-03-09T02:00:00.000Z', { trigger: 'pre_restore' }),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByAge).toBe(1);
+      expect(rows.map((r) => r.id)).toEqual(['fresh']);
+      expect(order).toEqual(['object:db-backups/expired.dump', 'row:expired']);
+    });
+
+    it('honours a custom oldDatabaseRetentionHours', async () => {
+      build({ oldDatabaseRetentionHours: 1 });
+      rows = [
+        run('just-old', '2026-03-10T01:00:00.000Z', { trigger: 'pre_restore' }),
+        run('very-fresh', '2026-03-10T02:45:00.000Z', { trigger: 'pre_restore' }),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByAge).toBe(1);
+      expect(rows.map((r) => r.id)).toEqual(['very-fresh']);
+    });
+
+    it('does not age-prune a non-completed pre_restore run', async () => {
+      rows = [
+        run('failed-rollback', '2026-03-01T02:00:00.000Z', {
+          trigger: 'pre_restore',
+          status: 'failed',
+        }),
+      ];
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.prunedByAge).toBe(0);
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Robustness — pruning must never fail a successful backup
+  // ---------------------------------------------------------------------------
+
+  describe('robustness', () => {
+    it('never throws when settings cannot be read', async () => {
+      systemSettings.getSettings.mockRejectedValue(new Error('db down'));
+
+      await expect(service.pruneAfterSuccessfulRun()).resolves.toEqual({
+        prunedByCount: 0,
+        prunedByAge: 0,
+        errors: 0,
+      });
+    });
+
+    it('never throws when a query fails', async () => {
+      prisma.databaseBackupRun.findMany.mockRejectedValue(new Error('boom'));
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      expect(result.errors).toBe(2);
+    });
+
+    it('falls back to the schema defaults on garbage settings', async () => {
+      build({ retentionCount: 'seven' as unknown as number });
+      rows = Array.from({ length: 9 }, (_, i) =>
+        run(`r${i}`, `2026-03-0${i + 1}T02:00:00.000Z`),
+      );
+
+      const result = await service.pruneAfterSuccessfulRun();
+
+      // Default retentionCount is 7 → 2 pruned out of 9.
+      expect(result.prunedByCount).toBe(2);
+    });
+  });
+});

--- a/apps/api/src/db-backup/database-backup-retention.service.ts
+++ b/apps/api/src/db-backup/database-backup-retention.service.ts
@@ -1,0 +1,236 @@
+// =============================================================================
+// Database Backup retention pruning (issue #342, epic #339)
+// =============================================================================
+//
+// Each dump is plausibly several GB (#339's sizing), so `retentionCount × dump
+// size` is the real ongoing storage cost of this feature — 7 dailies is easily
+// 20-35 GB. Pruning is therefore not housekeeping, it is the cost control.
+//
+// Two clocks, deliberately:
+//
+//   1. COUNT-based, for `manual` and `scheduled` runs. Keep the newest
+//      `databaseBackup.retentionCount` completed runs; hard-delete the rest,
+//      oldest first.
+//
+//   2. AGE-based, for `pre_restore` runs, which are EXEMPT from (1). In
+//      `restoreRollbackMode='pre_restore_dump'` (#340) such a dump IS the
+//      rollback for a restore that just happened; evicting it because seven
+//      nightly backups have since run would silently destroy a recovery path
+//      while the restore it protects is still fresh. They age out on
+//      `oldDatabaseRetentionHours` instead — the same window a retained `_old`
+//      database would have lived for, so both rollback strategies expire
+//      together.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+
+/** Schema defaults (#340), used only when a setting is missing/garbage. */
+const DEFAULT_RETENTION_COUNT = 7;
+const DEFAULT_OLD_DATABASE_RETENTION_HOURS = 168;
+
+interface PrunableRun {
+  id: string;
+  storageProvider: string | null;
+  storageKey: string | null;
+  bucket: string | null;
+}
+
+export interface DatabaseBackupPruneResult {
+  /** Rows removed by the count-based rule (manual + scheduled runs). */
+  prunedByCount: number;
+  /** Rows removed by the age-based rule (`pre_restore` runs). */
+  prunedByAge: number;
+  /** Runs whose storage object could not be deleted, so the row was kept. */
+  errors: number;
+}
+
+@Injectable()
+export class DatabaseBackupRetentionService {
+  private readonly logger = new Logger(DatabaseBackupRetentionService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly systemSettings: SystemSettingsService,
+    private readonly providerResolver: StorageProviderResolver,
+  ) {}
+
+  /**
+   * Run both retention rules. Called after each successful backup — pruning at
+   * the moment new bytes land is what keeps the high-water mark at
+   * `retentionCount + 1` rather than letting it drift on a separate schedule.
+   *
+   * Never throws: a retention failure must not turn an otherwise successful
+   * backup into a failed one. The backup already exists and is verified; a
+   * missed prune costs storage, a thrown error would cost the run.
+   */
+  async pruneAfterSuccessfulRun(): Promise<DatabaseBackupPruneResult> {
+    const result: DatabaseBackupPruneResult = {
+      prunedByCount: 0,
+      prunedByAge: 0,
+      errors: 0,
+    };
+
+    let retentionCount = DEFAULT_RETENTION_COUNT;
+    let oldDatabaseRetentionHours = DEFAULT_OLD_DATABASE_RETENTION_HOURS;
+    try {
+      const settings = (await this.systemSettings.getSettings()) as any;
+      const cfg = settings?.databaseBackup ?? {};
+      retentionCount = positiveInt(cfg.retentionCount, DEFAULT_RETENTION_COUNT);
+      oldDatabaseRetentionHours = positiveInt(
+        cfg.oldDatabaseRetentionHours,
+        DEFAULT_OLD_DATABASE_RETENTION_HOURS,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Could not read databaseBackup settings for retention; skipping prune: ${errorMessage(err)}`,
+      );
+      return result;
+    }
+
+    try {
+      const byCount = await this.pruneByCount(retentionCount);
+      result.prunedByCount = byCount.pruned;
+      result.errors += byCount.errors;
+    } catch (err) {
+      result.errors += 1;
+      this.logger.warn(`Count-based backup prune failed: ${errorMessage(err)}`);
+    }
+
+    try {
+      const byAge = await this.prunePreRestoreByAge(oldDatabaseRetentionHours);
+      result.prunedByAge = byAge.pruned;
+      result.errors += byAge.errors;
+    } catch (err) {
+      result.errors += 1;
+      this.logger.warn(`Age-based pre-restore prune failed: ${errorMessage(err)}`);
+    }
+
+    if (result.prunedByCount > 0 || result.prunedByAge > 0) {
+      this.logger.log(
+        `Database backup retention: pruned ${result.prunedByCount} by count, ` +
+          `${result.prunedByAge} expired pre-restore dump(s)` +
+          (result.errors > 0 ? `, ${result.errors} could not be removed` : ''),
+      );
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rule 1 — count-based, excluding `pre_restore`
+  // ---------------------------------------------------------------------------
+
+  private async pruneByCount(
+    retentionCount: number,
+  ): Promise<{ pruned: number; errors: number }> {
+    const rows = await this.prisma.databaseBackupRun.findMany({
+      where: {
+        status: 'completed',
+        // The exemption. A pre-restore dump is a rollback artifact, not one of
+        // the N routine backups the admin asked to keep, and must not be able
+        // to push a routine backup out of the retention window either.
+        trigger: { not: 'pre_restore' },
+      },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true, storageProvider: true, storageKey: true, bucket: true },
+    });
+
+    // Newest-first, so everything past the keep-window is excess. Reversed so
+    // deletion proceeds oldest-first: if the loop dies partway through, what
+    // survives is still the newest N-ish backups rather than an arbitrary set.
+    const excess = rows.slice(retentionCount).reverse();
+    return this.deleteRuns(excess);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rule 2 — age-based, `pre_restore` only
+  // ---------------------------------------------------------------------------
+
+  private async prunePreRestoreByAge(
+    retentionHours: number,
+  ): Promise<{ pruned: number; errors: number }> {
+    const cutoff = new Date(Date.now() - retentionHours * 60 * 60 * 1000);
+
+    const rows = await this.prisma.databaseBackupRun.findMany({
+      where: {
+        status: 'completed',
+        trigger: 'pre_restore',
+        startedAt: { lt: cutoff },
+      },
+      orderBy: { startedAt: 'asc' },
+      select: { id: true, storageProvider: true, storageKey: true, bucket: true },
+    });
+
+    return this.deleteRuns(rows);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared deletion path
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Delete the storage object FIRST, then the row.
+   *
+   * The ordering is the whole point: a failure between the two steps must leave
+   * an orphaned ROW (visible in the admin UI, re-prunable on the next run) and
+   * never an orphaned multi-GB OBJECT (invisible, since nothing points at it
+   * once the row is gone, and billable forever). So a failed object delete
+   * aborts that run's prune and keeps its row.
+   */
+  private async deleteRuns(
+    runs: PrunableRun[],
+  ): Promise<{ pruned: number; errors: number }> {
+    let pruned = 0;
+    let errors = 0;
+
+    for (const run of runs) {
+      try {
+        await this.deleteStorageObject(run);
+      } catch (err) {
+        errors += 1;
+        this.logger.warn(
+          `Keeping database backup row ${run.id}: its storage object could not be deleted: ${errorMessage(err)}`,
+        );
+        continue;
+      }
+
+      try {
+        await this.prisma.databaseBackupRun.delete({ where: { id: run.id } });
+        pruned += 1;
+      } catch (err) {
+        errors += 1;
+        this.logger.warn(
+          `Deleted the object for database backup ${run.id} but could not delete the row: ${errorMessage(err)}`,
+        );
+      }
+    }
+
+    return { pruned, errors };
+  }
+
+  private async deleteStorageObject(run: PrunableRun): Promise<void> {
+    // A run that never got as far as naming a key has nothing to delete; its
+    // row is still prunable.
+    if (!run.storageProvider || !run.storageKey) return;
+
+    const provider = await this.providerResolver.getProviderFor(
+      run.storageProvider,
+      run.bucket,
+    );
+    await provider.delete(run.storageKey);
+  }
+}
+
+function positiveInt(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  const n = Math.trunc(value);
+  return n >= 1 ? n : fallback;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/api/src/db-backup/db-backup-schedule.task.spec.ts
+++ b/apps/api/src/db-backup/db-backup-schedule.task.spec.ts
@@ -1,0 +1,492 @@
+import { Logger } from '@nestjs/common';
+
+// The timezone assertion in this spec is about the ARGUMENT `nextCronDate`
+// receives, not about re-testing the cron library, so the real implementation
+// is kept and merely wrapped in a spy.
+jest.mock('../workflows/util/cron.util', () => {
+  const actual = jest.requireActual('../workflows/util/cron.util');
+  return { ...actual, nextCronDate: jest.fn(actual.nextCronDate) };
+});
+
+import { nextCronDate } from '../workflows/util/cron.util';
+import { DatabaseBackupScheduleTask } from './db-backup-schedule.task';
+import { DatabaseBackupAlreadyRunningError } from './db-backup.errors';
+
+const nextCronDateMock = nextCronDate as jest.MockedFunction<typeof nextCronDate>;
+
+interface RunRow {
+  id: string;
+  status: string;
+  startedAt: Date | null;
+  lastHeartbeatAt: Date | null;
+  storageProvider: string | null;
+  storageKey: string | null;
+  bucket: string | null;
+}
+
+function runRow(over: Partial<RunRow> = {}): RunRow {
+  return {
+    id: 'run-1',
+    status: 'running',
+    startedAt: new Date('2026-03-10T01:00:00.000Z'),
+    lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z'),
+    storageProvider: 's3',
+    storageKey: 'db-backups/run-1.dump',
+    bucket: 'memoria',
+    ...over,
+  };
+}
+
+/**
+ * Faithfully evaluates the `where` the task builds for its staleness sweep, so
+ * "a fresh heartbeat is untouched" is proven by the real cutoff the task
+ * computed from `runStaleMinutes` rather than by a hand-fed fixture list.
+ */
+function applyStaleWhere(rows: RunRow[], where: any): RunRow[] {
+  const cutoff: Date = where.OR[0].lastHeartbeatAt.lt;
+  return rows.filter(
+    (r) =>
+      r.status === where.status &&
+      ((r.lastHeartbeatAt !== null && r.lastHeartbeatAt.getTime() < cutoff.getTime()) ||
+        (r.lastHeartbeatAt === null &&
+          r.startedAt !== null &&
+          r.startedAt.getTime() < cutoff.getTime())),
+  );
+}
+
+const DEFAULT_SETTINGS = {
+  enabled: true,
+  frequency: 'daily' as const,
+  dayOfWeek: 0,
+  dayOfMonth: 1,
+  timeOfDay: '02:00',
+  timezone: 'UTC',
+  retentionCount: 7,
+  runStaleMinutes: 30,
+  oldDatabaseRetentionHours: 168,
+};
+
+describe('DatabaseBackupScheduleTask (issue #342)', () => {
+  let prisma: any;
+  let systemSettings: any;
+  let runner: any;
+  let retention: any;
+  let providerResolver: any;
+  let provider: any;
+  let task: DatabaseBackupScheduleTask;
+
+  /** Rows the staleness sweep's findMany filters over. */
+  let staleCandidates: RunRow[];
+  /** What findFirst (the "latest run" lookup) returns. */
+  let latestRun: { id: string; startedAt: Date | null } | null;
+
+  function build(settingsOverride: Record<string, unknown> = {}) {
+    staleCandidates = [];
+    latestRun = null;
+
+    prisma = {
+      databaseBackupRun: {
+        findMany: jest.fn(async ({ where }: any) => applyStaleWhere(staleCandidates, where)),
+        findFirst: jest.fn(async () => latestRun),
+        updateMany: jest.fn(async () => ({ count: 1 })),
+      },
+    };
+    systemSettings = {
+      getSettings: jest.fn(async () => ({
+        databaseBackup: { ...DEFAULT_SETTINGS, ...settingsOverride },
+      })),
+    };
+    runner = { runBackup: jest.fn(async () => ({ runId: 'new-run' })) };
+    retention = { pruneAfterSuccessfulRun: jest.fn(async () => ({ prunedByCount: 0, prunedByAge: 0, errors: 0 })) };
+    provider = { delete: jest.fn(async () => undefined) };
+    providerResolver = { getProviderFor: jest.fn(async () => provider) };
+
+    task = new DatabaseBackupScheduleTask(
+      prisma,
+      systemSettings,
+      runner,
+      retention,
+      providerResolver,
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-03-10T02:05:00.000Z'));
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    delete process.env['DB_BACKUP_SCHEDULE_ENABLED'];
+    build();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    delete process.env['DB_BACKUP_SCHEDULE_ENABLED'];
+  });
+
+  // ---------------------------------------------------------------------------
+  // Firing
+  // ---------------------------------------------------------------------------
+
+  describe('firing a due backup', () => {
+    it('fires when the last run predates the current boundary', async () => {
+      // Boundary for daily @02:00 UTC, now = 02:05Z, is today 02:00Z.
+      latestRun = { id: 'old', startedAt: new Date('2026-03-09T02:00:10.000Z') };
+
+      await task.handleTick();
+
+      expect(runner.runBackup).toHaveBeenCalledTimes(1);
+      expect(runner.runBackup).toHaveBeenCalledWith({
+        trigger: 'scheduled',
+        createdById: null,
+      });
+    });
+
+    it('fires when there has never been a run at all', async () => {
+      latestRun = null;
+
+      await task.handleTick();
+
+      expect(runner.runBackup).toHaveBeenCalledTimes(1);
+    });
+
+    it('prunes retention only after a successful run', async () => {
+      latestRun = null;
+
+      await task.handleTick();
+
+      expect(retention.pruneAfterSuccessfulRun).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT double-fire within one window — a run at/after the boundary suppresses the tick', async () => {
+      latestRun = { id: 'today', startedAt: new Date('2026-03-10T02:00:05.000Z') };
+
+      await task.handleTick();
+      // A second tick 10 minutes later must still not fire.
+      jest.setSystemTime(new Date('2026-03-10T02:15:00.000Z'));
+      await task.handleTick();
+
+      expect(runner.runBackup).not.toHaveBeenCalled();
+      expect(retention.pruneAfterSuccessfulRun).not.toHaveBeenCalled();
+    });
+
+    it('treats a run started exactly ON the boundary as already fired', async () => {
+      latestRun = { id: 'exact', startedAt: new Date('2026-03-10T02:00:00.000Z') };
+
+      await task.handleTick();
+
+      expect(runner.runBackup).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when databaseBackup.enabled is false', async () => {
+      build({ enabled: false });
+      latestRun = null;
+
+      await task.handleTick();
+
+      expect(runner.runBackup).not.toHaveBeenCalled();
+      // The staleness sweep still runs — releasing an orphaned run must not
+      // depend on the schedule being switched on.
+      expect(prisma.databaseBackupRun.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects a weekly schedule (no fire on the wrong day)', async () => {
+      // 2026-03-10 is a Tuesday; a Monday schedule last fired on the 9th.
+      build({ frequency: 'weekly', dayOfWeek: 1 });
+      latestRun = { id: 'mon', startedAt: new Date('2026-03-09T02:00:01.000Z') };
+
+      await task.handleTick();
+
+      expect(runner.runBackup).not.toHaveBeenCalled();
+    });
+
+    it('respects a monthly schedule', async () => {
+      build({ frequency: 'monthly', dayOfMonth: 1 });
+      latestRun = { id: 'feb', startedAt: new Date('2026-02-01T02:00:01.000Z') };
+
+      // Boundary is 2026-03-01T02:00Z, which is after the February run.
+      await task.handleTick();
+
+      expect(runner.runBackup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // P2002 / concurrency
+  // ---------------------------------------------------------------------------
+
+  describe('losing the single-active-run race', () => {
+    it('no-ops (does not throw, does not prune) when the runner reports a run already in progress', async () => {
+      latestRun = null;
+      runner.runBackup.mockRejectedValue(new DatabaseBackupAlreadyRunningError('other-run'));
+
+      await expect(task.handleTick()).resolves.toBeUndefined();
+
+      expect(retention.pruneAfterSuccessfulRun).not.toHaveBeenCalled();
+      expect(Logger.prototype.error).not.toHaveBeenCalled();
+    });
+
+    it('swallows (and logs) any other runner failure without pruning', async () => {
+      latestRun = null;
+      runner.runBackup.mockRejectedValue(new Error('pg_dump exited 1'));
+
+      await expect(task.handleTick()).resolves.toBeUndefined();
+
+      expect(retention.pruneAfterSuccessfulRun).not.toHaveBeenCalled();
+      expect(Logger.prototype.error).toHaveBeenCalled();
+    });
+
+    it('never throws even when settings cannot be read', async () => {
+      systemSettings.getSettings.mockRejectedValue(new Error('db down'));
+
+      await expect(task.handleTick()).resolves.toBeUndefined();
+      expect(Logger.prototype.error).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Kill-switch + overlap guard
+  // ---------------------------------------------------------------------------
+
+  describe('DB_BACKUP_SCHEDULE_ENABLED', () => {
+    it('fully disables the task when set to "false"', async () => {
+      process.env['DB_BACKUP_SCHEDULE_ENABLED'] = 'false';
+      latestRun = null;
+      staleCandidates = [runRow({ lastHeartbeatAt: new Date('2026-03-10T00:00:00.000Z') })];
+
+      await task.handleTick();
+
+      expect(systemSettings.getSettings).not.toHaveBeenCalled();
+      expect(prisma.databaseBackupRun.findMany).not.toHaveBeenCalled();
+      expect(runner.runBackup).not.toHaveBeenCalled();
+    });
+
+    it('stays enabled for any other value', async () => {
+      process.env['DB_BACKUP_SCHEDULE_ENABLED'] = 'true';
+      latestRun = null;
+
+      await task.handleTick();
+
+      expect(runner.runBackup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('skips a tick while a previous tick is still in flight', async () => {
+    latestRun = null;
+    let release: () => void = () => undefined;
+    let signalEntered: () => void = () => undefined;
+    const entered = new Promise<void>((resolve) => { signalEntered = resolve; });
+    runner.runBackup.mockImplementation(() => {
+      signalEntered();
+      return new Promise<void>((resolve) => { release = () => resolve(); });
+    });
+
+    const first = task.handleTick();
+    await entered; // the first tick is now parked inside runBackup
+    await task.handleTick(); // second tick lands mid-run
+
+    expect(runner.runBackup).toHaveBeenCalledTimes(1);
+    release();
+    await first;
+  });
+
+  // ---------------------------------------------------------------------------
+  // Timezone
+  // ---------------------------------------------------------------------------
+
+  describe('timezone handling', () => {
+    it('passes the configured timezone to nextCronDate as its third argument', async () => {
+      build({ timezone: 'America/Costa_Rica' });
+      latestRun = null;
+
+      await task.handleTick();
+
+      expect(nextCronDateMock).toHaveBeenCalled();
+      for (const call of nextCronDateMock.mock.calls) {
+        expect(call[2]).toBe('America/Costa_Rica');
+      }
+    });
+
+    it('fires at the correct local wall-clock time in a non-UTC zone', async () => {
+      // 08:05Z is 02:05 in America/Costa_Rica (UTC-6), so the 02:00 local
+      // boundary (08:00Z) has just passed and the 07:00Z run predates it.
+      jest.setSystemTime(new Date('2026-03-10T08:05:00.000Z'));
+      build({ timezone: 'America/Costa_Rica' });
+      latestRun = { id: 'earlier', startedAt: new Date('2026-03-10T07:00:00.000Z') };
+
+      await task.handleTick();
+
+      expect(runner.runBackup).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire at the same instant when the zone is UTC — the zone genuinely changes the boundary', async () => {
+      jest.setSystemTime(new Date('2026-03-10T08:05:00.000Z'));
+      build({ timezone: 'UTC' });
+      // In UTC the boundary was 02:00Z, and the 07:00Z run is after it.
+      latestRun = { id: 'earlier', startedAt: new Date('2026-03-10T07:00:00.000Z') };
+
+      await task.handleTick();
+
+      expect(runner.runBackup).not.toHaveBeenCalled();
+    });
+
+    it('stands down rather than firing in the wrong zone when the IANA name is unknown', async () => {
+      build({ timezone: 'Mars/Olympus_Mons' });
+      latestRun = null;
+
+      await expect(task.handleTick()).resolves.toBeUndefined();
+
+      expect(runner.runBackup).not.toHaveBeenCalled();
+      expect(Logger.prototype.warn).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Staleness sweep
+  // ---------------------------------------------------------------------------
+
+  describe('staleness release', () => {
+    it('marks a run with a stale heartbeat as terminal `stale` and deletes its partial object', async () => {
+      // runStaleMinutes=30, now=02:05Z → cutoff 01:35Z.
+      staleCandidates = [
+        runRow({ id: 'dead', lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z') }),
+      ];
+      latestRun = { id: 'dead', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+
+      await task.handleTick();
+
+      expect(prisma.databaseBackupRun.updateMany).toHaveBeenCalledTimes(1);
+      const [[args]] = prisma.databaseBackupRun.updateMany.mock.calls;
+      expect(args.where).toEqual({ id: 'dead', status: 'running' });
+      expect(args.data.status).toBe('stale');
+      expect(args.data.finishedAt).toBeInstanceOf(Date);
+      expect(typeof args.data.lastError).toBe('string');
+
+      expect(providerResolver.getProviderFor).toHaveBeenCalledWith('s3', 'memoria');
+      expect(provider.delete).toHaveBeenCalledWith('db-backups/run-1.dump');
+    });
+
+    it('never requeues a stale run — it is terminal, the next boundary is the retry', async () => {
+      staleCandidates = [
+        runRow({ id: 'dead', lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z') }),
+      ];
+      latestRun = { id: 'dead', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+
+      await task.handleTick();
+
+      const [[args]] = prisma.databaseBackupRun.updateMany.mock.calls;
+      expect(args.data.status).toBe('stale');
+      expect(['pending', 'running']).not.toContain(args.data.status);
+      // And nothing was restarted on this tick's behalf.
+      expect(runner.runBackup).not.toHaveBeenCalled();
+    });
+
+    it('leaves a run with a fresh heartbeat untouched', async () => {
+      staleCandidates = [
+        runRow({ id: 'alive', lastHeartbeatAt: new Date('2026-03-10T02:04:30.000Z') }),
+      ];
+      latestRun = { id: 'alive', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+
+      await task.handleTick();
+
+      expect(prisma.databaseBackupRun.updateMany).not.toHaveBeenCalled();
+      expect(provider.delete).not.toHaveBeenCalled();
+    });
+
+    it('honours a custom runStaleMinutes', async () => {
+      build({ runStaleMinutes: 120 });
+      // Same 01:00Z heartbeat is only 65 minutes old — still alive at 120.
+      staleCandidates = [
+        runRow({ id: 'slow', lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z') }),
+      ];
+      latestRun = { id: 'slow', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+
+      await task.handleTick();
+
+      expect(prisma.databaseBackupRun.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('ages a zombie row with no heartbeat at all by startedAt', async () => {
+      staleCandidates = [
+        runRow({
+          id: 'zombie',
+          lastHeartbeatAt: null,
+          startedAt: new Date('2026-03-10T00:30:00.000Z'),
+        }),
+      ];
+      latestRun = { id: 'zombie', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+
+      await task.handleTick();
+
+      expect(prisma.databaseBackupRun.updateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not delete the object when the row was no longer `running`', async () => {
+      staleCandidates = [
+        runRow({ id: 'raced', lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z') }),
+      ];
+      latestRun = { id: 'raced', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+      prisma.databaseBackupRun.updateMany.mockResolvedValue({ count: 0 });
+
+      await task.handleTick();
+
+      expect(provider.delete).not.toHaveBeenCalled();
+    });
+
+    it('a failed object delete does not abort the tick', async () => {
+      staleCandidates = [
+        runRow({ id: 'dead', lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z') }),
+      ];
+      latestRun = null;
+      provider.delete.mockRejectedValue(new Error('S3 exploded'));
+
+      await expect(task.handleTick()).resolves.toBeUndefined();
+
+      // The row was still released, and the schedule still fired.
+      expect(prisma.databaseBackupRun.updateMany).toHaveBeenCalledTimes(1);
+      expect(runner.runBackup).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips object deletion for a run that never named a storage key', async () => {
+      staleCandidates = [
+        runRow({
+          id: 'nokey',
+          lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z'),
+          storageProvider: null,
+          storageKey: null,
+        }),
+      ];
+      latestRun = { id: 'nokey', startedAt: new Date('2026-03-10T02:00:30.000Z') };
+
+      await task.handleTick();
+
+      expect(prisma.databaseBackupRun.updateMany).toHaveBeenCalledTimes(1);
+      expect(providerResolver.getProviderFor).not.toHaveBeenCalled();
+    });
+
+    it('releases the stale run BEFORE attempting to fire, so the guard is free', async () => {
+      staleCandidates = [
+        runRow({ id: 'dead', lastHeartbeatAt: new Date('2026-03-10T01:00:00.000Z') }),
+      ];
+      latestRun = null;
+
+      const order: string[] = [];
+      prisma.databaseBackupRun.updateMany.mockImplementation(async () => {
+        order.push('release');
+        return { count: 1 };
+      });
+      runner.runBackup.mockImplementation(async () => {
+        order.push('fire');
+        return { runId: 'new-run' };
+      });
+
+      await task.handleTick();
+
+      expect(order).toEqual(['release', 'fire']);
+    });
+  });
+});

--- a/apps/api/src/db-backup/db-backup-schedule.task.ts
+++ b/apps/api/src/db-backup/db-backup-schedule.task.ts
@@ -1,0 +1,343 @@
+// =============================================================================
+// Database Backup scheduling + staleness sweep (issue #342, epic #339)
+// =============================================================================
+//
+// One never-throwing cron, two jobs per tick, in this order:
+//
+//   1. RELEASE STALE RUNS. Any `running` row whose `lastHeartbeatAt` has fallen
+//      outside `databaseBackup.runStaleMinutes` is marked `stale` (+finishedAt)
+//      and its partial storage object best-effort deleted.
+//   2. FIRE A DUE BACKUP. Translate the friendly `databaseBackup.*` schedule to
+//      a cron expression, compute the most recent fire boundary at/before now,
+//      and start a run unless one already started at/after that boundary.
+//
+// Stale release runs FIRST so a run orphaned by a crash does not cost an extra
+// 10-minute tick before the schedule can resume — the two jobs are independent,
+// and the acceptance criterion ("the next tick marks it stale, and a subsequent
+// backup can then start") is satisfied either way.
+//
+// THE DELIBERATE ASYMMETRY WITH THE ENRICHMENT QUEUE: a stale run is TERMINAL
+// and is never requeued. Automatically restarting a multi-GB dump that just
+// died — very possibly because it OOM-killed the process — is not obviously
+// right, and the next scheduled tick is the natural retry. Do not "fix" this
+// into an auto-restart.
+//
+// Why the sweep exists at all: this feature deliberately forgoes the enrichment
+// queue's stuck-job recovery (#339), so without it ONE OOM-killed backup holds
+// the `database_backup_runs_active_uniq_idx` slot forever and silently blocks
+// every future backup — the worst failure mode this feature has.
+//
+// This task is INDEPENDENT of `ENRICHMENT_WORKER_MODE`: it is not a queue
+// worker, so it must keep running under `ENRICHMENT_WORKER_MODE=off`. Its own
+// kill-switch is `DB_BACKUP_SCHEDULE_ENABLED=false`, following the
+// `THUMBNAIL_REPAIR_ENABLED` / `NOTIFICATIONS_RECONCILE_ENABLED` precedent.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+import { isValidCron, nextCronDate } from '../workflows/util/cron.util';
+import { DatabaseBackupRunnerService } from './database-backup-runner.service';
+import { DatabaseBackupRetentionService } from './database-backup-retention.service';
+import { DatabaseBackupAlreadyRunningError } from './db-backup.errors';
+import { buildCronExpression, DatabaseBackupFrequency } from './schedule.util';
+
+/**
+ * How far back `previousFireBoundary` searches for the last fire time. Must
+ * exceed the longest gap any supported frequency can produce — 31 days for a
+ * monthly schedule — with headroom.
+ */
+const BOUNDARY_LOOKBACK_DAYS = 40;
+
+/** Hard bound on the boundary walk so a pathological cron cannot spin. */
+const BOUNDARY_MAX_STEPS = 256;
+
+/** Schema defaults (#340), used only when a setting is missing/garbage. */
+const DEFAULT_RUN_STALE_MINUTES = 30;
+
+interface DatabaseBackupScheduleConfig {
+  enabled: boolean;
+  frequency: DatabaseBackupFrequency;
+  dayOfWeek: number;
+  dayOfMonth: number;
+  timeOfDay: string;
+  timezone: string;
+  runStaleMinutes: number;
+}
+
+@Injectable()
+export class DatabaseBackupScheduleTask {
+  private readonly logger = new Logger(DatabaseBackupScheduleTask.name);
+
+  /**
+   * In-process overlap guard (mirrors `NotificationReconcileTask`). A tick that
+   * fires a backup can run for tens of minutes — far longer than the 10-minute
+   * cron slot — so without this a single slow dump would stack ticks behind it.
+   *
+   * Single-process only, and sufficient: across replicas the real guard is the
+   * partial unique index in the database, which turns a concurrent start into a
+   * P2002 that this task treats as a no-op.
+   */
+  private sweepInFlight = false;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly systemSettings: SystemSettingsService,
+    private readonly runner: DatabaseBackupRunnerService,
+    private readonly retention: DatabaseBackupRetentionService,
+    private readonly providerResolver: StorageProviderResolver,
+  ) {}
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async handleTick(): Promise<void> {
+    if (process.env['DB_BACKUP_SCHEDULE_ENABLED'] === 'false') {
+      return;
+    }
+
+    if (this.sweepInFlight) {
+      this.logger.debug('Database backup schedule tick already in flight; skipping');
+      return;
+    }
+    this.sweepInFlight = true;
+
+    try {
+      const config = await this.readConfig();
+
+      // (1) Free the single-active-run slot before (2) tries to claim it.
+      await this.releaseStaleRuns(config.runStaleMinutes);
+
+      // (2) Fire, if due.
+      await this.fireDueBackup(config);
+    } catch (err) {
+      // A cron tick must never throw. Everything here is retried on the next
+      // tick 10 minutes from now.
+      this.logger.error('Database backup schedule tick failed', err as Error);
+    } finally {
+      this.sweepInFlight = false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // (1) Staleness sweep — a direct port of NodeBackupStaleTask.markStaleRuns()
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mark every `running` run whose heartbeat has gone quiet as `stale`, and
+   * best-effort delete the partial object it was uploading.
+   *
+   * The row is transitioned FIRST: the row is the guard, and releasing it is
+   * the load-bearing half. Object deletion is cleanup — if it fails, the row
+   * keeps its `storageKey`, so the orphan is visible and fixable rather than
+   * invisible and billable.
+   *
+   * Rows with a NULL `lastHeartbeatAt` are aged by `startedAt` instead — the
+   * same defence `EnrichmentAdminService` applies to zombie rows that never got
+   * their first progress write.
+   */
+  private async releaseStaleRuns(runStaleMinutes: number): Promise<number> {
+    const cutoff = new Date(Date.now() - runStaleMinutes * 60 * 1000);
+
+    const candidates = await this.prisma.databaseBackupRun.findMany({
+      where: {
+        status: 'running',
+        OR: [
+          { lastHeartbeatAt: { lt: cutoff } },
+          { lastHeartbeatAt: null, startedAt: { lt: cutoff } },
+        ],
+      },
+      select: { id: true, storageProvider: true, storageKey: true, bucket: true },
+    });
+
+    let released = 0;
+    for (const run of candidates) {
+      // Conditional update: if the run completed between the read and here, it
+      // is no longer `running` and must not be stomped into `stale`.
+      const { count } = await this.prisma.databaseBackupRun.updateMany({
+        where: { id: run.id, status: 'running' },
+        data: {
+          status: 'stale',
+          finishedAt: new Date(),
+          lastError:
+            'Run released as stale: no heartbeat within databaseBackup.runStaleMinutes ' +
+            '(the API process most likely died mid-dump). Not retried automatically; ' +
+            'the next scheduled run is the retry.',
+        },
+      });
+      if (count === 0) continue;
+
+      released += 1;
+      await this.deletePartialObject(run);
+    }
+
+    if (released > 0) {
+      this.logger.warn(`Released ${released} stale database backup run(s)`);
+    }
+    return released;
+  }
+
+  private async deletePartialObject(run: {
+    id: string;
+    storageProvider: string | null;
+    storageKey: string | null;
+    bucket: string | null;
+  }): Promise<void> {
+    if (!run.storageProvider || !run.storageKey) return;
+    try {
+      const provider = await this.providerResolver.getProviderFor(
+        run.storageProvider,
+        run.bucket,
+      );
+      await provider.delete(run.storageKey);
+      this.logger.log(
+        `Deleted partial database backup object ${run.storageProvider}:${run.storageKey} from stale run ${run.id}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Could not delete partial object ${run.storageKey} of stale run ${run.id}: ${errorMessage(err)}`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // (2) Fire a due backup
+  // ---------------------------------------------------------------------------
+
+  private async fireDueBackup(config: DatabaseBackupScheduleConfig): Promise<void> {
+    if (!config.enabled) return;
+
+    const expr = buildCronExpression(
+      config.frequency,
+      config.dayOfWeek,
+      config.dayOfMonth,
+      config.timeOfDay,
+    );
+    // `buildCronExpression` clamps its inputs so this should be unreachable;
+    // it is here so a future field addition cannot feed a malformed expression
+    // into CronTime (which throws) from inside a cron tick.
+    if (!isValidCron(expr)) {
+      this.logger.warn(`Refusing to schedule an invalid backup cron: "${expr}"`);
+      return;
+    }
+
+    const now = new Date();
+    const boundary = this.previousFireBoundary(expr, now, config.timezone);
+    if (!boundary) return;
+
+    // THE ANTI-DOUBLE-FIRE RULE. The tick fires every 10 minutes, so several
+    // ticks fall after each boundary; comparing the most recent run's start
+    // against the boundary — rather than against "did we fire recently" — is
+    // what makes exactly one run happen per boundary, statelessly, with no
+    // `lastRunAt` column to keep in sync and no drift after a restart.
+    const latest = await this.prisma.databaseBackupRun.findFirst({
+      where: { startedAt: { not: null } },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true, startedAt: true },
+    });
+    if (latest?.startedAt && latest.startedAt.getTime() >= boundary.getTime()) {
+      return;
+    }
+
+    this.logger.log(
+      `Starting scheduled database backup for boundary ${boundary.toISOString()} (cron "${expr}" @ ${config.timezone})`,
+    );
+
+    try {
+      await this.runner.runBackup({ trigger: 'scheduled', createdById: null });
+    } catch (err) {
+      if (err instanceof DatabaseBackupAlreadyRunningError) {
+        // NOT an error. Another replica (or a manual start) won the race for
+        // the partial unique index — the guard did exactly its job, and the
+        // backup this tick wanted is already happening.
+        this.logger.debug(
+          `Scheduled backup skipped: a run is already in progress (${err.activeRunId ?? 'unknown'})`,
+        );
+        return;
+      }
+      // The runner has already marked the run `failed`, deleted its partial
+      // object and logged the cause; there is nothing to retry here. The next
+      // boundary is the retry.
+      this.logger.error(
+        `Scheduled database backup failed: ${errorMessage(err)}`,
+      );
+      return;
+    }
+
+    // Only a SUCCESSFUL run prunes: retention keeps the newest N *good*
+    // backups, so pruning after a failure could evict a good backup and
+    // replace it with nothing.
+    await this.retention.pruneAfterSuccessfulRun();
+  }
+
+  /**
+   * The most recent fire time of `expr` at or before `now`, evaluated in
+   * `timezone`, or null when the schedule has not fired within the lookback.
+   *
+   * `nextCronDate` only walks forward, so this steps forward from a point
+   * safely before the previous fire and keeps the last time that is still
+   * <= now. The walk is bounded (40 days back = at most ~40 steps for a daily
+   * schedule) and capped besides.
+   *
+   * The timezone is passed EXPLICITLY as `nextCronDate`'s third argument, not
+   * left to the `CronTime` constructor: `getNextDateFrom` derives its zone from
+   * the start argument unless one is given, so omitting it would silently
+   * evaluate "02:00" in the server's zone instead of the admin's.
+   */
+  private previousFireBoundary(
+    expr: string,
+    now: Date,
+    timezone: string,
+  ): Date | null {
+    let cursor = new Date(now.getTime() - BOUNDARY_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    let last: Date | null = null;
+
+    for (let step = 0; step < BOUNDARY_MAX_STEPS; step++) {
+      let next: Date;
+      try {
+        next = nextCronDate(expr, cursor, timezone);
+      } catch (err) {
+        // An unknown IANA zone makes CronTime throw. Log once and stand down
+        // rather than firing at the wrong wall-clock time in a fallback zone.
+        this.logger.warn(
+          `Could not evaluate backup schedule "${expr}" in timezone "${timezone}": ${errorMessage(err)}`,
+        );
+        return null;
+      }
+      if (next.getTime() > now.getTime()) break;
+      last = next;
+      cursor = new Date(next.getTime() + 1000);
+    }
+
+    return last;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Settings
+  // ---------------------------------------------------------------------------
+
+  private async readConfig(): Promise<DatabaseBackupScheduleConfig> {
+    const settings = (await this.systemSettings.getSettings()) as any;
+    const cfg = settings?.databaseBackup ?? {};
+    return {
+      enabled: cfg.enabled === true,
+      frequency: (cfg.frequency ?? 'daily') as DatabaseBackupFrequency,
+      dayOfWeek: typeof cfg.dayOfWeek === 'number' ? cfg.dayOfWeek : 0,
+      dayOfMonth: typeof cfg.dayOfMonth === 'number' ? cfg.dayOfMonth : 1,
+      timeOfDay: typeof cfg.timeOfDay === 'string' ? cfg.timeOfDay : '02:00',
+      timezone:
+        typeof cfg.timezone === 'string' && cfg.timezone.trim().length > 0
+          ? cfg.timezone
+          : 'UTC',
+      runStaleMinutes:
+        typeof cfg.runStaleMinutes === 'number' && cfg.runStaleMinutes >= 1
+          ? Math.trunc(cfg.runStaleMinutes)
+          : DEFAULT_RUN_STALE_MINUTES,
+    };
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/api/src/db-backup/db-backup.module.ts
+++ b/apps/api/src/db-backup/db-backup.module.ts
@@ -2,7 +2,9 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { SettingsModule } from '../settings/settings.module';
 import { StorageProvidersModule } from '../storage/providers/storage-providers.module';
+import { DatabaseBackupRetentionService } from './database-backup-retention.service';
 import { DatabaseBackupRunnerService } from './database-backup-runner.service';
+import { DatabaseBackupScheduleTask } from './db-backup-schedule.task';
 
 /**
  * DbBackupModule — PostgreSQL Database Backup & Restore (epic #339, issue #341).
@@ -23,10 +25,23 @@ import { DatabaseBackupRunnerService } from './database-backup-runner.service';
  *
  * Exports the runner so #342's scheduler cron and #343's admin controller can
  * both drive a run without duplicating any of the lifecycle.
+ *
+ * #342 adds two providers alongside it:
+ *   - DatabaseBackupScheduleTask: the every-10-minutes cron that fires due
+ *     backups and releases stale runs. Registered as a plain provider — Nest's
+ *     ScheduleModule discovers `@Cron` methods on any instantiated provider, so
+ *     no per-module import is needed (same as TrashPurgeTask/NodeBackupStaleTask).
+ *   - DatabaseBackupRetentionService: exported too, so #343's manual-run
+ *     endpoint can prune on the same rules the scheduler uses rather than
+ *     growing a second retention policy.
  */
 @Module({
   imports: [PrismaModule, SettingsModule, StorageProvidersModule],
-  providers: [DatabaseBackupRunnerService],
-  exports: [DatabaseBackupRunnerService],
+  providers: [
+    DatabaseBackupRunnerService,
+    DatabaseBackupRetentionService,
+    DatabaseBackupScheduleTask,
+  ],
+  exports: [DatabaseBackupRunnerService, DatabaseBackupRetentionService],
 })
 export class DbBackupModule {}

--- a/apps/api/src/db-backup/schedule.util.spec.ts
+++ b/apps/api/src/db-backup/schedule.util.spec.ts
@@ -1,0 +1,180 @@
+import { buildCronExpression, parseTimeOfDay } from './schedule.util';
+import { isValidCron, nextCronDate } from '../workflows/util/cron.util';
+
+describe('buildCronExpression (issue #342)', () => {
+  // The exhaustive table the issue asks for: every frequency, boundary days,
+  // and boundary times, each pinned to its exact expected cron string.
+  const cases: Array<{
+    label: string;
+    frequency: 'daily' | 'weekly' | 'monthly';
+    dayOfWeek: number;
+    dayOfMonth: number;
+    timeOfDay: string;
+    expected: string;
+  }> = [
+    // --- daily -------------------------------------------------------------
+    {
+      label: 'daily @ 02:00 (the schema default)',
+      frequency: 'daily',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '02:00',
+      expected: '0 2 * * *',
+    },
+    {
+      label: 'daily @ 00:00 (midnight)',
+      frequency: 'daily',
+      dayOfWeek: 3,
+      dayOfMonth: 15,
+      timeOfDay: '00:00',
+      expected: '0 0 * * *',
+    },
+    {
+      label: 'daily @ 23:59 (last minute of the day)',
+      frequency: 'daily',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '23:59',
+      expected: '59 23 * * *',
+    },
+    {
+      label: 'daily @ 09:05 (leading zeros are stripped)',
+      frequency: 'daily',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '09:05',
+      expected: '5 9 * * *',
+    },
+
+    // --- weekly ------------------------------------------------------------
+    {
+      label: 'weekly Sunday @ 02:00',
+      frequency: 'weekly',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '02:00',
+      expected: '0 2 * * 0',
+    },
+    {
+      label: 'weekly Monday @ 02:00 (the issue example)',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      dayOfMonth: 1,
+      timeOfDay: '02:00',
+      expected: '0 2 * * 1',
+    },
+    {
+      label: 'weekly Saturday @ 00:00',
+      frequency: 'weekly',
+      dayOfWeek: 6,
+      dayOfMonth: 28,
+      timeOfDay: '00:00',
+      expected: '0 0 * * 6',
+    },
+    {
+      label: 'weekly ignores dayOfMonth entirely',
+      frequency: 'weekly',
+      dayOfWeek: 4,
+      dayOfMonth: 28,
+      timeOfDay: '13:30',
+      expected: '30 13 * * 4',
+    },
+
+    // --- monthly -----------------------------------------------------------
+    {
+      label: 'monthly day 1 @ 02:00 (the issue example)',
+      frequency: 'monthly',
+      dayOfWeek: 0,
+      dayOfMonth: 1,
+      timeOfDay: '02:00',
+      expected: '0 2 1 * *',
+    },
+    {
+      label: 'monthly day 28 @ 02:00 (the schema max)',
+      frequency: 'monthly',
+      dayOfWeek: 0,
+      dayOfMonth: 28,
+      timeOfDay: '02:00',
+      expected: '0 2 28 * *',
+    },
+    {
+      label: 'monthly day 28 @ 00:00 (max day, midnight)',
+      frequency: 'monthly',
+      dayOfWeek: 5,
+      dayOfMonth: 28,
+      timeOfDay: '00:00',
+      expected: '0 0 28 * *',
+    },
+    {
+      label: 'monthly ignores dayOfWeek entirely',
+      frequency: 'monthly',
+      dayOfWeek: 6,
+      dayOfMonth: 15,
+      timeOfDay: '17:45',
+      expected: '45 17 15 * *',
+    },
+  ];
+
+  it.each(cases)('$label → $expected', ({ frequency, dayOfWeek, dayOfMonth, timeOfDay, expected }) => {
+    expect(buildCronExpression(frequency, dayOfWeek, dayOfMonth, timeOfDay)).toBe(expected);
+  });
+
+  it('produces expressions the shared isValidCron gate accepts', () => {
+    for (const c of cases) {
+      const expr = buildCronExpression(c.frequency, c.dayOfWeek, c.dayOfMonth, c.timeOfDay);
+      expect(isValidCron(expr)).toBe(true);
+    }
+  });
+
+  it('produces expressions the shared nextCronDate helper can evaluate', () => {
+    const from = new Date('2026-03-10T12:00:00.000Z');
+    for (const c of cases) {
+      const expr = buildCronExpression(c.frequency, c.dayOfWeek, c.dayOfMonth, c.timeOfDay);
+      const next = nextCronDate(expr, from, 'UTC');
+      expect(next.getTime()).toBeGreaterThan(from.getTime());
+    }
+  });
+
+  describe('defensive clamping (schema already validates; hand-edited JSON may not)', () => {
+    it('clamps an out-of-range dayOfWeek', () => {
+      expect(buildCronExpression('weekly', 9, 1, '02:00')).toBe('0 2 * * 6');
+      expect(buildCronExpression('weekly', -3, 1, '02:00')).toBe('0 2 * * 0');
+    });
+
+    it('clamps dayOfMonth to 28 — days 29-31 do not exist in February', () => {
+      expect(buildCronExpression('monthly', 0, 31, '02:00')).toBe('0 2 28 * *');
+      expect(buildCronExpression('monthly', 0, 0, '02:00')).toBe('0 2 1 * *');
+    });
+
+    it('falls back to 02:00 on an unparseable timeOfDay', () => {
+      expect(buildCronExpression('daily', 0, 1, 'not-a-time')).toBe('0 2 * * *');
+      expect(buildCronExpression('daily', 0, 1, '24:00')).toBe('0 2 * * *');
+      expect(buildCronExpression('daily', 0, 1, '02:60')).toBe('0 2 * * *');
+      expect(buildCronExpression('daily', 0, 1, '')).toBe('0 2 * * *');
+    });
+
+    it('treats an unknown frequency as daily', () => {
+      expect(buildCronExpression('hourly' as never, 0, 1, '02:00')).toBe('0 2 * * *');
+    });
+  });
+});
+
+describe('parseTimeOfDay', () => {
+  it.each([
+    ['00:00', 0, 0],
+    ['02:00', 2, 0],
+    ['09:05', 9, 5],
+    ['23:59', 23, 59],
+  ])('parses %s', (input, hour, minute) => {
+    expect(parseTimeOfDay(input)).toEqual({ hour, minute });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseTimeOfDay('  07:30 ')).toEqual({ hour: 7, minute: 30 });
+  });
+
+  it('falls back to 02:00 on garbage', () => {
+    expect(parseTimeOfDay('7:30')).toEqual({ hour: 2, minute: 0 });
+    expect(parseTimeOfDay(undefined as never)).toEqual({ hour: 2, minute: 0 });
+  });
+});

--- a/apps/api/src/db-backup/schedule.util.ts
+++ b/apps/api/src/db-backup/schedule.util.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// Database Backup schedule translation (issue #342, epic #339)
+// =============================================================================
+//
+// The admin UI (#345) exposes a friendly frequency + day + time picker, NOT raw
+// cron syntax — deliberately, and unlike `workflows.cronExpression`. This module
+// is the single translation point from those fields to the 5-field cron string
+// the scheduler evaluates, kept pure and dependency-free so it is exhaustively
+// unit-testable without a Nest context, a clock, or a database.
+//
+// Everything downstream (`DatabaseBackupScheduleTask`) consumes only the string
+// produced here and the shared `nextCronDate`/`isValidCron` helpers in
+// `workflows/util/cron.util.ts` — there is no second cron implementation.
+// =============================================================================
+
+export type DatabaseBackupFrequency = 'daily' | 'weekly' | 'monthly';
+
+/** Mirrors the `databaseBackup.timeOfDay` schema regex (#340). */
+const TIME_OF_DAY_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+/** Used only when a stored value is somehow unparseable; the schema default. */
+const FALLBACK_HOUR = 2;
+const FALLBACK_MINUTE = 0;
+
+/**
+ * Translate the stored `databaseBackup.*` schedule fields into a 5-field cron
+ * expression (`minute hour day-of-month month day-of-week`).
+ *
+ *   daily,   02:00                → `0 2 * * *`
+ *   weekly,  Monday    @ 02:00    → `0 2 * * 1`
+ *   monthly, day 1     @ 02:00    → `0 2 1 * *`
+ *
+ * The irrelevant field is `*` for each frequency: a weekly schedule does not
+ * constrain day-of-month, and a monthly one does not constrain day-of-week —
+ * setting both would AND them in some cron implementations and OR them in
+ * others, which is exactly the ambiguity this picker exists to avoid.
+ *
+ * Inputs are clamped rather than rejected. The Zod schema already validates
+ * every one of them on the write path (`dayOfWeek` 0–6, `dayOfMonth` 1–28,
+ * `timeOfDay` HH:mm), so a bad value here can only come from hand-edited JSON —
+ * and a scheduler that silently produces a *valid* cron is strictly better than
+ * one that throws inside a cron tick. `dayOfMonth` is capped at 28 for the same
+ * reason the schema caps it: days 29–31 do not exist in every month, so a
+ * "monthly" backup on the 31st would silently skip February.
+ */
+export function buildCronExpression(
+  frequency: DatabaseBackupFrequency,
+  dayOfWeek: number,
+  dayOfMonth: number,
+  timeOfDay: string,
+): string {
+  const { hour, minute } = parseTimeOfDay(timeOfDay);
+
+  switch (frequency) {
+    case 'weekly':
+      return `${minute} ${hour} * * ${clampInt(dayOfWeek, 0, 6, 0)}`;
+    case 'monthly':
+      return `${minute} ${hour} ${clampInt(dayOfMonth, 1, 28, 1)} * *`;
+    case 'daily':
+    default:
+      return `${minute} ${hour} * * *`;
+  }
+}
+
+/**
+ * Split `"HH:mm"` into numeric cron fields. Returns them as numbers so the
+ * emitted expression is the canonical `0 2 * * *` rather than `00 02 * * *` —
+ * both parse identically, but the canonical form is what the UI, the docs and
+ * every test in this repo show.
+ */
+export function parseTimeOfDay(timeOfDay: string): {
+  hour: number;
+  minute: number;
+} {
+  const match =
+    typeof timeOfDay === 'string' ? TIME_OF_DAY_RE.exec(timeOfDay.trim()) : null;
+  if (!match) {
+    return { hour: FALLBACK_HOUR, minute: FALLBACK_MINUTE };
+  }
+  return { hour: Number(match[1]), minute: Number(match[2]) };
+}
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  const n = Math.trunc(value);
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}


### PR DESCRIPTION
## Summary

Makes database backups fire on an admin-configured cadence, releases a run orphaned by a crashed or redeployed API process, and prunes old backups past the retention count.

The staleness sweep is the load-bearing part: it is **the replacement for the enrichment queue's stuck-job recovery that this feature deliberately forgoes** (see #339). Without it, one OOM-killed backup silently holds the single-active-run guard forever and blocks every future backup — the worst possible failure mode for a backup system.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #342
Part of epic #339
Depends on #340 and #341 (both merged)

## Changes Made

- **`schedule.util.ts`** — pure `buildCronExpression(frequency, dayOfWeek, dayOfMonth, timeOfDay)`; daily@02:00 → `0 2 * * *`, weekly Mon → `0 2 * * 1`, monthly day 1 → `0 2 1 * *`.
- **`db-backup-schedule.task.ts`** — a never-throwing `@Cron(EVERY_10_MINUTES)` task shaped like `TrashPurgeTask` / `NodeBackupStaleTask`, doing two jobs per tick:
  1. **Fire due backups** — reuses `nextCronDate`/`isValidCron` from `workflows/util/cron.util.ts` rather than new cron math, passing the timezone explicitly as the third argument. Compares the fire boundary against the most recent `startedAt` so it cannot double-fire within a tick window. A start that loses the race to the partial unique index (P2002) is treated as a **no-op, not an error** — that guard is doing its job.
  2. **Release stale runs** — any `running` row whose `lastHeartbeatAt` is older than `databaseBackup.runStaleMinutes` becomes `stale` with `finishedAt` set, and its partial storage object is best-effort deleted.
- **`database-backup-retention.service.ts`** — prunes `completed` runs beyond `retentionCount`, oldest first, **storage object before DB row** so a mid-prune failure leaves an orphaned row (visible, fixable) rather than an orphaned multi-GB object (invisible, billable).
- Registered in `db-backup.module.ts`.

### Two deliberate design choices preserved

- **A stale run is terminal and never requeued.** Automatically restarting a multi-GB dump that just died is not obviously right; the next scheduled tick is the natural retry. This is a conscious asymmetry with the enrichment queue.
- **`trigger='pre_restore'` runs are exempt from count-based pruning.** In `pre_restore_dump` rollback mode those dumps *are* the rollback for a restore, so evicting one because seven nightly backups happened since would silently destroy a recovery path. They are pruned on their own clock via `oldDatabaseRetentionHours` instead.

The task is independent of `ENRICHMENT_WORKER_MODE` (it is not a queue worker, so it runs even under `off`), gated by the new env kill-switch **`DB_BACKUP_SCHEDULE_ENABLED`** (default `true`), with an in-process `sweepInFlight` guard against overlapping ticks.

## Testing

- [x] Unit tests pass — full API suite: **304 suites, 7293 tests passed, 0 failed**
- [x] Type checks pass — `npx tsc --noEmit` clean
- [ ] E2E tests pass (not run)
- [ ] Manual testing completed (not possible — see below)

Coverage: exhaustive frequency/day/time → cron table including `dayOfMonth=28` and midnight `00:00`; fires when due and does not double-fire within a window; no-ops on P2002; respects `DB_BACKUP_SCHEDULE_ENABLED=false`; honors a non-UTC timezone (asserts `nextCronDate` received the tz argument); stale heartbeat → `stale` + partial object deleted while a fresh heartbeat is untouched; retention prunes oldest-first, deletes object before row, and never prunes a `pre_restore` run by count.

The "worker failed to exit gracefully" warning also appears on the pre-change baseline and is not introduced here.

### Not verified — requires a live database

No Docker or PostgreSQL in the development environment, so these acceptance criteria are **unexercised**:

- A scheduled run actually firing once (not repeatedly) against a real clock and database.
- A non-UTC timezone firing at the correct wall-clock local time end-to-end (the tz argument is asserted in a unit test, but not observed).
- Killing the API mid-run and watching the next tick mark the row `stale` so a subsequent backup can start.
- Real retention pruning deleting an object from a bucket.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (inline; user-facing docs land in #346)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HS1v19WgTyEnUvsw8ECEYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HS1v19WgTyEnUvsw8ECEYM)_