### PR TITLE
fix: /profile person picker pageSize cap + missing createdAt (#371)

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -527,6 +527,35 @@ describe('AuthService', () => {
       expect(result.permissions).toContain('user_settings:read');
     });
 
+    it('should include createdAt as an ISO string in the response (issue #371)', async () => {
+      const mockUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        displayName: null,
+        providerDisplayName: 'Provider Name',
+        profileImageUrl: null,
+        providerProfileImageUrl: 'https://example.com/photo.jpg',
+        isActive: true,
+        createdAt: new Date('2026-01-15T10:30:00.000Z'),
+        userRoles: [
+          {
+            role: {
+              name: 'viewer',
+              rolePermissions: [{ permission: { name: 'user_settings:read' } }],
+            },
+          },
+        ],
+      };
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser as any);
+
+      const result = await service.getCurrentUser('user-1');
+
+      expect(result).toHaveProperty('createdAt');
+      expect(typeof result.createdAt).toBe('string');
+      expect(result.createdAt).toBe(mockUser.createdAt.toISOString());
+    });
+
     it('should prefer user display name over provider', async () => {
       const mockUser = {
         id: 'user-1',

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -648,6 +648,7 @@ export class AuthService {
       displayName,
       profileImageUrl,
       isActive: user.isActive,
+      createdAt: user.createdAt.toISOString(),
       roles,
       permissions,
     };

--- a/apps/api/src/auth/dto/auth-user.dto.ts
+++ b/apps/api/src/auth/dto/auth-user.dto.ts
@@ -48,6 +48,12 @@ export class CurrentUserDto {
   isActive!: boolean;
 
   @ApiProperty({
+    example: '2026-01-15T10:30:00.000Z',
+    description: 'Account creation timestamp',
+  })
+  createdAt!: string;
+
+  @ApiProperty({
     type: [RoleDto],
     description: 'User roles',
   })

--- a/apps/api/test/auth/auth.integration.spec.ts
+++ b/apps/api/test/auth/auth.integration.spec.ts
@@ -63,6 +63,22 @@ describe('Auth Controller (Integration)', () => {
       });
     });
 
+    it('should include createdAt as an ISO string (issue #371)', async () => {
+      const user = await createMockTestUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/auth/me')
+        .set(authHeader(user.accessToken))
+        .expect(200);
+
+      expect(response.body.data).toHaveProperty('createdAt');
+      expect(typeof response.body.data.createdAt).toBe('string');
+      // ISO 8601 timestamp
+      expect(response.body.data.createdAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+
     it('should return 401 without token', async () => {
       await request(context.app.getHttpServer())
         .get('/api/auth/me')

--- a/apps/web/src/__tests__/components/user/LinkedPersonCard.test.tsx
+++ b/apps/web/src/__tests__/components/user/LinkedPersonCard.test.tsx
@@ -62,7 +62,7 @@ describe('LinkedPersonCard', () => {
     vi.clearAllMocks();
     mockListPeople.mockResolvedValue({
       items: [],
-      meta: { page: 1, pageSize: 200, totalItems: 0, totalPages: 0 },
+      meta: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
     });
   });
 
@@ -121,7 +121,7 @@ describe('LinkedPersonCard', () => {
       );
       mockListPeople.mockResolvedValue({
         items: [],
-        meta: { page: 1, pageSize: 200, totalItems: 0, totalPages: 0 },
+        meta: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
       });
 
       render(<LinkedPersonCard profile={makeProfile()} onLinkChange={vi.fn()} />);
@@ -180,7 +180,7 @@ describe('LinkedPersonCard', () => {
             favorite: false,
           },
         ],
-        meta: { page: 1, pageSize: 200, totalItems: 1, totalPages: 1 },
+        meta: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
       });
 
       render(<LinkedPersonCard profile={makeProfile()} onLinkChange={vi.fn()} />);
@@ -212,7 +212,7 @@ describe('LinkedPersonCard', () => {
             favorite: false,
           },
         ],
-        meta: { page: 1, pageSize: 200, totalItems: 1, totalPages: 1 },
+        meta: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
       });
       const onLinkChange = vi.fn().mockResolvedValue(undefined);
       const user = userEvent.setup();
@@ -235,6 +235,127 @@ describe('LinkedPersonCard', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Regression coverage for issue #371 — GET /api/people pageSize contract
+  // and pagination/error-surfacing.
+  // -------------------------------------------------------------------------
+  describe('pageSize and pagination (issue #371)', () => {
+    it('never requests a pageSize greater than the API cap of 100', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        flagsResult({ features: { faceRecognition: true } }),
+      );
+      mockListPeople.mockResolvedValue({
+        items: [],
+        meta: { page: 1, pageSize: 100, totalItems: 0, totalPages: 1 },
+      });
+
+      render(<LinkedPersonCard profile={makeProfile()} onLinkChange={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(mockListPeople).toHaveBeenCalled();
+      });
+
+      // The load-bearing regression assertion: the old code requested 200,
+      // which the API rejects (`.max(100)` in `people.dto.ts`). Every call
+      // must request a pageSize the API actually accepts.
+      for (const call of mockListPeople.mock.calls) {
+        const opts = call[1] as { pageSize?: number } | undefined;
+        expect(opts?.pageSize).toBeDefined();
+        expect(opts!.pageSize as number).toBeLessThanOrEqual(100);
+      }
+      expect(mockListPeople).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ page: 1, pageSize: 100 }),
+      );
+    });
+
+    it('pages through multiple pages and accumulates people from every page', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        flagsResult({ features: { faceRecognition: true } }),
+      );
+
+      const pageOnePerson = {
+        id: 'person-page-1',
+        name: 'Page One Person',
+        isUnlabeled: false,
+        faceCount: 3,
+        coverFace: null,
+        profileMediaItemId: null,
+        profileCrop: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        favorite: false,
+      };
+      const pageTwoPerson = {
+        id: 'person-page-2',
+        name: 'Page Two Person',
+        isUnlabeled: false,
+        faceCount: 1,
+        coverFace: null,
+        profileMediaItemId: null,
+        profileCrop: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        favorite: false,
+      };
+
+      mockListPeople.mockImplementation(async (_circleId, opts) => {
+        if (opts?.page === 2) {
+          return {
+            items: [pageTwoPerson],
+            meta: { page: 2, pageSize: 100, totalItems: 2, totalPages: 2 },
+          };
+        }
+        return {
+          items: [pageOnePerson],
+          meta: { page: 1, pageSize: 100, totalItems: 2, totalPages: 2 },
+        };
+      });
+
+      const user = userEvent.setup();
+      render(<LinkedPersonCard profile={makeProfile()} onLinkChange={vi.fn()} />);
+
+      const input = await screen.findByLabelText(/Find a person/i);
+
+      await waitFor(() => {
+        expect(mockListPeople).toHaveBeenCalledTimes(2);
+      });
+      expect(mockListPeople).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.objectContaining({ page: 1, pageSize: 100 }),
+      );
+      expect(mockListPeople).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.objectContaining({ page: 2, pageSize: 100 }),
+      );
+
+      await user.click(input);
+      expect(await screen.findByText('Page One Person')).toBeInTheDocument();
+      expect(await screen.findByText('Page Two Person')).toBeInTheDocument();
+    });
+
+    it('surfaces the real rejection message when every circle fails to load', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        flagsResult({ features: { faceRecognition: true } }),
+      );
+      mockListPeople.mockRejectedValue(
+        new Error('Request failed with status code 400'),
+      );
+
+      render(<LinkedPersonCard profile={makeProfile()} onLinkChange={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Request failed with status code 400'),
+        ).toBeInTheDocument();
+      });
+      // The old hard-coded fallback string must not appear.
+      expect(screen.queryByText('Failed to load people.')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Unlink affordance
   // -------------------------------------------------------------------------
   describe('unlink affordance', () => {
@@ -244,7 +365,7 @@ describe('LinkedPersonCard', () => {
       );
       mockListPeople.mockResolvedValue({
         items: [],
-        meta: { page: 1, pageSize: 200, totalItems: 0, totalPages: 0 },
+        meta: { page: 1, pageSize: 100, totalItems: 0, totalPages: 0 },
       });
       const onLinkChange = vi.fn().mockResolvedValue(undefined);
       const user = userEvent.setup();

--- a/apps/web/src/components/user/LinkedPersonCard.tsx
+++ b/apps/web/src/components/user/LinkedPersonCard.tsx
@@ -23,8 +23,20 @@ import { listPeople } from '../../services/face';
 import type { PersonListItem } from '../../services/face';
 import type { UserProfile } from '../../services/userProfile';
 
-/** Upper bound on people loaded per circle — enough to search, bounded per request. */
-const PEOPLE_PAGE_SIZE = 200;
+/**
+ * Rows requested per page. Must not exceed the API's cap — `GET /api/people`
+ * validates `pageSize` with `.max(100)` (`apps/api/src/face/dto/people.dto.ts`)
+ * and 400s on anything larger, which used to make every request in
+ * `loadPeople` fail at once.
+ */
+const PEOPLE_REQUEST_PAGE_SIZE = 100;
+
+/**
+ * Hard ceiling on how many people are loaded per circle across all pages.
+ * Bounded, not a preference: a circle with tens of thousands of detected
+ * faces must not turn the picker into an unbounded paging loop.
+ */
+const MAX_PEOPLE_PER_CIRCLE = 1000;
 
 interface PersonOption {
   person: PersonListItem;
@@ -79,22 +91,43 @@ export function LinkedPersonCard({
     setLoadingPeople(true);
     setLoadError(null);
     try {
-      // One request per circle, tolerated individually: a single circle failing
-      // (e.g. a permission edge) must not blank out the whole picker.
+      // One (possibly multi-page) fetch per circle, tolerated individually: a
+      // single circle failing entirely (e.g. a permission edge) must not blank
+      // out the whole picker.
       const results = await Promise.allSettled(
-        circles.map((circle) =>
-          listPeople(circle.id, { pageSize: PEOPLE_PAGE_SIZE }).then((resp) => ({
-            circle,
-            items: resp.items,
-          })),
-        ),
+        circles.map(async (circle) => {
+          const items: PersonListItem[] = [];
+          const first = await listPeople(circle.id, {
+            page: 1,
+            pageSize: PEOPLE_REQUEST_PAGE_SIZE,
+          });
+          items.push(...first.items);
+
+          let page = 1;
+          while (
+            page < first.meta.totalPages &&
+            items.length < MAX_PEOPLE_PER_CIRCLE
+          ) {
+            page += 1;
+            const next = await listPeople(circle.id, {
+              page,
+              pageSize: PEOPLE_REQUEST_PAGE_SIZE,
+            });
+            items.push(...next.items);
+            if (next.items.length === 0) break;
+          }
+
+          return { circle, items };
+        }),
       );
 
       const collected: PersonOption[] = [];
+      let firstRejection: unknown = undefined;
       let anyFailed = false;
       for (const result of results) {
         if (result.status === 'rejected') {
           anyFailed = true;
+          if (firstRejection === undefined) firstRejection = result.reason;
           continue;
         }
         const { circle, items } = result.value;
@@ -110,7 +143,11 @@ export function LinkedPersonCard({
 
       setPeople(collected);
       if (anyFailed && collected.length === 0) {
-        setLoadError('Failed to load people.');
+        setLoadError(
+          firstRejection instanceof Error
+            ? firstRejection.message
+            : String(firstRejection),
+        );
       }
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : 'Failed to load people');


### PR DESCRIPTION
## Summary

Fixes two defects on `/profile` reported in #371: the Linked Person picker was completely non-functional in every deployment, and "Member since" rendered `Invalid Date`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #371

## Changes Made

- `apps/api/src/auth/auth.service.ts` / `apps/api/src/auth/dto/auth-user.dto.ts` — `GET /api/auth/me` now returns `createdAt`, which the web `User` type already expected. Fixes the `Invalid Date` shown under "Member since".
- `apps/web/src/components/user/LinkedPersonCard.tsx` — `loadPeople` requested `pageSize: 200`, but `GET /api/people` caps `pageSize` at 100 and rejects anything larger, so every per-circle request 400'd and the card always showed a hard-coded `Failed to load people.`. Now requests `pageSize: 100`, pages through `meta.totalPages` up to a bounded `MAX_PEOPLE_PER_CIRCLE` ceiling so large circles remain searchable, and surfaces the real rejection message instead of a generic string when every circle fails.
- `apps/api/src/auth/auth.service.spec.ts`, `apps/api/test/auth/auth.integration.spec.ts` — assert `createdAt` is present and ISO-formatted on `GET /api/auth/me`.
- `apps/web/src/__tests__/components/user/LinkedPersonCard.test.tsx` — assert every `listPeople` call uses `pageSize <= 100`, that multi-page circles are paged through and accumulated, and that a total failure surfaces the real error message.

## Testing

- [x] Unit tests pass (`npm test`) — 62 backend tests, 10 frontend tests, all passing
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

### Test Instructions

1. Enable `features.faceRecognition`, ensure a circle has detected people.
2. Log in and go to `/profile`.
3. Confirm the Linked Person card shows a searchable picker (not `Failed to load people.`) and "Member since" shows a real date.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published


---
_Generated by [Claude Code](https://claude.ai/code/session_01TMy5N715av3f8B1euFHNQT)_