### PR TITLE
feat(web): location picker — geolocate drops a pin, always-grabbable marker, smarter centre, confirm row

### DIFF
--- a/apps/web/src/__tests__/components/media/BulkLocationDialog.test.tsx
+++ b/apps/web/src/__tests__/components/media/BulkLocationDialog.test.tsx
@@ -161,6 +161,9 @@ describe('BulkLocationDialog', () => {
       });
     });
 
+    // Issue #376 fix 4 promoted the faint "Pin: <lat>, <lng>" caption into a
+    // bordered confirm row; the raw coordinate is still shown, now without the
+    // "Pin:" prefix and beneath the address being committed.
     it('shows pin coordinates after pin is set', async () => {
       const user = userEvent.setup();
       render(<BulkLocationDialog {...defaultProps} />);
@@ -168,8 +171,9 @@ describe('BulkLocationDialog', () => {
       await user.click(screen.getByTestId('set-pin'));
 
       await waitFor(() => {
-        expect(screen.getByText(/pin:/i)).toBeInTheDocument();
+        expect(screen.getByTestId('location-confirm-row')).toBeInTheDocument();
       });
+      expect(screen.getByText(/9\.92810, -84\.09070/)).toBeInTheDocument();
     });
 
     it('shows geocoded location label after reverse geocode', async () => {
@@ -179,7 +183,7 @@ describe('BulkLocationDialog', () => {
       await user.click(screen.getByTestId('set-pin'));
 
       await waitFor(() => {
-        expect(screen.getByText(/La Fortuna/)).toBeInTheDocument();
+        expect(screen.getByText(/use this location: .*La Fortuna/i)).toBeInTheDocument();
       });
     });
   });

--- a/apps/web/src/__tests__/components/media/LocationPickerMap.test.tsx
+++ b/apps/web/src/__tests__/components/media/LocationPickerMap.test.tsx
@@ -49,7 +49,7 @@ vi.mock('leaflet', () => {
 vi.mock('react-leaflet', () => {
   // Marker exposes the icon html as a data attribute so the icon-SVG suite
   // can verify SVG content without a real Leaflet DOM.
-  const Marker = ({ position, icon, children, draggable, eventHandlers }: any) => {
+  const Marker = ({ position, icon, children, draggable, opacity, eventHandlers }: any) => {
     const iconHtml =
       icon && icon.options && typeof icon.options.html === 'string'
         ? icon.options.html
@@ -60,18 +60,25 @@ vi.mock('react-leaflet', () => {
         data-position={JSON.stringify(position)}
         data-icon-html={iconHtml}
         data-draggable={draggable ? 'true' : 'false'}
+        data-opacity={opacity === undefined ? '' : String(opacity)}
         onClick={() => eventHandlers?.click?.()}
+        // Double-click stands in for a Leaflet dragend so tests can exercise
+        // the drag path without a real Leaflet DOM.
+        onDoubleClick={() =>
+          eventHandlers?.dragend?.({ target: { getLatLng: () => ({ lat: 40.7, lng: -74 }) } })
+        }
       >
         {children}
       </div>
     );
   };
 
-  const MapContainer = ({ children, center, zoom, style }: any) => (
+  const MapContainer = ({ children, center, zoom, style, scrollWheelZoom }: any) => (
     <div
       data-testid="map-container"
       data-center={JSON.stringify(center)}
       data-zoom={zoom}
+      data-scroll-wheel-zoom={String(scrollWheelZoom)}
       style={style}
     >
       {children}
@@ -139,10 +146,75 @@ describe('LocationPickerMap', () => {
       expect(tile.getAttribute('data-url')).toContain('openstreetmap.org');
     });
 
-    it('should NOT render a Marker when value is null', () => {
+    // Issue #376 fix 2: a null value used to render NO marker at all, leaving
+    // nothing to grab and the click affordance undiscoverable.
+    it('should render a muted DRAGGABLE placeholder Marker when value is null', () => {
       const onChange = vi.fn();
       render(<LocationPickerMap value={null} onChange={onChange} />);
+      const marker = screen.getByTestId('marker');
+      expect(marker).toBeInTheDocument();
+      expect(marker.getAttribute('data-draggable')).toBe('true');
+      // Muted styling — an opacity below 1 marks it as "not chosen yet".
+      const opacity = Number(marker.getAttribute('data-opacity'));
+      expect(opacity).toBeGreaterThan(0);
+      expect(opacity).toBeLessThan(1);
+    });
+
+    it('should place the placeholder Marker at the map centre when value is null', () => {
+      const onChange = vi.fn();
+      render(
+        <LocationPickerMap
+          value={null}
+          onChange={onChange}
+          initialCenter={{ lat: 9.93, lng: -84.09 }}
+        />,
+      );
+      const marker = screen.getByTestId('marker');
+      expect(JSON.parse(marker.getAttribute('data-position') ?? '[]')).toEqual([9.93, -84.09]);
+    });
+
+    it('should report a coordinate when the placeholder Marker is dragged', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<LocationPickerMap value={null} onChange={onChange} />);
+
+      await user.dblClick(screen.getByTestId('marker'));
+
+      expect(onChange).toHaveBeenCalledWith({ lat: 40.7, lng: -74 });
+    });
+
+    it('should render the placeholder Marker with the inline-SVG defaultIcon', () => {
+      const onChange = vi.fn();
+      render(<LocationPickerMap value={null} onChange={onChange} />);
+      const iconHtml = screen.getByTestId('marker').getAttribute('data-icon-html') ?? '';
+      expect(iconHtml).toContain('<svg');
+      expect(iconHtml).not.toContain('.png');
+    });
+
+    // The three non-picker call sites (SearchPanel, ActionParamEditor,
+    // ConditionValueEditor) opt out, restoring the pre-#376 "no marker at all"
+    // look so they stay visually unchanged.
+    it('should render NO Marker when value is null and showPlaceholderMarker is false', () => {
+      const onChange = vi.fn();
+      render(
+        <LocationPickerMap value={null} onChange={onChange} showPlaceholderMarker={false} />,
+      );
       expect(screen.queryByTestId('marker')).not.toBeInTheDocument();
+    });
+
+    it('should still render the real Marker when a value exists and the placeholder is off', () => {
+      const onChange = vi.fn();
+      render(
+        <LocationPickerMap
+          value={{ lat: 9.93, lng: -84.09 }}
+          onChange={onChange}
+          showPlaceholderMarker={false}
+        />,
+      );
+      const marker = screen.getByTestId('marker');
+      expect(JSON.parse(marker.getAttribute('data-position') ?? '[]')).toEqual([9.93, -84.09]);
+      // The real pin is never muted.
+      expect(marker.getAttribute('data-opacity')).toBe('');
     });
 
     it('should render a Marker when value is provided', () => {
@@ -233,6 +305,162 @@ describe('LocationPickerMap', () => {
       );
       const mapEl = container.querySelector('[style*="height"]');
       expect(mapEl?.getAttribute('style')).toContain('500px');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #376 fix 3 — initialCenter framing hint
+  // -------------------------------------------------------------------------
+  describe('initialCenter', () => {
+    it('opens on initialCenter (zoomed in) when there is no value', () => {
+      const onChange = vi.fn();
+      render(
+        <LocationPickerMap
+          value={null}
+          onChange={onChange}
+          initialCenter={{ lat: 48.8566, lng: 2.3522 }}
+        />,
+      );
+      const container = screen.getByTestId('map-container');
+      expect(JSON.parse(container.getAttribute('data-center') ?? '[]')).toEqual([48.8566, 2.3522]);
+      expect(container.getAttribute('data-zoom')).not.toBe('2');
+    });
+
+    it('is outranked by an actual value', () => {
+      const onChange = vi.fn();
+      render(
+        <LocationPickerMap
+          value={{ lat: 10, lng: 20 }}
+          onChange={onChange}
+          initialCenter={{ lat: 48.8566, lng: 2.3522 }}
+        />,
+      );
+      const container = screen.getByTestId('map-container');
+      expect(JSON.parse(container.getAttribute('data-center') ?? '[]')).toEqual([10, 20]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #376 fix 4 — scrollWheelZoom is a prop, default on
+  // -------------------------------------------------------------------------
+  describe('scrollWheelZoom', () => {
+    it('defaults to true', () => {
+      render(<LocationPickerMap value={null} onChange={vi.fn()} />);
+      expect(screen.getByTestId('map-container').getAttribute('data-scroll-wheel-zoom')).toBe(
+        'true',
+      );
+    });
+
+    it('can be turned off by the caller', () => {
+      render(<LocationPickerMap value={null} onChange={vi.fn()} scrollWheelZoom={false} />);
+      expect(screen.getByTestId('map-container').getAttribute('data-scroll-wheel-zoom')).toBe(
+        'false',
+      );
+    });
+  });
+});
+
+// ============================================================================
+// Issue #376 fix 1 — "Use my location"
+// ============================================================================
+
+describe('LocationPickerMap — Use my location', () => {
+  const getCurrentPosition = vi.fn();
+
+  /** Position fixture used by the stubbed geolocation API. */
+  function makePosition(overrides: Partial<{ latitude: number; longitude: number }> = {}) {
+    return { coords: { latitude: 9.9281, longitude: -84.0907, ...overrides } };
+  }
+
+  /** GeolocationPositionError-shaped fixture. */
+  function makeGeoError(overrides: Partial<{ code: number }> = {}) {
+    return { code: 1, PERMISSION_DENIED: 1, POSITION_UNAVAILABLE: 2, TIMEOUT: 3, ...overrides };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentPosition.mockImplementation((success: (p: unknown) => void) => {
+      success(makePosition());
+    });
+    Object.defineProperty(globalThis.navigator, 'geolocation', {
+      value: { getCurrentPosition },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('does NOT call onChange from the on-mount auto-locate', () => {
+    const onChange = vi.fn();
+    render(<LocationPickerMap value={null} onChange={onChange} />);
+
+    // The recenter-only probe ran…
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+    // …but must never overwrite/author a coordinate.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onChange on an explicit press when geolocateSetsValue is true (default)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<LocationPickerMap value={null} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /use my location/i }));
+
+    expect(onChange).toHaveBeenCalledWith({ lat: 9.9281, lng: -84.0907 });
+  });
+
+  it('does NOT call onChange on an explicit press when geolocateSetsValue is false', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <LocationPickerMap value={null} onChange={onChange} geolocateSetsValue={false} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /use my location/i }));
+
+    // Still recentered (the probe ran) but the value is untouched.
+    expect(getCurrentPosition).toHaveBeenCalledTimes(2);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('surfaces MapControls-style copy when permission is denied', async () => {
+    const user = userEvent.setup();
+    getCurrentPosition.mockImplementation(
+      (_success: unknown, failure: (e: unknown) => void) => {
+        failure(makeGeoError({ code: 1 }));
+      },
+    );
+    render(<LocationPickerMap value={null} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /use my location/i }));
+
+    expect(await screen.findByText(/location permission denied/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the generic failure copy for a non-permission error', async () => {
+    const user = userEvent.setup();
+    getCurrentPosition.mockImplementation(
+      (_success: unknown, failure: (e: unknown) => void) => {
+        failure(makeGeoError({ code: 3 }));
+      },
+    );
+    render(<LocationPickerMap value={null} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /use my location/i }));
+
+    expect(await screen.findByText(/could not determine your location/i)).toBeInTheDocument();
+  });
+
+  it('stays silent when the on-mount probe fails', async () => {
+    getCurrentPosition.mockImplementation(
+      (_success: unknown, failure: (e: unknown) => void) => {
+        failure(makeGeoError({ code: 1 }));
+      },
+    );
+    render(<LocationPickerMap value={null} onChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/location permission denied/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/components/media/LocationSearchPicker.test.tsx
+++ b/apps/web/src/__tests__/components/media/LocationSearchPicker.test.tsx
@@ -17,23 +17,29 @@ import { LocationSearchPicker } from '../../../components/media/LocationSearchPi
 // Mock LocationPickerMap — exposes a button to simulate pin placement
 // ---------------------------------------------------------------------------
 vi.mock('../../../components/media/LocationPickerMap', () => ({
-  LocationPickerMap: ({
-    onChange,
-  }: {
-    value: { lat: number; lng: number } | null;
-    onChange: (latlng: { lat: number; lng: number }) => void;
-    height?: number;
-    center?: [number, number];
-  }) => (
-    <div data-testid="location-picker-map">
-      <button
-        type="button"
-        data-testid="set-pin"
-        onClick={() => onChange({ lat: 9.9281, lng: -84.0907 })}
-      >
-        Set Pin
-      </button>
-    </div>
+  LocationPickerMap: vi.fn(
+    ({
+      onChange,
+    }: {
+      value: { lat: number; lng: number } | null;
+      onChange: (latlng: { lat: number; lng: number }) => void;
+      height?: number;
+      center?: [number, number];
+      initialCenter?: { lat: number; lng: number };
+      scrollWheelZoom?: boolean;
+      geolocateSetsValue?: boolean;
+      showPlaceholderMarker?: boolean;
+    }) => (
+      <div data-testid="location-picker-map">
+        <button
+          type="button"
+          data-testid="set-pin"
+          onClick={() => onChange({ lat: 9.9281, lng: -84.0907 })}
+        >
+          Set Pin
+        </button>
+      </div>
+    ),
   ),
 }));
 
@@ -46,18 +52,33 @@ vi.mock('../../../services/media', () => ({
 }));
 
 import { searchPlaces, reverseGeocode } from '../../../services/media';
+import { LocationPickerMap } from '../../../components/media/LocationPickerMap';
 
 const mockSearchPlaces = vi.mocked(searchPlaces);
 const mockReverseGeocode = vi.mocked(reverseGeocode);
+const mockLocationPickerMap = vi.mocked(LocationPickerMap);
 
-const geoResult = {
-  country: 'Costa Rica',
-  countryCode: 'CR',
-  admin1: 'Alajuela',
-  admin2: null,
-  locality: 'La Fortuna',
-  placeName: 'Arenal',
-};
+/** Reverse-geocode result factory — override any field, `null` blanks it. */
+function makeGeoResult(overrides: Partial<Record<string, string | null>> = {}) {
+  return {
+    country: 'Costa Rica',
+    countryCode: 'CR',
+    admin1: 'Alajuela',
+    admin2: null,
+    locality: 'La Fortuna',
+    placeName: 'Arenal',
+    ...overrides,
+  } as never;
+}
+
+const geoResult = makeGeoResult();
+
+/** Props the stubbed LocationPickerMap was last rendered with. */
+function lastMapProps(): Record<string, unknown> {
+  const calls = mockLocationPickerMap.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as unknown as Record<string, unknown>;
+}
 
 describe('LocationSearchPicker', () => {
   beforeEach(() => {
@@ -156,8 +177,107 @@ describe('LocationSearchPicker', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText(/pin:/i)).not.toBeInTheDocument();
+      expect(screen.queryByTestId('location-confirm-row')).not.toBeInTheDocument();
     });
     expect(mockReverseGeocode).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #376 fix 4 — the confirm row
+  // -------------------------------------------------------------------------
+  describe('confirm row', () => {
+    it('shows the resolving state while the address lookup is in flight', async () => {
+      // Never settles — holds the component in the resolving state.
+      mockReverseGeocode.mockReturnValue(new Promise(() => {}) as never);
+
+      render(
+        <LocationSearchPicker value={{ lat: 9.9281, lng: -84.0907 }} onChange={vi.fn()} />,
+      );
+
+      expect(await screen.findByText(/finding address/i)).toBeInTheDocument();
+      expect(screen.getByTestId('location-confirm-row')).toBeInTheDocument();
+      expect(screen.queryByText(/use this location/i)).not.toBeInTheDocument();
+    });
+
+    it('reads "Use this location: <address>" once resolved', async () => {
+      render(
+        <LocationSearchPicker value={{ lat: 9.9281, lng: -84.0907 }} onChange={vi.fn()} />,
+      );
+
+      expect(
+        await screen.findByText(/use this location: La Fortuna, Alajuela, Costa Rica/i),
+      ).toBeInTheDocument();
+      // The raw coordinate stays visible underneath.
+      expect(screen.getByText(/9\.92810, -84\.09070/)).toBeInTheDocument();
+    });
+
+    it('falls back to "Coordinates only" when the lookup returns no address parts', async () => {
+      mockReverseGeocode.mockResolvedValue(
+        makeGeoResult({ locality: null, admin1: null, country: null }),
+      );
+
+      render(
+        <LocationSearchPicker value={{ lat: 9.9281, lng: -84.0907 }} onChange={vi.fn()} />,
+      );
+
+      expect(
+        await screen.findByText(/coordinates only — no address found/i),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to "Coordinates only" when the lookup fails outright', async () => {
+      mockReverseGeocode.mockRejectedValue(new Error('boom'));
+
+      render(
+        <LocationSearchPicker value={{ lat: 9.9281, lng: -84.0907 }} onChange={vi.fn()} />,
+      );
+
+      expect(
+        await screen.findByText(/coordinates only — no address found/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders no confirm row at all when there is no coordinate yet', () => {
+      render(<LocationSearchPicker value={null} onChange={vi.fn()} />);
+      expect(screen.queryByTestId('location-confirm-row')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #376 fixes 1 + 3 + 4 — props forwarded to the map
+  // -------------------------------------------------------------------------
+  describe('map props', () => {
+    it('forwards initialCenter to the map', () => {
+      render(
+        <LocationSearchPicker
+          value={null}
+          onChange={vi.fn()}
+          initialCenter={{ lat: 48.8566, lng: 2.3522 }}
+        />,
+      );
+      expect(lastMapProps().initialCenter).toEqual({ lat: 48.8566, lng: 2.3522 });
+    });
+
+    it('enables all three behavioural additions by default', () => {
+      render(<LocationSearchPicker value={null} onChange={vi.fn()} />);
+      expect(lastMapProps().scrollWheelZoom).toBe(true);
+      expect(lastMapProps().geolocateSetsValue).toBe(true);
+      expect(lastMapProps().showPlaceholderMarker).toBe(true);
+    });
+
+    it('lets the caller turn all three off', () => {
+      render(
+        <LocationSearchPicker
+          value={null}
+          onChange={vi.fn()}
+          scrollWheelZoom={false}
+          geolocateSetsValue={false}
+          showPlaceholderMarker={false}
+        />,
+      );
+      expect(lastMapProps().scrollWheelZoom).toBe(false);
+      expect(lastMapProps().geolocateSetsValue).toBe(false);
+      expect(lastMapProps().showPlaceholderMarker).toBe(false);
+    });
   });
 });

--- a/apps/web/src/__tests__/components/media/MediaDetailDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/media/MediaDetailDrawer.test.tsx
@@ -162,17 +162,23 @@ vi.mock('../../../components/media/TagAutocomplete', () => ({
 vi.mock('../../../hooks/useLocationSuggestions', () => ({
   useSuggestLocation: vi.fn(),
   useItemAutoAppliedSuggestion: vi.fn(),
+  useItemLocationCandidate: vi.fn(),
 }));
 
 vi.mock('../../../services/locationSuggestions', () => ({
   revertLocationSuggestion: vi.fn(),
 }));
 
-import { useSuggestLocation, useItemAutoAppliedSuggestion } from '../../../hooks/useLocationSuggestions';
+import {
+  useSuggestLocation,
+  useItemAutoAppliedSuggestion,
+  useItemLocationCandidate,
+} from '../../../hooks/useLocationSuggestions';
 import { revertLocationSuggestion } from '../../../services/locationSuggestions';
 
 const mockUseSuggestLocation = vi.mocked(useSuggestLocation);
 const mockUseItemAutoAppliedSuggestion = vi.mocked(useItemAutoAppliedSuggestion);
+const mockUseItemLocationCandidate = vi.mocked(useItemLocationCandidate);
 const mockRevertLocationSuggestion = vi.mocked(revertLocationSuggestion);
 
 // ---------------------------------------------------------------------------
@@ -272,6 +278,7 @@ describe('MediaDetailDrawer', () => {
     // Default: no active suggest/revert state for location-inference affordances
     mockUseSuggestLocation.mockReturnValue({ suggest: vi.fn(), loading: false, error: null });
     mockUseItemAutoAppliedSuggestion.mockReturnValue({ suggestionId: null, loading: false });
+    mockUseItemLocationCandidate.mockReturnValue({ candidate: null, loading: false });
     mockRevertLocationSuggestion.mockResolvedValue({ id: 'suggestion-1', status: 'reverted' });
     mockRerunThumbnail.mockResolvedValue({ status: 'ready' });
   });

--- a/apps/web/src/__tests__/components/search/SearchPanelLocationPicker.test.tsx
+++ b/apps/web/src/__tests__/components/search/SearchPanelLocationPicker.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * SearchPanel — LocationPickerMap integration guard (issue #376).
+ *
+ * The location picker gained two behavioural props that default to ON
+ * (`geolocateSetsValue`, `scrollWheelZoom`). SearchPanel is NOT a location
+ * editor — it builds a search filter — so it must opt OUT of both, and its
+ * pin-drop behaviour must be exactly what it was before.
+ *
+ * LocationPickerMap is stubbed (same approach as the neighbouring SearchPanel
+ * suite) so we can inspect the props SearchPanel actually passes without
+ * pulling Leaflet into jsdom.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared BEFORE importing the module under test
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../services/media', () => ({
+  getLocationFacets: vi.fn(),
+  getExploreTags: vi.fn(),
+}));
+
+vi.mock('../../../components/search/PersonMultiSelect', () => ({
+  PersonMultiSelect: vi.fn(({ label }: { label: string }) => (
+    <div data-testid="person-multi-select">{label}</div>
+  )),
+}));
+
+vi.mock('../../../components/media/LocationPickerMap', () => ({
+  LocationPickerMap: vi.fn(
+    ({ onChange }: { onChange: (latlng: { lat: number; lng: number }) => void }) => (
+      <button
+        data-testid="location-picker-map"
+        onClick={() => onChange({ lat: 9.93, lng: -84.09 })}
+      >
+        Drop pin
+      </button>
+    ),
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks (Vitest requires this order)
+// ---------------------------------------------------------------------------
+
+import { SearchPanel } from '../../../components/search/SearchPanel';
+import { getLocationFacets, getExploreTags } from '../../../services/media';
+import { LocationPickerMap } from '../../../components/media/LocationPickerMap';
+
+const mockGetLocationFacets = vi.mocked(getLocationFacets);
+const mockGetExploreTags = vi.mocked(getExploreTags);
+const mockLocationPickerMap = vi.mocked(LocationPickerMap);
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+const CIRCLE_ID = 'circle-test-376';
+
+function makeFacets() {
+  return [
+    {
+      country: 'Costa Rica',
+      countryCode: 'CR',
+      count: 10,
+      regions: [{ name: 'San José', count: 10, localities: [{ name: 'Heredia', count: 10 }] }],
+    },
+  ];
+}
+
+function makeProps(
+  overrides: Partial<{
+    open: boolean;
+    onClose: ReturnType<typeof vi.fn>;
+    onSubmit: ReturnType<typeof vi.fn>;
+  }> = {},
+) {
+  return {
+    open: true,
+    circleId: CIRCLE_ID,
+    onClose: vi.fn(),
+    onSubmit: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function waitForLoaded() {
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+}
+
+/** Last props the stubbed LocationPickerMap was rendered with. */
+function lastMapProps(): Record<string, unknown> {
+  const calls = mockLocationPickerMap.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as unknown as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SearchPanel — location picker props are unchanged by #376', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetLocationFacets.mockResolvedValue(makeFacets() as never);
+    mockGetExploreTags.mockResolvedValue([]);
+  });
+
+  it('opts out of geolocate-sets-value so "Use my location" cannot write a filter', async () => {
+    const user = userEvent.setup();
+    render(<SearchPanel {...makeProps()} />);
+    await waitForLoaded();
+
+    await user.click(screen.getByRole('button', { name: /map radius/i }));
+
+    expect(lastMapProps().geolocateSetsValue).toBe(false);
+  });
+
+  it('opts out of scroll-wheel zoom so the panel keeps scrolling normally', async () => {
+    const user = userEvent.setup();
+    render(<SearchPanel {...makeProps()} />);
+    await waitForLoaded();
+
+    await user.click(screen.getByRole('button', { name: /map radius/i }));
+
+    expect(lastMapProps().scrollWheelZoom).toBe(false);
+  });
+
+  it('opts out of the placeholder marker so the panel is visually unchanged', async () => {
+    const user = userEvent.setup();
+    render(<SearchPanel {...makeProps()} />);
+    await waitForLoaded();
+
+    await user.click(screen.getByRole('button', { name: /map radius/i }));
+
+    expect(lastMapProps().showPlaceholderMarker).toBe(false);
+  });
+
+  it('still submits filters.near when a pin is dropped', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<SearchPanel {...makeProps({ onSubmit })} />);
+    await waitForLoaded();
+
+    await user.click(screen.getByRole('button', { name: /map radius/i }));
+    await user.click(screen.getByTestId('location-picker-map'));
+    await user.click(screen.getByRole('button', { name: /^search$/i }));
+
+    await waitFor(() => {
+      const call = onSubmit.mock.calls[0]?.[0] as { filters: Record<string, unknown> };
+      expect(call.filters).toMatchObject({
+        near: { lat: 9.93, lng: -84.09, radiusKm: expect.any(Number) },
+      });
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/workflows/builder/LocationPickerOptOut.test.tsx
+++ b/apps/web/src/__tests__/components/workflows/builder/LocationPickerOptOut.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Workflow builder — LocationPickerMap opt-out guard (issue #376).
+ *
+ * The location picker gained three behavioural props that default to ON
+ * (`geolocateSetsValue`, `scrollWheelZoom`, `showPlaceholderMarker`). Neither
+ * workflow-builder surface is a location editor — one edits a `set_location`
+ * action param, the other a map-radius condition value — and issue #376's
+ * acceptance criteria require both to stay visually and behaviourally
+ * unchanged, so both must opt out of all three.
+ *
+ * LocationPickerMap is stubbed so the props can be inspected without pulling
+ * Leaflet into jsdom.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '../../../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared BEFORE importing the modules under test
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../components/media/LocationPickerMap', () => ({
+  LocationPickerMap: vi.fn(() => <div data-testid="location-picker-map" />),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks (Vitest requires this order)
+// ---------------------------------------------------------------------------
+
+import { ActionParamEditor } from '../../../../components/workflows/builder/ActionParamEditor';
+import { ConditionValueEditor } from '../../../../components/workflows/builder/ConditionValueEditor';
+import { LocationPickerMap } from '../../../../components/media/LocationPickerMap';
+import type {
+  WorkflowActionInstance,
+  WorkflowFieldDescriptor,
+} from '../../../../types/workflows';
+
+const mockLocationPickerMap = vi.mocked(LocationPickerMap);
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeSetLocationAction(
+  overrides: Partial<WorkflowActionInstance> = {},
+): WorkflowActionInstance {
+  return { type: 'set_location', ...overrides } as WorkflowActionInstance;
+}
+
+function makeGeoRadiusField(
+  overrides: Partial<WorkflowFieldDescriptor> = {},
+): WorkflowFieldDescriptor {
+  return {
+    key: 'near',
+    label: 'Near location (map radius)',
+    valueType: 'geo-radius',
+    operators: ['within'],
+    ...overrides,
+  } as WorkflowFieldDescriptor;
+}
+
+/** Props the stubbed LocationPickerMap was last rendered with. */
+function lastMapProps(): Record<string, unknown> {
+  const calls = mockLocationPickerMap.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as unknown as Record<string, unknown>;
+}
+
+/** Every #376 behavioural addition must be explicitly disabled. */
+function expectFullyOptedOut() {
+  const props = lastMapProps();
+  expect(props.geolocateSetsValue).toBe(false);
+  expect(props.scrollWheelZoom).toBe(false);
+  expect(props.showPlaceholderMarker).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ActionParamEditor — set_location map opts out of the #376 additions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables geolocate-sets-value, scroll zoom and the placeholder marker', () => {
+    render(
+      <ActionParamEditor
+        circleId="circle-1"
+        action={makeSetLocationAction()}
+        onChange={vi.fn()}
+        tags={[]}
+        albums={[]}
+      />,
+    );
+
+    expectFullyOptedOut();
+  });
+
+  it('keeps the opt-out once a pin has been chosen', () => {
+    render(
+      <ActionParamEditor
+        circleId="circle-1"
+        action={makeSetLocationAction({ lat: 9.93, lng: -84.09 } as Partial<WorkflowActionInstance>)}
+        onChange={vi.fn()}
+        tags={[]}
+        albums={[]}
+      />,
+    );
+
+    expectFullyOptedOut();
+    expect(lastMapProps().value).toEqual({ lat: 9.93, lng: -84.09 });
+  });
+});
+
+describe('ConditionValueEditor — geo-radius map opts out of the #376 additions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables geolocate-sets-value, scroll zoom and the placeholder marker', () => {
+    render(
+      <ConditionValueEditor
+        circleId="circle-1"
+        field={makeGeoRadiusField()}
+        op="within"
+        value={null}
+        onChange={vi.fn()}
+        tags={[]}
+        albums={[]}
+      />,
+    );
+
+    expectFullyOptedOut();
+    // An unset condition still passes a null value — no implicit centre.
+    expect(lastMapProps().value).toBeNull();
+  });
+
+  it('keeps the opt-out once a centre has been chosen', () => {
+    render(
+      <ConditionValueEditor
+        circleId="circle-1"
+        field={makeGeoRadiusField()}
+        op="within"
+        value={{ lat: 9.93, lng: -84.09, radiusKm: 25 }}
+        onChange={vi.fn()}
+        tags={[]}
+        albums={[]}
+      />,
+    );
+
+    expectFullyOptedOut();
+    expect(lastMapProps().value).toEqual({ lat: 9.93, lng: -84.09 });
+  });
+});

--- a/apps/web/src/__tests__/hooks/useLocationSuggestions.test.ts
+++ b/apps/web/src/__tests__/hooks/useLocationSuggestions.test.ts
@@ -36,6 +36,7 @@ import {
   useLocationSuggestions,
   useSuggestLocation,
   useItemAutoAppliedSuggestion,
+  useItemLocationCandidate,
 } from '../../hooks/useLocationSuggestions';
 
 // ---------------------------------------------------------------------------
@@ -758,5 +759,76 @@ describe('useItemAutoAppliedSuggestion', () => {
 
       expect(result.current.suggestionId).toBe('suggestion-b');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useItemLocationCandidate (issue #376) — read-only framing hint for the
+// location picker: resolves the item's PENDING suggestion coordinates so the
+// map can open on them instead of a world view. It must never accept anything.
+// ---------------------------------------------------------------------------
+
+describe('useItemLocationCandidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries the pending suggestion for the item and exposes its coordinates', async () => {
+    mockListLocationSuggestions.mockResolvedValue(makeListResponse([makeSummary()]));
+
+    const { result } = renderHook(() =>
+      useItemLocationCandidate('circle-1', 'media-1', true),
+    );
+
+    await waitFor(() => {
+      expect(result.current.candidate).toEqual({ lat: 9.9281, lng: -84.0907 });
+    });
+    expect(mockListLocationSuggestions).toHaveBeenCalledWith({
+      circleId: 'circle-1',
+      mediaItemId: 'media-1',
+      status: 'pending',
+      page: 1,
+      pageSize: 1,
+    });
+    // Read-only: nothing is accepted, rejected, or reverted.
+    expect(mockAcceptLocationSuggestion).not.toHaveBeenCalled();
+    expect(mockRejectLocationSuggestion).not.toHaveBeenCalled();
+  });
+
+  it('resolves to null when the item has no pending suggestion', async () => {
+    mockListLocationSuggestions.mockResolvedValue(makeListResponse([]));
+
+    const { result } = renderHook(() =>
+      useItemLocationCandidate('circle-1', 'media-1', true),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.candidate).toBeNull();
+  });
+
+  it('does not query at all when disabled or when an id is missing', () => {
+    const { result } = renderHook(() =>
+      useItemLocationCandidate('circle-1', 'media-1', false),
+    );
+    expect(mockListLocationSuggestions).not.toHaveBeenCalled();
+    expect(result.current.candidate).toBeNull();
+
+    renderHook(() => useItemLocationCandidate('', 'media-1', true));
+    expect(mockListLocationSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failed lookup — a missing hint is not an error', async () => {
+    mockListLocationSuggestions.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() =>
+      useItemLocationCandidate('circle-1', 'media-1', true),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.candidate).toBeNull();
   });
 });

--- a/apps/web/src/components/media/LocationPickerMap.tsx
+++ b/apps/web/src/components/media/LocationPickerMap.tsx
@@ -1,26 +1,93 @@
 /**
  * LocationPickerMap — an interactive Leaflet map for picking a single coordinate.
- * Click anywhere on the map to place/move a draggable marker.
+ *
+ * Three ways to set the coordinate:
+ *   1. Click anywhere on the map.
+ *   2. Drag the pin. When no coordinate is set yet a MUTED PLACEHOLDER pin is
+ *      rendered at the map centre (kept pinned to the centre as the map moves)
+ *      so there is always something grabbable — previously a null `value`
+ *      rendered no marker at all and the click affordance was undiscoverable.
+ *      Suppressible via `showPlaceholderMarker`.
+ *   3. Press "Use my location" (only when `geolocateSetsValue` is true).
+ *
+ * Geolocation has TWO distinct paths, deliberately:
+ *   - ON MOUNT: a silent, recenter-only probe. It must NEVER write a value —
+ *     doing so would silently overwrite an existing coordinate.
+ *   - EXPLICIT BUTTON PRESS: recenters AND (when `geolocateSetsValue`) reports
+ *     the coordinate up through `onChange`, with MapControls-style error
+ *     messaging in a snackbar.
+ *
+ * Backward compatibility: every prop added here is OPTIONAL and defaults to the
+ * NEW behaviour, so the intended consumer (LocationSearchPicker) gets all of it
+ * for free. The three non-picker call sites (SearchPanel, ActionParamEditor,
+ * ConditionValueEditor) explicitly opt out of all three additions
+ * (`geolocateSetsValue`, `scrollWheelZoom`, `showPlaceholderMarker`) so they
+ * remain visually and behaviourally identical to before — an acceptance
+ * criterion of issue #376.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { defaultIcon } from '../../lib/leaflet-setup';
 import { MapContainer, TileLayer, Marker, useMapEvents, useMap } from 'react-leaflet';
 import type { LeafletMouseEvent } from 'leaflet';
-import { Box, IconButton } from '@mui/material';
+import { Box, IconButton, Snackbar, Alert } from '@mui/material';
 import MyLocationIcon from '@mui/icons-material/MyLocation';
 
-interface LocationPickerMapProps {
-  value: { lat: number; lng: number } | null;
-  onChange: (latlng: { lat: number; lng: number }) => void;
-  height?: number;
-  center?: [number, number];
+export interface LatLngValue {
+  lat: number;
+  lng: number;
 }
 
+interface LocationPickerMapProps {
+  value: LatLngValue | null;
+  onChange: (latlng: LatLngValue) => void;
+  height?: number;
+  /** Recenters the map whenever this changes (e.g. a chosen search result). */
+  center?: [number, number];
+  /**
+   * Where the map should OPEN when there is no `value` yet. Unlike `center`
+   * this is an initial framing hint only — it does not force a later recenter.
+   */
+  initialCenter?: LatLngValue;
+  /**
+   * When true (default) an EXPLICIT "Use my location" press also sets the
+   * coordinate via `onChange`, not just the map view. The on-mount auto-locate
+   * is always recenter-only regardless of this flag.
+   */
+  geolocateSetsValue?: boolean;
+  /** Mouse-wheel zoom. Default true — off for embedded/scrollable call sites. */
+  scrollWheelZoom?: boolean;
+  /**
+   * Render the muted, draggable placeholder pin at the map centre while
+   * `value` is null. Default true. Set false to restore the pre-#376 look,
+   * where a null value renders no marker at all.
+   */
+  showPlaceholderMarker?: boolean;
+}
+
+/** Opacity applied to the placeholder pin so it reads as "not set yet". */
+const PLACEHOLDER_PIN_OPACITY = 0.55;
+
 // Inner component that handles map events (must be inside MapContainer)
-function ClickHandler({ onChange }: { onChange: (latlng: { lat: number; lng: number }) => void }) {
+function ClickHandler({ onChange }: { onChange: (latlng: LatLngValue) => void }) {
   useMapEvents({
     click(e: LeafletMouseEvent) {
       onChange({ lat: e.latlng.lat, lng: e.latlng.lng });
+    },
+  });
+  return null;
+}
+
+/**
+ * Reports the map's live centre upward so the placeholder pin can stay pinned
+ * to the middle of the viewport while no coordinate has been chosen.
+ * Optional-chained throughout so a partially-stubbed react-leaflet (unit tests)
+ * cannot throw.
+ */
+function CenterTracker({ onCenter }: { onCenter: (center: [number, number]) => void }) {
+  const map = useMapEvents({
+    move() {
+      const c = map?.getCenter?.();
+      if (c) onCenter([c.lat, c.lng]);
     },
   });
   return null;
@@ -36,30 +103,46 @@ function MapRecenterer({ center }: { center: [number, number] }) {
   return null;
 }
 
+interface GeoRequestHandlers {
+  onLocated?: (coords: LatLngValue) => void;
+  onError?: (message: string) => void;
+}
+
 function useGeoLocation() {
   const [geoCenter, setGeoCenter] = useState<[number, number] | null>(null);
   const [geoPending, setGeoPending] = useState(false);
   const requestedRef = useRef(false);
 
-  const requestLocation = useCallback(() => {
-    if (typeof navigator === 'undefined' || !('geolocation' in navigator)) return;
+  const requestLocation = useCallback((handlers?: GeoRequestHandlers) => {
+    if (typeof navigator === 'undefined' || !('geolocation' in navigator)) {
+      handlers?.onError?.('Geolocation is not supported by your browser.');
+      return;
+    }
     setGeoPending(true);
     navigator.geolocation.getCurrentPosition(
       (pos) => {
-        setGeoCenter([pos.coords.latitude, pos.coords.longitude]);
+        const coords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+        setGeoCenter([coords.lat, coords.lng]);
         setGeoPending(false);
+        handlers?.onLocated?.(coords);
       },
-      () => {
-        // denied or error — leave geoCenter null
+      (err) => {
         setGeoPending(false);
+        // Mirrors MapControls' permission-denied / generic-failure copy.
+        const denied = err?.code === (err?.PERMISSION_DENIED ?? 1);
+        handlers?.onError?.(
+          denied ? 'Location permission denied.' : 'Could not determine your location.',
+        );
       },
-      { timeout: 8000 },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
     );
   }, []);
 
   useEffect(() => {
     if (requestedRef.current) return;
     requestedRef.current = true;
+    // Recenter-only, and silent: no onLocated (would overwrite an existing
+    // coordinate) and no onError (the user did not ask for this).
     requestLocation();
   }, [requestLocation]);
 
@@ -71,28 +154,59 @@ export function LocationPickerMap({
   onChange,
   height = 300,
   center,
+  initialCenter,
+  geolocateSetsValue = true,
+  scrollWheelZoom = true,
+  showPlaceholderMarker = true,
 }: LocationPickerMapProps) {
   const { geoCenter, requestLocation } = useGeoLocation();
+  const [geoError, setGeoError] = useState<string | null>(null);
 
   const defaultCenter: [number, number] = value
     ? [value.lat, value.lng]
-    : center ?? [20, 0];
-  const defaultZoom = value ? 13 : 2;
+    : initialCenter
+      ? [initialCenter.lat, initialCenter.lng]
+      : center ?? [20, 0];
+  const defaultZoom = value || initialCenter ? 13 : 2;
+
+  // Live position of the placeholder pin shown while `value` is null. Seeded
+  // from the initial view and then kept in sync with the map centre.
+  const [placeholderPos, setPlaceholderPos] = useState<[number, number]>(() => defaultCenter);
+
+  useEffect(() => {
+    if (center) setPlaceholderPos(center);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [center?.[0], center?.[1]]);
+
+  useEffect(() => {
+    if (geoCenter) setPlaceholderPos(geoCenter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [geoCenter?.[0], geoCenter?.[1]]);
 
   const handleDrag = useCallback(
-    (e: { target: { getLatLng: () => { lat: number; lng: number } } }) => {
+    (e: { target: { getLatLng: () => LatLngValue } }) => {
       const latlng = e.target.getLatLng();
       onChange({ lat: latlng.lat, lng: latlng.lng });
     },
     [onChange],
   );
 
+  const handleGeolocateClick = useCallback(() => {
+    setGeoError(null);
+    requestLocation({
+      onLocated: (coords) => {
+        if (geolocateSetsValue) onChange(coords);
+      },
+      onError: (message) => setGeoError(message),
+    });
+  }, [requestLocation, geolocateSetsValue, onChange]);
+
   return (
-    <Box sx={{ position: 'relative' }}>
+    <Box sx={{ position: 'relative', maxWidth: '100%', overflow: 'hidden' }}>
       <MapContainer
         center={defaultCenter}
         zoom={defaultZoom}
-        scrollWheelZoom={false}
+        scrollWheelZoom={scrollWheelZoom}
         style={{ height, width: '100%', borderRadius: 8, cursor: 'crosshair' }}
       >
         <TileLayer
@@ -101,19 +215,30 @@ export function LocationPickerMap({
         />
         <ClickHandler onChange={onChange} />
         {center && <MapRecenterer center={center} />}
-        {!value && !center && geoCenter && <MapRecenterer center={geoCenter} />}
-        {value && (
+        {!value && !center && !initialCenter && geoCenter && <MapRecenterer center={geoCenter} />}
+        {value ? (
           <Marker
             position={[value.lat, value.lng]}
             icon={defaultIcon}
             draggable
             eventHandlers={{ dragend: handleDrag }}
           />
-        )}
+        ) : showPlaceholderMarker ? (
+          <>
+            <CenterTracker onCenter={setPlaceholderPos} />
+            <Marker
+              position={placeholderPos}
+              icon={defaultIcon}
+              draggable
+              opacity={PLACEHOLDER_PIN_OPACITY}
+              eventHandlers={{ dragend: handleDrag }}
+            />
+          </>
+        ) : null}
       </MapContainer>
       {typeof navigator !== 'undefined' && 'geolocation' in navigator && (
         <IconButton
-          onClick={requestLocation}
+          onClick={handleGeolocateClick}
           size="small"
           aria-label="Use my location"
           sx={{
@@ -129,6 +254,16 @@ export function LocationPickerMap({
           <MyLocationIcon fontSize="small" />
         </IconButton>
       )}
+      <Snackbar
+        open={!!geoError}
+        autoHideDuration={5000}
+        onClose={() => setGeoError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="warning" variant="filled" onClose={() => setGeoError(null)}>
+          {geoError}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/apps/web/src/components/media/LocationSearchPicker.tsx
+++ b/apps/web/src/components/media/LocationSearchPicker.tsx
@@ -2,10 +2,16 @@
  * LocationSearchPicker — a self-contained location picker that bundles:
  *   1. A debounced place-search Autocomplete (with a graceful 503 fallback).
  *   2. An interactive LocationPickerMap for dropping/dragging a pin.
- *   3. A reverse-geocode preview box for the currently selected coordinate.
+ *   3. A reverse-geocode CONFIRM ROW for the currently selected coordinate.
  *
  * It is a controlled component: the parent owns the `value` coordinate and is
- * notified of changes through `onChange`. All search + preview state is internal.
+ * notified of changes through `onChange`. All search + confirm state is internal.
+ *
+ * The confirm row is a PRESENTATION layer over the reverse-geocode state that
+ * already existed here (same single lookup, same `lastGeocodedRef` guard): it
+ * promotes what used to be a faint caption into a bordered row that names the
+ * address being committed, with an explicit resolving state and an explicit
+ * "no address found" fallback so a coordinate-only pin never looks broken.
  */
 import { useState, useEffect, useCallback, useRef } from 'react';
 import {
@@ -18,7 +24,7 @@ import {
   InputAdornment,
   TextField,
 } from '@mui/material';
-import { Search as SearchIcon } from '@mui/icons-material';
+import { Search as SearchIcon, Place as PlaceIcon } from '@mui/icons-material';
 import { LocationPickerMap } from './LocationPickerMap';
 import { searchPlaces, reverseGeocode } from '../../services/media';
 import type { GeoSearchResult, GeoReverseResult } from '../../types/media';
@@ -30,7 +36,18 @@ interface LocationSearchPickerProps {
   center?: [number, number]; // recenters map when a search result is picked
   height?: number; // map height, default 280
   disabled?: boolean; // disables the autocomplete during save
-  showPreview?: boolean; // reverse-geocode preview box, default true
+  showPreview?: boolean; // reverse-geocode confirm row, default true
+  /**
+   * Where the map should OPEN when `value` is null (the caller's best guess:
+   * the item's own coords, an inferred candidate, …). Framing hint only.
+   */
+  initialCenter?: { lat: number; lng: number };
+  /** Mouse-wheel zoom on the map. Default true for this picker. */
+  scrollWheelZoom?: boolean;
+  /** Explicit "Use my location" also sets the coordinate. Default true. */
+  geolocateSetsValue?: boolean;
+  /** Muted draggable pin at the map centre while no coordinate is set. Default true. */
+  showPlaceholderMarker?: boolean;
 }
 
 export function LocationSearchPicker({
@@ -40,6 +57,10 @@ export function LocationSearchPicker({
   height = 280,
   disabled = false,
   showPreview = true,
+  initialCenter,
+  scrollWheelZoom = true,
+  geolocateSetsValue = true,
+  showPlaceholderMarker = true,
 }: LocationSearchPickerProps) {
   const [inputValue, setInputValue] = useState('');
   const [options, setOptions] = useState<GeoSearchResult[]>([]);
@@ -214,24 +235,58 @@ export function LocationSearchPicker({
         onChange={onChange}
         height={height}
         center={mapCenter ?? undefined}
+        initialCenter={initialCenter}
+        scrollWheelZoom={scrollWheelZoom}
+        geolocateSetsValue={geolocateSetsValue}
+        showPlaceholderMarker={showPlaceholderMarker}
       />
 
-      {/* Reverse geocode preview */}
-      {showPreview && (geoLoading || geoLabel || value) && (
-        <Box sx={{ mt: 1.5, p: 1.5, backgroundColor: 'action.hover', borderRadius: 1 }}>
+      {/* Confirm row — names the address about to be committed. */}
+      {showPreview && (geoLoading || value) && (
+        <Box
+          data-testid="location-confirm-row"
+          sx={{
+            mt: 1.5,
+            p: 1.5,
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 1,
+            backgroundColor: 'action.hover',
+            maxWidth: '100%',
+            overflow: 'hidden',
+          }}
+        >
           {geoLoading ? (
             <Stack direction="row" sx={{ alignItems: 'center' }} spacing={1}>
-              <CircularProgress size={14} />
-              <Typography variant="caption">Looking up location...</Typography>
-            </Stack>
-          ) : value ? (
-            <>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Pin: {value.lat.toFixed(5)}, {value.lng.toFixed(5)}
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">
+                Finding address…
               </Typography>
-              {geoLabel && <Typography variant="body2" sx={{ fontWeight: 500 }}>{geoLabel}</Typography>}
-            </>
-          ) : null}
+            </Stack>
+          ) : (
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start', minWidth: 0 }}>
+              <PlaceIcon fontSize="small" color="primary" sx={{ mt: '2px', flexShrink: 0 }} />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="body2"
+                  sx={{ fontWeight: 600, overflowWrap: 'anywhere' }}
+                >
+                  {geoLabel
+                    ? `Use this location: ${geoLabel}`
+                    : 'Coordinates only — no address found'}
+                </Typography>
+                {value && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', overflowWrap: 'anywhere' }}
+                  >
+                    {value.lat.toFixed(5)}, {value.lng.toFixed(5)}
+                  </Typography>
+                )}
+              </Box>
+            </Stack>
+          )}
         </Box>
       )}
     </Box>

--- a/apps/web/src/components/media/MediaDetailDrawer.tsx
+++ b/apps/web/src/components/media/MediaDetailDrawer.tsx
@@ -70,7 +70,11 @@ import type { MediaTagStatusType } from '../../services/tagging';
 import { useMediaMetadata } from '../../hooks/useMediaMetadata';
 import type { MediaMetadataStatusType } from '../../services/metadata';
 import { rerunThumbnail } from '../../services/thumbnail';
-import { useSuggestLocation, useItemAutoAppliedSuggestion } from '../../hooks/useLocationSuggestions';
+import {
+  useSuggestLocation,
+  useItemAutoAppliedSuggestion,
+  useItemLocationCandidate,
+} from '../../hooks/useLocationSuggestions';
 import { revertLocationSuggestion } from '../../services/locationSuggestions';
 
 // ---------------------------------------------------------------------------
@@ -484,6 +488,17 @@ export function MediaDetailDrawer({
     item?.circleId ?? '',
     item?.id ?? '',
     isInferred,
+  );
+
+  // Framing hint for the inline location picker. Only fetched while the picker
+  // is actually open AND the item has no coordinates of its own — the rung
+  // above this one in the ladder.
+  const itemHasCoords =
+    (fullItem ?? item)?.takenLat !== null && (fullItem ?? item)?.takenLng !== null;
+  const { candidate: inferredCandidate } = useItemLocationCandidate(
+    item?.circleId ?? '',
+    item?.id ?? '',
+    locationEditOpen && !itemHasCoords,
   );
 
   const handleSuggestLocation = useCallback(() => {
@@ -906,6 +921,20 @@ export function MediaDetailDrawer({
                 displayItem.takenLat !== null && displayItem.takenLng !== null
                   ? [displayItem.takenLat, displayItem.takenLng]
                   : undefined
+              }
+              /*
+               * Opening frame, in priority order:
+               *   1. the item's own coordinates,
+               *   2. its pending Location-Inference candidate,
+               *   3. navigator.geolocation — handled inside LocationPickerMap's
+               *      recenter-only on-mount probe, which runs precisely when
+               *      neither of the above is supplied,
+               *   4. the map's existing world-view default.
+               */
+              initialCenter={
+                displayItem.takenLat !== null && displayItem.takenLng !== null
+                  ? { lat: displayItem.takenLat, lng: displayItem.takenLng }
+                  : inferredCandidate ?? undefined
               }
             />
             {locationError && <Alert severity="error" sx={{ mt: 1 }}>{locationError}</Alert>}

--- a/apps/web/src/components/search/SearchPanel.tsx
+++ b/apps/web/src/components/search/SearchPanel.tsx
@@ -404,6 +404,16 @@ export function SearchPanel({ open, onClose, circleId, onSubmit }: SearchPanelPr
                     value={pinLocation}
                     onChange={(latlng) => setPinLocation(latlng)}
                     height={260}
+                    // Search filters must only change when the user places a
+                    // pin, never as a side effect of "Use my location", and
+                    // wheel-zoom would hijack scrolling inside this panel.
+                    // The placeholder pin is suppressed too: this panel must
+                    // stay visually identical (issue #376), and its own
+                    // "Click the map to drop a pin" caption already carries
+                    // the affordance.
+                    geolocateSetsValue={false}
+                    scrollWheelZoom={false}
+                    showPlaceholderMarker={false}
                   />
                   {!pinLocation && (
                     <Typography

--- a/apps/web/src/components/workflows/builder/ActionParamEditor.tsx
+++ b/apps/web/src/components/workflows/builder/ActionParamEditor.tsx
@@ -256,6 +256,14 @@ export function ActionParamEditor({
             value={pin}
             onChange={(latlng) => set({ lat: latlng.lat, lng: latlng.lng })}
             height={220}
+            // A workflow action param must only change on a deliberate pin
+            // placement; wheel-zoom would hijack the builder's scrolling; and
+            // the placeholder pin would read as an already-chosen location for
+            // a param that is still unset. This surface stays visually and
+            // behaviourally unchanged (issue #376).
+            geolocateSetsValue={false}
+            scrollWheelZoom={false}
+            showPlaceholderMarker={false}
           />
           {pin && (
             <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>

--- a/apps/web/src/components/workflows/builder/ConditionValueEditor.tsx
+++ b/apps/web/src/components/workflows/builder/ConditionValueEditor.tsx
@@ -229,6 +229,14 @@ export function ConditionValueEditor({
           value={pin}
           onChange={(latlng) => onChange({ ...latlng, radiusKm })}
           height={220}
+          // A workflow condition value must only change on a deliberate pin
+          // placement; wheel-zoom would hijack the builder's scrolling; and
+          // the placeholder pin would read as an already-chosen centre for a
+          // map-radius condition that is still unset. This surface stays
+          // visually and behaviourally unchanged (issue #376).
+          geolocateSetsValue={false}
+          scrollWheelZoom={false}
+          showPlaceholderMarker={false}
         />
         <Typography variant="body2" sx={{ mt: 1 }}>
           Radius: {radiusKm} km

--- a/apps/web/src/hooks/useLocationSuggestions.ts
+++ b/apps/web/src/hooks/useLocationSuggestions.ts
@@ -191,6 +191,15 @@ export function useSuggestLocation(mediaId: string, onRefresh: () => void) {
 }
 
 // ---------------------------------------------------------------------------
+// useItemLocationCandidate — resolves the PENDING LocationSuggestion for one
+// item so a location picker can OPEN framed on the inferred candidate rather
+// than a world view. Read-only: it never accepts the suggestion, it only
+// borrows its coordinates as a map-framing hint. Uses the same `mediaItemId`
+// query param as useItemAutoAppliedSuggestion below (an exact, server-side
+// lookup — no client-side scanning), just with status='pending'.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // useItemAutoAppliedSuggestion — resolves the LocationSuggestion row backing
 // an item whose coordSource === 'inferred', so the drawer's Revert action can
 // call POST /location-suggestions/:id/revert (the id there is the SUGGESTION
@@ -198,6 +207,39 @@ export function useSuggestLocation(mediaId: string, onRefresh: () => void) {
 // GET /media/location-suggestions for an exact, server-side lookup — no
 // client-side scanning of a bounded page of results.
 // ---------------------------------------------------------------------------
+
+export function useItemLocationCandidate(circleId: string, mediaItemId: string, enabled: boolean) {
+  const [candidate, setCandidate] = useState<{ lat: number; lng: number } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || !circleId || !mediaItemId) {
+      setCandidate(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    listLocationSuggestions({ circleId, mediaItemId, status: 'pending', page: 1, pageSize: 1 })
+      .then((result) => {
+        if (cancelled) return;
+        const suggestion = result.items[0];
+        setCandidate(suggestion ? { lat: suggestion.lat, lng: suggestion.lng } : null);
+      })
+      .catch(() => {
+        // A missing candidate is not an error — the caller just falls through
+        // to the next rung of its framing ladder.
+        if (!cancelled) setCandidate(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [circleId, mediaItemId, enabled]);
+
+  return { candidate, loading };
+}
 
 export function useItemAutoAppliedSuggestion(circleId: string, mediaItemId: string, enabled: boolean) {
   const [suggestionId, setSuggestionId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Part 4 of 4 of epic #372, and the independent one — it shares no code with the location-grouping work and can land in any order.

The draggable-pin map already existed (`LocationPickerMap` wrapped by `LocationSearchPicker`), click-or-drag already saved a location, and the search box was already optional. This PR closes the four rough edges around it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #376 · Relates to #372

## Changes Made

1. **"Use my location" sets the coordinate.** `useGeoLocation()` previously called `setGeoCenter` and never `onChange`, so the crosshair only re-centred the map. It now also calls `onChange` — but only on the **explicit button press**. The on-mount auto-locate stays recenter-only, or it would silently overwrite an existing coordinate. A test asserts the mount path does not fire `onChange`.
2. **A coordinate-less photo shows a grabbable pin.** Previously `value == null` rendered no `<Marker>` at all. There is now a muted, draggable placeholder at the map centre, synced to the centre until first interaction, alongside the existing click-to-place.
3. **The picker opens somewhere sensible.** New optional `initialCenter` prop. `MediaDetailDrawer` resolves it as: the item's own coords → its pending location-inference candidate (via the **existing** `GET /api/media/location-suggestions` endpoint and service wrapper — no new endpoint) → `navigator.geolocation` → the previous `[20,0]` default.
4. **Confirm row and scroll zoom.** The reverse-geocoded address is promoted from a faint caption into a bordered *"Use this location: …"* row with distinct resolving and *"Coordinates only — no address found"* states. `scrollWheelZoom` becomes a prop defaulting to `true` for the picker; `LocationMiniMap` is untouched and stays disabled.

## The five call sites

`LocationPickerMap` is used by `LocationSearchPicker`, `SearchPanel`, `ActionParamEditor` and `ConditionValueEditor` (plus `MediaDetailDrawer` indirectly). All four new props — `initialCenter`, `geolocateSetsValue`, `scrollWheelZoom`, `showPlaceholderMarker` — are **optional and backward-compatible**, and the three defaults that represent behaviour changes are explicitly opted out of in `SearchPanel`, `ActionParamEditor` and `ConditionValueEditor`.

That matters because in those surfaces a geolocate press would silently author a search filter or a workflow action param, and wheel-zoom would hijack scrolling inside the search drawer and the workflow builder. The issue only asked for `SearchPanel` to opt out of `geolocateSetsValue`, but the acceptance criterion that all three stay "visually and behaviourally unchanged" is the stronger constraint, so the opt-out covers all three props in all three places. The props still *default* to the new behaviour, as specified, for the intended consumer.

The placeholder pin reuses `defaultIcon` from `lib/leaflet-setup.ts` at reduced opacity rather than introducing a second icon — Leaflet's stock PNG icon does not render under Vite.

## Testing

- [x] Unit tests pass (`npm run web:test`)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

```
apps/web  npx tsc --noEmit  → exit 0

Targeted (media + search + workflows + hooks):
  Test Files  35 passed (35)
       Tests  598 passed (598)

Full suite, before the final opt-out commit:
  Test Files  223 passed (223)
       Tests  4480 passed (4480)
```

New/updated coverage: the geolocate button fires `onChange` when `geolocateSetsValue` is true and not when false; the mount auto-locate never fires it; a null `value` still renders a draggable marker; the placeholder is suppressed by `showPlaceholderMarker={false}`; the confirm row's resolving and no-address states; and `SearchPanel`'s pin-drop → `filters.near` path is re-asserted unchanged.

One pre-existing test changed beyond new coverage: `BulkLocationDialog.test.tsx` asserted `getByText(/pin:/i)` against the old faint caption that fix 4 replaced, so it now asserts the confirm row plus the raw coordinate.

### Manual verification worth doing

Browser-level behaviour that unit tests can't fully cover: real `navigator.geolocation` permission-denied and timeout paths (error copy is lifted verbatim from `MapControls`), and the feel of the drag interaction on a touch device.

## Additional Notes

No API changes, no new endpoints, no schema changes — `apps/web` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCMUKgEkxdM25YPGCyfJCc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCMUKgEkxdM25YPGCyfJCc)_