### PR TITLE
feat(web): Nav Phase 1 — Console mode, remove duplicated rows, top-bar circle chip

### DIFF
--- a/apps/web/src/__tests__/components/navigation/AppBar.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/AppBar.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../utils/test-utils';
 import { AppBar } from '../../../components/navigation/AppBar';
 import { APP_NAME } from '../../../constants/app';
+import type { Circle } from '../../../types/circles';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -37,9 +38,112 @@ vi.mock('../../../components/media/MediaUploadDialog', () => ({
   ),
 }));
 
+// useCircle is mocked directly (rather than relying on test-utils' single-
+// circle CircleContext wrapper) so the CircleChip tests below can exercise a
+// real multi-circle menu and assert on `setActiveCircle` calls — the same
+// pattern UserMenu.test.tsx already uses for the circle switcher it used to
+// own before spec §3.3 moved it here.
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+import { useCircle } from '../../../hooks/useCircle';
+
+const mockUseCircle = vi.mocked(useCircle);
+
+const mockCircle1: Circle = {
+  id: 'circle-1',
+  name: "Test User's Library",
+  description: null,
+  ownerId: 'test-user-id',
+  isPersonal: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const mockCircle2: Circle = {
+  id: 'circle-2',
+  name: 'Family Circle',
+  description: 'Our family',
+  ownerId: 'test-user-id',
+  isPersonal: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+function makeCircleDefaults(overrides: Record<string, unknown> = {}) {
+  return {
+    circles: [mockCircle1],
+    activeCircle: mockCircle1,
+    activeCircleId: mockCircle1.id,
+    activeCircleRole: 'circle_admin' as const,
+    loading: false,
+    setActiveCircle: vi.fn().mockResolvedValue(undefined),
+    refreshCircles: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Viewport helper — computes `matches` from the actual min-width/max-width
+// embedded in MUI's compiled breakpoint query string, so a single `px` value
+// drives every `useMediaQuery(...)` call in the component consistently
+// (AppBar reads three different breakpoints: up('md'), down('sm'),
+// down('md')). Mirrors the technique in NotificationPanel.test.tsx, made
+// width-based instead of a fixed query-string check.
+// ---------------------------------------------------------------------------
+
+function setViewportWidth(px: number) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => {
+      const min = query.match(/min-width:\s*([\d.]+)px/);
+      const max = query.match(/max-width:\s*([\d.]+)px/);
+      let matches = true;
+      if (min) matches = matches && px >= parseFloat(min[1]);
+      if (max) matches = matches && px <= parseFloat(max[1]);
+      return {
+        matches,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      };
+    }),
+  });
+}
+
+function restoreDefaultViewport() {
+  // Matches setup.ts's baseline: every query reports `matches: false`.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 // ---------------------------------------------------------------------------
 
 describe('AppBar', () => {
+  beforeEach(() => {
+    mockUseCircle.mockReturnValue(makeCircleDefaults());
+  });
+
+  afterEach(() => {
+    restoreDefaultViewport();
+  });
+
   describe('Rendering', () => {
     it('should render app title', () => {
       render(<AppBar />);
@@ -195,6 +299,24 @@ describe('AppBar', () => {
       await user.click(logoImg);
       expect(logoImg).toBeInTheDocument();
     });
+
+    it('hides the wordmark below the sm breakpoint (phone)', () => {
+      setViewportWidth(360); // < 600 → down('sm') matches → isPhone=true
+
+      render(<AppBar />);
+
+      expect(screen.getByRole('img', { name: APP_NAME })).toBeInTheDocument();
+      expect(screen.queryByText(APP_NAME)).not.toBeInTheDocument();
+    });
+
+    it('shows the wordmark at and above the sm breakpoint', () => {
+      setViewportWidth(700); // >= 600 → down('sm') does not match → isPhone=false
+
+      render(<AppBar />);
+
+      expect(screen.getByRole('img', { name: APP_NAME })).toBeInTheDocument();
+      expect(screen.getByText(APP_NAME)).toBeInTheDocument();
+    });
   });
 
   describe('Upload button', () => {
@@ -219,6 +341,145 @@ describe('AppBar', () => {
       await user.click(uploadBtn);
 
       expect(screen.getByTestId('upload-dialog')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Circle chip (spec §3.3) — promoted into the top bar
+  // =========================================================================
+
+  describe('Circle chip', () => {
+    it('renders the active circle name', () => {
+      render(<AppBar />);
+
+      expect(screen.getByText("Test User's Library")).toBeInTheDocument();
+    });
+
+    it('opens the circle menu on click', async () => {
+      const user = userEvent.setup();
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ circles: [mockCircle1, mockCircle2] }));
+
+      render(<AppBar />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('menuitem', { name: /family circle/i })).toBeInTheDocument();
+    });
+
+    it('calls setActiveCircle when a different circle is picked', async () => {
+      const setActiveCircle = vi.fn().mockResolvedValue(undefined);
+      mockUseCircle.mockReturnValue(
+        makeCircleDefaults({ circles: [mockCircle1, mockCircle2], setActiveCircle }),
+      );
+
+      const user = userEvent.setup();
+      render(<AppBar />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const familyItem = await screen.findByRole('menuitem', { name: /family circle/i });
+      await user.click(familyItem);
+
+      await waitFor(() => {
+        expect(setActiveCircle).toHaveBeenCalledWith('circle-2');
+      });
+    });
+
+    it('navigates to /circles when "Manage Circles" is clicked', async () => {
+      const user = userEvent.setup();
+      render(<AppBar />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const manageItem = await screen.findByRole('menuitem', { name: /manage circles/i });
+      await user.click(manageItem);
+
+      // The chip's menu closes and the app navigates — asserted via the menu
+      // disappearing, since AppBar itself does not mock useNavigate here.
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('renders nothing when there is no active circle', () => {
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ activeCircle: null, activeCircleId: null }));
+
+      render(<AppBar />);
+
+      expect(screen.queryByRole('button', { name: /active circle/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Admin drill-down header (spec §4.4) — down('md') + an /admin/* route
+  // =========================================================================
+
+  describe('Admin drill-down (phone/tablet)', () => {
+    it('renders Back + the resolved page title, and hides the circle chip, upload button, and search', () => {
+      setViewportWidth(500); // < 900 → down('md') matches → isCompactNav=true
+
+      render(<AppBar />, {
+        wrapperOptions: { route: '/admin/settings/jobs', authenticated: true },
+      });
+
+      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Job Queue' })).toBeInTheDocument();
+
+      expect(screen.queryByRole('button', { name: /active circle/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /upload media/i })).not.toBeInTheDocument();
+      // TopbarSearch is entirely absent — no hamburger either, since it too
+      // is dropped from this header per spec §4.4.
+      expect(screen.queryByRole('button', { name: 'toggle drawer' })).not.toBeInTheDocument();
+    });
+
+    it('back from a detail page (e.g. Job Queue) navigates to the hub, /admin/settings', async () => {
+      const user = userEvent.setup();
+      setViewportWidth(500);
+
+      render(<AppBar />, {
+        wrapperOptions: { route: '/admin/settings/jobs', authenticated: true },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+
+      // No mocked useNavigate here; assert via the route-dependent title,
+      // which flips to the hub's title once the MemoryRouter has actually
+      // navigated to /admin/settings.
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+      });
+    });
+
+    it('back from the hub itself (/admin/settings) navigates to /', async () => {
+      const user = userEvent.setup();
+      setViewportWidth(500);
+
+      render(<AppBar />, {
+        wrapperOptions: { route: '/admin/settings', authenticated: true },
+      });
+
+      expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+
+      // Having left /admin entirely, the drill-down header itself
+      // unmounts — the normal toolbar (with the circle chip) takes over.
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /active circle/i })).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+    });
+
+    it('renders the normal toolbar (circle chip present) at the same narrow width on a non-admin route', () => {
+      setViewportWidth(500);
+
+      render(<AppBar />, {
+        wrapperOptions: { route: '/', authenticated: true },
+      });
+
+      expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /active circle/i })).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/components/navigation/CircleChip.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/CircleChip.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * Tests for CircleChip (issue #389, epic #388, spec §3.3/§4.1).
+ *
+ * The active-circle switcher promoted into the top bar. `useCircle` is
+ * mocked directly (the same pattern AppBar.test.tsx and the former
+ * UserMenu.test.tsx circle-section tests use) so a real multi-circle menu can
+ * be exercised deterministically.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+import { CircleChip } from '../../../components/navigation/CircleChip';
+import type { Circle } from '../../../types/circles';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import { useCircle } from '../../../hooks/useCircle';
+
+const mockUseCircle = vi.mocked(useCircle);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockCircle1: Circle = {
+  id: 'circle-1',
+  name: 'Personal Library',
+  description: null,
+  ownerId: 'test-user-id',
+  isPersonal: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const mockCircle2: Circle = {
+  id: 'circle-2',
+  name: 'Family Circle',
+  description: 'Our family',
+  ownerId: 'test-user-id',
+  isPersonal: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const LONG_NAME_CIRCLE: Circle = {
+  ...mockCircle1,
+  id: 'circle-long',
+  name: 'The Extremely Long Extended Family Photo Archive Circle Name',
+};
+
+function makeCircleDefaults(overrides: Record<string, unknown> = {}) {
+  return {
+    circles: [mockCircle1, mockCircle2],
+    activeCircle: mockCircle1,
+    activeCircleId: mockCircle1.id,
+    activeCircleRole: 'circle_admin' as const,
+    loading: false,
+    setActiveCircle: vi.fn().mockResolvedValue(undefined),
+    refreshCircles: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('CircleChip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCircle.mockReturnValue(makeCircleDefaults());
+  });
+
+  // =========================================================================
+  // No active circle -> renders nothing
+  // =========================================================================
+
+  describe('no active circle', () => {
+    it('renders null when there is no active circle', () => {
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ activeCircle: null, activeCircleId: null }));
+
+      const { container } = render(<CircleChip />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  // =========================================================================
+  // Rendering
+  // =========================================================================
+
+  describe('rendering', () => {
+    it('renders the active circle name as its visible label', () => {
+      render(<CircleChip />);
+
+      expect(screen.getByText('Personal Library')).toBeInTheDocument();
+    });
+
+    it('renders as a real <button>, not a div-with-role', () => {
+      render(<CircleChip />);
+
+      const chip = screen.getByRole('button', { name: /active circle/i });
+      expect(chip.tagName).toBe('BUTTON');
+    });
+
+    it('sets an accessible name that carries the full circle name', () => {
+      render(<CircleChip />);
+
+      expect(
+        screen.getByRole('button', { name: 'Active circle: Personal Library. Change circle.' }),
+      ).toBeInTheDocument();
+    });
+
+    it('re-renders the accessible name when the active circle changes', () => {
+      const { rerender } = render(<CircleChip />);
+      expect(screen.getByRole('button', { name: /Active circle: Personal Library/ })).toBeInTheDocument();
+
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ activeCircle: mockCircle2, activeCircleId: 'circle-2' }));
+      rerender(<CircleChip />);
+
+      expect(screen.getByRole('button', { name: /Active circle: Family Circle/ })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Active circle: Personal Library/ })).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Menu open/close + aria-expanded
+  // =========================================================================
+
+  describe('menu interaction', () => {
+    it('is closed by default (aria-expanded absent)', () => {
+      render(<CircleChip />);
+
+      const chip = screen.getByRole('button', { name: /active circle/i });
+      expect(chip).not.toHaveAttribute('aria-expanded');
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('opens the menu on click and flips aria-expanded to true', async () => {
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      const chip = screen.getByRole('button', { name: /active circle/i });
+      await user.click(chip);
+
+      await waitFor(() => {
+        expect(chip).toHaveAttribute('aria-expanded', 'true');
+      });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('lists every member circle plus a "Manage Circles" item', async () => {
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: 'Personal Library' })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('menuitem', { name: 'Family Circle' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /manage circles/i })).toBeInTheDocument();
+    });
+
+    it('closes the menu when a circle is picked', async () => {
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const familyItem = await screen.findByRole('menuitem', { name: 'Family Circle' });
+      await user.click(familyItem);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // =========================================================================
+  // Selecting a circle
+  // =========================================================================
+
+  describe('selecting a circle', () => {
+    it('calls setActiveCircle with the clicked circle id', async () => {
+      const setActiveCircle = vi.fn().mockResolvedValue(undefined);
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ setActiveCircle }));
+
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const familyItem = await screen.findByRole('menuitem', { name: 'Family Circle' });
+      await user.click(familyItem);
+
+      await waitFor(() => {
+        expect(setActiveCircle).toHaveBeenCalledWith('circle-2');
+      });
+    });
+
+    it('marks the currently active circle as selected in the menu', async () => {
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+
+      const activeItem = await screen.findByRole('menuitem', { name: 'Personal Library' });
+      expect(activeItem.classList.contains('Mui-selected')).toBe(true);
+
+      const otherItem = screen.getByRole('menuitem', { name: 'Family Circle' });
+      expect(otherItem.classList.contains('Mui-selected')).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Manage Circles
+  // =========================================================================
+
+  describe('Manage Circles', () => {
+    it('navigates to /circles when clicked', async () => {
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const manageItem = await screen.findByRole('menuitem', { name: /manage circles/i });
+      await user.click(manageItem);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/circles');
+      });
+    });
+
+    it('closes the menu after navigating', async () => {
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const manageItem = await screen.findByRole('menuitem', { name: /manage circles/i });
+      await user.click(manageItem);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does NOT call setActiveCircle when only "Manage Circles" is clicked', async () => {
+      const setActiveCircle = vi.fn().mockResolvedValue(undefined);
+      mockUseCircle.mockReturnValue(makeCircleDefaults({ setActiveCircle }));
+
+      const user = userEvent.setup();
+      render(<CircleChip />);
+
+      await user.click(screen.getByRole('button', { name: /active circle/i }));
+      const manageItem = await screen.findByRole('menuitem', { name: /manage circles/i });
+      await user.click(manageItem);
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/circles'));
+      expect(setActiveCircle).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Long-name truncation (spec §3.3's "never widen the toolbar" rule)
+  // =========================================================================
+
+  describe('long circle name truncation', () => {
+    it('caps the label with a maxWidth and keeps ellipsis truncation styling regardless of name length', () => {
+      mockUseCircle.mockReturnValue(
+        makeCircleDefaults({ activeCircle: LONG_NAME_CIRCLE, activeCircleId: LONG_NAME_CIRCLE.id }),
+      );
+
+      render(<CircleChip />);
+
+      const chip = screen.getByRole('button', { name: new RegExp(LONG_NAME_CIRCLE.name) });
+      // The button itself is capped so a long name cannot widen the toolbar.
+      expect(chip).toHaveStyle({ minWidth: '0px' });
+
+      // The inner label span is the element that actually clips the text.
+      const label = screen.getByText(LONG_NAME_CIRCLE.name);
+      expect(label).toHaveStyle({
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      });
+    });
+
+    it('still renders the FULL name in the accessible name even though it is visually truncated', () => {
+      mockUseCircle.mockReturnValue(
+        makeCircleDefaults({ activeCircle: LONG_NAME_CIRCLE, activeCircleId: LONG_NAME_CIRCLE.id }),
+      );
+
+      render(<CircleChip />);
+
+      expect(
+        screen.getByRole('button', {
+          name: `Active circle: ${LONG_NAME_CIRCLE.name}. Change circle.`,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -1,10 +1,33 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { screen, waitFor, fireEvent, act } from '@testing-library/react';
+/**
+ * Tests for the Library/Console Sidebar (issue #389, epic #388).
+ *
+ * The drawer now has exactly two modes, selected purely by `location.pathname`
+ * (spec §3.2):
+ *   - LIBRARY mode (any non-`/admin/*` route) renders the 14 primary rows.
+ *   - CONSOLE mode (any `/admin/*` route) swaps the drawer's CONTENTS for the
+ *     same permission-gated admin catalog `SettingsHubPage` renders, sourced
+ *     from the single shared `config/adminSections.tsx` declaration, plus a
+ *     "Back to library" affordance.
+ *
+ * Eight rows that used to live in the drawer are gone because each duplicates
+ * chrome already on screen elsewhere (spec §1.2): Circles, Notifications,
+ * User Settings (all now in the AppBar/UserMenu), and Job Queue / Worker
+ * Nodes / Storage Insights / Public Sharing (now reachable only through
+ * Console). This file asserts their absence explicitly, not just their
+ * replacements' presence — a regression that silently reintroduces one of
+ * them would otherwise pass every other assertion here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockUser, mockAdminUser } from '../../utils/test-utils';
 import { Sidebar } from '../../../components/navigation/Sidebar';
+import { visibleAdminSections } from '../../../config/adminSections';
 
-// Mock react-router-dom
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
 const mockNavigate = vi.fn();
 const mockLocation = { pathname: '/' };
 
@@ -17,96 +40,113 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-// Mock usePermissions hook
 vi.mock('../../../hooks/usePermissions', () => ({
   usePermissions: vi.fn(),
 }));
 
-// Mock useAlbums hook to prevent real API calls in tests
-vi.mock('../../../hooks/useAlbums', () => ({
-  useAlbums: vi.fn(() => ({
-    albums: [],
-    meta: null,
-    isLoading: false,
-    error: null,
-    fetchAlbums: vi.fn().mockResolvedValue(undefined),
-    addAlbum: vi.fn().mockResolvedValue(undefined),
-    updateAlbum: vi.fn().mockResolvedValue(undefined),
-    deleteAlbum: vi.fn().mockResolvedValue(undefined),
-  })),
-}));
-
-// Mock CreateAlbumDialog to avoid rendering its internals in navigation tests
-vi.mock('../../../components/album/CreateAlbumDialog', () => ({
-  CreateAlbumDialog: () => null,
-}));
-
-// The sidebar gates its "AI Enhancements" entry on GET /api/features and reads
-// the badge count from GET /api/media/review-counts. The feature-flag hook is
-// mocked outright; the counts endpoint is mocked at the SERVICE layer (the real
-// `useReviewCounts` hook runs) so these tests can assert on whether a request
-// was actually issued — that is the regression issue #204 is about. The default
-// below leaves the flag OFF, which both keeps every pre-existing menu-item
-// count in this file correct AND means navigation tests make no network calls.
 vi.mock('../../../hooks/useFeatureFlags', () => ({
   useFeatureFlags: vi.fn(),
 }));
 
-// Partial mock: only the two count-bearing calls are stubbed, every other
-// export of the media service keeps its real implementation. `getDashboard` is
-// stubbed purely so the specs below can assert the sidebar never calls it.
+vi.mock('../../../hooks/useWorkflowSubjects', () => ({
+  useWorkflowsEnabled: vi.fn(),
+}));
+
+// The sidebar's "AI Enhancements" badge is the sole consumer of
+// GET /api/media/review-counts, and it only fires while the enhancer flag is
+// on (issue #204) — partial-mock the media service so these tests can assert
+// a request was (or was not) actually issued, not just what rendered.
 vi.mock('../../../services/media', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../services/media')>()),
   getReviewCounts: vi.fn(),
   getDashboard: vi.fn(),
 }));
 
-// The Notifications entry's badge (issue #250) reads the SAME module-level
-// `useNotifications` store as the AppBar bell (issue #249). Mock only the
-// store's network seam — `useNotifications` itself is left REAL — so the
-// "one shared poller" tests below exercise the actual refcounting code, not a
-// stand-in for it.
-vi.mock('../../../services/notifications', () => ({
-  getUnreadCount: vi.fn(),
-  listNotifications: vi.fn(),
-  markNotificationRead: vi.fn(),
-  dismissNotification: vi.fn(),
-  markAllNotificationsRead: vi.fn(),
-  dismissAllNotifications: vi.fn(),
-  deleteNotification: vi.fn(),
-}));
-
 import { usePermissions } from '../../../hooks/usePermissions';
 import { useFeatureFlags } from '../../../hooks/useFeatureFlags';
+import { useWorkflowsEnabled } from '../../../hooks/useWorkflowSubjects';
 import { getReviewCounts, getDashboard } from '../../../services/media';
-import { getUnreadCount, listNotifications } from '../../../services/notifications';
-import { __resetNotificationsStoreForTests } from '../../../hooks/useNotifications';
-import { NotificationBell } from '../../../components/notifications/NotificationBell';
 
 const mockGetReviewCounts = vi.mocked(getReviewCounts);
 const mockGetDashboard = vi.mocked(getDashboard);
-const mockGetUnreadCount = vi.mocked(getUnreadCount);
-const mockListNotifications = vi.mocked(listNotifications);
+
+// ---------------------------------------------------------------------------
+// Permission mock helpers
+// ---------------------------------------------------------------------------
+
+function permissionsMock(overrides: {
+  isAdmin?: boolean;
+  permissions?: string[];
+  hasPermission?: (perm: string) => boolean;
+} = {}) {
+  const { isAdmin = false, permissions = [], hasPermission } = overrides;
+  return {
+    permissions: new Set(permissions),
+    roles: new Set(isAdmin ? ['admin'] : []),
+    hasPermission: hasPermission ?? ((perm: string) => permissions.includes(perm)),
+    hasAnyPermission: vi.fn(),
+    hasAllPermissions: vi.fn(),
+    hasRole: vi.fn(),
+    hasAnyRole: vi.fn(),
+    isAdmin,
+  };
+}
+
+function setNonAdmin() {
+  vi.mocked(usePermissions).mockReturnValue(permissionsMock());
+}
+
+function setAdmin(permissions: string[] = []) {
+  vi.mocked(usePermissions).mockReturnValue(permissionsMock({ isAdmin: true, permissions }));
+}
+
+/** Every permission any admin card in the catalog is gated behind. */
+const ALL_ADMIN_PERMISSIONS = Array.from(
+  new Set(
+    visibleAdminSections(() => true)
+      .flatMap((s) => s.cards)
+      .map((c) => c.permission)
+      .filter((p): p is string => Boolean(p)),
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// Feature-flag mock helpers
+// ---------------------------------------------------------------------------
 
 /**
- * Configure the enhancer feature flag and the review-counts response.
+ * Configure `useFeatureFlags` (drives both the AI Enhancements entry and,
+ * transitively through the real `useMemoriesEnabled`, the Memories entry) and
+ * `useWorkflowsEnabled`.
  *
- * @param enabled  `null` = flag still loading, `false`/`true` = resolved value.
- * @param pendingEnhancements  count the endpoint resolves with; omit to leave
- *   the request permanently in flight (the hook's `data` stays null), which is
- *   how the sidebar looks before the counts land.
+ * `null` for either boolean means "flag not resolved yet" (hidden); a
+ * boolean resolves it. `pendingEnhancements` seeds the review-counts response
+ * consumed by the AI Enhancements badge; omit to leave that request
+ * permanently in flight.
  */
-function mockEnhancer(
-  enabled: boolean | null,
-  pendingEnhancements?: number,
-): void {
+function mockFlags(options: {
+  pictureEnhancement?: boolean | null;
+  memories?: boolean | null;
+  workflows?: boolean | null;
+  pendingEnhancements?: number;
+} = {}) {
+  const { pictureEnhancement = null, memories = null, workflows = null, pendingEnhancements } = options;
+
+  const features: Record<string, boolean> | null =
+    pictureEnhancement === null && memories === null
+      ? null
+      : {
+          ...(pictureEnhancement !== null ? { pictureEnhancement } : {}),
+          ...(memories !== null ? { memories } : {}),
+        };
+
   vi.mocked(useFeatureFlags).mockReturnValue({
-    features: enabled === null ? null : { pictureEnhancement: enabled },
+    features,
     pictureEnhancement:
-      enabled === null
+      pictureEnhancement === null
         ? null
         : {
-            enabled,
+            enabled: pictureEnhancement,
             allowReplace: true,
             blockReplaceOnDownscale: false,
             model: 'gpt-image-1',
@@ -116,33 +156,38 @@ function mockEnhancer(
     refresh: vi.fn().mockResolvedValue(undefined),
   });
 
-  if (pendingEnhancements === undefined) {
-    mockGetReviewCounts.mockReturnValue(new Promise(() => {}));
-  } else {
-    mockGetReviewCounts.mockResolvedValue({
-      pendingBurstGroups: 0,
-      pendingDuplicateGroups: 0,
-      pendingLocationSuggestions: 0,
-      pendingEnhancements,
-    });
+  vi.mocked(useWorkflowsEnabled).mockReturnValue(workflows);
+
+  if (pictureEnhancement === true) {
+    if (pendingEnhancements === undefined) {
+      mockGetReviewCounts.mockReturnValue(new Promise(() => {}));
+    } else {
+      mockGetReviewCounts.mockResolvedValue({
+        pendingBurstGroups: 0,
+        pendingDuplicateGroups: 0,
+        pendingLocationSuggestions: 0,
+        pendingEnhancements,
+      });
+    }
   }
 }
 
-/**
- * Named nav-entry sets shared by the tests below. Encoding the actual entries
- * (rather than a bare integer) means adding/removing a sidebar item produces a
- * clear "X is missing" / "Y leaked in" failure instead of an opaque
- * "expected N to be M" — see issue #202.
- */
-const BASE_ENTRIES = [
+/** All three optional flags resolved ON, for the "14 rows" catalog test. */
+function mockAllFlagsOn(pendingEnhancements = 0) {
+  mockFlags({ pictureEnhancement: true, memories: true, workflows: true, pendingEnhancements });
+}
+
+// ---------------------------------------------------------------------------
+// Shared row-name catalogs
+// ---------------------------------------------------------------------------
+
+/** The full 14-row Library catalog when every optional flag is enabled. */
+const LIBRARY_ALL_FLAGS_ROWS = [
   'Photos',
+  'Memories',
   'Explore',
   'Map',
-  'Circles',
   'Albums',
-  // Notification Center entry (issue #250). Its badge reads the SAME
-  // `useNotifications` module store as the AppBar bell — one poller, not two.
-  'Notifications',
   'People',
   'Archive',
   'Trash',
@@ -150,20 +195,21 @@ const BASE_ENTRIES = [
   'Review Duplicates',
   'Review Insights',
   'Location Suggestions',
+  'Workflows',
+  'AI Enhancements',
 ];
-const NON_ADMIN_ENTRIES = [...BASE_ENTRIES, 'User Settings'];
-const ADMIN_HUB_ENTRIES = [...BASE_ENTRIES, 'Settings', 'User Settings'];
-const ADMIN_FULL_GATED_ENTRIES = [
-  ...BASE_ENTRIES,
+
+/** Rows that used to exist and must never reappear in Library mode. */
+const REMOVED_LIBRARY_ROWS = [
+  'Circles',
+  'Notifications',
+  'User Settings',
   'Settings',
   'Job Queue',
   'Worker Nodes',
   'Storage Insights',
   'Public Sharing',
-  'User Settings',
 ];
-const GATED_ADMIN_ONLY_ENTRIES = ['Settings', 'Job Queue', 'Worker Nodes', 'Storage Insights', 'Public Sharing'];
-const FEATURE_FLAGGED_ENTRIES = ['Workflows', 'AI Enhancements'];
 
 describe('Sidebar', () => {
   const mockOnClose = vi.fn();
@@ -171,1438 +217,555 @@ describe('Sidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLocation.pathname = '/';
-    mockEnhancer(null);
-    __resetNotificationsStoreForTests();
-    mockGetUnreadCount.mockResolvedValue(0);
-    mockListNotifications.mockResolvedValue({
-      items: [],
-      meta: { page: 1, pageSize: 10, totalItems: 0, totalPages: 0 },
-    });
+    mockFlags();
   });
 
-  afterEach(() => {
-    __resetNotificationsStoreForTests();
-    vi.useRealTimers();
-  });
+  // =========================================================================
+  // Library mode — the 14-row catalog (Required case 1)
+  // =========================================================================
 
-  describe('Rendering', () => {
-    it('should render Drawer component even when open is false', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      // The key test: calling render should work without the component returning null
-      // Even though drawer content won't be in DOM with keepMounted: false and open: false,
-      // the component should still render the Drawer JSX (MUI handles visibility)
-      const result = render(<Sidebar open={false} onClose={mockOnClose} />);
-
-      // Verify render was successful (result should have standard RTL properties)
-      expect(result).toHaveProperty('container');
-      expect(result).toHaveProperty('baseElement');
-    });
-
-    it('should render Drawer component when open is true', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+  describe('Library mode', () => {
+    it('renders exactly the 14 expected rows with every flag on, and nothing else', () => {
+      setNonAdmin();
+      mockAllFlagsOn();
 
       const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      const drawer = container.querySelector('.MuiDrawer-root');
-      expect(drawer).not.toBeNull();
-      expect(drawer).toBeDefined();
-    });
-
-    it('should render visible menu items', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Non-admin users should see Photos, Explore, Map, and User Settings
-      expect(container.textContent).toContain('Photos');
-      expect(container.textContent).toContain('Explore');
-      expect(container.textContent).toContain('Map');
-      expect(container.textContent).toContain('User Settings');
-    });
-
-    it('should not render admin menu items for non-admin users', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Admin section should not be visible for non-admins
-      // After the settings refactor the admin section is a single "Settings" link
-      expect(container.textContent).not.toContain('Administration');
-    });
-
-    it('should render admin menu items for admin users', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
-        wrapperOptions: { user: mockAdminUser },
-      });
-
-      // After the settings refactor the admin section collapses to a single "Settings" hub link
-      expect(container.textContent).toContain('Photos');
-      expect(container.textContent).toContain('Explore');
-      expect(container.textContent).toContain('Map');
-      expect(container.textContent).toContain('User Settings');
-      // Admin hub entry
-      expect(container.textContent).toContain('Settings');
-      // Individual admin sub-pages are NOT in the sidebar anymore
-    });
-  });
-
-  describe('ModalProps Configuration', () => {
-    it('should have keepMounted set to false', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const drawer = container.querySelector('.MuiDrawer-root');
-      expect(drawer).not.toBeNull();
-      // keepMounted: false means content unmounts when closed
-    });
-
-    it('should have disablePortal set to true', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const drawer = container.querySelector('.MuiDrawer-root');
-      expect(drawer).not.toBeNull();
-      // disablePortal: true keeps Modal in component tree
-    });
-  });
-
-  describe('Menu Item Visibility Filtering', () => {
-    it('should filter menu items based on visibility property', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Only items with visible: true should be rendered for a non-admin viewer.
-      NON_ADMIN_ENTRIES.forEach((label) => {
+      LIBRARY_ALL_FLAGS_ROWS.forEach((label) => {
         expect(screen.getByText(label)).toBeInTheDocument();
       });
 
-      // Admin-only and feature-flag-gated entries must not leak through.
-      [...GATED_ADMIN_ONLY_ENTRIES, ...FEATURE_FLAGGED_ENTRIES].forEach((label) => {
+      const buttons = container.querySelectorAll('.MuiListItemButton-root');
+      expect(buttons).toHaveLength(LIBRARY_ALL_FLAGS_ROWS.length);
+    });
+
+    it('never renders Circles, Notifications, User Settings, Settings, Job Queue, Worker Nodes, Storage Insights, or Public Sharing', () => {
+      setNonAdmin();
+      mockAllFlagsOn();
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      REMOVED_LIBRARY_ROWS.forEach((label) => {
         expect(screen.queryByText(label)).not.toBeInTheDocument();
       });
-
-      // No unnamed extras: exactly the named set above renders.
-      const menuButtons = container.querySelectorAll('.MuiListItemButton-root');
-      expect(menuButtons).toHaveLength(NON_ADMIN_ENTRIES.length);
     });
 
-    it('should show all menu items when user is admin', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
-        wrapperOptions: { user: mockAdminUser },
-      });
-
-      // After the settings refactor the admin section collapses from many individual
-      // links to a single "Settings" hub entry. hasPermission is unconfigured/false
-      // here, so the extra permission-gated admin entries must NOT render.
-      ADMIN_HUB_ENTRIES.forEach((label) => {
-        expect(screen.getByText(label)).toBeInTheDocument();
-      });
-      ['Job Queue', 'Worker Nodes', 'Storage Insights', 'Public Sharing', ...FEATURE_FLAGGED_ENTRIES].forEach(
-        (label) => {
-          expect(screen.queryByText(label)).not.toBeInTheDocument();
-        },
-      );
-
-      const menuButtons = container.querySelectorAll('.MuiListItemButton-root');
-      expect(menuButtons).toHaveLength(ADMIN_HUB_ENTRIES.length);
-    });
-
-    it('should dynamically update menu items when isAdmin changes', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { rerender, container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Non-admin: no Administration section
-      expect(container.textContent).not.toContain('Administration');
-
-      // Update to admin
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      rerender(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // After becoming admin, the Administration section with "Settings" hub appears
-      expect(container.textContent).toContain('Administration');
-    });
-  });
-
-  describe('Navigation Behavior', () => {
-    it('should call onClose BEFORE navigate when menu item is clicked', async () => {
-      const callOrder: string[] = [];
-
-      const trackingOnClose = vi.fn(() => {
-        callOrder.push('onClose');
-      });
-
-      mockNavigate.mockImplementation(() => {
-        callOrder.push('navigate');
-      });
-
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={trackingOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      // User Settings is the last button in the sidebar (pinned at bottom)
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const settingsButton = buttons[buttons.length - 1] as HTMLElement;
-      fireEvent.click(settingsButton);
-
-      // onClose should be called immediately (synchronously)
-      expect(trackingOnClose).toHaveBeenCalledTimes(1);
-
-      // Wait for navigate to be called (it's in setTimeout(0))
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledTimes(1);
-      });
-
-      // Verify order: onClose should be called BEFORE navigate
-      expect(callOrder).toEqual(['onClose', 'navigate']);
-    });
-
-    it('should navigate to / when Photos menu item is clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const photosButton = buttons[0] as HTMLElement; // Photos is the first item
-      fireEvent.click(photosButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/');
-      });
-    });
-
-    it('should navigate to settings when User Settings menu item is clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      // User Settings is the last button in the sidebar (pinned at bottom)
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const settingsButton = buttons[buttons.length - 1] as HTMLElement;
-      fireEvent.click(settingsButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/settings');
-      });
-    });
-
-    it('should navigate to /search when Explore is clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const exploreButton = buttons[1] as HTMLElement; // Explore is the second item
-      fireEvent.click(exploreButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/search');
-      });
-    });
-
-    it('should navigate to /map when Map is clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const mapButton = buttons[2] as HTMLElement; // Map is the third item
-      fireEvent.click(mapButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/map');
-      });
-    });
-
-    it('should navigate to admin/settings when the Settings hub item is clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
+    it('renders the same removed rows check for an admin viewer too (Library mode ignores role)', () => {
+      setAdmin(ALL_ADMIN_PERMISSIONS);
+      mockAllFlagsOn();
 
       render(<Sidebar open={true} onClose={mockOnClose} />, {
         wrapperOptions: { user: mockAdminUser },
       });
 
-      // After the settings refactor the admin section is a single "Settings" entry.
-      // Query by accessible text instead of a hardcoded index so inserting new
-      // nav items doesn't require renumbering this test.
-      const adminSettingsButton = screen
-        .getByText('Settings')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(adminSettingsButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/admin/settings');
+      // "Settings" itself is never a Library row; the mode-switch affordance
+      // is a distinct "Console" label (asserted separately below).
+      REMOVED_LIBRARY_ROWS.forEach((label) => {
+        expect(screen.queryByText(label)).not.toBeInTheDocument();
       });
+      expect(screen.getByText('Console')).toBeInTheDocument();
+    });
+
+    it('drops Memories, Workflows, and AI Enhancements when their flags are off/unresolved', () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: false, memories: false, workflows: false });
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      expect(screen.queryByText('Memories')).not.toBeInTheDocument();
+      expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
+      expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
+
+      // The 9 rows that are never flag-gated still render.
+      ['Photos', 'Explore', 'Map', 'Albums', 'People', 'Archive', 'Trash', 'Review Bursts', 'Review Duplicates', 'Review Insights', 'Location Suggestions'].forEach(
+        (label) => {
+          expect(screen.getByText(label)).toBeInTheDocument();
+        },
+      );
     });
   });
 
-  describe('Permission-Gated Admin Nav Items', () => {
-    it('does not render Job Queue, Storage Insights, or Public Sharing when admin lacks the gating permissions', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn().mockReturnValue(false),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
+  // =========================================================================
+  // Console mode (Required cases 2-4)
+  // =========================================================================
 
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
+  describe('Console mode', () => {
+    it('renders the admin section labels and card titles, and "Back to library", when granted every permission', () => {
+      mockLocation.pathname = '/admin/settings/jobs';
+      setAdmin(ALL_ADMIN_PERMISSIONS);
+
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
         wrapperOptions: { user: mockAdminUser },
       });
 
-      expect(container.textContent).not.toContain('Job Queue');
-      expect(container.textContent).not.toContain('Storage Insights');
-      expect(container.textContent).not.toContain('Public Sharing');
+      expect(screen.getByText('Back to library')).toBeInTheDocument();
+
+      const fullCatalog = visibleAdminSections(() => true);
+      fullCatalog.forEach((section) => {
+        expect(screen.getByText(section.label)).toBeInTheDocument();
+        section.cards.forEach((card) => {
+          expect(screen.getByText(card.title)).toBeInTheDocument();
+        });
+      });
     });
 
-    it('renders Job Queue when admin has jobs:read', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(['jobs:read']),
-        roles: new Set(['admin']),
-        hasPermission: (perm: string) => perm === 'jobs:read',
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
+    it('does not render any Library-mode row (Photos, Albums, People, ...)', () => {
+      mockLocation.pathname = '/admin/settings/jobs';
+      setAdmin(ALL_ADMIN_PERMISSIONS);
 
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
         wrapperOptions: { user: mockAdminUser },
       });
 
-      expect(container.textContent).toContain('Job Queue');
-      expect(container.textContent).not.toContain('Storage Insights');
-      expect(container.textContent).not.toContain('Public Sharing');
+      // "Memories" is excluded from this check: it is ALSO a genuine admin
+      // card title (AI & Enrichment > Memories, the digest/generation
+      // settings page) — its presence here is expected, not a leak of the
+      // Library nav row. Every other Library row has no admin-card homonym.
+      LIBRARY_ALL_FLAGS_ROWS.filter((label) => label !== 'Memories').forEach((label) => {
+        expect(screen.queryByText(label)).not.toBeInTheDocument();
+      });
 
-      const jobQueueButton = screen.getByText('Job Queue').closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(jobQueueButton);
+      // The Library "Memories" row specifically is confirmed absent by
+      // checking it isn't reachable via /memories (the admin card instead
+      // targets /admin/settings/memories) — see the Console navigation test
+      // for "Memories" -> "/admin/settings/memories".
+    });
+
+    it('never renders the Console mode-switch affordance while already in Console mode', () => {
+      mockLocation.pathname = '/admin/settings/jobs';
+      setAdmin(ALL_ADMIN_PERMISSIONS);
+
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
+        wrapperOptions: { user: mockAdminUser },
+      });
+
+      // Only ONE "Console" appearance is expected anywhere: there is none —
+      // the way out is "Back to library", not a second Console button.
+      expect(screen.queryByText('Console')).not.toBeInTheDocument();
+    });
+
+    it('respects per-card permission gates: lacking jobs:read hides Job Queue (and Job Queue Insights, Worker Nodes)', () => {
+      mockLocation.pathname = '/admin/settings/jobs';
+      setAdmin(['system_settings:read']); // no jobs:read
+
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
+        wrapperOptions: { user: mockAdminUser },
+      });
+
+      expect(screen.queryByText('Job Queue')).not.toBeInTheDocument();
+      expect(screen.queryByText('Job Queue Insights')).not.toBeInTheDocument();
+      expect(screen.queryByText('Worker Nodes')).not.toBeInTheDocument();
+      // A card gated on a DIFFERENT, granted permission still renders.
+      expect(screen.getByText('System')).toBeInTheDocument();
+    });
+
+    it('renders Job Queue once jobs:read is granted, and navigates to it on click', async () => {
+      mockLocation.pathname = '/admin/settings';
+      setAdmin(['jobs:read']);
+
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
+        wrapperOptions: { user: mockAdminUser },
+      });
+
+      const button = screen.getByText('Job Queue').closest('.MuiListItemButton-root') as HTMLElement;
+      fireEvent.click(button);
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/admin/settings/jobs');
       });
     });
 
-    it('renders Storage Insights when admin has system_settings:read', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(['system_settings:read']),
-        roles: new Set(['admin']),
-        hasPermission: (perm: string) => perm === 'system_settings:read',
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
-        wrapperOptions: { user: mockAdminUser },
-      });
-
-      expect(container.textContent).toContain('Storage Insights');
-
-      const storageInsightsButton = screen
-        .getByText('Storage Insights')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(storageInsightsButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/admin/settings/storage/insights');
-      });
-    });
-
-    it('renders Public Sharing when admin has shares:manage_any', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(['shares:manage_any']),
-        roles: new Set(['admin']),
-        hasPermission: (perm: string) => perm === 'shares:manage_any',
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
-        wrapperOptions: { user: mockAdminUser },
-      });
-
-      expect(container.textContent).toContain('Public Sharing');
-
-      const publicSharingButton = screen
-        .getByText('Public Sharing')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(publicSharingButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/admin/settings/sharing');
-      });
-    });
-
-    it('renders all three gated items together when admin has all three permissions', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(['jobs:read', 'system_settings:read', 'shares:manage_any']),
-        roles: new Set(['admin']),
-        hasPermission: (perm: string) =>
-          ['jobs:read', 'system_settings:read', 'shares:manage_any'].includes(perm),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
-        wrapperOptions: { user: mockAdminUser },
-      });
-
-      // jobs:read gates BOTH "Job Queue" and "Worker Nodes".
-      ADMIN_FULL_GATED_ENTRIES.forEach((label) => {
-        expect(screen.getByText(label)).toBeInTheDocument();
-      });
-
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      expect(buttons).toHaveLength(ADMIN_FULL_GATED_ENTRIES.length);
-    });
-  });
-
-  describe('Active Menu Item Highlighting', () => {
-    it('should highlight current route', () => {
-      mockLocation.pathname = '/settings';
-
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const settingsButton = screen.getByText('User Settings').closest('.MuiListItemButton-root') as HTMLElement;
-      expect(settingsButton.classList.contains('Mui-selected')).toBe(true);
-    });
-
-    it('should not highlight non-current routes', () => {
+    it('a non-admin never sees the Console affordance in Library mode', () => {
       mockLocation.pathname = '/';
-
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+      setNonAdmin();
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      const settingsButton = screen.getByText('User Settings').closest('.MuiListItemButton-root') as HTMLElement;
-      expect(settingsButton.classList.contains('Mui-selected')).toBe(false);
+      expect(screen.queryByText('Console')).not.toBeInTheDocument();
     });
 
-    it('should highlight admin routes when on admin page', () => {
-      // After the settings refactor, the single admin hub item at /admin/settings
-      // becomes highlighted for any /admin/* route (startsWith match).
-      mockLocation.pathname = '/admin/settings';
+    it('renders the Console affordance at the foot of Library mode for an admin, and it navigates to /admin/settings', async () => {
+      mockLocation.pathname = '/';
+      setAdmin(ALL_ADMIN_PERMISSIONS);
 
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
+      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
+        wrapperOptions: { user: mockAdminUser },
       });
+
+      const consoleButton = screen.getByText('Console').closest('.MuiListItemButton-root') as HTMLElement;
+
+      // Pinned at the very foot: the last button in the drawer.
+      const buttons = container.querySelectorAll('.MuiListItemButton-root');
+      expect(buttons[buttons.length - 1]).toBe(consoleButton);
+
+      fireEvent.click(consoleButton);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/admin/settings');
+      });
+    });
+
+    it('"Back to library" navigates to /', async () => {
+      mockLocation.pathname = '/admin/settings/jobs';
+      setAdmin(ALL_ADMIN_PERMISSIONS);
 
       render(<Sidebar open={true} onClose={mockOnClose} />, {
         wrapperOptions: { user: mockAdminUser },
       });
 
-      // Find the admin Settings button by its accessible text and verify it is selected
-      const adminSettingsButton = screen
-        .getByText('Settings')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      expect(adminSettingsButton.classList.contains('Mui-selected')).toBe(true);
-    });
-  });
+      const backButton = screen.getByText('Back to library').closest('.MuiListItemButton-root') as HTMLElement;
+      fireEvent.click(backButton);
 
-  describe('Drawer Close Behavior', () => {
-    it('should pass onClose prop to Drawer', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // The onClose prop is passed to Drawer - verify drawer is rendered
-      const drawer = container.querySelector('.MuiDrawer-root');
-      expect(drawer).not.toBeNull();
-      expect(mockOnClose).toHaveBeenCalledTimes(0);
-    });
-
-    it('should call onClose for each menu item click', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const photosButton = buttons[0] as HTMLElement; // Photos is the first item
-      fireEvent.click(photosButton);
-
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
-
-      // User Settings is the last button in the sidebar (pinned at bottom)
-      const allButtons = container.querySelectorAll('.MuiListItemButton-root');
-      const settingsButton = allButtons[allButtons.length - 1] as HTMLElement;
-      fireEvent.click(settingsButton);
-
-      expect(mockOnClose).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe('Menu Icons', () => {
-    it('should render icons for all menu items', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(['admin']),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: true,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />, {
-        wrapperOptions: { user: mockAdminUser },
-      });
-
-      // hasPermission is unconfigured/false here, so no extra permission-gated admin
-      // items render — every entry that does render must carry its own icon.
-      ADMIN_HUB_ENTRIES.forEach((label) => {
-        const button = screen.getByText(label).closest('.MuiListItemButton-root') as HTMLElement;
-        expect(button.querySelector('.MuiListItemIcon-root')).not.toBeNull();
-      });
-
-      const icons = container.querySelectorAll('.MuiListItemIcon-root');
-      expect(icons).toHaveLength(ADMIN_HUB_ENTRIES.length);
-    });
-
-    it('should highlight icon for selected menu item', () => {
-      mockLocation.pathname = '/settings';
-
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const settingsButton = screen.getByText('User Settings').closest('.MuiListItemButton-root') as HTMLElement;
-      const icon = settingsButton?.querySelector('.MuiListItemIcon-root');
-
-      expect(icon).not.toBeNull();
-      expect(icon).toBeDefined();
-      // Icon should have primary color styling when selected
-    });
-  });
-
-  describe('Accessibility', () => {
-    it('should render drawer with proper structure', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Drawer should be rendered with buttons
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      expect(buttons.length).toBeGreaterThan(0);
-    });
-
-    it('should have accessible button labels', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Verify text content for accessibility
-      expect(container.textContent).toContain('Photos');
-      expect(container.textContent).toContain('Explore');
-      expect(container.textContent).toContain('Map');
-      expect(container.textContent).toContain('User Settings');
-    });
-
-    it('should be keyboard navigable', async () => {
-      const user = userEvent.setup();
-
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // Use container query to bypass aria-hidden wrapping
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const photosButton = buttons[0] as HTMLElement; // Photos is the first item, path /
-
-      // Should be able to focus and activate with keyboard
-      photosButton.focus();
-      expect(photosButton).toHaveFocus();
-
-      await user.keyboard('{Enter}');
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/');
       });
     });
   });
 
-  describe('Regression Tests', () => {
-    it('should NOT return null when open is false (critical bug fix)', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+  // =========================================================================
+  // aria-current (Required case 5, spec §7)
+  // =========================================================================
 
-      // CRITICAL REGRESSION TEST:
-      // Previously, the component conditionally returned null when open was false:
-      // if (!open) return null; // ❌ WRONG - caused backdrop click issues
-      //
-      // This caused UI blocking issues because:
-      // 1. The component was completely removed from the React tree
-      // 2. When reopened, React had to remount everything
-      // 3. This caused backdrop click handlers to become stale/broken
-      //
-      // The fix: Component always returns the Drawer JSX:
-      // return <Drawer open={open} ... /> // ✅ CORRECT - let MUI handle visibility
-      //
-      // This test verifies the component doesn't throw and renders successfully
-      expect(() => {
-        render(<Sidebar open={false} onClose={mockOnClose} />);
-      }).not.toThrow();
-
-      // Also verify it works when open
-      expect(() => {
-        render(<Sidebar open={true} onClose={mockOnClose} />);
-      }).not.toThrow();
-    });
-
-    it('should close drawer before navigation to prevent backdrop issues', async () => {
-      let drawerClosed = false;
-      let navigationOccurred = false;
-
-      const trackingOnClose = vi.fn(() => {
-        drawerClosed = true;
-        // At the moment onClose is called, navigation should not have occurred yet
-        expect(navigationOccurred).toBe(false);
-      });
-
-      mockNavigate.mockImplementation(() => {
-        navigationOccurred = true;
-        // Drawer should already be closed when navigation occurs
-        expect(drawerClosed).toBe(true);
-      });
-
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      const { container } = render(<Sidebar open={true} onClose={trackingOnClose} />);
-
-      // Use container query + fireEvent to bypass MUI modal aria-hidden wrapping
-      const buttons = container.querySelectorAll('.MuiListItemButton-root');
-      const photosButton = buttons[0] as HTMLElement; // Photos is the first button
-      fireEvent.click(photosButton);
-
-      // Drawer close should happen synchronously
-      expect(drawerClosed).toBe(true);
-
-      // Wait for navigation to occur (it's in setTimeout(0))
-      await waitFor(() => {
-        expect(navigationOccurred).toBe(true);
-      });
-    });
-
-    it('should maintain ModalProps configuration for backdrop click handling', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+  describe('aria-current="page"', () => {
+    it('is set on the active row in Library mode and on no other row', () => {
+      mockLocation.pathname = '/';
+      setNonAdmin();
 
       const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      const drawer = container.querySelector('.MuiDrawer-root');
-      expect(drawer).not.toBeNull();
-      expect(drawer).toBeDefined();
+      const photosButton = screen.getByText('Photos').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(photosButton).toHaveAttribute('aria-current', 'page');
 
-      // Critical: disablePortal: true keeps Modal in component tree
-      // This prevents backdrop click issues after navigation
-      // keepMounted: false ensures drawer content unmounts when closed
+      const others = Array.from(container.querySelectorAll('.MuiListItemButton-root')).filter(
+        (el) => el !== photosButton,
+      );
+      others.forEach((el) => expect(el).not.toHaveAttribute('aria-current'));
+    });
+
+    it('is set on the active row in Console mode', () => {
+      mockLocation.pathname = '/admin/settings/jobs';
+      setAdmin(['jobs:read']);
+
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
+        wrapperOptions: { user: mockAdminUser },
+      });
+
+      const jobQueueButton = screen.getByText('Job Queue').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(jobQueueButton).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('longest-prefix-wins: at /admin/settings/jobs/insights, aria-current lands on "Job Queue Insights" and NOT on "Job Queue"', () => {
+      mockLocation.pathname = '/admin/settings/jobs/insights';
+      setAdmin(['jobs:read']);
+
+      render(<Sidebar open={true} onClose={mockOnClose} />, {
+        wrapperOptions: { user: mockAdminUser },
+      });
+
+      const jobQueueButton = screen.getByText('Job Queue').closest('.MuiListItemButton-root') as HTMLElement;
+      const insightsButton = screen
+        .getByText('Job Queue Insights')
+        .closest('.MuiListItemButton-root') as HTMLElement;
+
+      expect(insightsButton).toHaveAttribute('aria-current', 'page');
+      expect(jobQueueButton).not.toHaveAttribute('aria-current');
+      // `selected` (the MUI visual state) must agree with aria-current.
+      expect(insightsButton.classList.contains('Mui-selected')).toBe(true);
+      expect(jobQueueButton.classList.contains('Mui-selected')).toBe(false);
     });
   });
 
-  describe('Utilities Section', () => {
-    it('renders a "Utilities" subheader', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+  // =========================================================================
+  // Segment-boundary matching (Required case 6, spec §3.5)
+  // =========================================================================
 
-      render(<Sidebar open={true} onClose={mockOnClose} />);
+  describe('segment-boundary matching (owns())', () => {
+    it('activates no row at /reviewer (must not fuzzy-match "Review ..." rows)', () => {
+      mockLocation.pathname = '/reviewer';
+      setNonAdmin();
 
-      expect(screen.getByText('Utilities')).toBeInTheDocument();
+      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const selected = container.querySelectorAll('.Mui-selected');
+      expect(selected).toHaveLength(0);
     });
 
-    it('renders Review Bursts, Review Duplicates, and Location Suggestions as descendants of the Utilities list', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+    it('does not activate "Review Bursts" at /burstsfoo', () => {
+      mockLocation.pathname = '/burstsfoo';
+      setNonAdmin();
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      expect(screen.getByText('Review Bursts')).toBeInTheDocument();
-      expect(screen.getByText('Review Duplicates')).toBeInTheDocument();
-      expect(screen.getByText('Location Suggestions')).toBeInTheDocument();
-
-      const utilitiesSubheader = screen.getByText('Utilities');
-      const utilitiesList = utilitiesSubheader.closest('.MuiList-root');
-      expect(utilitiesList).not.toBeNull();
-      expect(utilitiesList!.textContent).toContain('Review Bursts');
-      expect(utilitiesList!.textContent).toContain('Review Duplicates');
-      expect(utilitiesList!.textContent).toContain('Location Suggestions');
+      const burstsButton = screen.getByText('Review Bursts').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(burstsButton.classList.contains('Mui-selected')).toBe(false);
     });
 
-    it('no longer includes Review Bursts, Review Duplicates, or Location Suggestions under the Library list', () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+    it('activates Photos ONLY on an exact match at /', () => {
+      mockLocation.pathname = '/';
+      setNonAdmin();
+
+      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const photosButton = screen.getByText('Photos').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(photosButton.classList.contains('Mui-selected')).toBe(true);
+
+      const selected = container.querySelectorAll('.Mui-selected');
+      expect(selected).toHaveLength(1);
+    });
+
+    it('activates a nested route via a genuine segment boundary (e.g. /bursts/some-id activates Review Bursts)', () => {
+      mockLocation.pathname = '/bursts/some-id';
+      setNonAdmin();
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      const librarySubheader = screen.getByText('Library');
-      const libraryList = librarySubheader.closest('.MuiList-root');
-      expect(libraryList).not.toBeNull();
-
-      // Library retains People, Archive, Trash
-      expect(libraryList!.textContent).toContain('People');
-      expect(libraryList!.textContent).toContain('Archive');
-      expect(libraryList!.textContent).toContain('Trash');
-
-      // The three utility items moved out of Library
-      expect(libraryList!.textContent).not.toContain('Review Bursts');
-      expect(libraryList!.textContent).not.toContain('Review Duplicates');
-      expect(libraryList!.textContent).not.toContain('Location Suggestions');
+      const burstsButton = screen.getByText('Review Bursts').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(burstsButton.classList.contains('Mui-selected')).toBe(true);
     });
   });
 
-  describe('AI Enhancements Entry (issue #201)', () => {
-    const nonAdmin = () => ({
-      permissions: new Set<string>(),
-      roles: new Set<string>(),
-      hasPermission: vi.fn(),
-      hasAnyPermission: vi.fn(),
-      hasAllPermissions: vi.fn(),
-      hasRole: vi.fn(),
-      hasAnyRole: vi.fn(),
-      isAdmin: false,
+  // =========================================================================
+  // Drawer plumbing — unchanged by this issue, still load-bearing
+  // =========================================================================
+
+  describe('Drawer plumbing', () => {
+    it('renders the Drawer JSX even when open is false (never returns null)', () => {
+      setNonAdmin();
+      expect(() => render(<Sidebar open={false} onClose={mockOnClose} />)).not.toThrow();
     });
 
-    it('is hidden while the feature flag is still loading (null)', () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(null);
+    it('renders the Drawer when open is true', () => {
+      setNonAdmin();
+      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
+      expect(container.querySelector('.MuiDrawer-root')).not.toBeNull();
+    });
+
+    it('calls onClose BEFORE navigate on a row click', async () => {
+      setNonAdmin();
+      const callOrder: string[] = [];
+      const trackingOnClose = vi.fn(() => callOrder.push('onClose'));
+      mockNavigate.mockImplementation(() => callOrder.push('navigate'));
+
+      render(<Sidebar open={true} onClose={trackingOnClose} />);
+
+      fireEvent.click(screen.getByText('Photos').closest('.MuiListItemButton-root') as HTMLElement);
+
+      expect(trackingOnClose).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
+      expect(callOrder).toEqual(['onClose', 'navigate']);
+    });
+  });
+
+  // =========================================================================
+  // Navigation targets for a sample of rows
+  // =========================================================================
+
+  describe('Navigation targets', () => {
+    it.each([
+      ['Photos', '/'],
+      ['Explore', '/search'],
+      ['Map', '/map'],
+      ['Albums', '/albums'],
+      ['People', '/people'],
+      ['Archive', '/archive'],
+      ['Trash', '/trash'],
+      ['Review Bursts', '/bursts'],
+      ['Review Duplicates', '/duplicates'],
+      ['Review Insights', '/review-insights'],
+      ['Location Suggestions', '/location-suggestions'],
+    ])('navigates to %s -> %s', async (label, path) => {
+      setNonAdmin();
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      fireEvent.click(screen.getByText(label).closest('.MuiListItemButton-root') as HTMLElement);
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(path));
+    });
+  });
+
+  // =========================================================================
+  // AI Enhancements entry — flag gate + badge (issue #201/#204, preserved)
+  // =========================================================================
+
+  describe('AI Enhancements entry', () => {
+    it('is hidden while the flag is unresolved', () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: null });
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
       expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
     });
 
-    it('is hidden when picture enhancement is disabled', () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(false, 4);
+    it('is hidden when disabled', () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: false });
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
       expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
     });
 
-    it('renders under Utilities when picture enhancement is enabled', () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true);
+    it('renders under Utilities and navigates to /enhancements when enabled', async () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: true });
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      expect(screen.getByText('AI Enhancements')).toBeInTheDocument();
+      const utilitiesList = screen.getByText('Utilities').closest('.MuiList-root') as HTMLElement;
+      expect(within(utilitiesList).getByText('AI Enhancements')).toBeInTheDocument();
 
-      const utilitiesList = screen.getByText('Utilities').closest('.MuiList-root');
-      expect(utilitiesList).not.toBeNull();
-      expect(utilitiesList!.textContent).toContain('AI Enhancements');
-    });
-
-    it('navigates to /enhancements when clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true);
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const button = screen
-        .getByText('AI Enhancements')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(button);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/enhancements');
-      });
-    });
-
-    it('stays highlighted on a nested /enhancements/... route (prefix match)', () => {
-      mockLocation.pathname = '/enhancements/some-id';
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true);
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const button = screen
-        .getByText('AI Enhancements')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      expect(button.classList.contains('Mui-selected')).toBe(true);
+      fireEvent.click(screen.getByText('AI Enhancements').closest('.MuiListItemButton-root') as HTMLElement);
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/enhancements'));
     });
 
     it('renders the pending count as a badge', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true, 7);
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: true, pendingEnhancements: 7 });
 
       const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
       await waitFor(() => {
-        const badge = container.querySelector('.MuiBadge-badge');
-        expect(badge).not.toBeNull();
-        expect(badge!.textContent).toBe('7');
+        expect(container.querySelector('.MuiBadge-badge')!.textContent).toBe('7');
       });
     });
 
     it('caps the badge at 999+', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true, 1500);
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: true, pendingEnhancements: 1500 });
 
       const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
       await waitFor(() => {
         expect(container.querySelector('.MuiBadge-badge')!.textContent).toBe('999+');
       });
     });
 
-    it('renders no badge when the count is zero', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true, 0);
+    it('renders no badge when the pending count is zero', async () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: true, pendingEnhancements: 0 });
 
       const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      await waitFor(() => {
-        expect(mockGetReviewCounts).toHaveBeenCalled();
-      });
-
-      expect(screen.getByText('AI Enhancements')).toBeInTheDocument();
-      expect(container.querySelector('.MuiBadge-badge')).toBeNull();
-    });
-
-    it('renders no badge while the count request is still in flight', () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true);
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      expect(screen.getByText('AI Enhancements')).toBeInTheDocument();
+      await waitFor(() => expect(mockGetReviewCounts).toHaveBeenCalled());
       expect(container.querySelector('.MuiBadge-badge')).toBeNull();
     });
   });
 
-  // The point of issue #204: the badge count no longer comes from the heavy
-  // dashboard endpoint, and no counts request is made at all unless the badge
-  // that consumes it is actually rendered.
-  describe('Review-counts request gating (issue #204)', () => {
-    const nonAdmin = () => ({
-      permissions: new Set<string>(),
-      roles: new Set<string>(),
-      hasPermission: vi.fn(),
-      hasAnyPermission: vi.fn(),
-      hasAllPermissions: vi.fn(),
-      hasRole: vi.fn(),
-      hasAnyRole: vi.fn(),
-      isAdmin: false,
-    });
+  // =========================================================================
+  // Review-counts request gating (issue #204, preserved)
+  // =========================================================================
 
-    it('issues NO review-counts request while the enhancer flag is still loading', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(null);
-
+  describe('Review-counts request gating', () => {
+    it('issues no request while the enhancer flag is unresolved or disabled', async () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: null });
       render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // The sidebar has fully rendered — a request, had one been issued, would
-      // already have been kicked off by the hook's mount effect.
       expect(screen.getByText('Photos')).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
-      });
       expect(mockGetReviewCounts).not.toHaveBeenCalled();
     });
 
-    it('issues NO review-counts request when the enhancer feature is disabled', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(false, 4);
+    it('requests counts for the active circle when enabled, and never calls the full dashboard', async () => {
+      setNonAdmin();
+      mockFlags({ pictureEnhancement: true, pendingEnhancements: 3 });
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      expect(screen.getByText('Photos')).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
-      });
-      expect(mockGetReviewCounts).not.toHaveBeenCalled();
-    });
-
-    it('requests the counts for the active circle when the enhancer is enabled, and badges the result', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true, 3);
-
-      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      // `circle-1` is the active circle supplied by the test-utils wrapper.
       await waitFor(() => {
         expect(mockGetReviewCounts).toHaveBeenCalledWith('circle-1');
       });
-
-      await waitFor(() => {
-        expect(container.querySelector('.MuiBadge-badge')!.textContent).toBe('3');
-      });
-    });
-
-    it('never fetches the full dashboard for the badge count', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockEnhancer(true, 3);
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      await waitFor(() => {
-        expect(mockGetReviewCounts).toHaveBeenCalledTimes(1);
-      });
-
-      // The sidebar used to read this one integer out of GET /api/media/dashboard,
-      // which also returns On This Day / recent / favorites with a signed
-      // thumbnail URL per item.
       expect(mockGetDashboard).not.toHaveBeenCalled();
     });
   });
 
-  describe('Albums Navigation', () => {
-    it('renders exactly one nav entry labeled "Albums" and no per-album rows', () => {
-      // The Sidebar collapsed from enumerating individual albums to a single
-      // static "Albums" nav entry — useAlbums is mocked with albums: [] above
-      // to prove the count doesn't come from (or vary with) real album data.
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
+  // =========================================================================
+  // Memories entry (issue #309, preserved)
+  // =========================================================================
 
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      expect(screen.getAllByText('Albums')).toHaveLength(1);
-
-      const albumsButton = screen
-        .getByText('Albums')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      expect(albumsButton).not.toBeNull();
-    });
-
-    it('navigates to /albums when the Albums item is clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue({
-        permissions: new Set(),
-        roles: new Set(),
-        hasPermission: vi.fn(),
-        hasAnyPermission: vi.fn(),
-        hasAllPermissions: vi.fn(),
-        hasRole: vi.fn(),
-        hasAnyRole: vi.fn(),
-        isAdmin: false,
-      });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const albumsButton = screen
-        .getByText('Albums')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(albumsButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/albums');
-      });
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Notifications entry (issue #250) — badge + shared-poller regression guard
-  // ---------------------------------------------------------------------------
-  describe('Notifications entry (issue #250)', () => {
-    const nonAdmin = () => ({
-      permissions: new Set<string>(),
-      roles: new Set<string>(),
-      hasPermission: vi.fn(),
-      hasAnyPermission: vi.fn(),
-      hasAllPermissions: vi.fn(),
-      hasRole: vi.fn(),
-      hasAnyRole: vi.fn(),
-      isAdmin: false,
-    });
-
-    it('renders the Notifications nav entry', () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      expect(screen.getByText('Notifications')).toBeInTheDocument();
-    });
-
-    it('navigates to /notifications when clicked', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const button = screen
-        .getByText('Notifications')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      fireEvent.click(button);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/notifications');
-      });
-    });
-
-    it('renders the unread count from the shared store as a badge', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockGetUnreadCount.mockResolvedValue(4);
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      await waitFor(() => {
-        const button = screen
-          .getByText('Notifications')
-          .closest('.MuiListItemButton-root') as HTMLElement;
-        const badge = button.querySelector('.MuiBadge-badge');
-        expect(badge).not.toBeNull();
-        expect(badge!.textContent).toBe('4');
-      });
-    });
-
-    it('renders no badge when the unread count is zero', async () => {
-      vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-      mockGetUnreadCount.mockResolvedValue(0);
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      await waitFor(() => {
-        expect(mockGetUnreadCount).toHaveBeenCalled();
-      });
-      const button = screen
-        .getByText('Notifications')
-        .closest('.MuiListItemButton-root') as HTMLElement;
-      expect(button.querySelector('.MuiBadge-badge')).toBeNull();
-    });
-
-    // The regression this guards against: the sidebar entry starting its own
-    // independent poll timer instead of sharing the bell's single one — see
-    // `useNotifications.ts`'s "ONE poller, three surfaces" doc and the
-    // equivalent assertions in `useNotifications.test.ts` /
-    // `NotificationBell.test.tsx`, mirrored here across the two REAL surfaces
-    // together for the first time.
-    describe('shares the bell\'s single poller — no second poller sneaks in', () => {
-      it('mounting the sidebar AND the bell together issues only ONE unread-count request, not two', async () => {
-        vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-        mockGetUnreadCount.mockResolvedValue(2);
-
-        render(
-          <>
-            <Sidebar open={true} onClose={mockOnClose} />
-            <NotificationBell />
-          </>,
-        );
-
-        await waitFor(() => {
-          expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
-        });
-      });
-
-      it('the ONE shared poller ticks once per interval regardless of both surfaces being mounted', async () => {
-        vi.useFakeTimers();
-        vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-        mockGetUnreadCount.mockResolvedValue(2);
-
-        render(
-          <>
-            <Sidebar open={true} onClose={mockOnClose} />
-            <NotificationBell />
-          </>,
-        );
-
-        await act(async () => {
-          await Promise.resolve();
-        });
-        expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
-
-        await act(async () => {
-          vi.advanceTimersByTime(60_000);
-          await Promise.resolve();
-        });
-
-        // ONE additional tick from the ONE shared interval — not two (which a
-        // second independent poller in the sidebar would produce).
-        expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
-      });
-
-      it('polling continues (from the bell) after the sidebar unmounts — proving the sidebar is a subscriber, not the owner, of the poller', async () => {
-        vi.useFakeTimers();
-        vi.mocked(usePermissions).mockReturnValue(nonAdmin());
-        mockGetUnreadCount.mockResolvedValue(2);
-
-        const { unmount } = render(<Sidebar open={true} onClose={mockOnClose} />);
-        render(<NotificationBell />);
-
-        await act(async () => {
-          await Promise.resolve();
-        });
-
-        unmount(); // sidebar goes away; the bell is still mounted
-
-        await act(async () => {
-          vi.advanceTimersByTime(60_000);
-          await Promise.resolve();
-        });
-
-        expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
-      });
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Memories entry (issue #309, epic #300)
-  //
-  // Same strict-true convention the AI Enhancements entry above documents, and
-  // for the same reason: `features.memories` defaults OFF, so a truthy check
-  // would flash the entry in for one render while the flags load and a flags
-  // outage (which leaves `features` null) would show a nav item pointing at a
-  // surface the API answers with empty lists.
-  // ---------------------------------------------------------------------------
-  describe('Memories entry (issue #309)', () => {
-    /** Set the raw feature record directly; the enhancer flag stays off. */
-    function mockMemories(features: Record<string, boolean> | null): void {
-      vi.mocked(useFeatureFlags).mockReturnValue({
-        features,
-        pictureEnhancement: null,
-        isLoading: false,
-        error: null,
-        refresh: vi.fn().mockResolvedValue(undefined),
-      });
-    }
-
+  describe('Memories entry', () => {
     it('is hidden when the flag is off', () => {
-      mockMemories({ memories: false });
+      setNonAdmin();
+      mockFlags({ memories: false });
       render(<Sidebar open={true} onClose={mockOnClose} />);
-
       expect(screen.queryByText('Memories')).not.toBeInTheDocument();
     });
 
-    it('is hidden when the flag key is absent entirely', () => {
-      mockMemories({});
+    it('is hidden while the flag is unresolved', () => {
+      setNonAdmin();
+      mockFlags({ memories: null });
       render(<Sidebar open={true} onClose={mockOnClose} />);
-
       expect(screen.queryByText('Memories')).not.toBeInTheDocument();
     });
 
-    it('is hidden when the flags failed to load', () => {
-      mockMemories(null);
-      render(<Sidebar open={true} onClose={mockOnClose} />);
+    it('appears in the primary section and navigates to /memories when enabled', async () => {
+      setNonAdmin();
+      mockFlags({ memories: true });
 
-      expect(screen.queryByText('Memories')).not.toBeInTheDocument();
-    });
-
-    it('appears in the primary section when the flag is on', () => {
-      mockMemories({ memories: true });
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
       expect(screen.getByText('Memories')).toBeInTheDocument();
-    });
-
-    it('navigates to /memories when clicked', async () => {
-      mockMemories({ memories: true });
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
       fireEvent.click(screen.getByText('Memories'));
       await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/memories'));
+    });
+  });
+
+  // =========================================================================
+  // Workflows entry
+  // =========================================================================
+
+  describe('Workflows entry', () => {
+    it('is hidden while unresolved', () => {
+      setNonAdmin();
+      mockFlags({ workflows: null });
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+      expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
+    });
+
+    it('is hidden when disabled', () => {
+      setNonAdmin();
+      mockFlags({ workflows: false });
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+      expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
+    });
+
+    it('renders under Utilities and navigates to /workflows when enabled', async () => {
+      setNonAdmin();
+      mockFlags({ workflows: true });
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const utilitiesList = screen.getByText('Utilities').closest('.MuiList-root') as HTMLElement;
+      expect(within(utilitiesList).getByText('Workflows')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Workflows'));
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/workflows'));
+    });
+  });
+
+  // =========================================================================
+  // Accessibility
+  // =========================================================================
+
+  describe('Accessibility', () => {
+    it('is keyboard navigable — Enter on a focused row triggers navigation', async () => {
+      const user = userEvent.setup();
+      setNonAdmin();
+
+      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const photosButton = container.querySelector('.MuiListItemButton-root') as HTMLElement;
+      photosButton.focus();
+      expect(photosButton).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
+    });
+
+    it('every row carries an icon', () => {
+      setNonAdmin();
+      mockAllFlagsOn();
+
+      const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const icons = container.querySelectorAll('.MuiListItemIcon-root');
+      expect(icons).toHaveLength(LIBRARY_ALL_FLAGS_ROWS.length);
     });
   });
 });

--- a/apps/web/src/__tests__/components/navigation/UserMenu.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/UserMenu.test.tsx
@@ -9,13 +9,7 @@ vi.mock('../../../hooks/usePermissions', () => ({
   usePermissions: vi.fn(),
 }));
 
-// Mock useCircle hook (test-utils' default MockCircleProvider only supplies a
-// single circle, which isn't enough to exercise multi-circle selection UI)
-vi.mock('../../../hooks/useCircle', () => ({
-  useCircle: vi.fn(),
-}));
-
-// Mock react-router-dom's useNavigate so we can assert on "Manage Circles" navigation
+// Mock react-router-dom's useNavigate so navigation can be asserted on.
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -26,43 +20,8 @@ vi.mock('react-router-dom', async () => {
 });
 
 import { usePermissions } from '../../../hooks/usePermissions';
-import { useCircle } from '../../../hooks/useCircle';
 
 const mockUsePermissions = vi.mocked(usePermissions);
-const mockUseCircle = vi.mocked(useCircle);
-
-const mockCircle1 = {
-  id: 'circle-1',
-  name: 'Personal Library',
-  description: null,
-  ownerId: 'test-user-id',
-  isPersonal: true,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-};
-
-const mockCircle2 = {
-  id: 'circle-2',
-  name: 'Family Circle',
-  description: 'Our family',
-  ownerId: 'test-user-id',
-  isPersonal: false,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-};
-
-function makeCircleDefaults(overrides: Record<string, unknown> = {}) {
-  return {
-    circles: [mockCircle1, mockCircle2],
-    activeCircle: mockCircle1,
-    activeCircleId: 'circle-1',
-    activeCircleRole: 'circle_admin' as const,
-    loading: false,
-    setActiveCircle: vi.fn().mockResolvedValue(undefined),
-    refreshCircles: vi.fn().mockResolvedValue(undefined),
-    ...overrides,
-  };
-}
 
 describe('UserMenu', () => {
   beforeEach(() => {
@@ -80,8 +39,6 @@ describe('UserMenu', () => {
       hasAnyRole: vi.fn(),
       isAdmin: false,
     });
-
-    mockUseCircle.mockReturnValue(makeCircleDefaults());
   });
 
   describe('Rendering', () => {
@@ -411,8 +368,14 @@ describe('UserMenu', () => {
     });
   });
 
-  describe('Circle Section', () => {
-    it('shows a "Manage Circles" menu item', async () => {
+  // ===========================================================================
+  // Circle section removal (spec §3.3) — the switcher and "Manage Circles"
+  // moved to the top-bar CircleChip; this menu is account-scope only now. See
+  // CircleChip.test.tsx for the switcher's own coverage.
+  // ===========================================================================
+
+  describe('Circle section removal', () => {
+    it('does not show a "Manage Circles" menu item', async () => {
       const user = userEvent.setup();
 
       render(<UserMenu />);
@@ -420,11 +383,12 @@ describe('UserMenu', () => {
       await user.click(screen.getByRole('button'));
 
       await waitFor(() => {
-        expect(screen.getByRole('menuitem', { name: /manage circles/i })).toBeInTheDocument();
+        expect(screen.getByRole('menu')).toBeInTheDocument();
       });
+      expect(screen.queryByRole('menuitem', { name: /manage circles/i })).not.toBeInTheDocument();
     });
 
-    it('shows both circle names as menu items', async () => {
+    it('does not show any circle name as a menu item', async () => {
       const user = userEvent.setup();
 
       render(<UserMenu />);
@@ -432,32 +396,13 @@ describe('UserMenu', () => {
       await user.click(screen.getByRole('button'));
 
       await waitFor(() => {
-        expect(screen.getByRole('menuitem', { name: /personal library/i })).toBeInTheDocument();
+        expect(screen.getByRole('menu')).toBeInTheDocument();
       });
-      expect(screen.getByRole('menuitem', { name: /family circle/i })).toBeInTheDocument();
+      // The active circle supplied by the test-utils wrapper.
+      expect(screen.queryByText("Test User's Library")).not.toBeInTheDocument();
     });
 
-    it('calls setActiveCircle with the clicked circle id', async () => {
-      const setActiveCircle = vi.fn().mockResolvedValue(undefined);
-      mockUseCircle.mockReturnValue(makeCircleDefaults({ setActiveCircle }));
-
-      const user = userEvent.setup();
-
-      render(<UserMenu />);
-
-      await user.click(screen.getByRole('button'));
-
-      const familyItem = await screen.findByRole('menuitem', { name: /family circle/i });
-      await user.click(familyItem);
-
-      await waitFor(() => {
-        expect(setActiveCircle).toHaveBeenCalledWith('circle-2');
-      });
-    });
-
-    it('shows a disabled "No circles yet" item when circles list is empty', async () => {
-      mockUseCircle.mockReturnValue(makeCircleDefaults({ circles: [] }));
-
+    it('menu items are limited to Profile, Settings, and Logout for a non-admin', async () => {
       const user = userEvent.setup();
 
       render(<UserMenu />);
@@ -465,28 +410,13 @@ describe('UserMenu', () => {
       await user.click(screen.getByRole('button'));
 
       await waitFor(() => {
-        expect(screen.getByText('No circles yet')).toBeInTheDocument();
-      });
-    });
-
-    it('navigates to /circles when "Manage Circles" is clicked', async () => {
-      const user = userEvent.setup();
-
-      render(<UserMenu />);
-
-      await user.click(screen.getByRole('button'));
-
-      const manageItem = await screen.findByRole('menuitem', { name: /manage circles/i });
-      await user.click(manageItem);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/circles');
+        expect(screen.getByRole('menu')).toBeInTheDocument();
       });
 
-      // Menu should also close after navigation
-      await waitFor(() => {
-        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-      });
+      expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+      expect(screen.getByRole('menuitem', { name: /profile/i })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /^settings$/i })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /logout/i })).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/__tests__/components/notifications/NotificationPanel.test.tsx
+++ b/apps/web/src/__tests__/components/notifications/NotificationPanel.test.tsx
@@ -207,6 +207,33 @@ describe('NotificationPanel', () => {
   });
 
   // =========================================================================
+  // Footer "See all notifications" (issue #389 — the deleted Sidebar
+  // "Notifications" row means this footer button is now the ONLY path to
+  // /notifications).
+  // =========================================================================
+
+  describe('footer', () => {
+    it('reads "See all notifications"', () => {
+      setNotificationsState({ hasLoadedList: true, items: [] });
+      renderPanel();
+
+      expect(screen.getByRole('button', { name: 'See all notifications' })).toBeInTheDocument();
+    });
+
+    it('navigates to /notifications and closes the panel when clicked', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      setNotificationsState({ hasLoadedList: true, items: [] });
+      render(<NotificationPanel open anchorEl={null} onClose={onClose} />);
+
+      await user.click(screen.getByRole('button', { name: 'See all notifications' }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('/notifications');
+    });
+  });
+
+  // =========================================================================
   // Mark all as read
   // =========================================================================
 

--- a/apps/web/src/__tests__/config/adminSections.test.ts
+++ b/apps/web/src/__tests__/config/adminSections.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for `config/adminSections.tsx` (issue #389, epic #388).
+ *
+ * This module is the single declaration consumed by three surfaces
+ * (SettingsHubPage, Sidebar Console mode, AppBar's admin-title resolver), so
+ * its two pure functions — `visibleAdminSections` and `adminPageTitle` — are
+ * the load-bearing logic the whole "Console invents no new admin IA" claim
+ * (spec §3.2) rests on. Covered directly here rather than only indirectly
+ * through the three consumers.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ADMIN_SECTIONS,
+  ADMIN_HUB_PATH,
+  ADMIN_HUB_TITLE,
+  visibleAdminSections,
+  adminPageTitle,
+} from '../../config/adminSections';
+
+/** Flatten every card across every section, for whole-catalog assertions. */
+function allCards() {
+  return ADMIN_SECTIONS.flatMap((section) => section.cards);
+}
+
+function allowAll() {
+  return () => true;
+}
+
+function allowNone() {
+  return () => false;
+}
+
+function allowOnly(...allowed: string[]) {
+  return (permission: string) => allowed.includes(permission);
+}
+
+describe('adminSections', () => {
+  describe('module shape sanity', () => {
+    it('exposes the hub path and title constants', () => {
+      expect(ADMIN_HUB_PATH).toBe('/admin/settings');
+      expect(ADMIN_HUB_TITLE).toBe('Settings');
+    });
+
+    it('every card carries a component (not an element) as its Icon', () => {
+      allCards().forEach((card) => {
+        // A component reference is a function (or, for some MUI icon
+        // exports, an object wrapping one via forwardRef) — either way it is
+        // NOT a rendered element, which would be a plain object with a
+        // `$$typeof` symbol and `props`.
+        expect(typeof card.Icon === 'function' || typeof card.Icon === 'object').toBe(true);
+        expect(card.Icon).not.toBeNull();
+      });
+    });
+
+    it('every card with a path has a permission or is explicitly alwaysShow', () => {
+      // Not a hard requirement of the type, but every card actually declared
+      // today is permission-gated — this pins that fact so a future card
+      // added with neither is caught, since it would be visible to everyone
+      // with no way to hide it.
+      allCards().forEach((card) => {
+        if (!card.path) return;
+        expect(Boolean(card.permission) || Boolean(card.alwaysShow)).toBe(true);
+      });
+    });
+  });
+
+  describe('visibleAdminSections', () => {
+    it('drops individual cards the permission gate rejects', () => {
+      const sections = visibleAdminSections(allowOnly('jobs:read'));
+      const titles = sections.flatMap((s) => s.cards.map((c) => c.title));
+
+      expect(titles).toContain('Job Queue');
+      expect(titles).toContain('Job Queue Insights');
+      expect(titles).toContain('Worker Nodes');
+      expect(titles).not.toContain('System');
+      expect(titles).not.toContain('AI Providers');
+      expect(titles).not.toContain('Database Backup');
+    });
+
+    it('drops a whole section when every one of its cards is rejected', () => {
+      // Only db_backup:read passes — the only card that unlocks is
+      // "Database Backup" (Operations). Every other section becomes empty
+      // and must not appear at all, not appear with an empty cards array.
+      const sections = visibleAdminSections(allowOnly('db_backup:read'));
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0].label).toBe('Operations');
+      expect(sections[0].cards.map((c) => c.title)).toEqual(['Database Backup']);
+    });
+
+    it('returns every section/card when every permission is granted', () => {
+      const sections = visibleAdminSections(allowAll());
+
+      expect(sections).toHaveLength(ADMIN_SECTIONS.length);
+      const totalCards = sections.reduce((sum, s) => sum + s.cards.length, 0);
+      expect(totalCards).toBe(allCards().length);
+    });
+
+    it('returns nothing when no permission is granted', () => {
+      const sections = visibleAdminSections(allowNone());
+      expect(sections).toEqual([]);
+    });
+
+    describe('query filtering', () => {
+      it('filters cards by title, case-insensitively', () => {
+        const sections = visibleAdminSections(allowAll(), 'job');
+        const titles = sections.flatMap((s) => s.cards.map((c) => c.title));
+
+        expect(titles.sort()).toEqual(['Job Queue', 'Job Queue Insights']);
+      });
+
+      it('matches regardless of the query\'s casing', () => {
+        const lower = visibleAdminSections(allowAll(), 'job queue');
+        const upper = visibleAdminSections(allowAll(), 'JOB QUEUE');
+        const mixed = visibleAdminSections(allowAll(), 'Job Queue');
+
+        const titlesOf = (sections: ReturnType<typeof visibleAdminSections>) =>
+          sections.flatMap((s) => s.cards.map((c) => c.title)).sort();
+
+        expect(titlesOf(lower)).toEqual(titlesOf(upper));
+        expect(titlesOf(lower)).toEqual(titlesOf(mixed));
+      });
+
+      it('does not match on description text, only the title', () => {
+        // "PostgreSQL" appears only in the Database Backup card's
+        // description, never in any card title.
+        const sections = visibleAdminSections(allowAll(), 'PostgreSQL');
+        expect(sections).toEqual([]);
+      });
+
+      it('returns [] for a query that matches nothing', () => {
+        const sections = visibleAdminSections(allowAll(), 'zzz-not-a-real-setting');
+        expect(sections).toEqual([]);
+      });
+
+      it('an empty/whitespace-only query behaves like no query at all', () => {
+        const noQuery = visibleAdminSections(allowAll());
+        const emptyQuery = visibleAdminSections(allowAll(), '');
+        const whitespaceQuery = visibleAdminSections(allowAll(), '   ');
+
+        expect(emptyQuery).toEqual(noQuery);
+        expect(whitespaceQuery).toEqual(noQuery);
+      });
+
+      it('a permission-gated card stays hidden regardless of a matching search text', () => {
+        // "Job Queue" matches the query text, but the caller cannot see it —
+        // the classic filter-bypasses-authz bug this function must not have.
+        const sections = visibleAdminSections(allowNone(), 'job');
+        expect(sections).toEqual([]);
+      });
+
+      it('a permission-gated card stays hidden even with an ALLOWED but wrong permission', () => {
+        // Caller can see "Database Backup" cards but is searching for "job" —
+        // the only cards matching "job" require jobs:read, which is absent.
+        const sections = visibleAdminSections(allowOnly('db_backup:read'), 'job');
+        expect(sections).toEqual([]);
+      });
+    });
+  });
+
+  describe('adminPageTitle', () => {
+    it('returns null for a path outside /admin', () => {
+      expect(adminPageTitle('/')).toBeNull();
+      expect(adminPageTitle('/settings')).toBeNull();
+      expect(adminPageTitle('/administrator')).toBeNull(); // not a segment match
+    });
+
+    it('returns the hub title for the hub path itself', () => {
+      expect(adminPageTitle('/admin/settings')).toBe('Settings');
+    });
+
+    it('returns the hub title for bare /admin', () => {
+      expect(adminPageTitle('/admin')).toBe('Settings');
+    });
+
+    it('resolves an exact card path to that card\'s title', () => {
+      expect(adminPageTitle('/admin/settings/jobs')).toBe('Job Queue');
+    });
+
+    it('longest-prefix-wins: a nested detail route resolves to the more specific card', () => {
+      // /admin/settings/jobs/insights is a prefix-match for BOTH the "Job
+      // Queue" card (/admin/settings/jobs) and an exact match for "Job Queue
+      // Insights" (/admin/settings/jobs/insights) — the longer path must win.
+      expect(adminPageTitle('/admin/settings/jobs/insights')).toBe('Job Queue Insights');
+    });
+
+    it('a path nested one level under "Job Queue" (not "Insights") resolves to "Job Queue"', () => {
+      expect(adminPageTitle('/admin/settings/jobs/some-detail')).toBe('Job Queue');
+    });
+
+    it('resolves a deeply-nested detail route to its parent card (Worker Nodes)', () => {
+      expect(adminPageTitle('/admin/settings/nodes/abc/backup')).toBe('Worker Nodes');
+    });
+
+    it('falls back to the hub title for an unknown /admin/* path', () => {
+      expect(adminPageTitle('/admin/settings/nonexistent-page')).toBe('Settings');
+    });
+  });
+});

--- a/apps/web/src/__tests__/hooks/useScrollRestoration.test.ts
+++ b/apps/web/src/__tests__/hooks/useScrollRestoration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for useScrollRestoration (issue #389, epic #388).
+ *
+ * Scroll restoration is called out in the issue as "the criterion most likely
+ * to regress silently" (spec §4.4) — a manual "seems fine" check would not
+ * catch a future refactor that, say, swaps `window.scrollY` for an element's
+ * `scrollTop`, or drops the rAF retry loop and starts clamping to whatever
+ * height the page happens to have on the first frame. These tests drive the
+ * hook directly with `renderHook`, so they exercise the real save/restore
+ * state machine rather than a page that merely calls it.
+ *
+ * jsdom reports 0 for `document.documentElement.scrollHeight` and
+ * `window.innerHeight` by default, so both are stubbed per test via
+ * `Object.defineProperty(..., { configurable: true, value })`. `rAF`/`cAF`
+ * are replaced with a hand-rolled, manually-flushable queue so the retry loop
+ * can be driven deterministically frame-by-frame instead of racing real
+ * timers.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useScrollRestoration } from '../../hooks/useScrollRestoration';
+
+// ---------------------------------------------------------------------------
+// Manual rAF queue — lets each test decide exactly when a "frame" happens.
+// ---------------------------------------------------------------------------
+
+let nextId: number;
+let queue: Map<number, FrameRequestCallback>;
+
+function stubRaf() {
+  nextId = 1;
+  queue = new Map();
+
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((cb: FrameRequestCallback): number => {
+      const id = nextId++;
+      queue.set(id, cb);
+      return id;
+    }),
+  );
+
+  vi.stubGlobal(
+    'cancelAnimationFrame',
+    vi.fn((id: number): void => {
+      queue.delete(id);
+    }),
+  );
+}
+
+/** Run every callback currently queued (one simulated frame). New callbacks
+ * scheduled by those callbacks land in the queue for the NEXT flush, mirroring
+ * real rAF semantics. */
+function flushFrame(): void {
+  const callbacks = Array.from(queue.values());
+  queue.clear();
+  callbacks.forEach((cb) => cb(0));
+}
+
+function setDocumentHeight(scrollHeight: number, innerHeight: number): void {
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    configurable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: innerHeight,
+  });
+}
+
+function setScrollY(value: number): void {
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    value,
+  });
+}
+
+const STORAGE_KEY = 'mh:scroll:test-key';
+
+beforeEach(() => {
+  stubRaf();
+  window.sessionStorage.clear();
+  // setup.ts already stubs window.scrollTo as a plain vi.fn(); replace it
+  // with a fresh spy per test so call counts never leak across tests.
+  window.scrollTo = vi.fn();
+  setDocumentHeight(0, 0);
+  setScrollY(0);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.sessionStorage.clear();
+});
+
+describe('useScrollRestoration', () => {
+  describe('restore', () => {
+    it('restores a saved offset once the document is tall enough', () => {
+      window.sessionStorage.setItem(STORAGE_KEY, '500');
+      setDocumentHeight(1000, 500); // maxScroll = 500 === target
+
+      renderHook(() => useScrollRestoration('test-key'));
+
+      // The initial restore attempt is scheduled synchronously in the mount
+      // effect; one flushed frame is enough since the document is already
+      // tall enough on the first try.
+      flushFrame();
+
+      expect(window.scrollTo).toHaveBeenCalledWith({ top: 500, behavior: 'auto' });
+    });
+
+    it('retries across frames until the document grows tall enough', () => {
+      window.sessionStorage.setItem(STORAGE_KEY, '800');
+      setDocumentHeight(200, 500); // maxScroll = -300, far short of 800
+
+      renderHook(() => useScrollRestoration('test-key'));
+
+      flushFrame(); // attempt #1 — still short, schedules a retry
+      expect(window.scrollTo).not.toHaveBeenCalled();
+
+      flushFrame(); // attempt #2 — still short
+      expect(window.scrollTo).not.toHaveBeenCalled();
+
+      // Content has now rendered enough to satisfy the saved offset.
+      setDocumentHeight(1300, 500); // maxScroll = 800
+
+      flushFrame(); // attempt #3 — succeeds
+      expect(window.scrollTo).toHaveBeenCalledWith({ top: 800, behavior: 'auto' });
+    });
+
+    it('does not attempt to restore when there is no saved offset', () => {
+      setDocumentHeight(2000, 500);
+
+      renderHook(() => useScrollRestoration('test-key'));
+      flushFrame();
+
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when disabled', () => {
+      window.sessionStorage.setItem(STORAGE_KEY, '500');
+      setDocumentHeight(1000, 500);
+
+      renderHook(() => useScrollRestoration('test-key', { enabled: false }));
+      flushFrame();
+      flushFrame();
+
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('namespaces the storage key so two surfaces never collide', () => {
+      window.sessionStorage.setItem('mh:scroll:other-key', '999');
+      setDocumentHeight(2000, 500);
+
+      // Mounting under 'test-key' must not pick up 'other-key''s saved value.
+      renderHook(() => useScrollRestoration('test-key'));
+      flushFrame();
+
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('save', () => {
+    it('writes the current scroll offset (coalesced through rAF) on a scroll event', () => {
+      renderHook(() => useScrollRestoration('test-key'));
+
+      setScrollY(240);
+      window.dispatchEvent(new Event('scroll'));
+
+      // Not written synchronously — coalesced to the next frame.
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+      flushFrame();
+
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('240');
+    });
+
+    it('coalesces many scroll events within one frame into a single write', () => {
+      renderHook(() => useScrollRestoration('test-key'));
+
+      const scheduleCalls = vi.mocked(window.requestAnimationFrame).mock.calls.length;
+
+      setScrollY(10);
+      window.dispatchEvent(new Event('scroll'));
+      setScrollY(20);
+      window.dispatchEvent(new Event('scroll'));
+      setScrollY(30);
+      window.dispatchEvent(new Event('scroll'));
+
+      // Only one additional rAF was scheduled for the whole burst.
+      expect(vi.mocked(window.requestAnimationFrame).mock.calls.length).toBe(scheduleCalls + 1);
+
+      flushFrame();
+
+      // The write reflects whatever scrollY was AT FLUSH TIME (the last of
+      // the three), not the first event that triggered the schedule.
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('30');
+    });
+  });
+
+  describe('unmount', () => {
+    it('writes a final offset reading on unmount', () => {
+      const { unmount } = renderHook(() => useScrollRestoration('test-key'));
+
+      setScrollY(77);
+      unmount();
+
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('77');
+    });
+
+    it('removes the scroll listener on unmount', () => {
+      const removeSpy = vi.spyOn(window, 'removeEventListener');
+      const { unmount } = renderHook(() => useScrollRestoration('test-key'));
+
+      unmount();
+
+      expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+      removeSpy.mockRestore();
+    });
+  });
+
+  describe('sessionStorage failures degrade gracefully', () => {
+    it('does not throw when every sessionStorage access throws (e.g. Safari private mode)', () => {
+      const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+      const throwing: Storage = {
+        getItem: () => {
+          throw new Error('SecurityError');
+        },
+        setItem: () => {
+          throw new Error('SecurityError');
+        },
+        removeItem: () => {},
+        clear: () => {},
+        key: () => null,
+        length: 0,
+      };
+      Object.defineProperty(window, 'sessionStorage', {
+        configurable: true,
+        value: throwing,
+      });
+
+      try {
+        setDocumentHeight(2000, 500);
+        setScrollY(50);
+
+        let renderResult: ReturnType<typeof renderHook> | undefined;
+        expect(() => {
+          renderResult = renderHook(() => useScrollRestoration('test-key'));
+        }).not.toThrow();
+
+        expect(() => flushFrame()).not.toThrow();
+
+        window.dispatchEvent(new Event('scroll'));
+        expect(() => flushFrame()).not.toThrow();
+
+        expect(() => renderResult?.unmount()).not.toThrow();
+
+        // A throwing read degrades to "nothing to restore" — no programmatic
+        // scroll is ever attempted.
+        expect(window.scrollTo).not.toHaveBeenCalled();
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(window, 'sessionStorage', originalDescriptor);
+        }
+      }
+    });
+  });
+});

--- a/apps/web/src/__tests__/navigation/reachability.test.tsx
+++ b/apps/web/src/__tests__/navigation/reachability.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Reachability regression (issue #389, epic #388, spec §9).
+ *
+ * The single most important test in this epic: issue #389 deletes eight
+ * drawer rows (Circles, Notifications, User Settings, Settings, Job Queue,
+ * Worker Nodes, Storage Insights, Public Sharing) because each duplicates
+ * chrome that is already on screen elsewhere. Deleting a NAV ROW must never
+ * delete the ROUTE it pointed at — every one of those destinations remains
+ * reachable via a URL (Console mode, a bookmark, a deep link, browser
+ * back/forward), even though no drawer entry names it directly anymore.
+ *
+ * Approach: a real `MemoryRouter` render at each path would need the full
+ * provider stack (Auth, Circle, Theme, MSW-backed data fetches for every
+ * lazy-loaded page component) mocked to the point of tautology — asserting
+ * little beyond "our own mocks resolved". Instead this statically parses the
+ * ACTUAL `src/App.tsx` source for its `<Route path="...">` declarations and
+ * checks the required paths are present in that set. This is a genuine
+ * regression guard, not a tautology: deleting (or renaming, or moving outside
+ * the parsed <Routes> tree) any of the `<Route path="...">` lines below makes
+ * this test fail, because the string is re-extracted from the file on every
+ * run rather than hardcoded as "known good".
+ *
+ * The parse is intentionally strict about what counts as a route declaration
+ * (`<Route path="...">` exactly, one match per opening tag) precisely so it
+ * cannot silently match zero routes and pass vacuously — the sanity check at
+ * the bottom of this file asserts a realistic minimum route count for that
+ * reason.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// NOTE: deliberately `dirname(...)` + `resolve(...)` rather than the more
+// idiomatic `new URL('../../App.tsx', import.meta.url)` — Vite statically
+// analyzes that exact `new URL(relative, import.meta.url)` shape as an asset
+// reference and rewrites it, which under Vitest's transform produces a
+// non-URL value and a confusing "TypeError: Invalid URL" at collection time.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_TSX_PATH = resolve(HERE, '../../App.tsx');
+
+/**
+ * Extract every `<Route path="...">` declaration from the raw source text.
+ * Deliberately does NOT try to parse JSX/TSX with a real parser — a plain
+ * regex over the source is more resilient to this file's own churn (import
+ * ordering, comments, formatting) while still failing hard if a `path="..."`
+ * attribute is removed, renamed, or the `<Route` tag itself disappears.
+ */
+function extractRoutePaths(source: string): string[] {
+  const matches = source.matchAll(/<Route\s+path="([^"]+)"/g);
+  return Array.from(matches, (m) => m[1]);
+}
+
+const appSource = readFileSync(APP_TSX_PATH, 'utf-8');
+const routePaths = extractRoutePaths(appSource);
+const routePathSet = new Set(routePaths);
+
+// The eight destinations that lost their dedicated Sidebar row in issue #389
+// (spec §1.2 / §3.2), plus the routes their replacements now point at.
+const REQUIRED_REACHABLE_PATHS = [
+  '/circles', // was: drawer "Circles" row -> now: UserMenu / CircleChip "Manage Circles"
+  '/notifications', // was: drawer "Notifications" row -> now: AppBar bell -> "See all notifications"
+  '/settings', // was: drawer "User Settings" row -> now: UserMenu "Settings"
+  '/admin/settings', // was: implicit via the old drawer's admin shortcuts -> now: Sidebar "Console"
+  '/admin/settings/jobs', // was: drawer "Job Queue" row -> now: Console > Operations > Job Queue
+  '/admin/settings/nodes', // was: drawer "Worker Nodes" row -> now: Console > Operations > Worker Nodes
+  '/admin/settings/storage/insights', // was: drawer "Storage Insights" row -> now: Console > Storage > Storage Insights
+  '/admin/settings/sharing', // was: drawer "Public Sharing" row -> now: Console > Operations > Public Sharing
+];
+
+describe('navigation reachability (issue #389)', () => {
+  it('parses a realistic number of routes out of App.tsx (parser sanity check)', () => {
+    // App.tsx currently declares 60+ routes. A number this low would mean the
+    // regex broke (e.g. App.tsx switched to a different Route JSX shape) and
+    // every assertion below would be vacuously trivial to satisfy — so this
+    // guards the guard.
+    expect(routePaths.length).toBeGreaterThan(40);
+  });
+
+  it.each(REQUIRED_REACHABLE_PATHS)(
+    'the route removed drawer rows pointed at, %s, still exists in App.tsx',
+    (path) => {
+      expect(routePathSet.has(path)).toBe(true);
+    },
+  );
+
+  it('every required path is declared exactly once (no accidental duplicate/shadowing route)', () => {
+    REQUIRED_REACHABLE_PATHS.forEach((path) => {
+      const occurrences = routePaths.filter((p) => p === path).length;
+      expect(occurrences).toBe(1);
+    });
+  });
+
+  it('none of the required paths resolve only through the wildcard fallback', () => {
+    // The wildcard `<Route path="*">` redirects everything unmatched to "/".
+    // If one of the required paths were accidentally deleted, React Router
+    // would silently fall through to this and land the user on Home instead
+    // of 404ing loudly — asserting the literal path string exists (above) is
+    // what actually catches that, but this pins the fallback's shape too so
+    // a future refactor of the catch-all doesn't quietly change what
+    // "unreachable" looks like.
+    expect(appSource).toMatch(/<Route\s+path="\*"\s+element=\{<Navigate to="\/" replace \/>\}/);
+  });
+
+  it('every required path sits inside the authenticated <Layout> route tree, not a bare public route', () => {
+    // All eight are legitimately behind auth (admin console pages and
+    // personal pages like /circles, /settings, /notifications) — pin that
+    // they appear after the `<Route element={<Layout />}>` opening tag and
+    // before its matching closing `</Route>` that precedes the full-bleed
+    // Layout block, so a future refactor can't silently move one of them out
+    // to a public, unauthenticated route without this test noticing.
+    const layoutStart = appSource.indexOf('<Route element={<Layout />}>');
+    const fullBleedStart = appSource.indexOf('<Route element={<Layout fullBleed />}>');
+    expect(layoutStart).toBeGreaterThan(-1);
+    expect(fullBleedStart).toBeGreaterThan(layoutStart);
+
+    const layoutBlock = appSource.slice(layoutStart, fullBleedStart);
+    REQUIRED_REACHABLE_PATHS.forEach((path) => {
+      expect(layoutBlock).toContain(`<Route path="${path}"`);
+    });
+  });
+});

--- a/apps/web/src/__tests__/pages/SettingsHubPage.test.tsx
+++ b/apps/web/src/__tests__/pages/SettingsHubPage.test.tsx
@@ -8,7 +8,7 @@
  * The page renders a grid of cards grouped by section. Visibility of each card
  * depends on hasPermission(card.permission). The page redirects non-admins to /.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockAdminUser } from '../utils/test-utils';
@@ -342,6 +342,281 @@ describe('SettingsHubPage', () => {
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/admin/settings/archiving');
       });
+    });
+  });
+
+  // ===========================================================================
+  // Search (issue #389, spec §4.4 requirement 4)
+  // ===========================================================================
+
+  describe('search', () => {
+    const FULL_PERMISSIONS = [
+      'system_settings:read',
+      'users:read',
+      'ai_settings:read',
+      'face_settings:read',
+      'geo_settings:read',
+      'storage_settings:read',
+      'jobs:read',
+      'db_backup:read',
+      'shares:manage_any',
+    ];
+
+    beforeEach(() => {
+      mockUsePermissions.mockReturnValue(adminPermissionsMock(FULL_PERMISSIONS) as any);
+    });
+
+    it('has a "Search settings" text field', () => {
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByLabelText('Search settings')).toBeInTheDocument();
+    });
+
+    it('filters cards by title as the user types', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.type(screen.getByLabelText('Search settings'), 'job');
+
+      expect(screen.getByText('Job Queue')).toBeInTheDocument();
+      expect(screen.getByText('Job Queue Insights')).toBeInTheDocument();
+      expect(screen.queryByText('AI Providers')).not.toBeInTheDocument();
+      expect(screen.queryByText('System')).not.toBeInTheDocument();
+    });
+
+    it('filtering is case-insensitive', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.type(screen.getByLabelText('Search settings'), 'JOB');
+
+      expect(screen.getByText('Job Queue')).toBeInTheDocument();
+    });
+
+    it('a group whose every card is filtered out is not rendered at all', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.type(screen.getByLabelText('Search settings'), 'job');
+
+      // "Storage" section has no card with "job" in its title.
+      expect(screen.queryByText('Storage')).not.toBeInTheDocument();
+      // "Operations" (home of Job Queue) still renders.
+      expect(screen.getByText('Operations')).toBeInTheDocument();
+    });
+
+    it('shows the "No settings match" message for a query that matches nothing', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.type(screen.getByLabelText('Search settings'), 'zzz-nonexistent-setting');
+
+      expect(screen.getByText(/No settings match/)).toBeInTheDocument();
+      // Not a blank page in some other sense either — no section headings.
+      expect(screen.queryByText('General')).not.toBeInTheDocument();
+      expect(screen.queryByText('Operations')).not.toBeInTheDocument();
+    });
+
+    it('clearing the field restores the full, unfiltered list', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      const field = screen.getByLabelText('Search settings');
+      await user.type(field, 'job');
+      expect(screen.queryByText('AI Providers')).not.toBeInTheDocument();
+
+      await user.clear(field);
+
+      expect(screen.getByText('AI Providers')).toBeInTheDocument();
+      expect(screen.getByText('Job Queue')).toBeInTheDocument();
+      expect(screen.getByText('General')).toBeInTheDocument();
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    it('the clear ("x") button also restores the full list', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.type(screen.getByLabelText('Search settings'), 'job');
+      await user.click(screen.getByRole('button', { name: 'Clear settings search' }));
+
+      expect(screen.getByLabelText('Search settings')).toHaveValue('');
+      expect(screen.getByText('AI Providers')).toBeInTheDocument();
+    });
+
+    it('does not match on description text, only the card title', async () => {
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      // "PostgreSQL" appears only in the Database Backup card's description.
+      await user.type(screen.getByLabelText('Search settings'), 'PostgreSQL');
+
+      expect(screen.getByText(/No settings match/)).toBeInTheDocument();
+    });
+
+    it('a permission-gated card stays hidden regardless of a matching search text (filter never bypasses authz)', async () => {
+      // This admin lacks jobs:read entirely.
+      mockUsePermissions.mockReturnValue(
+        adminPermissionsMock(['system_settings:read', 'users:read']) as any,
+      );
+      const user = userEvent.setup();
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await user.type(screen.getByLabelText('Search settings'), 'job');
+
+      expect(screen.queryByText('Job Queue')).not.toBeInTheDocument();
+      expect(screen.queryByText('Job Queue Insights')).not.toBeInTheDocument();
+      expect(screen.getByText(/No settings match/)).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Phone drill-down vs. tablet/desktop card grid (spec §4.4)
+  // ===========================================================================
+
+  describe('responsive layout', () => {
+    function setViewportWidth(px: number) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => {
+          const min = query.match(/min-width:\s*([\d.]+)px/);
+          const max = query.match(/max-width:\s*([\d.]+)px/);
+          let matches = true;
+          if (min) matches = matches && px >= parseFloat(min[1]);
+          if (max) matches = matches && px <= parseFloat(max[1]);
+          return {
+            matches,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          };
+        }),
+      });
+    }
+
+    afterEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    });
+
+    beforeEach(() => {
+      mockUsePermissions.mockReturnValue(
+        adminPermissionsMock(['system_settings:read', 'users:read', 'ai_settings:read']) as any,
+      );
+    });
+
+    it('renders a drill-down list on phone: titles present, descriptions absent, chevrons present', () => {
+      setViewportWidth(400); // < 900 → down('md') matches → isPhone=true
+
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText('System')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Configure core system settings, application behavior, and global defaults.'),
+      ).not.toBeInTheDocument();
+
+      // The row itself is a ListItemButton with a trailing chevron icon.
+      const row = screen.getByText('System').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(row).not.toBeNull();
+      expect(row.querySelector('[data-testid="ChevronRightIcon"]')).not.toBeNull();
+    });
+
+    it('renders the card grid with descriptions on tablet/desktop', () => {
+      setViewportWidth(1200); // >= 900 → down('md') does not match → isPhone=false
+
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText('System')).toBeInTheDocument();
+      expect(
+        screen.getByText('Configure core system settings, application behavior, and global defaults.'),
+      ).toBeInTheDocument();
+
+      // Rendered as a card, not a drill-down list row.
+      expect(screen.getByText('System').closest('.MuiCard-root')).not.toBeNull();
+      expect(screen.queryByText('System')?.closest('.MuiListItemButton-root')).toBeNull();
+    });
+
+    it('drops descriptions but keeps a per-section grouping on phone', () => {
+      setViewportWidth(400);
+
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      expect(screen.getByText('General')).toBeInTheDocument();
+      expect(screen.getByText('System')).toBeInTheDocument();
+      expect(screen.getByText('Users & Allowlist')).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Scroll restoration integration (spec §4.4 — "the single make-or-break
+  // detail"). The hook itself is unit-tested directly in
+  // hooks/useScrollRestoration.test.ts; this proves SettingsHubPage actually
+  // wires it up under the 'admin-settings-hub' key.
+  // ===========================================================================
+
+  describe('scroll restoration', () => {
+    const STORAGE_KEY = 'mh:scroll:admin-settings-hub';
+
+    beforeEach(() => {
+      mockUsePermissions.mockReturnValue(
+        adminPermissionsMock(['system_settings:read', 'users:read']) as any,
+      );
+      window.sessionStorage.clear();
+    });
+
+    afterEach(() => {
+      window.sessionStorage.clear();
+      Object.defineProperty(document.documentElement, 'scrollHeight', {
+        configurable: true,
+        value: 0,
+      });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 0 });
+    });
+
+    it('attempts to restore a saved scroll offset on mount', async () => {
+      window.sessionStorage.setItem(STORAGE_KEY, '350');
+      Object.defineProperty(document.documentElement, 'scrollHeight', {
+        configurable: true,
+        value: 2000,
+      });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+      window.scrollTo = vi.fn();
+
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      await waitFor(() => {
+        expect(window.scrollTo).toHaveBeenCalledWith({ top: 350, behavior: 'auto' });
+      });
+    });
+
+    it('does not attempt to scroll when nothing was saved', async () => {
+      Object.defineProperty(document.documentElement, 'scrollHeight', {
+        configurable: true,
+        value: 2000,
+      });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+      window.scrollTo = vi.fn();
+
+      render(<SettingsHubPage />, { wrapperOptions: { user: mockAdminUser } });
+
+      // Give any stray rAF a moment to fire, then assert nothing happened.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(window.scrollTo).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/components/navigation/AppBar.tsx
+++ b/apps/web/src/components/navigation/AppBar.tsx
@@ -16,15 +16,18 @@ import {
   Brightness7 as LightModeIcon,
   Menu as MenuIcon,
   CloudUpload as UploadIcon,
+  ArrowBack as ArrowBackIcon,
 } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useThemeContext } from '../../contexts/ThemeContext';
 import { useCircle } from '../../hooks/useCircle';
 import { useMediaRefresh } from '../../contexts/MediaRefreshContext';
 import { UserMenu } from './UserMenu';
+import { CircleChip } from './CircleChip';
 import { NotificationBell } from '../notifications/NotificationBell';
 import { TopbarSearch } from '../search/TopbarSearch';
 import { MediaUploadDialog } from '../media/MediaUploadDialog';
+import { ADMIN_HUB_PATH, adminPageTitle } from '../../config/adminSections';
 import { APP_NAME } from '../../constants/app';
 import appLogo from '../../assets/app_logo.png';
 
@@ -35,11 +38,17 @@ interface AppBarProps {
 export function AppBar({ onMenuClick }: AppBarProps) {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const { isDarkMode, toggleMode } = useThemeContext();
   const { activeCircle } = useCircle();
   const { triggerRefresh } = useMediaRefresh();
   const isMd = useMediaQuery(theme.breakpoints.up('md'));
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  // Console mode does not exist below `md` (spec §4.4): there is no rail to
+  // swap, so the admin surface is a drill-down and the top bar becomes its
+  // header. Note this is `down('md')`, not the `isPhone` (`down('sm')`) used
+  // for the wordmark — a tablet has a rail and keeps the normal toolbar.
+  const isCompactNav = useMediaQuery(theme.breakpoints.down('md'));
 
   const [uploadOpen, setUploadOpen] = useState(false);
   const [uploadSnackbar, setUploadSnackbar] = useState(false);
@@ -49,6 +58,20 @@ export function AppBar({ onMenuClick }: AppBarProps) {
     triggerRefresh();
     setUploadSnackbar(true);
   }, [triggerRefresh]);
+
+  // Segment-safe, so a future `/administration` route can never be mistaken for
+  // the admin surface — the same rule spec §3.5 mandates for destination
+  // ownership, applied to the one prefix this component cares about.
+  const isAdminRoute = pathname === '/admin' || pathname.startsWith('/admin/');
+  const adminDrillDown = isCompactNav && isAdminRoute;
+
+  // Up one level, expressed as an explicit destination rather than
+  // `navigate(-1)`: history can contain anything (a deep link, a redirect, a
+  // reload), whereas "the level above this page" is a property of the route.
+  // In the ordinary drill-down flow (hub → detail → back) the two agree, which
+  // is spec §4.4 requirement 3.
+  const adminBackTarget =
+    pathname === ADMIN_HUB_PATH || pathname === '/admin' ? '/' : ADMIN_HUB_PATH;
 
   return (
     <>
@@ -63,96 +86,161 @@ export function AppBar({ onMenuClick }: AppBarProps) {
           zIndex: theme.zIndex.appBar,
         }}
       >
-        {/* `gap` tightens on phone. At 360px the trailing cluster is now
-            hamburger + logo + collapsed search + upload + BELL + theme +
-            avatar; with the desktop 8px gap the row measures ~354px against
-            360px of viewport — 6px of slack, which a slightly larger system
-            font or a 2-digit badge would blow through. Dropping to 4px below
-            `sm` buys back 24px (six inter-item gaps) so the row measures
-            ~330px and the flex-growing search wrapper absorbs the remainder
-            instead of the toolbar overflowing. See
+        {/* `gap` tightens on phone. At 360px the row is hamburger + logo +
+            CIRCLE CHIP + collapsed search + upload + bell + theme + avatar;
+            with the desktop 8px gap the fixed items alone measured ~354px
+            against 360px of viewport — 6px of slack, which a slightly larger
+            system font or a 2-digit badge would blow through. Dropping to 4px
+            below `sm` buys back ~28px so the fixed items measure ~330px. See
             docs/audits/mobile-topbar-audit.md for the previous regression of
-            this class. */}
+            this class.
+
+            The chip is added on top of that ~330px, which is why it (alone in
+            this row) shrinks: on a 360px device it renders truncated to
+            whatever is left rather than overflowing, and it reaches its full
+            108px cap around 430px. That squeeze is transitional — issue #390
+            moves search out of the top bar into a tab and #392 deletes the
+            hamburger, together returning ~80px to this row on phone. */}
         <Toolbar sx={{ gap: { xs: 0.5, sm: 1 }, position: 'relative' }}>
-          {/* Hamburger */}
-          <IconButton
-            color="inherit"
-            aria-label="toggle drawer"
-            edge="start"
-            onClick={onMenuClick}
-            sx={{ flexShrink: 0 }}
-          >
-            <MenuIcon />
-          </IconButton>
-
-          {/* Brand — logo always shown; wordmark added on tablet/desktop */}
-          <Box
-            onClick={() => navigate('/')}
-            sx={{ display: 'flex', alignItems: 'center', gap: 1, cursor: 'pointer', flexShrink: 0 }}
-          >
-            <Box
-              component="img"
-              src={appLogo}
-              alt={APP_NAME}
-              sx={{ height: 32, width: 'auto', display: 'block', objectFit: 'contain' }}
-            />
-            {!isPhone && (
-              <Typography
-                variant="h6"
-                component="div"
-                sx={{
-                  fontWeight: 600,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {APP_NAME}
-              </Typography>
-            )}
-          </Box>
-
-          {/* Central search pill — takes available space */}
-          <TopbarSearch />
-
-          {/* Upload button */}
-          {activeCircle && (
-            isMd ? (
-              <Button
-                variant="outlined"
-                size="small"
-                startIcon={<UploadIcon />}
-                onClick={() => setUploadOpen(true)}
-                aria-label="Upload media"
-                sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
-              >
-                Upload
-              </Button>
-            ) : (
+          {adminDrillDown ? (
+            <>
+              {/* Admin drill-down header (spec §4.4). Everything that is not
+                  back / title / avatar is dropped: nearly every admin page is
+                  global rather than circle-scoped, so the circle chip, upload
+                  and search buy nothing here, and a title that survives
+                  "Near-Duplicate Detection" is worth more than any of them.
+                  The theme toggle goes too — it is not admin-specific, it is
+                  reachable from user Settings, and keeping it would leave the
+                  title ~40px to truncate into on a 360px screen.
+                  The bottom bar still carries Library navigation on these
+                  screens, so dropping the brand does not strand anyone. */}
               <IconButton
                 color="inherit"
-                aria-label="Upload media"
-                onClick={() => setUploadOpen(true)}
+                aria-label="Back"
+                edge="start"
+                onClick={() => navigate(adminBackTarget)}
                 sx={{ flexShrink: 0 }}
               >
-                <UploadIcon />
+                <ArrowBackIcon />
               </IconButton>
-            )
+
+              <Typography
+                variant="h6"
+                component="h1"
+                noWrap
+                sx={{
+                  flexGrow: 1,
+                  minWidth: 0,
+                  fontWeight: 600,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {adminPageTitle(pathname)}
+              </Typography>
+
+              <UserMenu />
+            </>
+          ) : (
+            <>
+              {/* Hamburger. Stays for this phase — the drawer is not removed
+                  until issue #392. */}
+              <IconButton
+                color="inherit"
+                aria-label="toggle drawer"
+                edge="start"
+                onClick={onMenuClick}
+                sx={{ flexShrink: 0 }}
+              >
+                <MenuIcon />
+              </IconButton>
+
+              {/* Brand — logo always shown; wordmark added on tablet/desktop */}
+              <Box
+                onClick={() => navigate('/')}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                }}
+              >
+                <Box
+                  component="img"
+                  src={appLogo}
+                  alt={APP_NAME}
+                  sx={{ height: 32, width: 'auto', display: 'block', objectFit: 'contain' }}
+                />
+                {!isPhone && (
+                  <Typography
+                    variant="h6"
+                    component="div"
+                    sx={{
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {APP_NAME}
+                  </Typography>
+                )}
+              </Box>
+
+              {/* Active circle — the one piece of chrome that renders at every
+                  breakpoint, and on phone it occupies the space the wordmark
+                  already vacated. It is the ONLY shrinkable item in this row:
+                  every icon button is `flexShrink: 0` and `TopbarSearch`'s
+                  collapsed phone state bottoms out at its 40px icon, so when
+                  the row would overflow the chip is what gives, and the
+                  toolbar cannot push the app shell sideways. See CircleChip's
+                  own comment for the minWidth/maxWidth rule. */}
+              <CircleChip />
+
+              {/* Central search pill — takes available space */}
+              <TopbarSearch />
+
+              {/* Upload button */}
+              {activeCircle && (
+                isMd ? (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<UploadIcon />}
+                    onClick={() => setUploadOpen(true)}
+                    aria-label="Upload media"
+                    sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+                  >
+                    Upload
+                  </Button>
+                ) : (
+                  <IconButton
+                    color="inherit"
+                    aria-label="Upload media"
+                    onClick={() => setUploadOpen(true)}
+                    sx={{ flexShrink: 0 }}
+                  >
+                    <UploadIcon />
+                  </IconButton>
+                )
+              )}
+
+              {/* Notifications (between upload and the theme toggle) */}
+              <NotificationBell />
+
+              {/* Theme Toggle */}
+              <IconButton
+                onClick={toggleMode}
+                color="inherit"
+                aria-label="toggle theme"
+                sx={{ flexShrink: 0 }}
+              >
+                {isDarkMode ? <LightModeIcon /> : <DarkModeIcon />}
+              </IconButton>
+
+              {/* User Menu */}
+              <UserMenu />
+            </>
           )}
-
-          {/* Notifications (between upload and the theme toggle) */}
-          <NotificationBell />
-
-          {/* Theme Toggle */}
-          <IconButton
-            onClick={toggleMode}
-            color="inherit"
-            aria-label="toggle theme"
-            sx={{ flexShrink: 0 }}
-          >
-            {isDarkMode ? <LightModeIcon /> : <DarkModeIcon />}
-          </IconButton>
-
-          {/* User Menu */}
-          <UserMenu />
         </Toolbar>
       </MuiAppBar>
 

--- a/apps/web/src/components/navigation/CircleChip.tsx
+++ b/apps/web/src/components/navigation/CircleChip.tsx
@@ -1,0 +1,137 @@
+/**
+ * CircleChip — the active-circle switcher, promoted into the top bar.
+ *
+ * Spec §3.3 / §4.1: the active circle is the app's most important state and was
+ * previously two taps deep inside the avatar menu (open avatar → pick circle).
+ * Surfacing it as always-visible chrome makes "which library am I looking at?"
+ * answerable at a glance and switchable in one tap, and is what lets `UserMenu`
+ * drop its circle section entirely rather than becoming a second path to the
+ * same action.
+ *
+ * Rendered as a real `<button>` (not MUI's `Chip`, whose clickable form is a
+ * `div` with `role="button"`) so it is keyboard- and AT-native for free, then
+ * styled as a pill. §7 requires the accessible name to carry the circle name,
+ * since the visible label is truncated at narrow widths.
+ */
+
+import { useState, useCallback } from 'react';
+import { Box, Button, Divider, ListItemText, Menu, MenuItem } from '@mui/material';
+import {
+  ArrowDropDown as ArrowDropDownIcon,
+  GroupWork as GroupWorkIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useCircle } from '../../hooks/useCircle';
+
+export function CircleChip() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const { circles, activeCircle, setActiveCircle } = useCircle();
+  const navigate = useNavigate();
+
+  const open = Boolean(anchorEl);
+
+  const handleOpen = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const handleClose = useCallback(() => setAnchorEl(null), []);
+
+  const handleSelect = useCallback(
+    (circleId: string) => {
+      handleClose();
+      void setActiveCircle(circleId);
+    },
+    [handleClose, setActiveCircle],
+  );
+
+  const handleManage = useCallback(() => {
+    handleClose();
+    navigate('/circles');
+  }, [handleClose, navigate]);
+
+  // Before CircleContext resolves (and for a user who somehow has no circle)
+  // there is nothing to name, and an empty pill would read as a broken control
+  // rather than a loading one.
+  if (!activeCircle) return null;
+
+  return (
+    <>
+      <Button
+        onClick={handleOpen}
+        color="inherit"
+        endIcon={<ArrowDropDownIcon />}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        aria-controls={open ? 'circle-chip-menu' : undefined}
+        aria-label={`Active circle: ${activeCircle.name}. Change circle.`}
+        sx={{
+          // `minWidth: 0` + `flexShrink: 1` + a capped `maxWidth` are the three
+          // halves of one rule: a long circle name must never widen the
+          // toolbar. Without `minWidth: 0` a flex item's min-width is its
+          // min-content width, so "Extended Family Photos" would push the row
+          // past the viewport and give the whole app a horizontal scrollbar —
+          // the same failure mode as issue #291 (see the `minWidth: 0` comment
+          // in `common/Layout.tsx`). The cap tightens hard on phone, where the
+          // toolbar's width budget is nearly spent before the chip is added.
+          minWidth: 0,
+          flexShrink: 1,
+          maxWidth: { xs: 108, sm: 160, md: 200 },
+          height: 36, // ≥36px touch target; MUI's own Chip is only 32.
+          px: { xs: 0.75, sm: 1 },
+          borderRadius: 5,
+          textTransform: 'none',
+          fontWeight: 500,
+          backgroundColor: 'action.hover',
+          '&:hover': { backgroundColor: 'action.selected' },
+          // The trailing caret is the affordance; the leading icon is
+          // decoration, and on phone the pixels are worth more as label.
+          '& .MuiButton-endIcon': { ml: 0.25, mr: -0.5 },
+        }}
+      >
+        <Box
+          component="span"
+          sx={{
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {activeCircle.name}
+        </Box>
+      </Button>
+
+      <Menu
+        id="circle-chip-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        transformOrigin={{ horizontal: 'left', vertical: 'top' }}
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+        slotProps={{
+          paper: { sx: { minWidth: 220, maxWidth: 320, mt: 0.5 } },
+        }}
+      >
+        {circles.map((c) => (
+          <MenuItem
+            key={c.id}
+            selected={c.id === activeCircle.id}
+            onClick={() => handleSelect(c.id)}
+          >
+            <ListItemText
+              primary={c.name}
+              slotProps={{ primary: { noWrap: true } }}
+            />
+          </MenuItem>
+        ))}
+
+        <Divider />
+
+        <MenuItem onClick={handleManage}>
+          <ListItemText primary="Manage Circles" />
+          <GroupWorkIcon fontSize="small" sx={{ ml: 2, color: 'text.secondary' }} />
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/apps/web/src/components/navigation/Sidebar.tsx
+++ b/apps/web/src/components/navigation/Sidebar.tsx
@@ -16,10 +16,9 @@ import {
 } from '@mui/material';
 import {
   Home as HomeIcon,
-  Settings as SettingsIcon,
   AdminPanelSettings as AdminIcon,
+  ArrowBack as ArrowBackIcon,
   Map as MapIcon,
-  GroupWork as GroupWorkIcon,
   Groups as GroupsIcon,
   Explore as ExploreIcon,
   PhotoAlbum as AlbumIcon,
@@ -28,14 +27,10 @@ import {
   Delete as DeleteOutlineIcon,
   ContentCopy as ContentCopyIcon,
   MyLocation as MyLocationIcon,
-  WorkHistory as WorkHistoryIcon,
-  Hub as HubIcon,
   Insights as InsightsIcon,
-  Public as PublicIcon,
   AccountTree as AccountTreeIcon,
   AutoFixHigh as AutoFixHighIcon,
   AutoAwesomeMotion as AutoAwesomeMotionIcon,
-  NotificationsNone as NotificationsNoneIcon,
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { usePermissions } from '../../hooks/usePermissions';
@@ -43,7 +38,7 @@ import { useWorkflowsEnabled } from '../../hooks/useWorkflowSubjects';
 import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useMemoriesEnabled } from '../../hooks/useMemoriesEnabled';
 import { useReviewCounts } from '../../hooks/useReviewCounts';
-import { useNotifications } from '../../hooks/useNotifications';
+import { ADMIN_HUB_PATH, visibleAdminSections } from '../../config/adminSections';
 
 interface SidebarProps {
   open: boolean;
@@ -60,10 +55,17 @@ interface NavItemDef {
 
 const DRAWER_WIDTH = 240;
 
-function isActive(itemPath: string, currentPath: string): boolean {
-  if (itemPath === '/') return currentPath === '/';
-  return currentPath.startsWith(itemPath);
-}
+/**
+ * Does `prefix` own `path`? Matches on SEGMENT boundaries — the path must equal
+ * the prefix or continue with a `/`.
+ *
+ * Spec §3.5: a bare `startsWith` makes `/review` match `/reviewer` and
+ * `/bursts` match `/burstsfoo`. That was a latent bug in the old `isActive`,
+ * and it becomes load-bearing here because the same helper now decides whether
+ * the whole drawer renders in Console mode.
+ */
+const owns = (prefix: string, path: string): boolean =>
+  prefix === '/' ? path === '/' : path === prefix || path.startsWith(`${prefix}/`);
 
 export function Sidebar({ open, onClose }: SidebarProps) {
   const theme = useTheme();
@@ -83,17 +85,24 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     enabled: pictureEnhancement?.enabled === true,
   });
   const pendingEnhancements = reviewCounts?.pendingEnhancements ?? 0;
-  // The SAME module-level store the AppBar bell reads (issue #249). It is
-  // reference-counted: `acquire()` only starts the 60s timer when the FIRST
-  // enabled subscriber mounts, and `startTimer()` additionally no-ops while a
-  // timer already exists — so this second consumer adds a subscriber, never a
-  // second poller, and the sidebar badge can never drift from the bell's.
-  const { unreadCount } = useNotifications();
   // Same module-level flag cache the enhancer entry above reads — this adds no
   // second request. `=== true` for the same reason documented there: the entry
   // must not flash in while the flags load, and a flags outage must hide it.
   const memoriesEnabled = useMemoriesEnabled();
 
+  // Console mode (spec §3.2): at any `/admin/*` route the drawer swaps its
+  // CONTENTS, not the app shell — same Drawer, same NavItem, no second Layout.
+  // This is what removes the old cost of every admin-to-admin move routing back
+  // through the hub landing page, and it lets the admin surface grow past 25
+  // pages without global navigation ever growing a row.
+  const isConsole = owns('/admin', location.pathname);
+
+  // Eight rows were removed in issue #389 because each duplicates chrome that
+  // is already on screen (spec §1.2): Circles (top-bar circle chip + avatar
+  // menu), Notifications (the AppBar bell, same badge, with a persistent "See
+  // all notifications" footer), User Settings (avatar menu), and the five
+  // ADMINISTRATION shortcuts — an arbitrary sample of a 23-page hub, now
+  // carried in full by Console mode below.
   const primaryItems: NavItemDef[] = [
     { label: 'Photos', icon: <HomeIcon />, path: '/' },
     ...(memoriesEnabled === true
@@ -101,14 +110,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
       : []),
     { label: 'Explore', icon: <ExploreIcon />, path: '/search' },
     { label: 'Map', icon: <MapIcon />, path: '/map' },
-    { label: 'Circles', icon: <GroupWorkIcon />, path: '/circles' },
     { label: 'Albums', icon: <AlbumIcon />, path: '/albums' },
-    {
-      label: 'Notifications',
-      icon: <NotificationsNoneIcon />,
-      path: '/notifications',
-      badgeCount: unreadCount,
-    },
   ];
 
   const libraryItems: NavItemDef[] = [
@@ -140,21 +142,24 @@ export function Sidebar({ open, onClose }: SidebarProps) {
       : []),
   ];
 
-  const adminItems: NavItemDef[] = [
-    { label: 'Settings', icon: <AdminIcon />, path: '/admin/settings' },
-    ...(hasPermission('jobs:read')
-      ? [{ label: 'Job Queue', icon: <WorkHistoryIcon />, path: '/admin/settings/jobs' }]
-      : []),
-    ...(hasPermission('jobs:read')
-      ? [{ label: 'Worker Nodes', icon: <HubIcon />, path: '/admin/settings/nodes' }]
-      : []),
-    ...(hasPermission('system_settings:read')
-      ? [{ label: 'Storage Insights', icon: <InsightsIcon />, path: '/admin/settings/storage/insights' }]
-      : []),
-    ...(hasPermission('shares:manage_any')
-      ? [{ label: 'Public Sharing', icon: <PublicIcon />, path: '/admin/settings/sharing' }]
-      : []),
-  ];
+  // Console mode "invents no new admin IA" (spec §3.2) — these are the SAME
+  // five permission-gated sections the hub renders, from the one shared
+  // declaration, so the rail and the hub cannot drift apart.
+  const consoleSections = visibleAdminSections(hasPermission);
+
+  // Console paths genuinely nest (`/admin/settings/jobs` vs
+  // `/admin/settings/jobs/insights`), so `owns` alone would light up TWO rows
+  // and emit `aria-current="page"` twice. Longest prefix wins (spec §3.5) —
+  // the same rule `adminPageTitle` applies to resolve the page title.
+  const consoleActivePath = isConsole
+    ? consoleSections
+        .flatMap((section) => section.cards)
+        .reduce<string | null>((best, card) => {
+          if (!card.path || card.disabled) return best;
+          if (!owns(card.path, location.pathname)) return best;
+          return best === null || card.path.length > best.length ? card.path : best;
+        }, null)
+    : null;
 
   const handleNavigate = useCallback(
     (path: string) => {
@@ -177,12 +182,23 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     backgroundColor: theme.palette.background.paper,
   };
 
-  const NavItem = ({ item }: { item: NavItemDef }) => {
-    const active = isActive(item.path, location.pathname);
+  const NavItem = ({
+    item,
+    active: activeOverride,
+  }: {
+    item: NavItemDef;
+    /** Escape hatch for Console mode, where nesting needs longest-prefix-wins. */
+    active?: boolean;
+  }) => {
+    const active = activeOverride ?? owns(item.path, location.pathname);
     return (
       <ListItem disablePadding>
         <ListItemButton
           selected={active}
+          // `selected` alone is a visual state; assistive technology needs the
+          // explicit landmark (spec §7). Set here, once, so it holds in both
+          // Library and Console mode.
+          aria-current={active ? 'page' : undefined}
           onClick={() => handleNavigate(item.path)}
           sx={{
             borderRadius: 1,
@@ -226,7 +242,49 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     );
   };
 
-  const drawerContent = (
+  const consoleContent = (
+    <>
+      <Toolbar />
+      <Divider />
+      <Box sx={{ overflow: 'auto', flexGrow: 1, py: 1 }}>
+        {/* Console is a MODE, so the way out of it must be permanent and
+            obvious — never a route the user has to guess at (spec §3.2). */}
+        <List dense disablePadding>
+          <NavItem item={{ label: 'Back to library', icon: <ArrowBackIcon />, path: '/' }} />
+        </List>
+        <Divider sx={{ my: 1 }} />
+
+        {consoleSections.map((section) => (
+          <List
+            key={section.label}
+            dense
+            disablePadding
+            subheader={
+              <ListSubheader disableSticky sx={subheaderSx}>
+                {section.label}
+              </ListSubheader>
+            }
+          >
+            {section.cards.map((card) =>
+              !card.path || card.disabled ? null : (
+                <NavItem
+                  key={card.path}
+                  active={card.path === consoleActivePath}
+                  item={{
+                    label: card.title,
+                    icon: <card.Icon />,
+                    path: card.path,
+                  }}
+                />
+              ),
+            )}
+          </List>
+        ))}
+      </Box>
+    </>
+  );
+
+  const libraryContent = (
     <>
       <Toolbar />
       <Divider />
@@ -267,34 +325,25 @@ export function Sidebar({ open, onClose }: SidebarProps) {
             <NavItem key={item.path} item={item} />
           ))}
         </List>
-
-        {/* ADMINISTRATION section — only when isAdmin */}
-        {isAdmin && (
-          <List
-            dense
-            disablePadding
-            subheader={
-              <ListSubheader disableSticky sx={subheaderSx}>
-                Administration
-              </ListSubheader>
-            }
-          >
-            {adminItems.map((item) => (
-              <NavItem key={item.path} item={item} />
-            ))}
-          </List>
-        )}
       </Box>
 
-      <Divider />
-      {/* User Settings pinned at bottom */}
-      <List dense disablePadding sx={{ py: 0.5 }}>
-        <NavItem
-          item={{ label: 'User Settings', icon: <SettingsIcon />, path: '/settings' }}
-        />
-      </List>
+      {/* Console pinned at the foot, where User Settings used to sit. It is a
+          MODE affordance rather than one of the 14 rows — the epic counts it
+          separately, which is why it lives below the divider. */}
+      {isAdmin && (
+        <>
+          <Divider />
+          <List dense disablePadding sx={{ py: 0.5 }}>
+            <NavItem
+              item={{ label: 'Console', icon: <AdminIcon />, path: ADMIN_HUB_PATH }}
+            />
+          </List>
+        </>
+      )}
     </>
   );
+
+  const drawerContent = isConsole ? consoleContent : libraryContent;
 
   if (isDesktop) {
     return (

--- a/apps/web/src/components/navigation/UserMenu.tsx
+++ b/apps/web/src/components/navigation/UserMenu.tsx
@@ -15,19 +15,25 @@ import {
   AdminPanelSettings as AdminIcon,
   AccountCircle as ProfileIcon,
   Logout as LogoutIcon,
-  GroupWork as CircleIcon,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useAuthedImage } from '../../hooks/useAuthedImage';
 import { usePermissions } from '../../hooks/usePermissions';
-import { useCircle } from '../../hooks/useCircle';
 
+/**
+ * The avatar menu is ACCOUNT scope only.
+ *
+ * The circle switcher and "Manage Circles" used to live here; they moved to the
+ * top-bar `CircleChip` (spec §3.3). Circle is *context* — which library the
+ * whole app is currently pointed at — not an account setting, and leaving a
+ * copy here would make it the third path to one action (chip, drawer row, this
+ * menu) with no way for a user to tell which is canonical.
+ */
 export function UserMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const { user, logout } = useAuth();
   const { hasPermission } = usePermissions();
-  const { circles, activeCircle, setActiveCircle } = useCircle();
   const navigate = useNavigate();
   // An uploaded avatar lives behind the authenticated `/api/users/:id/avatar`
   // byte proxy, so a bare `src` would render broken; a provider URL passes
@@ -102,43 +108,6 @@ export function UserMenu() {
             {user.email}
           </Typography>
         </Box>
-
-        <Divider />
-
-        {/* Circle Section */}
-        <Typography
-          variant="overline"
-          sx={{ px: 2, pt: 1, display: 'block' }}
-          color="text.secondary"
-        >
-          Circle
-        </Typography>
-
-        {circles.length === 0 ? (
-          <MenuItem disabled>
-            <ListItemText>No circles yet</ListItemText>
-          </MenuItem>
-        ) : (
-          circles.map((c) => (
-            <MenuItem
-              key={c.id}
-              selected={c.id === activeCircle?.id}
-              onClick={() => void setActiveCircle(c.id)}
-            >
-              <ListItemIcon>
-                <CircleIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText>{c.name}</ListItemText>
-            </MenuItem>
-          ))
-        )}
-
-        <MenuItem onClick={() => handleNavigate('/circles')}>
-          <ListItemIcon>
-            <CircleIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Manage Circles</ListItemText>
-        </MenuItem>
 
         <Divider />
 

--- a/apps/web/src/components/notifications/NotificationPanel.tsx
+++ b/apps/web/src/components/notifications/NotificationPanel.tsx
@@ -195,8 +195,12 @@ export function NotificationPanel({ open, anchorEl, onClose }: NotificationPanel
 
       {/* Footer */}
       <Box sx={{ p: 1, flexShrink: 0 }}>
+        {/* "See all notifications", not "See all": with the Notifications drawer
+            row deleted (spec §3.3) this footer is the ONLY path to
+            /notifications, so its label has to name the destination without
+            relying on the surrounding popover for context. */}
         <Button fullWidth size="small" onClick={handleSeeAll} sx={{ minHeight: 40 }}>
-          See all
+          See all notifications
         </Button>
       </Box>
     </Box>

--- a/apps/web/src/config/adminSections.tsx
+++ b/apps/web/src/config/adminSections.tsx
@@ -1,0 +1,317 @@
+/**
+ * The admin (Console) information architecture — ONE declaration, three consumers.
+ *
+ * `SettingsHubPage` already grouped all admin pages into five permission-gated
+ * sections. That structure was good; it was just trapped inside a *page*, which
+ * is why every admin-to-admin move used to route back through a landing screen.
+ * Epic #388 / issue #389 promotes it from a destination into navigation, so the
+ * array now lives here and is consumed by:
+ *
+ *   1. `SettingsHubPage`      — the card grid (and the phone drill-down hub)
+ *   2. `Sidebar` Console mode — the rail's contents at any `/admin/*` route
+ *   3. `AppBar`               — resolving an admin route to its page title
+ *
+ * Console mode "invents no new admin IA" (spec §3.2) is enforced structurally by
+ * there being exactly one array: a card added here appears in all three surfaces,
+ * and none of them can drift from the others.
+ *
+ * `Icon` is a COMPONENT, not an element, deliberately — the hub renders it at
+ * 40px and the rail at ~20px, so the size cannot be baked into the declaration.
+ */
+
+import type { SvgIconComponent } from '@mui/icons-material';
+import {
+  AdminPanelSettings as AdminIcon,
+  People as PeopleIcon,
+  SmartToy as AiIcon,
+  LocalOffer as LocalOfferIcon,
+  Face as FaceIcon,
+  BurstMode as BurstModeIcon,
+  ContentCopy as ContentCopyIcon,
+  MyLocation as MyLocationIcon,
+  Map as MapIcon,
+  Storage as StorageIcon,
+  Insights as InsightsIcon,
+  WorkHistory as WorkHistoryIcon,
+  Archive as ArchiveIcon,
+  QueryStats as QueryStatsIcon,
+  Public as PublicIcon,
+  MonitorHeart as MonitorHeartIcon,
+  Movie as MovieIcon,
+  Hub as HubIcon,
+  Email as EmailIcon,
+  AccountTree as AccountTreeIcon,
+  AutoFixHigh as AutoFixHighIcon,
+  AutoAwesomeMotion as AutoAwesomeMotionIcon,
+} from '@mui/icons-material';
+
+export interface AdminCardDef {
+  title: string;
+  description: string;
+  Icon: SvgIconComponent;
+  path?: string;
+  disabled?: boolean;
+  permission?: string;
+  alwaysShow?: boolean;
+}
+
+export interface AdminSectionDef {
+  label: string;
+  cards: AdminCardDef[];
+}
+
+export const ADMIN_SECTIONS: AdminSectionDef[] = [
+  {
+    label: 'General',
+    cards: [
+      {
+        title: 'System',
+        description: 'Configure core system settings, application behavior, and global defaults.',
+        Icon: AdminIcon,
+        path: '/admin/settings/general',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Users & Allowlist',
+        description: 'Manage user accounts, roles, and control who can access the application.',
+        Icon: PeopleIcon,
+        path: '/admin/settings/users',
+        permission: 'users:read',
+      },
+      {
+        title: 'Archiving & Deletion',
+        description: 'Manage the Trash retention period and review how archiving and deletion work.',
+        Icon: ArchiveIcon,
+        path: '/admin/settings/archiving',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Email',
+        description: 'Configure the outbound email provider (AWS SES or SMTP) and test delivery.',
+        Icon: EmailIcon,
+        path: '/admin/settings/email',
+        permission: 'system_settings:read',
+      },
+    ],
+  },
+  {
+    label: 'AI & Enrichment',
+    cards: [
+      {
+        title: 'AI Providers',
+        description: 'Configure AI provider credentials and set the active model for search and tagging.',
+        Icon: AiIcon,
+        path: '/admin/settings/ai',
+        permission: 'ai_settings:read',
+      },
+      {
+        title: 'Tagging & Descriptions',
+        description: 'Manage the tag vocabulary and configure automatic photo tagging behavior.',
+        Icon: LocalOfferIcon,
+        path: '/admin/settings/tagging',
+        permission: 'ai_settings:read',
+      },
+      {
+        title: 'Face Recognition',
+        description: 'Set up face detection providers and configure recognition thresholds.',
+        Icon: FaceIcon,
+        path: '/admin/settings/face',
+        permission: 'face_settings:read',
+      },
+      {
+        title: 'Bursts & Similar Pictures',
+        description: 'Tune burst detection sensitivity, time windows, and review queue settings.',
+        Icon: BurstModeIcon,
+        path: '/admin/settings/bursts',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Near-Duplicate Detection',
+        description: 'Tune visual-duplicate matching sensitivity and run global backfills.',
+        Icon: ContentCopyIcon,
+        path: '/admin/settings/duplicates',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'AI Picture Enhancer',
+        description:
+          'Enable AI photo enhancement and set the quality, strength, and review presets.',
+        Icon: AutoFixHighIcon,
+        path: '/admin/settings/enhancer',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Memories',
+        description: 'Automatic memory curation, story feed, and email digests.',
+        Icon: AutoAwesomeMotionIcon,
+        path: '/admin/settings/memories',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Social Media Detection',
+        description: 'Detect TikTok/Instagram/Facebook videos and skip enrichment',
+        Icon: MovieIcon,
+        path: '/admin/settings/social-media',
+        permission: 'system_settings:read',
+      },
+    ],
+  },
+  {
+    label: 'Media',
+    cards: [
+      {
+        title: 'Geo Location',
+        description: 'Configure reverse geocoding providers and forward search settings.',
+        Icon: MapIcon,
+        path: '/admin/settings/geo',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Location Inference',
+        description: 'Tune GPS interpolation from nearby photos, auto-apply thresholds, and run global backfills.',
+        Icon: MyLocationIcon,
+        path: '/admin/settings/location-inference',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Location Groups',
+        description:
+          'Collapse duplicate geocoder spellings of a place into one canonical name; merge suggestions and define capture areas.',
+        Icon: PublicIcon,
+        path: '/admin/settings/location-groups',
+        permission: 'geo_settings:read',
+      },
+    ],
+  },
+  {
+    label: 'Storage',
+    cards: [
+      {
+        title: 'Storage Providers',
+        description:
+          'Manage S3, R2, and local storage credentials, set the active provider, and run migrations.',
+        Icon: StorageIcon,
+        path: '/admin/settings/storage/providers',
+        permission: 'storage_settings:read',
+      },
+      {
+        title: 'Storage Insights',
+        description: 'View precomputed storage usage metrics and trigger manual snapshot refreshes.',
+        Icon: InsightsIcon,
+        path: '/admin/settings/storage/insights',
+        permission: 'system_settings:read',
+      },
+    ],
+  },
+  {
+    label: 'Operations',
+    cards: [
+      {
+        title: 'Job Queue',
+        description: 'Monitor enrichment jobs, retry failed items, and reset stuck workers.',
+        Icon: WorkHistoryIcon,
+        path: '/admin/settings/jobs',
+        permission: 'jobs:read',
+      },
+      {
+        title: 'Job Queue Insights',
+        description: 'Live queue stats, per-type durations, and an ETA for the backlog.',
+        Icon: QueryStatsIcon,
+        path: '/admin/settings/jobs/insights',
+        permission: 'jobs:read',
+      },
+      {
+        title: 'Worker Nodes',
+        description: 'Distributed CLI worker nodes: fleet health, heartbeats, and per-node job stats.',
+        Icon: HubIcon,
+        path: '/admin/settings/nodes',
+        permission: 'jobs:read',
+      },
+      {
+        title: 'Database Backup',
+        description:
+          'Schedule and run PostgreSQL dumps to object storage; browse, download, and delete backups.',
+        Icon: StorageIcon,
+        path: '/admin/settings/db-backup',
+        permission: 'db_backup:read',
+      },
+      {
+        title: 'Public Sharing',
+        description: 'View and manage all public share links; revoke or set expirations in bulk.',
+        Icon: PublicIcon,
+        path: '/admin/settings/sharing',
+        permission: 'shares:manage_any',
+      },
+      {
+        title: 'Workflow Automation',
+        description: 'Control workflow blast radius, throughput, and safety; oversee runs across all circles.',
+        Icon: AccountTreeIcon,
+        path: '/admin/settings/workflows',
+        permission: 'system_settings:read',
+      },
+      {
+        title: 'Doctor',
+        description: 'Run configuration health diagnostics and see required action items',
+        Icon: MonitorHeartIcon,
+        path: '/admin/settings/doctor',
+        permission: 'system_settings:read',
+      },
+    ],
+  },
+];
+
+/** The Console hub itself — the one admin route that owns no card. */
+export const ADMIN_HUB_PATH = '/admin/settings';
+export const ADMIN_HUB_TITLE = 'Settings';
+
+/**
+ * Filter the sections to what `hasPermission` allows, dropping sections that end
+ * up empty. Every consumer runs the SAME gate, so a card an admin cannot open
+ * can never appear in one surface and not another.
+ *
+ * `query` (optional) additionally applies the client-side "Search settings"
+ * filter — a case-insensitive substring match on the card title (spec §4.4
+ * requirement 4). Matching on title only, not description, keeps the result set
+ * predictable: a two-letter query should not surface eight cards because their
+ * prose happens to share a word.
+ */
+export function visibleAdminSections(
+  hasPermission: (permission: string) => boolean,
+  query = '',
+): AdminSectionDef[] {
+  const needle = query.trim().toLowerCase();
+  return ADMIN_SECTIONS.map((section) => ({
+    label: section.label,
+    cards: section.cards.filter((card) => {
+      if (needle && !card.title.toLowerCase().includes(needle)) return false;
+      if (card.alwaysShow) return true;
+      if (!card.permission) return true;
+      return hasPermission(card.permission);
+    }),
+  })).filter((section) => section.cards.length > 0);
+}
+
+/**
+ * Resolve an `/admin/*` pathname to the human title of the page it renders.
+ *
+ * Longest-match wins so `/admin/settings/jobs/insights` resolves to "Job Queue
+ * Insights" rather than "Job Queue", and `/admin/settings/nodes/:id/backup`
+ * still resolves to its parent's "Worker Nodes" rather than falling back to the
+ * hub title. Returns `null` for a path that is not under `/admin`.
+ */
+export function adminPageTitle(pathname: string): string | null {
+  if (pathname !== '/admin' && !pathname.startsWith('/admin/')) return null;
+
+  let best: { title: string; length: number } | null = null;
+  for (const section of ADMIN_SECTIONS) {
+    for (const card of section.cards) {
+      if (!card.path) continue;
+      const matches = pathname === card.path || pathname.startsWith(`${card.path}/`);
+      if (matches && (!best || card.path.length > best.length)) {
+        best = { title: card.title, length: card.path.length };
+      }
+    }
+  }
+
+  return best?.title ?? ADMIN_HUB_TITLE;
+}

--- a/apps/web/src/hooks/useScrollRestoration.ts
+++ b/apps/web/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,162 @@
+import { useEffect } from 'react';
+
+/** How long to keep retrying a restore before giving up, in ms. */
+const RESTORE_DEADLINE_MS = 1000;
+
+/**
+ * Restore the document's scroll position when a list-like page is returned to.
+ *
+ * Epic #388 / issue #389 makes the admin surface a phone drill-down, and spec
+ * §4.4 calls scroll restoration "the single make-or-break detail": returning
+ * from a detail page to a 20-card hub and landing at the top — forcing the user
+ * to re-find their place — is precisely what makes drill-down feel bad rather
+ * than native. Phases 2 and 3 build two more hubs on the same pattern, so this
+ * is written as a generic hook rather than folded into `SettingsHubPage`.
+ *
+ * Three properties of this app decide the implementation:
+ *
+ *  1. **The scroller is the DOCUMENT.** `Layout.tsx`'s shell sets
+ *     `minHeight: 100dvh` and `<main>` is not an overflow container — the whole
+ *     page scrolls — so the position lives in `window.scrollY`, not in some
+ *     element's `scrollTop`. (`TimelineScrubber` already relies on the same
+ *     fact.)
+ *  2. **The page fully unmounts** when the user drills into a detail route, so
+ *     the offset cannot live in component state. `sessionStorage` survives the
+ *     remount (and a reload) while staying scoped to the tab, which is the
+ *     right lifetime for a scroll offset.
+ *  3. **Content renders asynchronously.** At mount the document is usually far
+ *     shorter than the saved offset, so a single `scrollTo` silently clamps to
+ *     the current bottom. This is why SPAs break restoration by default:
+ *     `history.pushState` restores nothing, and the browser cannot know the
+ *     eventual page height. The fix is to retry until the target is reachable.
+ *
+ * @param key      Stable identifier for the scrolled surface, e.g.
+ *                 `'admin-settings-hub'`. Namespaced into the storage key so
+ *                 two surfaces never share an offset.
+ * @param options  `enabled` (default `true`) makes the hook a no-op — useful
+ *                 when a page should only restore in one of its modes. The
+ *                 hook itself is still called unconditionally, per the rules
+ *                 of hooks.
+ */
+export function useScrollRestoration(
+  key: string,
+  options: { enabled?: boolean } = {},
+): void {
+  const { enabled = true } = options;
+
+  useEffect(() => {
+    // SSR / DOM-less test environments: nothing to save or restore.
+    if (!enabled || typeof window === 'undefined') return;
+
+    const storageKey = `mh:scroll:${key}`;
+
+    // Safari in private mode throws on ANY `sessionStorage` access, not just
+    // writes, so every touch of it is wrapped. A failure degrades to "no
+    // restoration" — never to a crashed page.
+    const read = (): number => {
+      try {
+        const raw = window.sessionStorage.getItem(storageKey);
+        if (raw === null) return 0;
+        const parsed = Number.parseInt(raw, 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+      } catch {
+        return 0;
+      }
+    };
+
+    const write = (value: number): void => {
+      try {
+        window.sessionStorage.setItem(storageKey, String(Math.round(value)));
+      } catch {
+        /* storage unavailable — restoration is a nicety, not a requirement */
+      }
+    };
+
+    let cancelled = false;
+    let saveFrame: number | null = null;
+    let restoreFrame: number | null = null;
+    // True only across the handful of frames spanning our own programmatic
+    // scroll, so the resulting scroll event is not mistaken for a user gesture.
+    let selfScrolling = false;
+
+    const abortRestore = () => {
+      if (restoreFrame !== null) {
+        window.cancelAnimationFrame(restoreFrame);
+        restoreFrame = null;
+      }
+    };
+
+    // --- Save -------------------------------------------------------------
+    // Coalesced through rAF: a scroll gesture fires dozens of events per
+    // second, and a synchronous `setItem` on each is a measurable jank source.
+    // One write per painted frame is both sufficient and cheap.
+    const handleScroll = () => {
+      if (selfScrolling) return;
+      // A genuine gesture wins outright — restoration must never fight the
+      // user for control of the viewport.
+      abortRestore();
+      if (saveFrame !== null) return;
+      saveFrame = window.requestAnimationFrame(() => {
+        saveFrame = null;
+        write(window.scrollY);
+      });
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    // --- Restore ----------------------------------------------------------
+    const target = read();
+    if (target > 0) {
+      const deadline = Date.now() + RESTORE_DEADLINE_MS;
+
+      const attempt = () => {
+        restoreFrame = null;
+        if (cancelled) return;
+
+        const maxScroll =
+          document.documentElement.scrollHeight - window.innerHeight;
+
+        if (maxScroll >= target) {
+          // The document is finally tall enough to honour the saved offset.
+          // ALWAYS instant: smooth-scrolling to a position the user was
+          // already at reads as the page sliding out from under them, and the
+          // long animation would keep colliding with the gesture guard above.
+          selfScrolling = true;
+          window.scrollTo({ top: target, behavior: 'auto' });
+          // Release the guard once the resulting scroll event has been
+          // dispatched — two frames is comfortably past it, and the worst case
+          // of being wrong is one skipped save, since restoration is done.
+          window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+              selfScrolling = false;
+            });
+          });
+          return;
+        }
+
+        // Still short — content is presumably mid-fetch or mid-render. Retry
+        // next frame, but only until the deadline: past it the page is most
+        // likely genuinely shorter than before (a card removed, a filter
+        // applied), and continuing to poll would burn frames forever.
+        if (Date.now() >= deadline) return;
+        restoreFrame = window.requestAnimationFrame(attempt);
+      };
+
+      restoreFrame = window.requestAnimationFrame(attempt);
+    }
+
+    return () => {
+      cancelled = true;
+      abortRestore();
+      window.removeEventListener('scroll', handleScroll);
+      if (saveFrame !== null) {
+        window.cancelAnimationFrame(saveFrame);
+        saveFrame = null;
+      }
+      // The pending rAF write (if any) was just cancelled, and a navigation can
+      // unmount between the last scroll event and its frame — so take one final
+      // reading here rather than losing up to a frame's worth of movement.
+      write(window.scrollY);
+    };
+  }, [key, enabled]);
+}

--- a/apps/web/src/pages/Admin/SettingsHubPage.tsx
+++ b/apps/web/src/pages/Admin/SettingsHubPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -6,292 +7,152 @@ import {
   CardContent,
   Chip,
   Grid,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
-  AdminPanelSettings as AdminIcon,
-  People as PeopleIcon,
-  SmartToy as AiIcon,
-  LocalOffer as LocalOfferIcon,
-  Face as FaceIcon,
-  BurstMode as BurstModeIcon,
-  ContentCopy as ContentCopyIcon,
-  MyLocation as MyLocationIcon,
-  Map as MapIcon,
-  Storage as StorageIcon,
-  Insights as InsightsIcon,
-  WorkHistory as WorkHistoryIcon,
-  Archive as ArchiveIcon,
-  QueryStats as QueryStatsIcon,
-  Public as PublicIcon,
-  MonitorHeart as MonitorHeartIcon,
-  Movie as MovieIcon,
-  Hub as HubIcon,
-  Email as EmailIcon,
-  AccountTree as AccountTreeIcon,
-  AutoFixHigh as AutoFixHighIcon,
-  AutoAwesomeMotion as AutoAwesomeMotionIcon,
+  Search as SearchIcon,
+  Clear as ClearIcon,
+  ChevronRight as ChevronRightIcon,
 } from '@mui/icons-material';
 import { usePermissions } from '../../hooks/usePermissions';
-
-interface CardDef {
-  title: string;
-  description: string;
-  icon: React.ReactElement;
-  path?: string;
-  disabled?: boolean;
-  permission?: string;
-  alwaysShow?: boolean;
-}
-
-interface SectionDef {
-  label: string;
-  cards: CardDef[];
-}
+import { useScrollRestoration } from '../../hooks/useScrollRestoration';
+import { visibleAdminSections } from '../../config/adminSections';
 
 export default function SettingsHubPage() {
   const navigate = useNavigate();
+  const theme = useTheme();
   const { isAdmin, hasPermission } = usePermissions();
+  // Phone treatment is a drill-down list rather than a card grid (spec §4.4):
+  // there is no rail to swap into Console mode at this size, so the hub IS the
+  // navigation and iOS Settings is the model every phone user already holds.
+  const isPhone = useMediaQuery(theme.breakpoints.down('md'));
+  const [query, setQuery] = useState('');
+
+  // The make-or-break detail of the drill-down (spec §4.4 requirement 1):
+  // returning from a page near the bottom of a 20-card list must land where the
+  // user left it, not at the top.
+  useScrollRestoration('admin-settings-hub');
 
   if (!isAdmin) {
     return <Navigate to="/" replace />;
   }
 
-  const sections: SectionDef[] = [
-    {
-      label: 'General',
-      cards: [
-        {
-          title: 'System',
-          description: 'Configure core system settings, application behavior, and global defaults.',
-          icon: <AdminIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/general',
-          permission: 'system_settings:read',
+  // ONE declaration, three consumers — see `config/adminSections.tsx`. The
+  // permission gate and the "Search settings" title match both live in the
+  // shared helper, so the hub, the Console rail, and the AppBar title resolver
+  // can never disagree about what an admin may see.
+  const sections = visibleAdminSections(hasPermission, query);
+  const trimmedQuery = query.trim();
+
+  const searchField = (
+    <TextField
+      value={query}
+      onChange={(e) => setQuery(e.target.value)}
+      size="small"
+      placeholder="Search settings"
+      // Client-side only over an in-memory array, so no debounce is warranted.
+      // 23 items across five groups is past the point where scanning beats
+      // typing, and unlike a rail or a tab strip it stays constant-effort for
+      // the user as the admin surface grows (spec §4.4 requirement 4).
+      sx={{ mb: 3, width: '100%', maxWidth: { xs: '100%', sm: 420 } }}
+      slotProps={{
+        htmlInput: { 'aria-label': 'Search settings' },
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" color="disabled" />
+            </InputAdornment>
+          ),
+          endAdornment: query ? (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                aria-label="Clear settings search"
+                onClick={() => setQuery('')}
+              >
+                <ClearIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
         },
-        {
-          title: 'Users & Allowlist',
-          description: 'Manage user accounts, roles, and control who can access the application.',
-          icon: <PeopleIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/users',
-          permission: 'users:read',
-        },
-        {
-          title: 'Archiving & Deletion',
-          description: 'Manage the Trash retention period and review how archiving and deletion work.',
-          icon: <ArchiveIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/archiving',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Email',
-          description: 'Configure the outbound email provider (AWS SES or SMTP) and test delivery.',
-          icon: <EmailIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/email',
-          permission: 'system_settings:read',
-        },
-      ],
-    },
-    {
-      label: 'AI & Enrichment',
-      cards: [
-        {
-          title: 'AI Providers',
-          description: 'Configure AI provider credentials and set the active model for search and tagging.',
-          icon: <AiIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/ai',
-          permission: 'ai_settings:read',
-        },
-        {
-          title: 'Tagging & Descriptions',
-          description: 'Manage the tag vocabulary and configure automatic photo tagging behavior.',
-          icon: <LocalOfferIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/tagging',
-          permission: 'ai_settings:read',
-        },
-        {
-          title: 'Face Recognition',
-          description: 'Set up face detection providers and configure recognition thresholds.',
-          icon: <FaceIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/face',
-          permission: 'face_settings:read',
-        },
-        {
-          title: 'Bursts & Similar Pictures',
-          description: 'Tune burst detection sensitivity, time windows, and review queue settings.',
-          icon: <BurstModeIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/bursts',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Near-Duplicate Detection',
-          description: 'Tune visual-duplicate matching sensitivity and run global backfills.',
-          icon: <ContentCopyIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/duplicates',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'AI Picture Enhancer',
-          description:
-            'Enable AI photo enhancement and set the quality, strength, and review presets.',
-          icon: <AutoFixHighIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/enhancer',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Memories',
-          description: 'Automatic memory curation, story feed, and email digests.',
-          icon: <AutoAwesomeMotionIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/memories',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Social Media Detection',
-          description: 'Detect TikTok/Instagram/Facebook videos and skip enrichment',
-          icon: <MovieIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/social-media',
-          permission: 'system_settings:read',
-        },
-      ],
-    },
-    {
-      label: 'Media',
-      cards: [
-        {
-          title: 'Geo Location',
-          description: 'Configure reverse geocoding providers and forward search settings.',
-          icon: <MapIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/geo',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Location Inference',
-          description: 'Tune GPS interpolation from nearby photos, auto-apply thresholds, and run global backfills.',
-          icon: <MyLocationIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/location-inference',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Location Groups',
-          description:
-            'Collapse duplicate geocoder spellings of a place into one canonical name; merge suggestions and define capture areas.',
-          icon: <PublicIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/location-groups',
-          permission: 'geo_settings:read',
-        },
-      ],
-    },
-    {
-      label: 'Storage',
-      cards: [
-        {
-          title: 'Storage Providers',
-          description:
-            'Manage S3, R2, and local storage credentials, set the active provider, and run migrations.',
-          icon: <StorageIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/storage/providers',
-          permission: 'storage_settings:read',
-        },
-        {
-          title: 'Storage Insights',
-          description: 'View precomputed storage usage metrics and trigger manual snapshot refreshes.',
-          icon: <InsightsIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/storage/insights',
-          permission: 'system_settings:read',
-        },
-      ],
-    },
-    {
-      label: 'Operations',
-      cards: [
-        {
-          title: 'Job Queue',
-          description: 'Monitor enrichment jobs, retry failed items, and reset stuck workers.',
-          icon: <WorkHistoryIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/jobs',
-          permission: 'jobs:read',
-        },
-        {
-          title: 'Job Queue Insights',
-          description: 'Live queue stats, per-type durations, and an ETA for the backlog.',
-          icon: <QueryStatsIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/jobs/insights',
-          permission: 'jobs:read',
-        },
-        {
-          title: 'Worker Nodes',
-          description: 'Distributed CLI worker nodes: fleet health, heartbeats, and per-node job stats.',
-          icon: <HubIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/nodes',
-          permission: 'jobs:read',
-        },
-        {
-          title: 'Database Backup',
-          description:
-            'Schedule and run PostgreSQL dumps to object storage; browse, download, and delete backups.',
-          icon: <StorageIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/db-backup',
-          permission: 'db_backup:read',
-        },
-        {
-          title: 'Public Sharing',
-          description: 'View and manage all public share links; revoke or set expirations in bulk.',
-          icon: <PublicIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/sharing',
-          permission: 'shares:manage_any',
-        },
-        {
-          title: 'Workflow Automation',
-          description: 'Control workflow blast radius, throughput, and safety; oversee runs across all circles.',
-          icon: <AccountTreeIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/workflows',
-          permission: 'system_settings:read',
-        },
-        {
-          title: 'Doctor',
-          description: 'Run configuration health diagnostics and see required action items',
-          icon: <MonitorHeartIcon sx={{ fontSize: 40 }} color="primary" />,
-          path: '/admin/settings/doctor',
-          permission: 'system_settings:read',
-        },
-      ],
-    },
-  ];
+      }}
+    />
+  );
 
   return (
     <Box sx={{ p: { xs: 2, md: 4 } }}>
       <Typography variant="h4" gutterBottom sx={{ fontWeight: 700 }}>
         Settings
       </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
         Manage system configuration, providers, and operational settings.
       </Typography>
 
-      {sections.map((section) => {
-        const visibleCards = section.cards.filter((card) => {
-          if (card.alwaysShow) return true;
-          if (!card.permission) return true;
-          return hasPermission(card.permission);
-        });
+      {searchField}
 
-        if (visibleCards.length === 0) return null;
+      {/* Only ever an empty SEARCH result — an admin with no visible sections
+          at all is a permission problem, not something to phrase as a miss. */}
+      {sections.length === 0 && trimmedQuery !== '' && (
+        <Typography variant="body2" color="text.secondary">
+          No settings match “{trimmedQuery}”.
+        </Typography>
+      )}
 
-        return (
-          <Box key={section.label} sx={{ mb: 4 }}>
-            <Typography
-              variant="overline"
-              sx={{
-                display: 'block',
-                mb: 1.5,
-                color: 'text.secondary',
-                fontWeight: 600,
-                letterSpacing: '0.1em',
-              }}
-            >
-              {section.label}
-            </Typography>
+      {sections.map((section) => (
+        <Box key={section.label} sx={{ mb: 4 }}>
+          <Typography
+            variant="overline"
+            sx={{
+              display: 'block',
+              mb: isPhone ? 0.5 : 1.5,
+              color: 'text.secondary',
+              fontWeight: 600,
+              letterSpacing: '0.1em',
+            }}
+          >
+            {section.label}
+          </Typography>
 
+          {isPhone ? (
+            // Title + chevron is the WHOLE row. Descriptions are deliberately
+            // dropped here: at this width they would triple the list's height
+            // and defeat the point of a scannable hierarchy — they stay on the
+            // tablet/desktop card grid below.
+            <List disablePadding>
+              {section.cards.map((card) => (
+                <ListItemButton
+                  key={card.title}
+                  disabled={card.disabled || !card.path}
+                  onClick={() => card.path && navigate(card.path)}
+                  sx={{
+                    borderRadius: 1,
+                    borderBottom: `1px solid ${theme.palette.divider}`,
+                  }}
+                >
+                  <ListItemIcon sx={{ minWidth: 40, color: 'primary.main' }}>
+                    <card.Icon fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText primary={card.title} />
+                  {card.disabled ? (
+                    <Chip label="Coming soon" size="small" />
+                  ) : (
+                    <ChevronRightIcon fontSize="small" color="disabled" />
+                  )}
+                </ListItemButton>
+              ))}
+            </List>
+          ) : (
             <Grid container spacing={2}>
-              {visibleCards.map((card) => (
+              {section.cards.map((card) => (
                 <Grid key={card.title} size={{ xs: 12, sm: 6, md: 4 }}>
                   {card.disabled ? (
                     <Card
@@ -303,7 +164,7 @@ export default function SettingsHubPage() {
                       variant="outlined"
                     >
                       <CardContent>
-                        {card.icon}
+                        <card.Icon sx={{ fontSize: 40 }} color="primary" />
                         <Typography
                           variant="subtitle1"
                           sx={{ fontWeight: 600, mt: 1 }}
@@ -323,7 +184,7 @@ export default function SettingsHubPage() {
                         sx={{ height: '100%', alignItems: 'flex-start' }}
                       >
                         <CardContent>
-                          {card.icon}
+                          <card.Icon sx={{ fontSize: 40 }} color="primary" />
                           <Typography
                             variant="subtitle1"
                             sx={{ fontWeight: 600, mt: 1 }}
@@ -340,9 +201,9 @@ export default function SettingsHubPage() {
                 </Grid>
               ))}
             </Grid>
-          </Box>
-        );
-      })}
+          )}
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/docs/specs/assets/navigation-ia-mockups.html
+++ b/docs/specs/assets/navigation-ia-mockups.html
@@ -1,0 +1,1402 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Standalone copy of the navigation IA proposal. Open directly in a browser.
+     Companion to docs/specs/navigation-ia.md -->
+<title>MemoriaHub Navigation — Redesign Proposal</title>
+<style>
+  /* ============================================================
+     TOKENS — light is the base; dark redefines tokens only.
+     ============================================================ */
+  :root {
+    --ground:        #EEF1F5;
+    --surface:       #FFFFFF;
+    --surface-sunk:  #E3E8EF;
+    --line:          #D2D9E3;
+    --line-soft:     #E4E9F0;
+    --ink:           #16191F;
+    --ink-2:         #3D4552;
+    --muted:         #6B7482;
+    --faint:         #97A0AE;
+
+    --accent:        #C8791A;   /* safelight amber — graphics */
+    --accent-text:   #8F5107;   /* text-safe on light ground */
+    --accent-wash:   #FBF1E4;
+    --accent-line:   #E8C79A;
+
+    --keep:          #2F6B4F;
+    --keep-wash:     #E6F0EA;
+    --cut:           #A33A2E;
+    --cut-wash:      #F7E7E4;
+
+    --frame:         #C6CEDA;   /* device bezel */
+    --chrome:        #F6F8FB;   /* app chrome inside mockups */
+    --tile:          #DDE3EC;   /* photo placeholder */
+    --tile-2:        #CCD5E1;
+
+    --shadow: 0 1px 2px rgba(16,25,40,.06), 0 8px 24px -12px rgba(16,25,40,.18);
+    --shadow-lift: 0 2px 4px rgba(16,25,40,.07), 0 18px 44px -20px rgba(16,25,40,.28);
+
+    --serif: Georgia, "Iowan Old Style", "Palatino Linotype", Palatino, ui-serif, serif;
+    --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, "Cascadia Mono", Menlo, Consolas, monospace;
+
+    --spine: 68ch;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground:        #0F1216;
+      --surface:       #171B21;
+      --surface-sunk:  #12161B;
+      --line:          #2A313B;
+      --line-soft:     #222831;
+      --ink:           #E6E9EE;
+      --ink-2:         #C3CAD4;
+      --muted:         #939BA8;
+      --faint:         #6E7684;
+
+      --accent:        #E5A257;
+      --accent-text:   #E9B071;
+      --accent-wash:   #241C11;
+      --accent-line:   #4A3820;
+
+      --keep:          #6FBF95;
+      --keep-wash:     #14231C;
+      --cut:           #E08579;
+      --cut-wash:      #261715;
+
+      --frame:         #333B47;
+      --chrome:        #1D222A;
+      --tile:          #262D37;
+      --tile-2:        #2F3742;
+
+      --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px -12px rgba(0,0,0,.6);
+      --shadow-lift: 0 2px 4px rgba(0,0,0,.45), 0 18px 44px -20px rgba(0,0,0,.75);
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground:        #0F1216;
+    --surface:       #171B21;
+    --surface-sunk:  #12161B;
+    --line:          #2A313B;
+    --line-soft:     #222831;
+    --ink:           #E6E9EE;
+    --ink-2:         #C3CAD4;
+    --muted:         #939BA8;
+    --faint:         #6E7684;
+
+    --accent:        #E5A257;
+    --accent-text:   #E9B071;
+    --accent-wash:   #241C11;
+    --accent-line:   #4A3820;
+
+    --keep:          #6FBF95;
+    --keep-wash:     #14231C;
+    --cut:           #E08579;
+    --cut-wash:      #261715;
+
+    --frame:         #333B47;
+    --chrome:        #1D222A;
+    --tile:          #262D37;
+    --tile-2:        #2F3742;
+
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px -12px rgba(0,0,0,.6);
+    --shadow-lift: 0 2px 4px rgba(0,0,0,.45), 0 18px 44px -20px rgba(0,0,0,.75);
+  }
+
+  /* ============================================================
+     BASE
+     ============================================================ */
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 0 24px; }
+  .spine { max-width: var(--spine); margin-inline: auto; }
+
+  h1, h2, h3 { font-family: var(--serif); font-weight: 600; text-wrap: balance; margin: 0; }
+  h1 { font-size: clamp(2.1rem, 1.4rem + 2.6vw, 3.3rem); line-height: 1.08; letter-spacing: -.015em; }
+  h2 { font-size: clamp(1.5rem, 1.2rem + 1.1vw, 2rem); line-height: 1.2; letter-spacing: -.01em; }
+  h3 { font-size: 1.12rem; line-height: 1.35; }
+  p { margin: 0; }
+  a { color: var(--accent-text); text-underline-offset: 3px; text-decoration-thickness: 1px; }
+  a:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 3px;
+  }
+
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: .69rem;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: var(--faint);
+  }
+
+  .lede { font-size: 1.16rem; line-height: 1.6; color: var(--ink-2); }
+  .note { font-size: .92rem; color: var(--muted); }
+  .mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+
+  /* ============================================================
+     MASTHEAD
+     ============================================================ */
+  header.masthead {
+    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+  }
+  .masthead-inner { padding: 56px 0 44px; display: flex; flex-direction: column; gap: 22px; }
+  .masthead .spine { display: flex; flex-direction: column; gap: 18px; }
+
+  .metrics {
+    display: flex; flex-wrap: wrap; gap: 10px 28px;
+    padding-top: 20px; border-top: 1px solid var(--line-soft);
+  }
+  .metric { display: flex; align-items: baseline; gap: 9px; }
+  .metric b {
+    font-family: var(--mono); font-size: 1.5rem; font-weight: 600;
+    color: var(--accent-text); font-variant-numeric: tabular-nums; letter-spacing: -.02em;
+  }
+  .metric span { font-size: .84rem; color: var(--muted); max-width: 17ch; line-height: 1.35; }
+
+  /* ============================================================
+     SECTIONS
+     ============================================================ */
+  section { padding: 62px 0; }
+  section + section { border-top: 1px solid var(--line-soft); }
+  .sec-head { display: flex; flex-direction: column; gap: 12px; margin-bottom: 34px; }
+  .stack { display: flex; flex-direction: column; gap: 20px; }
+  .stack-tight { display: flex; flex-direction: column; gap: 12px; }
+
+  /* ============================================================
+     TABLES
+     ============================================================ */
+  .table-scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: .9rem; }
+  th, td { text-align: left; padding: 11px 16px; border-bottom: 1px solid var(--line-soft); vertical-align: top; }
+  thead th {
+    font-family: var(--mono); font-size: .68rem; letter-spacing: .13em; text-transform: uppercase;
+    color: var(--faint); font-weight: 500; background: var(--surface-sunk);
+    border-bottom: 1px solid var(--line); white-space: nowrap;
+  }
+  tbody tr:last-child td { border-bottom: 0; }
+  td.dest { font-family: var(--mono); font-size: .82rem; color: var(--ink-2); white-space: nowrap; }
+
+  .pill {
+    display: inline-block; font-family: var(--mono); font-size: .68rem; letter-spacing: .06em;
+    padding: 2px 8px; border-radius: 999px; border: 1px solid; white-space: nowrap;
+  }
+  .pill.keep { color: var(--keep); background: var(--keep-wash); border-color: var(--keep); }
+  .pill.cut  { color: var(--cut);  background: var(--cut-wash);  border-color: var(--cut); }
+  .pill.move { color: var(--accent-text); background: var(--accent-wash); border-color: var(--accent-line); }
+
+  /* ============================================================
+     MOVES (ranked — number encodes payoff rank)
+     ============================================================ */
+  .moves { display: flex; flex-direction: column; gap: 0; border-top: 1px solid var(--line); }
+  .move {
+    display: grid; grid-template-columns: 46px 1fr auto; gap: 4px 20px;
+    padding: 22px 0; border-bottom: 1px solid var(--line-soft); align-items: start;
+  }
+  .move__rank {
+    font-family: var(--mono); font-size: 1.5rem; font-weight: 600; line-height: 1;
+    color: var(--accent); font-variant-numeric: tabular-nums; padding-top: 2px;
+  }
+  .move__body { display: flex; flex-direction: column; gap: 7px; }
+  .move__delta {
+    font-family: var(--mono); font-size: .82rem; color: var(--keep);
+    background: var(--keep-wash); border: 1px solid var(--keep);
+    padding: 3px 10px; border-radius: 999px; white-space: nowrap;
+  }
+  @media (max-width: 620px) {
+    .move { grid-template-columns: 34px 1fr; }
+    .move__delta { grid-column: 2; justify-self: start; }
+  }
+
+  /* ============================================================
+     RESEARCH CARDS
+     ============================================================ */
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; }
+  .card {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 20px; display: flex; flex-direction: column; gap: 10px; box-shadow: var(--shadow);
+  }
+  .card h3 { font-family: var(--sans); font-size: .95rem; font-weight: 650; letter-spacing: -.005em; }
+  .card p { font-size: .88rem; color: var(--ink-2); line-height: 1.55; }
+  .card .src { font-family: var(--mono); font-size: .7rem; color: var(--faint); margin-top: auto; padding-top: 4px; }
+
+  /* ============================================================
+     DEVICE MOCKUPS
+     ============================================================ */
+  .lab {
+    background: var(--surface-sunk);
+    border-block: 1px solid var(--line);
+    padding: 54px 0;
+  }
+  .rack { display: flex; gap: 26px; align-items: flex-end; overflow-x: auto; padding-bottom: 10px; }
+  .rack::-webkit-scrollbar { height: 8px; }
+  .rack::-webkit-scrollbar-thumb { background: var(--line); border-radius: 4px; }
+
+  .spec { display: flex; flex-direction: column; gap: 12px; flex: 0 0 auto; }
+  .spec__cap { display: flex; flex-direction: column; gap: 3px; }
+  .spec__cap b { font-size: .92rem; font-weight: 650; }
+  .spec__cap span { font-family: var(--mono); font-size: .7rem; color: var(--faint); letter-spacing: .05em; }
+
+  .device {
+    background: var(--chrome);
+    border: 1px solid var(--frame);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-lift);
+    display: flex; flex-direction: column;
+    font-size: 10px;
+  }
+  .d-phone   { width: 186px; height: 372px; }
+  .d-tablet  { width: 300px; height: 372px; }
+  .d-desktop { width: 560px; height: 372px; }
+
+  /* top bar inside device */
+  .d-top {
+    height: 30px; flex: 0 0 30px; background: var(--surface);
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: center; gap: 6px; padding: 0 8px;
+  }
+  .d-logo { width: 14px; height: 14px; border-radius: 4px; background: var(--accent); flex: 0 0 auto; }
+  .d-chip {
+    font-family: var(--mono); font-size: 8px; color: var(--ink-2);
+    border: 1px solid var(--line); border-radius: 999px; padding: 2px 6px;
+    white-space: nowrap; background: var(--ground);
+  }
+  .d-searchpill {
+    flex: 1 1 auto; min-width: 0; height: 17px; border-radius: 999px;
+    background: var(--ground); border: 1px solid var(--line);
+    display: flex; align-items: center; padding: 0 7px; gap: 5px;
+    font-family: var(--mono); font-size: 8px; color: var(--faint);
+  }
+  .d-spacer { flex: 1 1 auto; }
+  .d-ico { width: 13px; height: 13px; color: var(--muted); flex: 0 0 auto; }
+  .d-ico svg { width: 100%; height: 100%; display: block; }
+  .d-avatar { width: 14px; height: 14px; border-radius: 50%; background: var(--tile-2); flex: 0 0 auto; }
+  .d-dot {
+    position: relative;
+  }
+  .d-dot::after {
+    content: ""; position: absolute; top: -1px; right: -1px;
+    width: 5px; height: 5px; border-radius: 50%;
+    background: var(--accent); border: 1px solid var(--surface);
+  }
+
+  .d-main { flex: 1 1 auto; display: flex; min-height: 0; }
+  .d-canvas { flex: 1 1 auto; min-width: 0; padding: 7px; display: flex; flex-direction: column; gap: 6px; overflow: hidden; }
+
+  .d-sectlabel {
+    font-family: var(--mono); font-size: 7.5px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--faint);
+  }
+  .d-grid { display: grid; gap: 3px; }
+  .d-grid.c3 { grid-template-columns: repeat(3, 1fr); }
+  .d-grid.c4 { grid-template-columns: repeat(4, 1fr); }
+  .d-grid.c6 { grid-template-columns: repeat(6, 1fr); }
+  .d-tile { aspect-ratio: 1; background: var(--tile); border-radius: 2px; }
+  .d-tile.alt { background: var(--tile-2); }
+  .d-strip { display: flex; gap: 4px; }
+  .d-mem {
+    flex: 1 1 0; height: 40px; border-radius: 4px;
+    background: linear-gradient(160deg, var(--tile-2), var(--tile));
+  }
+
+  /* bottom nav (phone) */
+  .d-bottom {
+    flex: 0 0 34px; background: var(--surface); border-top: 1px solid var(--line-soft);
+    display: grid; grid-template-columns: repeat(4, 1fr); align-items: center;
+  }
+  .d-nav-item {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    font-family: var(--mono); font-size: 7px; color: var(--faint); letter-spacing: .02em;
+  }
+  .d-nav-item .d-ico { width: 14px; height: 14px; }
+  .d-nav-item.on { color: var(--accent-text); }
+  .d-nav-item.on .d-ico { color: var(--accent); }
+
+  /* rail (tablet / desktop) */
+  .d-rail {
+    flex: 0 0 auto; background: var(--surface); border-right: 1px solid var(--line-soft);
+    display: flex; flex-direction: column; padding: 7px 5px; gap: 3px;
+  }
+  .d-rail.collapsed { width: 52px; align-items: stretch; }
+  .d-rail.expanded { width: 128px; }
+  .d-rail-item {
+    display: flex; align-items: center; gap: 7px; border-radius: 6px;
+    padding: 5px 6px; color: var(--muted);
+    font-family: var(--mono); font-size: 8px; letter-spacing: .02em; white-space: nowrap;
+  }
+  .d-rail.collapsed .d-rail-item { flex-direction: column; gap: 2px; padding: 5px 2px; font-size: 6.5px; }
+  .d-rail-item.on { background: var(--accent-wash); color: var(--accent-text); }
+  .d-rail-item.on .d-ico { color: var(--accent); }
+  .d-rail-badge {
+    margin-left: auto; background: var(--accent); color: #fff;
+    border-radius: 999px; font-size: 6.5px; padding: 0 4px; line-height: 11px; min-width: 11px; text-align: center;
+  }
+  :root[data-theme="dark"] .d-rail-badge { color: #1A1206; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .d-rail-badge { color: #1A1206; } }
+  .d-rail-sep { height: 1px; background: var(--line-soft); margin: 4px 2px; }
+  .d-rail-foot { margin-top: auto; }
+
+  /* context pane (desktop) */
+  .d-pane {
+    flex: 0 0 118px; background: var(--surface); border-right: 1px solid var(--line-soft);
+    padding: 8px 7px; display: flex; flex-direction: column; gap: 4px; overflow: hidden;
+  }
+  .d-pane-row {
+    display: flex; align-items: center; gap: 6px;
+    font-family: var(--mono); font-size: 7.5px; color: var(--ink-2); padding: 3px 4px; border-radius: 4px;
+  }
+  .d-pane-row.on { background: var(--ground); }
+  .d-pane-sw { width: 12px; height: 12px; border-radius: 3px; background: var(--tile-2); flex: 0 0 auto; }
+  .d-pane-n { margin-left: auto; color: var(--faint); }
+
+  /* callout ticks under a device */
+  .ticks { display: flex; flex-direction: column; gap: 5px; max-width: 320px; }
+  .tick { display: flex; gap: 8px; font-size: .8rem; color: var(--ink-2); line-height: 1.45; }
+  .tick::before {
+    content: ""; flex: 0 0 auto; width: 5px; height: 5px; margin-top: 7px;
+    border-radius: 50%; background: var(--accent);
+  }
+
+  /* ============================================================
+     BEFORE / AFTER
+     ============================================================ */
+  .ba { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start; }
+  @media (max-width: 700px) { .ba { grid-template-columns: 1fr; } }
+  .ba-col { display: flex; flex-direction: column; gap: 10px; }
+  .ba-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .ba-head b { font-size: .9rem; }
+  .ba-list {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 8px; display: flex; flex-direction: column; gap: 1px;
+  }
+  .ba-row {
+    font-family: var(--mono); font-size: .74rem; padding: 3px 8px; border-radius: 4px;
+    color: var(--ink-2); display: flex; align-items: center; gap: 7px;
+  }
+  .ba-row.sub {
+    font-size: .66rem; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--faint); padding-top: 8px;
+  }
+  .ba-row.gone { color: var(--faint); text-decoration: line-through; text-decoration-color: var(--cut); }
+  .ba-row.new { background: var(--accent-wash); color: var(--accent-text); }
+  .ba-row.nest { padding-left: 22px; font-size: .7rem; color: var(--muted); }
+
+  /* ============================================================
+     TRADE-OFFS
+     ============================================================ */
+  .tradeoff {
+    background: var(--surface); border: 1px solid var(--line);
+    border-left: 3px solid var(--accent); border-radius: 8px;
+    padding: 16px 18px; display: flex; flex-direction: column; gap: 6px;
+  }
+  .tradeoff b { font-size: .92rem; }
+  .tradeoff p { font-size: .88rem; color: var(--ink-2); }
+
+  /* ============================================================
+     PHASES
+     ============================================================ */
+  .phases { display: flex; flex-direction: column; }
+  .phase {
+    display: grid; grid-template-columns: 116px 1fr; gap: 18px;
+    padding: 18px 0; border-bottom: 1px solid var(--line-soft); align-items: start;
+  }
+  .phase:first-child { border-top: 1px solid var(--line); }
+  .phase__k { font-family: var(--mono); font-size: .74rem; color: var(--faint); letter-spacing: .08em; text-transform: uppercase; padding-top: 3px; }
+  .phase__b { display: flex; flex-direction: column; gap: 5px; }
+  .phase__b b { font-size: .95rem; }
+  .phase__b p { font-size: .88rem; color: var(--ink-2); }
+  @media (max-width: 620px) { .phase { grid-template-columns: 1fr; gap: 6px; } }
+
+  /* ============================================================
+     SURFACE MOCKUPS — list rows, search, card grid, empty state
+     ============================================================ */
+  .d-bar2 {
+    height: 26px; flex: 0 0 26px; background: var(--surface);
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: center; gap: 7px; padding: 0 8px;
+    font-size: 9px; font-weight: 650; color: var(--ink);
+  }
+  .d-backarrow {
+    width: 12px; height: 12px; color: var(--muted); flex: 0 0 auto;
+  }
+  .d-backarrow svg { width: 100%; height: 100%; display: block; }
+
+  .d-search {
+    display: flex; align-items: center; gap: 5px;
+    height: 18px; border-radius: 999px; padding: 0 8px;
+    background: var(--ground); border: 1px solid var(--line);
+    font-family: var(--mono); font-size: 7.5px; color: var(--faint);
+    flex: 0 0 auto;
+  }
+
+  .d-listrow {
+    display: flex; align-items: center; gap: 7px;
+    padding: 5px 4px; border-radius: 4px;
+    font-size: 9px; color: var(--ink-2);
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .d-listrow:last-child { border-bottom: 0; }
+  .d-listrow__chev { margin-left: auto; color: var(--faint); font-size: 9px; }
+  .d-listrow__n {
+    margin-left: auto; font-family: var(--mono); font-size: 8.5px;
+    color: var(--accent-text); font-weight: 600; font-variant-numeric: tabular-nums;
+  }
+  .d-listrow__n.zero { color: var(--faint); font-weight: 400; }
+  .d-listrow__ico { width: 11px; height: 11px; color: var(--faint); flex: 0 0 auto; }
+  .d-listrow__ico svg { width: 100%; height: 100%; display: block; }
+
+  .d-cardgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+  .d-card2 { display: flex; flex-direction: column; gap: 3px; }
+  .d-card2__cover {
+    aspect-ratio: 4/3; border-radius: 4px;
+    background: linear-gradient(145deg, var(--tile-2), var(--tile));
+    position: relative; overflow: hidden;
+  }
+  .d-card2__cover::after {
+    content: ""; position: absolute; inset: 0;
+    background:
+      linear-gradient(115deg, transparent 46%, rgba(200,121,26,.16) 46% 54%, transparent 54%),
+      radial-gradient(circle at 72% 30%, rgba(200,121,26,.13), transparent 46%);
+  }
+  .d-card2__meta { display: flex; align-items: baseline; gap: 4px; padding: 0 1px; }
+  .d-card2__meta b { font-size: 8.5px; font-weight: 600; color: var(--ink); }
+  .d-card2__meta span {
+    font-family: var(--mono); font-size: 7.5px; color: var(--faint);
+    margin-left: auto; font-variant-numeric: tabular-nums;
+  }
+
+  .d-secondary {
+    display: flex; gap: 4px; padding-top: 5px; margin-top: 3px;
+    border-top: 1px solid var(--line-soft);
+  }
+  .d-secondary span {
+    flex: 1 1 0; text-align: center; font-size: 7.5px; color: var(--muted);
+    padding: 3px 0; border-radius: 4px; background: var(--ground);
+  }
+
+  .d-allclear {
+    flex: 1 1 auto; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 6px; padding: 0 14px;
+    text-align: center;
+  }
+  .d-allclear__mark {
+    width: 30px; height: 30px; border-radius: 50%;
+    background: var(--keep-wash); border: 1px solid var(--keep);
+    color: var(--keep); display: flex; align-items: center; justify-content: center;
+  }
+  .d-allclear__mark svg { width: 15px; height: 15px; display: block; }
+  .d-allclear b { font-size: 10px; color: var(--ink); }
+  .d-allclear span { font-size: 8px; color: var(--muted); line-height: 1.45; }
+
+  .d-chain {
+    margin-top: auto; display: flex; align-items: center; gap: 6px;
+    padding: 6px 8px; border-radius: 6px;
+    background: var(--accent-wash); border: 1px solid var(--accent-line);
+    font-size: 8.5px; color: var(--accent-text);
+  }
+  .d-chain span { margin-left: auto; font-family: var(--mono); }
+
+  footer { padding: 40px 0 64px; color: var(--faint); font-size: .82rem; }
+  footer a { color: var(--muted); }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+  <defs>
+    <symbol id="i-photos" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="3" width="7.5" height="7.5" rx="1.5"/><rect x="13.5" y="3" width="7.5" height="7.5" rx="1.5"/>
+      <rect x="3" y="13.5" width="7.5" height="7.5" rx="1.5"/><rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.5"/>
+    </symbol>
+    <symbol id="i-collections" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 3 3 7.5l9 4.5 9-4.5L12 3Z"/><path d="M3 12.5 12 17l9-4.5"/><path d="M3 17.5 12 22l9-4.5"/>
+    </symbol>
+    <symbol id="i-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="10.5" cy="10.5" r="6.5"/><path d="m20 20-4.7-4.7"/>
+    </symbol>
+    <symbol id="i-review" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M20.5 11.2V12a8.5 8.5 0 1 1-5-7.8"/><path d="m9 11.5 3 3 8.5-8.5"/>
+    </symbol>
+    <symbol id="i-console" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 6h16M4 12h16M4 18h16"/><circle cx="9" cy="6" r="2"/><circle cx="15" cy="12" r="2"/><circle cx="8" cy="18" r="2"/>
+    </symbol>
+    <symbol id="i-bell" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 8a6 6 0 1 0-12 0c0 6-2 7-2 7h16s-2-1-2-7"/><path d="M13.7 20a2 2 0 0 1-3.4 0"/>
+    </symbol>
+    <symbol id="i-upload" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 16V4"/><path d="m7 9 5-5 5 5"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/>
+    </symbol>
+    <symbol id="i-back" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M19 12H5"/><path d="m12 19-7-7 7-7"/>
+    </symbol>
+    <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="m5 13 4.5 4.5L19 8"/>
+    </symbol>
+  </defs>
+</svg>
+
+
+<header class="masthead">
+  <div class="wrap masthead-inner">
+    <div class="spine">
+      <p class="eyebrow">MemoriaHub · Information architecture · August 2026</p>
+      <h1>The sidebar is a feature list. It should be a map.</h1>
+      <p class="lede">
+        The drawer has 22 rows because every feature that shipped earned one. That is an
+        accurate picture of the codebase and a poor picture of what anyone is trying to do.
+        This proposal cuts primary navigation to four destinations and gives phone, tablet,
+        and desktop three genuinely different treatments instead of one drawer stretched
+        across all of them.
+      </p>
+      <div class="metrics">
+        <div class="metric"><b>22&nbsp;→&nbsp;4</b><span>primary destinations</span></div>
+        <div class="metric"><b>11</b><span>rows that duplicate visible chrome</span></div>
+        <div class="metric"><b>0</b><span>features made unreachable</span></div>
+      </div>
+    </div>
+  </div>
+</header>
+
+
+<!-- ============================ DIAGNOSIS ============================ -->
+<section>
+  <div class="wrap spine stack">
+    <div class="sec-head">
+      <p class="eyebrow">01 — Diagnosis</p>
+      <h2>Half the drawer is already on screen</h2>
+    </div>
+
+    <p>
+      Item count is the symptom, not the disease. The disease is that the drawer accumulated
+      one row per shipped feature, so it now mirrors the API surface rather than anyone's
+      mental model — and eleven of those rows lead somewhere the user can already reach
+      without opening the drawer at all.
+    </p>
+
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Drawer row</th><th>Already reachable from</th><th>Verdict</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="dest">Notifications</td><td>the bell in the AppBar, same badge</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">Circles</td><td>UserMenu — switcher <em>and</em> “Manage Circles”</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">User Settings</td><td>UserMenu → Settings</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">Job Queue</td><td rowspan="4" style="vertical-align:middle">the <span class="mono">/admin/settings</span> hub, which already indexes all 25 admin pages</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">Worker Nodes</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">Storage Insights</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">Public Sharing</td><td><span class="pill cut">duplicate</span></td></tr>
+          <tr><td class="dest">Photos · Explore · Map · Albums</td><td>BottomNav — visible on the same screen, on mobile</td><td><span class="pill cut">duplicate</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="note">
+      The four admin shortcuts are the clearest case: they are an arbitrary sample of a
+      25-page hub, hoisted into global navigation. That does not scale — the next admin page
+      shipped has no principled reason to be excluded, and no room to be included.
+    </p>
+
+    <p>
+      There is a second, structural problem underneath. MemoriaHub is self-hosted, so the
+      same person is both the family photo browser and the system operator. Those are two
+      different jobs with two different cadences — daily versus monthly — and right now they
+      compete for the same 240&nbsp;pixels. Every other photo app avoids this by not having an
+      operator at all. The fix is to separate the modes, not to keep re-ranking rows within one list.
+    </p>
+  </div>
+</section>
+
+
+<!-- ============================ RESEARCH ============================ -->
+<section>
+  <div class="wrap stack">
+    <div class="spine sec-head">
+      <p class="eyebrow">02 — What the field settled on</p>
+      <h2>Four findings that shaped this</h2>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <h3>Google Photos went to three tabs</h3>
+        <p>
+          The year-long redesign collapsed navigation to <b>Photos, Collections, Search</b>.
+          People &amp; pets, Places, Albums, Documents and Moments all moved <em>into</em>
+          Collections; Create and the Updates bell moved to the top bar. They accepted the
+          extra tap explicitly, in exchange for organized groupings over a flat list.
+        </p>
+        <p class="src">9to5google, Mar 2025</p>
+      </div>
+
+      <div class="card">
+        <h3>Material 3 deprecated the drawer</h3>
+        <p>
+          In the M3 Expressive update the navigation drawer is deprecated, replaced by an
+          <b>expanded navigation rail</b> — same functionality, adapts far better across
+          window size classes. A rail is always visible; a drawer costs a tap before any
+          navigation can begin.
+        </p>
+        <p class="src">m3.material.io · 9to5google, May 2025</p>
+      </div>
+
+      <div class="card">
+        <h3>Apple showed the failure mode</h3>
+        <p>
+          iOS&nbsp;18 Photos removed the tab bar for one scrolling page. The backlash was
+          immediate — “Albums particularly difficult to reach” — and Apple partially rolled
+          back in 18.1/18.2, adding <b>Customize&nbsp;&amp;&nbsp;Reorder</b>. Consolidation
+          works; deleting stable destinations does not.
+        </p>
+        <p class="src">MacRumors · TechRadar, Nov–Dec 2024</p>
+      </div>
+
+      <div class="card">
+        <h3>Three to five, and no more</h3>
+        <p>
+          Bottom tab navigation is the settled mobile standard, with <b>3–5 destinations</b>
+          the consistent recommendation and odd counts giving better visual rhythm. Four is
+          the ceiling that still leaves each label readable at 360&nbsp;px.
+        </p>
+        <p class="src">Mobile navigation UX surveys, 2025–26</p>
+      </div>
+    </div>
+
+    <p class="spine note" style="margin-top:8px">
+      The through-line: <b>every serious photo app consolidated into a small set of stable
+      destinations plus one rich hub</b> — and the one that instead removed destinations
+      entirely had to reverse course. This proposal sits deliberately on the Google side of
+      that line, with Apple's correction (user pinning) built in from the start rather than
+      bolted on after complaints.
+    </p>
+  </div>
+</section>
+
+
+<!-- ============================ THE IA ============================ -->
+<section>
+  <div class="wrap spine stack">
+    <div class="sec-head">
+      <p class="eyebrow">03 — The recommendation</p>
+      <h2>Four destinations, two modes</h2>
+    </div>
+
+    <p>
+      Everything the user does falls into four verbs: <b>look</b> at the timeline,
+      <b>browse</b> something curated, <b>find</b> one specific thing, and <b>decide</b> on
+      what the system has queued up for them. That last one is MemoriaHub's genuine
+      differentiator — unlike Google Photos, this app <em>generates work</em>: bursts to
+      resolve, duplicates to merge, locations to confirm, enhancements to approve. It
+      currently costs six drawer rows. It should cost one badged destination.
+    </p>
+
+    <div class="ba">
+      <div class="ba-col">
+        <div class="ba-head"><b>Today</b><span class="pill cut">22 rows</span></div>
+        <div class="ba-list">
+          <div class="ba-row gone">Photos</div>
+          <div class="ba-row gone">Memories</div>
+          <div class="ba-row gone">Explore</div>
+          <div class="ba-row gone">Map</div>
+          <div class="ba-row gone">Circles</div>
+          <div class="ba-row gone">Albums</div>
+          <div class="ba-row gone">Notifications</div>
+          <div class="ba-row sub">Library</div>
+          <div class="ba-row gone">People</div>
+          <div class="ba-row gone">Archive</div>
+          <div class="ba-row gone">Trash</div>
+          <div class="ba-row sub">Utilities</div>
+          <div class="ba-row gone">Review Bursts</div>
+          <div class="ba-row gone">Review Duplicates</div>
+          <div class="ba-row gone">Review Insights</div>
+          <div class="ba-row gone">Location Suggestions</div>
+          <div class="ba-row gone">Workflows</div>
+          <div class="ba-row gone">AI Enhancements</div>
+          <div class="ba-row sub">Administration</div>
+          <div class="ba-row gone">Settings</div>
+          <div class="ba-row gone">Job Queue</div>
+          <div class="ba-row gone">Worker Nodes</div>
+          <div class="ba-row gone">Storage Insights</div>
+          <div class="ba-row gone">Public Sharing</div>
+          <div class="ba-row sub">Pinned</div>
+          <div class="ba-row gone">User Settings</div>
+        </div>
+      </div>
+
+      <div class="ba-col">
+        <div class="ba-head"><b>Proposed</b><span class="pill keep">4 rows</span></div>
+        <div class="ba-list">
+          <div class="ba-row new">Photos</div>
+          <div class="ba-row nest">timeline · memories carousel</div>
+          <div class="ba-row new">Collections</div>
+          <div class="ba-row nest">Albums · People · Places</div>
+          <div class="ba-row nest">Memories · Map</div>
+          <div class="ba-row nest">Favorites · Archive · Trash</div>
+          <div class="ba-row new">Search</div>
+          <div class="ba-row nest">text · semantic · agentic</div>
+          <div class="ba-row new">Review <span style="margin-left:auto">12</span></div>
+          <div class="ba-row nest">Bursts · Duplicates</div>
+          <div class="ba-row nest">Locations · Enhancements</div>
+          <div class="ba-row nest">Insights · Automations</div>
+          <div class="ba-row sub">Top bar</div>
+          <div class="ba-row">Circle chip · Upload · Bell · Avatar</div>
+          <div class="ba-row sub">Second mode</div>
+          <div class="ba-row">Console → own rail at /admin</div>
+        </div>
+      </div>
+    </div>
+
+    <p class="note">
+      Nothing is deleted. Every one of the 22 rows lands somewhere specific — the mapping is
+      exhaustive, and it is the part worth arguing with:
+    </p>
+
+    <div class="table-scroll">
+      <table>
+        <thead><tr><th>Today</th><th>New home</th><th>Why</th></tr></thead>
+        <tbody>
+          <tr><td class="dest">Photos</td><td class="dest">Photos</td><td>unchanged — the daily destination</td></tr>
+          <tr><td class="dest">Memories</td><td class="dest">Photos carousel + Collections</td><td>the feed already renders on Home; Google removed its Memories tab for the same reason</td></tr>
+          <tr><td class="dest">Explore</td><td class="dest">Search</td><td>it routes to <span class="mono">/search</span> — name it what it is</td></tr>
+          <tr><td class="dest">Map</td><td class="dest">Collections › Places</td><td>a browse mode over places, not a peer of the timeline</td></tr>
+          <tr><td class="dest">Circles</td><td class="dest">top-bar circle chip</td><td>the app's most important state, currently buried two taps deep</td></tr>
+          <tr><td class="dest">Albums</td><td class="dest">Collections › Albums</td><td>the canonical curated container</td></tr>
+          <tr><td class="dest">Notifications</td><td class="dest">bell → “See all”</td><td>the bell is always visible and already badged</td></tr>
+          <tr><td class="dest">People</td><td class="dest">Collections › People</td><td>a collection of faces</td></tr>
+          <tr><td class="dest">Archive · Trash</td><td class="dest">Collections, bottom group</td><td>where every peer app puts them</td></tr>
+          <tr><td class="dest">Bursts · Duplicates · Locations · Enhancements</td><td class="dest">Review, as tabs</td><td>one inbox, one aggregate badge, one existing endpoint</td></tr>
+          <tr><td class="dest">Review Insights</td><td class="dest">Review › Insights tab</td><td>analytics about the queues, not a queue</td></tr>
+          <tr><td class="dest">Workflows</td><td class="dest">Review › Automations</td><td>“make the reviewing happen without me”</td></tr>
+          <tr><td class="dest">Settings + 4 admin pages</td><td class="dest">Console</td><td>separate mode, own rail, own cadence</td></tr>
+          <tr><td class="dest">User Settings</td><td class="dest">avatar menu</td><td>already there</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>
+      One implementation note worth flagging early: the Review badge needs no new backend.
+      <span class="mono">GET&nbsp;/api/media/review-counts</span> already returns exactly the
+      four integers in a single counts-only request — it was built for the sidebar's
+      enhancements badge. The aggregate is a sum of what you already fetch.
+    </p>
+  </div>
+</section>
+
+
+<!-- ============================ MOVES ============================ -->
+<section>
+  <div class="wrap spine stack">
+    <div class="sec-head">
+      <p class="eyebrow">04 — Ranked by payoff</p>
+      <h2>Four moves, largest first</h2>
+    </div>
+
+    <div class="moves">
+      <div class="move">
+        <div class="move__rank">1</div>
+        <div class="move__body">
+          <h3>Collapse the review queues into one badged destination</h3>
+          <p class="note">
+            Six rows become one. These queues are empty most of the time and full right after
+            an import — a burst of work, not a permanent fixture. A single badged inbox matches
+            that rhythm; six always-present rows do not.
+          </p>
+        </div>
+        <div class="move__delta">−5 rows</div>
+      </div>
+
+      <div class="move">
+        <div class="move__rank">2</div>
+        <div class="move__body">
+          <h3>Move the admin surface into its own mode</h3>
+          <p class="note">
+            Console gets its own rail at <span class="mono">/admin</span>, reached from the
+            avatar menu. The library nav stops carrying four arbitrary operator shortcuts, and
+            the 25-page hub finally has somewhere to grow.
+          </p>
+        </div>
+        <div class="move__delta">−5 rows</div>
+      </div>
+
+      <div class="move">
+        <div class="move__rank">3</div>
+        <div class="move__body">
+          <h3>Fold browse targets into Collections</h3>
+          <p class="note">
+            Albums, People, Places, Map, Memories, Archive and Trash become a visual hub with
+            cover thumbnails and counts — not a text list. This is the move that buys the extra
+            tap, so the hub has to be worth arriving at.
+          </p>
+        </div>
+        <div class="move__delta">−6 rows</div>
+      </div>
+
+      <div class="move">
+        <div class="move__rank">4</div>
+        <div class="move__body">
+          <h3>Give the top bar what belongs to the top bar</h3>
+          <p class="note">
+            Circle chip, upload, bell, avatar. Removing Circles, Notifications and User
+            Settings from the drawer costs nothing — all three are one tap away in chrome
+            that never scrolls off.
+          </p>
+        </div>
+        <div class="move__delta">−3 rows</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================ THE THREE LAYOUTS ============================ -->
+<div class="lab">
+  <div class="wrap stack">
+    <div class="spine sec-head">
+      <p class="eyebrow">05 — Three form factors</p>
+      <h2>Same four destinations, three different machines</h2>
+    </div>
+    <p class="spine note" style="margin-bottom:12px">
+      Drawn to relative scale. The destinations never change between breakpoints — what changes
+      is the chrome that carries them, and what each screen does with the space it saves.
+    </p>
+
+    <div class="rack">
+
+      <!-- ============ PHONE ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Phone</b>
+          <span>&lt; 600 px · compact · bottom bar, no drawer</span>
+        </div>
+        <div class="device d-phone">
+          <div class="d-top">
+            <div class="d-logo"></div>
+            <div class="d-chip">Familia ▾</div>
+            <div class="d-spacer"></div>
+            <div class="d-ico"><svg><use href="#i-upload"/></svg></div>
+            <div class="d-ico d-dot"><svg><use href="#i-bell"/></svg></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-canvas">
+              <div class="d-sectlabel">Memories</div>
+              <div class="d-strip">
+                <div class="d-mem"></div><div class="d-mem"></div><div class="d-mem"></div>
+              </div>
+              <div class="d-sectlabel">Sat 8 Aug</div>
+              <div class="d-grid c3">
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div>
+                <div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div>
+                <div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+              </div>
+            </div>
+          </div>
+          <div class="d-bottom">
+            <div class="d-nav-item on"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collections</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-search"/></svg></div>Search</div>
+            <div class="d-nav-item"><div class="d-ico d-dot"><svg><use href="#i-review"/></svg></div>Review</div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>No hamburger, no drawer.</b> The screen in the bug report stops existing.</span></div>
+          <div class="tick"><span><b>Search becomes a tab</b>, which frees the search field out of a toolbar that already measures ~354&nbsp;px against 360&nbsp;px of viewport — the crowding your own topbar audit documents.</span></div>
+          <div class="tick"><span><b>Circle chip replaces the wordmark.</b> On a phone, which circle you're in matters more than the app's name.</span></div>
+        </div>
+      </div>
+
+      <!-- ============ TABLET ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Tablet</b>
+          <span>600–1239 px · medium · collapsed rail</span>
+        </div>
+        <div class="device d-tablet">
+          <div class="d-top">
+            <div class="d-logo"></div>
+            <div class="d-chip">Familia ▾</div>
+            <div class="d-searchpill"><svg class="d-ico" style="width:9px;height:9px"><use href="#i-search"/></svg>Search your photos</div>
+            <div class="d-ico"><svg><use href="#i-upload"/></svg></div>
+            <div class="d-ico d-dot"><svg><use href="#i-bell"/></svg></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-rail collapsed">
+              <div class="d-rail-item on"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+              <div class="d-rail-item"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collect</div>
+              <div class="d-rail-item"><div class="d-ico d-dot"><svg><use href="#i-review"/></svg></div>Review</div>
+              <div class="d-rail-item d-rail-foot"><div class="d-ico"><svg><use href="#i-console"/></svg></div>Console</div>
+            </div>
+            <div class="d-canvas">
+              <div class="d-sectlabel">Memories</div>
+              <div class="d-strip">
+                <div class="d-mem"></div><div class="d-mem"></div><div class="d-mem"></div><div class="d-mem"></div>
+              </div>
+              <div class="d-sectlabel">Sat 8 Aug</div>
+              <div class="d-grid c4">
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+                <div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div>
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>Rail instead of drawer</b> — Material 3's own replacement. Always visible, so navigating costs zero taps instead of one.</span></div>
+          <div class="tick"><span><b>~52&nbsp;px of chrome instead of 240.</b> That is roughly one extra column of photos on a 768&nbsp;px screen.</span></div>
+          <div class="tick"><span><b>Search returns to the top bar</b> where there's width for it, and gives up its rail slot.</span></div>
+        </div>
+      </div>
+
+      <!-- ============ DESKTOP ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Desktop</b>
+          <span>≥ 1240 px · expanded · rail + context pane</span>
+        </div>
+        <div class="device d-desktop">
+          <div class="d-top">
+            <div class="d-logo"></div>
+            <div class="d-chip">Familia ▾</div>
+            <div class="d-searchpill"><svg class="d-ico" style="width:9px;height:9px"><use href="#i-search"/></svg>Search your photos, people, places…</div>
+            <div class="d-ico"><svg><use href="#i-upload"/></svg></div>
+            <div class="d-ico d-dot"><svg><use href="#i-bell"/></svg></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-rail expanded">
+              <div class="d-rail-item"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+              <div class="d-rail-item on"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collections</div>
+              <div class="d-rail-item"><div class="d-ico"><svg><use href="#i-review"/></svg></div>Review<span class="d-rail-badge">12</span></div>
+              <div class="d-rail-sep"></div>
+              <div class="d-rail-item" style="color:var(--faint)">Pinned</div>
+              <div class="d-rail-item"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>People</div>
+              <div class="d-rail-item d-rail-foot"><div class="d-ico"><svg><use href="#i-console"/></svg></div>Console</div>
+            </div>
+            <div class="d-pane">
+              <div class="d-sectlabel" style="padding:2px 4px 4px">Collections</div>
+              <div class="d-pane-row on"><div class="d-pane-sw"></div>Albums<span class="d-pane-n">24</span></div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>People<span class="d-pane-n">61</span></div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>Places<span class="d-pane-n">38</span></div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>Memories<span class="d-pane-n">17</span></div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>Map</div>
+              <div class="d-rail-sep"></div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>Favorites</div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>Archive</div>
+              <div class="d-pane-row"><div class="d-pane-sw"></div>Trash</div>
+            </div>
+            <div class="d-canvas">
+              <div class="d-sectlabel">Albums · 24</div>
+              <div class="d-grid c6">
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div>
+                <div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+                <div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div>
+                <div class="d-tile"></div><div class="d-tile alt"></div><div class="d-tile"></div>
+                <div class="d-tile alt"></div><div class="d-tile"></div><div class="d-tile alt"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>Expanded rail + context pane.</b> The second column shows what's <em>inside</em> the selected destination — so depth costs a glance, not a tap.</span></div>
+          <div class="tick"><span><b>Pinning lives here.</b> A user who works in People every day pins it to the rail; persisted in <span class="mono">user_settings.navigation</span>, alongside the existing <span class="mono">dataTables</span> namespace. This is Apple's post-backlash correction, built in up front.</span></div>
+          <div class="tick"><span><b>The rail collapses</b> to the tablet treatment on demand, and remembers the choice.</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+<!-- ============================ THE SURFACES ============================ -->
+<div class="lab" style="background: var(--ground)">
+  <div class="wrap stack">
+    <div class="spine sec-head">
+      <p class="eyebrow">06 — The surfaces</p>
+      <h2>What the destinations actually land on</h2>
+    </div>
+    <p class="spine note" style="margin-bottom:12px">
+      The frames above are <em>chrome</em> — how you move between destinations. These are the
+      surfaces themselves, all shown at phone size because that is where each decision was
+      hardest. Three of the four were designed after the chrome, and each replaced a tab-based
+      proposal that research ruled out.
+    </p>
+
+    <div class="rack">
+
+      <!-- ============ CONSOLE ON PHONE ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Console on phone</b>
+          <span>drill-down · no mode, no tabs</span>
+        </div>
+        <div class="device d-phone">
+          <div class="d-bar2">
+            <div class="d-backarrow"><svg><use href="#i-back"/></svg></div>
+            Settings
+            <div class="d-spacer"></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-canvas" style="gap:5px">
+              <div class="d-search">
+                <svg style="width:8px;height:8px"><use href="#i-search"/></svg>Search settings
+              </div>
+              <div class="d-sectlabel">General</div>
+              <div>
+                <div class="d-listrow">System<span class="d-listrow__chev">›</span></div>
+                <div class="d-listrow">Users &amp; Allowlist<span class="d-listrow__chev">›</span></div>
+                <div class="d-listrow">Email<span class="d-listrow__chev">›</span></div>
+              </div>
+              <div class="d-sectlabel">Operations</div>
+              <div>
+                <div class="d-listrow">Job Queue<span class="d-listrow__chev">›</span></div>
+                <div class="d-listrow">Worker Nodes<span class="d-listrow__chev">›</span></div>
+                <div class="d-listrow">Database Backup<span class="d-listrow__chev">›</span></div>
+                <div class="d-listrow">Doctor<span class="d-listrow__chev">›</span></div>
+              </div>
+            </div>
+          </div>
+          <div class="d-bottom">
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collections</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-search"/></svg></div>Search</div>
+            <div class="d-nav-item"><div class="d-ico d-dot"><svg><use href="#i-review"/></svg></div>Review</div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>Console mode does not exist here.</b> There is no rail to swap, so the admin area is a drill-down and the settings hub is the navigation.</span></div>
+          <div class="tick"><span><b>A tab strip was rejected.</b> 23 pages in a horizontal scroll is the documented anti-pattern; Apple's phone tab ceiling is 3–5; iOS Settings is a drill-down, so users already hold the model.</span></div>
+          <div class="tick"><span><b>The bottom bar stays Library nav</b> — you are always one tap from Photos, so this is a place you drilled into, not a mode you are stuck in.</span></div>
+          <div class="tick"><span><b>Search settings</b> is the piece that scales. At 40 admin pages a rail degrades; typing stays constant-effort.</span></div>
+        </div>
+      </div>
+
+      <!-- ============ REVIEW QUEUE LIST ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Review</b>
+          <span>a queue list · not tabs, at any size</span>
+        </div>
+        <div class="device d-phone">
+          <div class="d-bar2">
+            Review
+            <div class="d-spacer"></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-canvas" style="gap:5px">
+              <div>
+                <div class="d-listrow">
+                  <div class="d-listrow__ico"><svg><use href="#i-photos"/></svg></div>
+                  Bursts<span class="d-listrow__n">4</span>
+                </div>
+                <div class="d-listrow">
+                  <div class="d-listrow__ico"><svg><use href="#i-collections"/></svg></div>
+                  Duplicates<span class="d-listrow__n">6</span>
+                </div>
+                <div class="d-listrow">
+                  <div class="d-listrow__ico"><svg><use href="#i-search"/></svg></div>
+                  Locations<span class="d-listrow__n">2</span>
+                </div>
+                <div class="d-listrow">
+                  <div class="d-listrow__ico"><svg><use href="#i-review"/></svg></div>
+                  Enhancements<span class="d-listrow__n zero">—</span>
+                </div>
+              </div>
+              <div class="d-secondary" style="margin-top:2px">
+                <span>Insights</span><span>Automations</span>
+              </div>
+              <div class="d-chain">Next: 6 duplicates<span>→</span></div>
+            </div>
+          </div>
+          <div class="d-bottom">
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collections</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-search"/></svg></div>Search</div>
+            <div class="d-nav-item on"><div class="d-ico d-dot"><svg><use href="#i-review"/></svg></div>Review</div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>Review is an inbox, not six parallel views.</b> The job is clearing the badge, not visiting Duplicates — so counts are the content, and a tab bar buries them in labels.</span></div>
+          <div class="tick"><span><b>The row count is variable, 1–6, with feature flags.</b> A tab bar whose width swings with configuration destroys spatial memory; a list absorbs it.</span></div>
+          <div class="tick"><span><b>A drained queue reads as an em dash</b>, never "0". Fixed row order — sorting by count would make rows jump between visits.</span></div>
+          <div class="tick"><span><b>Chain-to-next</b> keeps you moving without a trip back to the hub. The counts are already loaded, so it is nearly free.</span></div>
+        </div>
+      </div>
+
+      <!-- ============ REVIEW ALL CLEAR ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Review · all clear</b>
+          <span>the payoff state</span>
+        </div>
+        <div class="device d-phone">
+          <div class="d-bar2">
+            Review
+            <div class="d-spacer"></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-canvas">
+              <div class="d-allclear">
+                <div class="d-allclear__mark"><svg><use href="#i-check"/></svg></div>
+                <b>You're all caught up</b>
+                <span>Nothing waiting on you. New suggestions appear here after your next import.</span>
+              </div>
+              <div class="d-secondary">
+                <span>Insights</span><span>Automations</span>
+              </div>
+            </div>
+          </div>
+          <div class="d-bottom">
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collections</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-search"/></svg></div>Search</div>
+            <div class="d-nav-item on"><div class="d-ico"><svg><use href="#i-review"/></svg></div>Review</div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>Not six rows of zero.</b> When every queue drains, the list is replaced by one confident state — the Inbox Zero payoff that makes clearing the backlog feel like something.</span></div>
+          <div class="tick"><span><b>The Review entry itself never disappears</b>, it just loses its badge. Navigation that changes shape is worse than navigation that is slightly long.</span></div>
+          <div class="tick"><span><b>Insights and Automations remain</b> — they are not queues, so they are unaffected by an empty inbox.</span></div>
+        </div>
+      </div>
+
+      <!-- ============ COLLECTIONS CARD GRID ============ -->
+      <div class="spec">
+        <div class="spec__cap">
+          <b>Collections</b>
+          <span>the hub that has to earn its tap</span>
+        </div>
+        <div class="device d-phone">
+          <div class="d-bar2">
+            Collections
+            <div class="d-spacer"></div>
+            <div class="d-avatar"></div>
+          </div>
+          <div class="d-main">
+            <div class="d-canvas" style="gap:6px">
+              <div class="d-cardgrid">
+                <div class="d-card2">
+                  <div class="d-card2__cover"></div>
+                  <div class="d-card2__meta"><b>Albums</b><span>24</span></div>
+                </div>
+                <div class="d-card2">
+                  <div class="d-card2__cover"></div>
+                  <div class="d-card2__meta"><b>People</b><span>61</span></div>
+                </div>
+                <div class="d-card2">
+                  <div class="d-card2__cover"></div>
+                  <div class="d-card2__meta"><b>Places</b><span>38</span></div>
+                </div>
+                <div class="d-card2">
+                  <div class="d-card2__cover"></div>
+                  <div class="d-card2__meta"><b>Memories</b><span>17</span></div>
+                </div>
+                <div class="d-card2">
+                  <div class="d-card2__cover"></div>
+                  <div class="d-card2__meta"><b>Map</b><span></span></div>
+                </div>
+              </div>
+              <div class="d-secondary">
+                <span>Favorites</span><span>Archive</span><span>Trash</span>
+              </div>
+            </div>
+          </div>
+          <div class="d-bottom">
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-photos"/></svg></div>Photos</div>
+            <div class="d-nav-item on"><div class="d-ico"><svg><use href="#i-collections"/></svg></div>Collections</div>
+            <div class="d-nav-item"><div class="d-ico"><svg><use href="#i-search"/></svg></div>Search</div>
+            <div class="d-nav-item"><div class="d-ico d-dot"><svg><use href="#i-review"/></svg></div>Review</div>
+          </div>
+        </div>
+        <div class="ticks">
+          <div class="tick"><span><b>This screen decides whether the whole proposal was worth it.</b> It is the one place an extra tap is spent — so real cover art and live counts are requirements, not polish.</span></div>
+          <div class="tick"><span><b>If this ships as a text list, the redesign makes the app worse.</b> That is the stated kill criterion on the issue.</span></div>
+          <div class="tick"><span><b>Favorites, Archive and Trash sit below a divider</b> — lower frequency, and Trash should never read as a primary browse target.</span></div>
+          <div class="tick"><span><b>Desktop never sees this grid.</b> The context pane already gives the overview, so a grid beside it would be a menu next to a menu — and desktop pays no extra tap at all.</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+<!-- ============================ CONSOLE ============================ -->
+<section>
+  <div class="wrap spine stack">
+    <div class="sec-head">
+      <p class="eyebrow">07 — The second mode</p>
+      <h2>Console is a place, not five shortcuts</h2>
+    </div>
+    <p>
+      Entering <span class="mono">/admin</span> swaps the rail's contents rather than the app
+      shell. The circle chip stays, the search pill goes, and a persistent “← Back to library”
+      sits at the top of the rail so the mode is always obviously escapable.
+    </p>
+    <p>
+      It invents no information architecture. <span class="mono">SettingsHubPage</span>
+      <em>already</em> groups all 23 admin pages into five sections — General, AI &amp;
+      Enrichment, Media, Storage, Operations — each card carrying its own permission gate.
+      That structure is good; it is just trapped in a <em>page</em>, which is why every
+      admin-to-admin move routes back through a landing screen today. Getting from Job Queue
+      to Doctor means returning to the hub, scrolling to Operations, and clicking.
+      <b>Console mode promotes that existing structure from a destination into navigation</b> —
+      a conditional on <span class="mono">location.pathname.startsWith('/admin')</span> inside
+      one component, reusing the hub's groups, labels and gates verbatim.
+    </p>
+    <p>
+      <b>On a phone the mode does not exist</b> — there is no rail to swap, so the admin area
+      is a drill-down instead (section 06). That is not a compromise: it is the pattern every
+      phone user already knows from iOS Settings, and the one that still works at 40 admin
+      pages.
+    </p>
+  </div>
+</section>
+
+
+<!-- ============================ TRADE-OFFS ============================ -->
+<section>
+  <div class="wrap spine stack">
+    <div class="sec-head">
+      <p class="eyebrow">08 — What this costs</p>
+      <h2>Three honest objections</h2>
+    </div>
+
+    <div class="tradeoff">
+      <b>People, Map and Albums each cost one more tap — on phone and tablet only.</b>
+      <p>
+        Real, and unavoidable — it's the same trade Google made deliberately. It's only worth
+        it if Collections is visually rich enough to be a destination in its own right: cover
+        thumbnails, live counts, recently-viewed first. If Collections ships as a text list,
+        this proposal makes the app worse. On desktop the context pane means no tap is paid at
+        all — so the expensive card grid is required precisely where the cost it offsets is
+        real, and nowhere else.
+      </p>
+    </div>
+
+    <div class="tradeoff">
+      <b>Queues get harder to notice.</b>
+      <p>
+        Mitigated three ways that already exist: the aggregate badge on Review, the
+        review-queue notifications the reconcile task writes hourly, and the Home banners. If
+        anything the current design under-signals — six quiet rows read as furniture, one
+        badge reads as work.
+      </p>
+    </div>
+
+    <div class="tradeoff">
+      <b>Don't hide Review when the count is zero.</b>
+      <p>
+        Tempting, and wrong. Navigation that changes shape is worse than navigation that's
+        slightly long — users can't find a feature they know exists, and can't build muscle
+        memory against a moving target. Keep the destination, drop the badge.
+      </p>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================ BUILD ============================ -->
+<section>
+  <div class="wrap spine stack">
+    <div class="sec-head">
+      <p class="eyebrow">09 — Sequencing</p>
+      <h2>Shippable in four increments</h2>
+    </div>
+    <p class="note">
+      Ordered so each phase stands alone and is independently revertible. Phase&nbsp;1 alone
+      removes eight rows without a single new page. Tracked as epic&nbsp;#388 with issues
+      #389&nbsp;–&nbsp;#392.
+    </p>
+
+    <div class="phases">
+      <div class="phase">
+        <div class="phase__k">#389 · deletions</div>
+        <div class="phase__b">
+          <b>Console mode + drop the duplicated rows</b>
+          <p>
+            Conditional rail at <span class="mono">/admin</span>; remove Circles,
+            Notifications, User Settings and the four admin shortcuts. Add the circle chip to
+            the top bar. No new routes, no new API. <span class="mono">−8 rows.</span>
+          </p>
+        </div>
+      </div>
+      <div class="phase">
+        <div class="phase__k">#390 · one new page</div>
+        <div class="phase__b">
+          <b>The Review hub</b>
+          <p>
+            <span class="mono">/review</span> as a queue list (section 06) wrapping the pages that
+            already exist, plus the aggregate badge off
+            <span class="mono">review-counts</span>. <span class="mono">−5 rows.</span>
+          </p>
+        </div>
+      </div>
+      <div class="phase">
+        <div class="phase__k">#391 · one new page</div>
+        <div class="phase__b">
+          <b>The Collections hub</b>
+          <p>
+            <span class="mono">/collections</span> as a visual grid over Albums, People,
+            Places, Memories, Map, Favorites, Archive, Trash. The riskiest phase — it's the
+            one that spends the extra tap. <span class="mono">−6 rows.</span>
+          </p>
+        </div>
+      </div>
+      <div class="phase">
+        <div class="phase__k">#392 · chrome</div>
+        <div class="phase__b">
+          <b>Rail, bottom bar, pinning</b>
+          <p>
+            Replace the drawer with a collapsed rail at <span class="mono">md</span> and an
+            expanded rail at <span class="mono">lg</span>; phone bottom bar goes to four items
+            and the drawer is deleted. Add
+            <span class="mono">user_settings.navigation.pinned</span>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<footer>
+  <div class="wrap spine">
+    <p>
+      Sources —
+      <a href="https://9to5google.com/2025/03/23/year-long-google-photos-redesign/">Google Photos redesign</a> ·
+      <a href="https://m3.material.io/components/navigation-rail/guidelines">M3 navigation rail</a> ·
+      <a href="https://9to5google.com/2025/05/14/material-3-expressive-navigation/">M3 Expressive navigation</a> ·
+      <a href="https://www.macrumors.com/2024/11/21/apples-photos-app-overhaul-controversial/">iOS 18 Photos reaction</a> ·
+      <a href="https://developer.android.com/develop/ui/views/layout/build-responsive-navigation">Android responsive navigation</a>
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/specs/navigation-ia.md
+++ b/docs/specs/navigation-ia.md
@@ -1,0 +1,675 @@
+# Navigation Information Architecture
+
+> **Status:** Proposed — tracked by epic [#388](https://github.com/marinoscar/MemoriaHub/issues/388) (issues [#389](https://github.com/marinoscar/MemoriaHub/issues/389), [#390](https://github.com/marinoscar/MemoriaHub/issues/390), [#391](https://github.com/marinoscar/MemoriaHub/issues/391), [#392](https://github.com/marinoscar/MemoriaHub/issues/392)). Nothing in this document is implemented yet.
+> **Interactive mockups:** [`assets/navigation-ia-mockups.html`](assets/navigation-ia-mockups.html) — open in a browser; the three breakpoint layouts are drawn to relative scale.
+
+This spec replaces MemoriaHub's single 22-row navigation drawer with **four primary
+destinations** and **two modes** (Library / Console), and gives phone, tablet, and desktop
+three genuinely different navigation treatments instead of one drawer stretched across all
+of them.
+
+---
+
+## 1. The problem
+
+### 1.1 Item count is the symptom, not the disease
+
+`apps/web/src/components/navigation/Sidebar.tsx` renders **22 rows across 4 sections** for an
+admin with all feature flags on:
+
+| Section | Count | Items |
+|---|---|---|
+| (primary, no subheader) | 7 | Photos, Memories, Explore, Map, Circles, Albums, Notifications |
+| `LIBRARY` | 3 | People, Archive, Trash |
+| `UTILITIES` | 6 | Review Bursts, Review Duplicates, Review Insights, Location Suggestions, Workflows, AI Enhancements |
+| `ADMINISTRATION` | 5 | Settings, Job Queue, Worker Nodes, Storage Insights, Public Sharing |
+| (pinned bottom) | 1 | User Settings |
+
+The disease is that the drawer accumulated **one row per shipped feature**, so it mirrors the
+API surface rather than any user's mental model. Trimming rows individually only delays the
+next time it bloats; the next feature has no principled reason to be excluded and no room to
+be included.
+
+### 1.2 Eleven rows duplicate chrome that is already on screen
+
+| Drawer row | Already reachable from | Source |
+|---|---|---|
+| Notifications | the bell in the AppBar, carrying the same badge | `AppBar.tsx` → `NotificationBell` |
+| Circles | UserMenu — circle switcher **and** "Manage Circles" | `UserMenu.tsx:117-141` |
+| User Settings | UserMenu → Settings | `UserMenu.tsx:153` |
+| Job Queue | the `/admin/settings` hub | `SettingsHubPage.tsx` |
+| Worker Nodes | ditto | ditto |
+| Storage Insights | ditto | ditto |
+| Public Sharing | ditto | ditto |
+| Photos, Explore, Map, Albums | BottomNav — visible on the same screen, on mobile | `BottomNav.tsx:55-58` |
+
+The four admin shortcuts are the clearest case: they are an **arbitrary sample of a 25-page
+hub**, hoisted into global navigation.
+
+### 1.3 The structural problem underneath
+
+MemoriaHub is self-hosted, so **the same person is both the family photo browser and the
+system operator**. Those are two jobs with two cadences — daily versus monthly — competing
+for the same 240 px. Every commercial photo app avoids this by not having an operator at
+all. The fix is to separate the modes, not to keep re-ranking rows inside one list.
+
+---
+
+## 2. Research basis
+
+Four findings shaped the target design. They are recorded here because they are the reason
+for choices that would otherwise look arbitrary.
+
+### 2.1 Google Photos consolidated to three tabs
+
+The year-long redesign collapsed navigation to **Photos, Collections, Search**. People &
+pets, Places, Albums, Documents and Moments all moved *into* Collections; Create and the
+Updates bell moved to the top bar. The extra tap was accepted explicitly, in exchange for
+organized groupings over a flat list. Notably, the redesign also **removed the Memories
+tab** — memories surface inside the Photos tab instead.
+([9to5google, Mar 2025](https://9to5google.com/2025/03/23/year-long-google-photos-redesign/))
+
+### 2.2 Material 3 deprecated the navigation drawer
+
+In the Material 3 Expressive update the navigation drawer is deprecated, replaced by the
+**expanded navigation rail** — mostly the same functionality, adapting far better across
+window size classes. A rail is always visible; a drawer costs a tap before navigation can
+begin. Google acknowledges an open gap: there is no officially recommended drawer
+replacement for phone-sized windows, which is why the phone treatment here is bottom-bar-only.
+([m3.material.io](https://m3.material.io/components/navigation-rail/guidelines) ·
+[9to5google, May 2025](https://9to5google.com/2025/05/14/material-3-expressive-navigation/))
+
+### 2.3 Apple iOS 18 Photos is the documented failure mode
+
+iOS 18 removed the tab bar entirely for a single scrolling page. Backlash was immediate —
+"Albums particularly difficult to reach" — and Apple partially rolled back in 18.1/18.2,
+adding **Customize & Reorder**. The lesson: consolidation works, deleting stable
+destinations does not, and user pinning should be designed in from the start rather than
+added after complaints.
+([MacRumors, Nov 2024](https://www.macrumors.com/2024/11/21/apples-photos-app-overhaul-controversial/))
+
+### 2.4 Bottom navigation: three to five destinations
+
+Bottom tab navigation is the settled mobile standard, with 3–5 destinations the consistent
+recommendation. Four is the ceiling that still leaves each label readable at 360 px — the
+narrowest viewport this app already accounts for (see
+[`docs/audits/mobile-topbar-audit.md`](../audits/mobile-topbar-audit.md)).
+
+### 2.5 The through-line
+
+Every serious photo app consolidated into a **small set of stable destinations plus one rich
+hub**; the one that instead removed destinations entirely had to reverse course. This design
+sits deliberately on the Google side of that line, with Apple's correction (pinning) built
+in up front.
+
+---
+
+## 3. Target information architecture
+
+### 3.1 Four destinations
+
+Every user action is one of four verbs:
+
+| Destination | Route | Verb | Contents |
+|---|---|---|---|
+| **Photos** | `/` | *look* | The timeline, with the Memories carousel on top (already rendered there today) |
+| **Collections** | `/collections` | *browse* | Albums, People, Places, Memories, Map, Favorites, Archive, Trash |
+| **Search** | `/search` | *find* | Text, semantic, and agentic search |
+| **Review** | `/review` | *decide* | Bursts, Duplicates, Locations, Enhancements, Insights, Automations |
+
+**Review is the destination worth defending.** Unlike every app surveyed in §2, MemoriaHub
+*generates work for its user*: bursts to resolve, duplicates to merge, locations to confirm,
+enhancements to approve, workflow runs to authorize. That is a genuine product
+differentiator that currently costs six quiet drawer rows which read as furniture. One
+badged inbox reads as work, and matches the actual rhythm — these queues are empty most of
+the time and full immediately after an import.
+
+### 3.2 Two modes
+
+**Library mode** (default) carries the four destinations above.
+
+**Console mode** is entered at any `/admin/*` route. The navigation chrome swaps its
+contents rather than the app shell, plus a persistent **← Back to library** affordance at
+the top so the mode is always obviously escapable. The circle chip stays; the search pill is
+hidden.
+
+The items it swaps to are **not new information architecture** — `SettingsHubPage` already
+groups all 23 admin pages into five sections (General, AI & Enrichment, Media, Storage,
+Operations), each card carrying its own permission gate. Console mode promotes that existing
+structure from a *page* into *navigation*, which is what removes the current cost of every
+admin-to-admin move routing back through a landing page. Console reuses the hub's groups,
+labels, and gates verbatim.
+
+**On a phone this mode does not exist** — there is no rail to swap, so the admin surface is
+a drill-down hierarchy instead. See §4.4.
+
+This is the cheapest structural change in the proposal — a conditional on
+`location.pathname.startsWith('/admin')` inside one component — and it permanently removes
+five rows while giving the admin surface room to grow past 25 pages without ever touching
+global navigation again.
+
+### 3.3 Complete destination mapping
+
+Nothing is deleted. All 22 rows land somewhere specific:
+
+| Today | New home | Rationale |
+|---|---|---|
+| Photos | **Photos** | Unchanged — the daily destination |
+| Memories | **Photos** carousel + **Collections › Memories** | The feed already renders on Home via `GET /api/memories/feed`; Google removed its Memories tab for the same reason (§2.1) |
+| Explore | **Search** | It routes to `/search` — name it what it is (see §3.4) |
+| Map | **Collections › Places › Map** | A browse mode over places, not a peer of the timeline |
+| Circles | **Top-bar circle chip** | The app's most important state, currently two taps deep in the avatar menu |
+| Albums | **Collections › Albums** | The canonical curated container |
+| Notifications | **Bell → "See all notifications"** | The bell is always visible and already badged |
+| People | **Collections › People** | A collection of faces |
+| Archive | **Collections**, bottom group | Where every peer app puts it |
+| Trash | **Collections**, bottom group | ditto |
+| Review Bursts | **Review › Bursts** | One inbox, one aggregate badge |
+| Review Duplicates | **Review › Duplicates** | ditto |
+| Location Suggestions | **Review › Locations** | ditto |
+| AI Enhancements | **Review › Enhancements** | ditto |
+| Review Insights | **Review › Insights** | Analytics *about* the queues, not a queue |
+| Workflows | **Review › Automations** | "Make the reviewing happen without me" |
+| Settings | **Console** | Separate mode, own cadence |
+| Job Queue | **Console › Jobs** | ditto |
+| Worker Nodes | **Console › Nodes** | ditto |
+| Storage Insights | **Console › Storage** | ditto |
+| Public Sharing | **Console › Sharing** | ditto |
+| User Settings | **Avatar menu** | Already there |
+
+### 3.4 Naming corrections
+
+Two collisions are fixed as part of this work:
+
+- **"Explore" currently routes to `/search`**, while a *separate* explore-style hub lives at
+  `/places` (`PlacesOverviewPage`). Two different things called explore. Resolution:
+  `/search` is named **Search**; `/places` becomes **Places** inside Collections.
+- **"Review Insights"** sits among four review *queues* but is an analytics page. It becomes
+  an entry inside Review rather than a sibling of the queues.
+
+### 3.5 The destination model — keys, route ownership, and active state
+
+Collapsing 22 rows into 4 creates a problem the current navigation does not have: **a
+destination must light up for routes whose paths do not resemble it.** Standing at
+`/bursts`, the active destination is Review — but `/bursts` does not start with `/review`.
+`Sidebar.tsx`'s current `isActive` (a bare `startsWith`) cannot express this, so the mapping
+must be declared explicitly.
+
+**Canonical destination keys** — the stable identifiers used by the nav components, the
+active-state resolver, and the `pinned` array in §5:
+
+```ts
+type DestinationKey = 'photos' | 'collections' | 'search' | 'review' | 'console';
+```
+
+**Route ownership.** Each destination owns a set of route prefixes. A route may be owned by
+at most one destination.
+
+| Destination | Owns |
+|---|---|
+| `photos` | `/` (exact only), `/media` |
+| `collections` | `/collections`, `/albums`, `/people`, `/places`, `/memories`, `/map`, `/archive`, `/trash`, `/tags` |
+| `search` | `/search` |
+| `review` | `/review`, `/bursts`, `/duplicates`, `/review-insights`, `/location-suggestions`, `/enhancements`, `/workflows`, `/review-runs`, `/location-suggestion-runs` |
+| `console` | `/admin` |
+
+Child routes are covered by their parent prefix (`/albums/:albumId`, `/bursts/:id`,
+`/memories/:id`, `/trash/runs/:runId`, `/places/countries`, `/workflows/:id/runs/:runId`, …)
+and do not need their own entries.
+
+**Routes owned by NO destination — deliberately:**
+
+`/settings`, `/profile`, `/circles`, `/circles/:id`, `/notifications`, `/activate`,
+`/login`, `/auth/callback`, `/s/:token`.
+
+These are reached from the top bar (avatar menu, circle chip, bell) or from outside the app
+entirely. **On these routes no destination renders as active, and that is correct, not a
+bug** — highlighting an unrelated destination would be worse than highlighting none. A test
+should assert this explicitly so a future contributor does not "fix" it.
+
+**Matching rule — segment boundaries, not raw `startsWith`.** A prefix matches when the
+path equals it or continues with `/`:
+
+```ts
+const owns = (prefix: string, path: string) =>
+  prefix === '/' ? path === '/' : path === prefix || path.startsWith(prefix + '/');
+```
+
+A bare `startsWith` would make `/review` match `/reviewer` and `/bursts` match `/burstsfoo`.
+This is a latent bug in the current `isActive` that the consolidation would amplify, since
+each destination now owns many more prefixes. Note `/review-insights` and `/review-runs` do
+**not** match the `/review` prefix under this rule — they are listed as their own prefixes
+above, which is why the table enumerates them rather than relying on `/review` to cover them.
+
+**Longest-prefix wins** if prefixes ever overlap. They do not today, and a test should assert
+that no route in `App.tsx` is claimed by two destinations — that assertion is what keeps this
+table honest as routes are added.
+
+---
+
+## 4. Per-breakpoint layouts
+
+The four destinations **never change between breakpoints**. What changes is the chrome that
+carries them, and what each screen does with the space it saves.
+
+Breakpoints use the MUI theme values already in the codebase (`xs 0 / sm 600 / md 900 /
+lg 1200`), which align closely with Material 3's compact / medium / expanded window classes.
+
+### 4.1 Phone — `< md` (bottom bar, **no drawer**)
+
+```
+┌──────────────────────────────────┐
+│ ▣  Familia ▾        ⬆  🔔•   ◯  │  top bar: logo, circle chip,
+├──────────────────────────────────┤  upload, bell, avatar
+│ MEMORIES                         │  NO hamburger, NO search field
+│ ▭▭▭  ▭▭▭  ▭▭▭                    │
+│ SAT 8 AUG                        │
+│ ▪ ▪ ▪                            │
+│ ▪ ▪ ▪                            │
+│ ▪ ▪ ▪                            │
+├──────────────────────────────────┤
+│  ▦       ◈        ⌕       ✓•     │  4-item bottom bar
+│ Photos Collections Search Review │
+└──────────────────────────────────┘
+```
+
+- **The drawer is deleted outright.** No hamburger. The screen in the original bug report
+  stops existing.
+- **Search becomes a tab**, which pulls the search field *out* of the top bar. Per
+  [`docs/audits/mobile-topbar-audit.md`](../audits/mobile-topbar-audit.md) that toolbar
+  already measures ~354 px against 360 px of viewport with the search pill present; removing
+  it resolves that crowding permanently rather than tuning gaps again.
+- **The circle chip replaces the wordmark.** On a phone, which circle you are in matters more
+  than the app's name.
+- Review carries a dot indicator rather than a numeric badge at this size.
+
+### 4.2 Tablet — `md` to `lg` (collapsed rail)
+
+```
+┌──────────────────────────────────────────────┐
+│ ▣ Familia ▾ [ ⌕ Search your photos ] ⬆ 🔔• ◯ │
+├────┬─────────────────────────────────────────┤
+│ ▦  │ MEMORIES                                │
+│Phot│ ▭▭▭  ▭▭▭  ▭▭▭  ▭▭▭                      │
+│ ◈  │ SAT 8 AUG                               │
+│Coll│ ▪ ▪ ▪ ▪                                 │
+│ ✓• │ ▪ ▪ ▪ ▪                                 │
+│Revw│ ▪ ▪ ▪ ▪                                 │
+│    │                                         │
+│ ⚙  │                                         │
+│Cons│                                         │
+└────┴─────────────────────────────────────────┘
+   ↑ 52px, always visible
+```
+
+- **Collapsed navigation rail instead of a temporary drawer** — Material 3's own replacement
+  (§2.2). Always visible, so navigating costs **zero taps instead of one**.
+- **~52 px of chrome instead of 240.** On a 768 px screen that is roughly one additional
+  column of photos.
+- **Search returns to the top bar** where there is width for it, and gives up its rail slot.
+  This is the one place the destination set differs by form factor, and it is deliberate:
+  the destination still exists, it is simply carried by different chrome.
+- Console sits pinned at the rail's foot, visually separated.
+
+### 4.3 Desktop — `≥ lg` (expanded rail + context pane)
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ ▣ Familia ▾ [ ⌕ Search your photos, people, places… ] ⬆ 🔔• ◯ │
+├────────────┬──────────────┬────────────────────────────────────┤
+│ ▦ Photos   │ COLLECTIONS  │ ALBUMS · 24                        │
+│ ◈ Collect… │ ▪ Albums  24 │ ▪ ▪ ▪ ▪ ▪ ▪                        │
+│ ✓ Review 12│ ▪ People  61 │ ▪ ▪ ▪ ▪ ▪ ▪                        │
+│ ─────────  │ ▪ Places  38 │ ▪ ▪ ▪ ▪ ▪ ▪                        │
+│ PINNED     │ ▪ Memories17 │ ▪ ▪ ▪ ▪ ▪ ▪                        │
+│ ◈ People   │ ▪ Map        │ ▪ ▪ ▪ ▪ ▪ ▪                        │
+│            │ ──────────   │                                    │
+│            │ ▪ Favorites  │                                    │
+│            │ ▪ Archive    │                                    │
+│ ⚙ Console  │ ▪ Trash      │                                    │
+└────────────┴──────────────┴────────────────────────────────────┘
+   ↑ 220px       ↑ 240px context pane (only for Collections/Review)
+```
+
+- **Expanded rail + context pane.** The second column shows what is *inside* the selected
+  destination, so depth costs a glance rather than a tap. This is what recovers the extra tap
+  that §6.1 concedes.
+- The context pane renders **only for Collections and Review**. Photos and Search are
+  single-surface destinations and render at full width.
+- **Pinning lives here** (§5). A user who works in People daily pins it into the rail.
+- The rail **collapses to the tablet treatment on demand** and remembers the choice.
+
+### 4.4 Console mode on a phone — a drill-down, not a mode
+
+Console mode (§3.2) is defined as "the rail swaps its contents." On a phone there is no
+rail, so there is nothing to swap. **The resolution is that Console mode does not exist on
+a phone at all: the admin surface is a drill-down hierarchy, and `SettingsHubPage` is the
+navigation.**
+
+```
+  Hub  (/admin/settings)              Detail  (/admin/settings/jobs)
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│ ←  Settings              ◯   │    │ ←  Job Queue             ◯   │
+├──────────────────────────────┤    ├──────────────────────────────┤
+│ ⌕ Search settings            │    │                              │
+│                              │    │  <JobsPage renders here>     │
+│ GENERAL                      │    │                              │
+│  ▸ System                    │    │                              │
+│  ▸ Users & Allowlist         │    │                              │
+│  ▸ Archiving & Deletion      │    │                              │
+│  ▸ Email                     │    │                              │
+│ AI & ENRICHMENT              │    │                              │
+│  ▸ AI Providers              │    │                              │
+│  ▸ Tagging & Descriptions    │    │                              │
+│  …                           │    │                              │
+├──────────────────────────────┤    ├──────────────────────────────┤
+│  ▦    ◈     ⌕     ✓•         │    │  ▦    ◈     ⌕     ✓•         │
+│Photos Coll Search Review     │    │Photos Coll Search Review     │
+└──────────────────────────────┘    └──────────────────────────────┘
+       ↑ bottom bar stays LIBRARY nav in both — always one tap out
+```
+
+**Why not a scrollable tab strip** (the first proposal, rejected):
+
+- Tabs are for **parallel** content; drill-down is for **hierarchical** content. Console is
+  23 pages inside 5 groups — a hierarchy.
+- 23 destinations in a horizontal strip is the documented anti-pattern: excess tabs force
+  horizontal scrolling that reduces discoverability, and shifting tab rows destroy the
+  spatial memory users rely on to remember where they have been
+  ([NN/g, *Tabs, Used Right*](https://www.nngroup.com/articles/tabs-used-right/)).
+- Apple's tab-bar ceiling on iPhone is 3–5 items.
+- iOS Settings — the reference mobile settings experience — is a drill-down, so every phone
+  user already holds the model.
+
+**Four requirements make this excellent rather than merely correct:**
+
+1. **Scroll position MUST be restored when returning to the hub.** This is the single
+   make-or-break detail. SPAs break it by default — `history.pushState` does not restore
+   position, and asynchronously rendered content means the browser does not know the page
+   height at restore time. Without it, returning from a page near the bottom of a 23-card
+   list dumps the user at the top to re-find their place, which is what makes drill-down
+   feel bad. With it, the pattern feels native.
+2. **The bottom bar stays Library navigation on every admin screen.** This is what keeps
+   the admin surface from being a trap: the user is always one tap from Photos. It is also
+   why no "← Back to library" affordance is needed on phone, unlike the rail treatments.
+3. **A back affordance in the top bar that agrees with the OS.** It navigates up one level
+   (detail → hub) and must never diverge from the browser/system back gesture.
+4. **A "Search settings" filter at the top of the hub.** A client-side filter over the
+   `sections` array `SettingsHubPage` already declares, matching on card title. Twenty-three
+   items across five groups is past the point where scanning beats typing — the same reason
+   iOS Settings has a search field. It also benefits desktop, and it is the only approach
+   that **scales**: at 40 admin pages a rail or tab strip degrades, while search stays
+   constant-effort for the user.
+
+**Top bar in the admin drill-down on phone:** back arrow + page title + avatar. The circle
+chip and upload button are dropped — nearly every admin page is global rather than
+circle-scoped, and the space is better spent on the title.
+
+**No new route, no new component, no change to any admin page.** The hierarchy already
+exists in `SettingsHubPage`'s five sections; this treatment simply stops hiding it behind a
+landing page the user must return to manually.
+
+### 4.5 The Review hub across breakpoints — a queue list, not tabs
+
+Review is **not six parallel views**. It is an inbox, and the distinction decides the
+component:
+
+- **The user's job is "clear the badge," not "visit Duplicates."** Nobody opens the app
+  wanting the Duplicates page specifically; they want to deal with what is pending.
+- **Counts change as the user works.** That is progress feedback. A list surfaces it; a tab
+  bar buries it in labels the user is not looking at.
+- **It is 4 + 2, not 6.** Four draining queues (Bursts, Duplicates, Locations,
+  Enhancements) plus two that are not queues at all (Insights is analytics, Automations is
+  configuration).
+- **The item count is VARIABLE, 1 to 6, depending on feature flags.** A tab bar whose width
+  and item count swing with configuration is the same spatial-memory failure as §4.4's
+  scrolling strip. A list absorbs variable length natively.
+
+Segmented controls were also considered and rejected: they are for 3–5 **mutually exclusive
+views of the same content**, and six-option segmented controls are specifically called out
+as a mobile anti-pattern.
+
+**The resolution: one model at every breakpoint — a queue list with counts.**
+
+| Breakpoint | Treatment |
+|---|---|
+| Phone (`< md`) | Full-screen hub list → drill into a queue → back |
+| Tablet (`md`–`lg`) | Same as phone; the 52 px rail has no room for a pane |
+| Desktop (`≥ lg`) | The same list rendered as §4.3's **context pane**, side by side with the queue — no drilling |
+
+```
+  Phone hub  (/review)                Desktop (rail + context pane + queue)
+┌──────────────────────────────┐    ┌────────┬──────────────┬──────────────┐
+│ Review                   ◯   │    │ Photos │ REVIEW       │ BURSTS · 4   │
+├──────────────────────────────┤    │ Collec…│ ▸ Bursts   4 │              │
+│ ▸ Bursts                  4  │    │ Review │ ▸ Duplicates6│  <BurstsPage>│
+│ ▸ Duplicates              6  │    │        │ ▸ Locations 2│              │
+│ ▸ Locations               2  │    │        │ ▸ Enhance…  –│              │
+│ ▸ Enhancements            –  │    │        │ ──────────   │              │
+│ ────────────────────────     │    │        │ ▸ Insights   │              │
+│ ▸ Insights                   │    │Console │ ▸ Automations│              │
+│ ▸ Automations                │    └────────┴──────────────┴──────────────┘
+├──────────────────────────────┤
+│  ▦    ◈     ⌕     ✓•         │       The context pane IS the hub list.
+│Photos Coll Search Review     │       Tabs are needed at no breakpoint.
+└──────────────────────────────┘
+```
+
+Because §4.3 already specifies a context pane for Review, **the queue list is a component
+that already had to exist.** Choosing a list over tabs therefore removes a component rather
+than adding one, and makes the phone and desktop treatments the same model at two sizes.
+
+**Four requirements:**
+
+1. **Counts MUST refresh when returning to the hub.** Clearing four bursts and coming back
+   to a stale "4" destroys the only progress feedback the feature has. Invalidate
+   `useReviewCounts` on return, do not serve a cached value.
+2. **Fixed row order — never sorted by count.** Sorting would make rows jump between
+   visits, which is the same spatial-memory failure the list exists to avoid. Order is
+   fixed; the counts move, the rows do not.
+3. **Chain-to-next.** On finishing a queue, offer the next non-empty one inline
+   ("Next: 6 duplicates →") rather than requiring a trip back to the hub. The counts are
+   already loaded, so this is nearly free, and it is what turns clearing a backlog from
+   tedious into satisfying.
+4. **A real all-clear state.** When every queue is zero, render one confident "You're all
+   caught up" rather than six rows of "0". A drained queue in the list reads as an em dash,
+   not a zero.
+
+**Deliberately deferred:** a *unified* review stream — one swipeable card deck mixing all
+four queues — would be the more ambitious answer, but each queue has a genuinely different
+decision UI (pick-the-best-of-N for bursts, confirm-a-map-pin for locations, accept/reject a
+rendered image for enhancements). Merging them is a redesign of four review surfaces, not a
+navigation change. Recorded here so the option is not lost, not scheduled.
+
+### 4.6 The Collections hub across breakpoints
+
+Collections has the **same two-surface shape as Review** (§4.5) and must resolve it the same
+way, or the two hubs will drift into different interaction models for no reason.
+
+| Breakpoint | Treatment |
+|---|---|
+| Phone (`< md`) | The full **card grid** (§6.1's rich hub) → tap a card → back |
+| Tablet (`md`–`lg`) | Same card grid, 3–4 columns |
+| Desktop (`≥ lg`) | The §4.3 **context pane** lists the collections; `/collections` resolves to the first entry (Albums) in the main area |
+
+**On desktop `/collections` does NOT render the card grid.** The context pane already gives
+the overview with live counts; a card grid beside it is a menu next to a menu. Landing
+directly in Albums puts photos on screen in zero clicks. This mirrors `/review` → first
+queue exactly.
+
+**This is also what makes §6.1's trade-off coherent.** The extra tap Collections introduces
+exists *only* on phone and tablet — desktop has the pane and pays no tap at all. So the
+expensive rich-card-grid requirement applies precisely where the cost it offsets is real.
+An implementer who reads §6.1 as "build cover art everywhere" is building it for a
+breakpoint that does not need it.
+
+**Favorites resolves to `/media?favorite=1`** — note `=1`, not `=true`.
+`MediaLibraryPage` reads `searchParams.get('favorite') === '1'`
+(`apps/web/src/pages/MediaLibrary`, and the API's `media-query.dto.ts` carries the matching
+filter), so `favorite=true` silently renders an UNFILTERED library rather than erroring.
+No new route is needed.
+
+**Pane contents mirror the card grid's ordering and grouping:** Albums, People, Places,
+Memories, Map — then a divider — Favorites, Archive, Trash. Feature-gated entries (Memories)
+hide in both surfaces from the same flag check.
+
+---
+
+## 5. Persistence — `user_settings.navigation`
+
+A new optional namespace in the existing `user_settings` JSONB. **No migration, no new
+endpoint, no new table, no new permission** — read and written through the existing
+`GET`/`PATCH`/`PUT /api/user-settings`, exactly like the `dataTables` namespace (issue #255)
+and the `notifications` namespace (issue #251).
+
+```ts
+navigation: {
+  pinned?: string[];        // ≤ 6 entries, each a PinnableKey (below)
+  railCollapsed?: boolean;  // desktop rail collapse preference
+}
+```
+
+**Pinnable keys are SUB-destinations, never the four primaries.** Pinning Photos would be
+meaningless — it is already in the rail. The pinnable set is exactly the entries that live
+one level down, inside the two hubs:
+
+```ts
+const PINNABLE_KEYS = [
+  // Collections (§4.6)
+  'albums', 'people', 'places', 'memories', 'map', 'favorites', 'archive', 'trash',
+  // Review (§4.5)
+  'bursts', 'duplicates', 'locations', 'enhancements', 'review-insights', 'automations',
+] as const;
+```
+
+Each key resolves to a route and a label through **one shared registry** also consumed by
+the two hubs and both context panes — so a pinned entry can never show a different label or
+target than the same entry in the pane it was pinned from.
+
+**A pinned key whose feature flag is off does not render**, and is *not* removed from
+storage — turning `features.memories` back on must restore the pin rather than silently
+having discarded it. This is the same "absent means default, never destroy user intent"
+posture as the rest of the namespace.
+
+**Every field is optional with no `.default()`.** Absent means "use the built-in defaults" —
+nothing pinned, rail expanded. This mirrors the explicit warning already documented for
+`dataTables` and `notifications` in `CLAUDE.md`: adding a `.default()` anywhere in this
+namespace inverts the absent-means-default rule and pins stored blobs to a snapshot of
+today's defaults.
+
+**PATCH merges field-wise** (`UserSettingsService.mergeNavigation`, shaped like the existing
+`mergeNotifications`): an unlisted field is untouched, a listed one is replaced wholesale,
+a field set to `null` is deleted, and `navigation: null` clears the namespace.
+
+`pinned` entries are validated against the known destination-key enum, and **unknown keys
+are dropped on read rather than rejected** — a pin referencing a destination removed in a
+later release must degrade to "not pinned", never to a 500 on every settings read.
+
+> **Three hand-maintained copies.** Per the pitfall documented in `CLAUDE.md`, this namespace
+> must be added to **all three** of `systemSettingsSchema`'s user-settings equivalents:
+> `userSettingsSchema` and its patch twin in
+> `apps/api/src/common/schemas/settings.schema.ts`, **and** the wire DTO in
+> `apps/api/src/settings/dto/`. A namespace present only in the first two validates
+> perfectly in unit tests while every real PATCH silently no-ops, because `nestjs-zod`
+> strips unknown keys.
+
+---
+
+## 6. Trade-offs and rejected alternatives
+
+### 6.1 People, Map and Albums each cost one more tap — accepted
+
+Real and unavoidable; it is the same trade Google made deliberately (§2.1). It is only worth
+it if **Collections is visually rich enough to be a destination in its own right**: cover
+thumbnails, live counts, recently-viewed first. **If Collections ships as a text list, this
+proposal makes the app worse.** Desktop pinning and the context pane (§4.3) recover the cost
+entirely for power users.
+
+### 6.2 Queues become less visible — mitigated by existing machinery
+
+Three mitigations already exist: the aggregate badge on Review, the hourly `review_queue_*`
+notifications written by `NotificationReconcileTask`, and the Home review banners. The
+current design arguably *under*-signals: six quiet rows read as furniture, one badge reads
+as work.
+
+### 6.3 Rejected — hiding Review when its count is zero
+
+Tempting and wrong. Navigation that changes shape is worse than navigation that is slightly
+long: users cannot find a feature they know exists, and cannot build muscle memory against a
+moving target. **Keep the destination, drop the badge.**
+
+### 6.4 Rejected — a collapsible `UTILITIES` section, collapsed by default
+
+Cheaper than the Review hub, but it hides the problem rather than fixing the IA. The six rows
+still exist, still mirror the feature list, and the next review queue still adds a seventh.
+
+### 6.5 Rejected — removing destinations entirely (the iOS 18 model)
+
+§2.3. Documented to fail, and reversed by its own author.
+
+---
+
+## 7. Accessibility requirements
+
+Non-negotiable, and part of each issue's acceptance criteria:
+
+- The rail is a `<nav>` with an accessible name; the active destination carries
+  `aria-current="page"`.
+- Every rail item exposes its label to assistive technology **even when collapsed**, where
+  the visible label is truncated or hidden.
+- Badges are not the sole carrier of meaning: the accessible name includes the count
+  ("Review, 12 items pending").
+- Focus order follows visual order across top bar → rail → context pane → main.
+- Keyboard focus has a visible state on every navigation control.
+- The rail collapse toggle is a real `<button>` with `aria-expanded`.
+- `prefers-reduced-motion` suppresses the rail expand/collapse transition.
+
+---
+
+## 8. Phasing
+
+Each phase stands alone and is independently revertible. Phase 1 removes eight rows without
+adding a single page.
+
+Tracked by epic [#388](https://github.com/marinoscar/MemoriaHub/issues/388).
+
+| Phase | Issue | Delivers | Rows |
+|---|---|---|---|
+| 1 | [#389](https://github.com/marinoscar/MemoriaHub/issues/389) | Console mode, duplicate removal, top-bar circle chip — no new routes, no new API | 22 → 14 |
+| 2 | [#390](https://github.com/marinoscar/MemoriaHub/issues/390) | The Review hub — one new route wrapping existing pages | 14 → 9 |
+| 3 | [#391](https://github.com/marinoscar/MemoriaHub/issues/391) | The Collections hub — one new route; the riskiest phase (§6.1) | 9 → 4 |
+| 4 | [#392](https://github.com/marinoscar/MemoriaHub/issues/392) | Rail, bottom bar, pinning — replaces the drawer; adds `user_settings.navigation` | chrome |
+
+**If scope must shrink:** Phase 1 alone is a clean win. Phases 1 + 2 + 4 deliver the full
+three-breakpoint chrome and skip the risky hub. Phase 3 is the only one that can make the
+app *worse* if executed poorly — see the bar it must clear in §6.1.
+
+---
+
+## 9. Testing requirements
+
+Per phase, at minimum:
+
+- **Unit (RTL):** the navigation component renders the expected destination set at each
+  breakpoint (`useMediaQuery` mocked); permission- and feature-flag-gated entries appear and
+  disappear correctly; `aria-current` tracks the active route.
+- **Route ownership (§3.5) — the highest-value test in the epic after reachability.** Three
+  assertions, all cheap and all guarding mistakes that are invisible in manual testing:
+  1. For every route declared in `App.tsx`, the active-state resolver returns either exactly
+     one destination or — for the explicitly unowned list in §3.5 — none. **No route may be
+     claimed by two destinations.** This is what keeps the ownership table honest as routes
+     are added, and it fails loudly the day someone adds a route and forgets the table.
+  2. Boundary matching: `/reviewer` does not activate Review, `/burstsfoo` does not activate
+     Review, `/media-something` does not activate Photos, and `/` activates Photos only on
+     exact match.
+  3. The unowned routes (`/settings`, `/profile`, `/circles`, `/notifications`) render **no**
+     active destination — asserted deliberately so a later contributor does not "fix" it into
+     highlighting something arbitrary.
+- **Regression:** every removed drawer row's destination is still reachable by its existing
+  route. This is the single most important test in the epic — the design's central claim is
+  that nothing becomes unreachable.
+- **Settings (Phase 4):** `navigation` namespace round-trips through PATCH/PUT; an unlisted
+  field is untouched; `null` clears; an over-cap `pinned` array is a 400, not a 500; an
+  unknown pinned key degrades to "not pinned".
+- **Typecheck** (`npm run typecheck`) and existing `Sidebar.test.tsx` updated rather than
+  deleted.


### PR DESCRIPTION
## Summary

Phase 1 of epic #388. Removes **eight of the drawer's 22 rows** (22 → 14) with no new routes, no new pages, and no API change, and promotes two pieces of information architecture out of places they were trapped in: the admin section list out of `SettingsHubPage`, and the circle switcher out of the avatar menu.

The rows removed are not a trim — each one duplicates chrome that is already on screen (spec §1.2). The four admin shortcuts were the clearest case: an arbitrary sample of a 23-page hub hoisted into global navigation, with no principled rule for what the next admin page should do.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Relates to #388
Fixes #389

## Changes Made

- **`docs/specs/navigation-ia.md` + mockups** — the epic's authoritative spec, landed on `main` so every phase issue references a path that resolves.
- **`src/config/adminSections.tsx` (new)** — one declaration of the admin IA, consumed by the hub, Console mode, and the AppBar title resolver. "Console invents no new admin IA" becomes a structural property rather than a promise.
- **Console mode** — any `/admin/*` route swaps the drawer's *contents*: a persistent "Back to library" row plus the five permission-gated admin sections. Same `Drawer`, same `NavItem`, no second `Layout`.
- **Eight rows removed** — Circles, Notifications, User Settings, and the five `ADMINISTRATION` shortcuts. `Console` is pinned at the foot for admins as a mode affordance (counted separately from the 14 rows).
- **`CircleChip` (new)** — the active circle as always-visible top-bar chrome at every breakpoint. `UserMenu` drops its circle section rather than becoming a third path to the same action.
- **Phone admin drill-down** (spec §4.4) — at `/admin/*` below `md` the toolbar becomes back + page title + avatar, and `SettingsHubPage` renders a drill-down list instead of the card grid. No tab strip: 23 pages in a horizontal scroll is the documented anti-pattern, and iOS Settings is the model every phone user already holds.
- **"Search settings"** — a client-side title filter over the shared array. The only approach that stays constant-effort as the admin surface grows.
- **`useScrollRestoration` (new)** — spec §4.4 calls this "the single make-or-break detail" of the drill-down. Phases 2 and 3 reuse it.
- **Bell footer** relabelled "See all notifications" — with the drawer row gone it is now the only path there, so it has to name the destination without relying on its surroundings.

### Two correctness fixes that rode along

- `isActive` matched a bare prefix, so `/review` would have matched `/reviewer`. Now matches on segment boundaries (spec §3.5) — load-bearing here, since the same helper decides whether the drawer is in Console mode at all.
- Console paths genuinely nest, so longest-prefix-wins picks the active row: at `/admin/settings/jobs/insights`, `aria-current="page"` lands on *Job Queue Insights* and not also on *Job Queue*.

## Testing

- [x] Unit tests pass (`npm test`) — full `apps/web` suite: **232 files / 4611 tests green**
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — n/a (no runtime environment in this session; covered by the suites below)

163 tests added or rewritten across `Sidebar`, `AppBar`, `UserMenu`, `NotificationPanel`, `SettingsHubPage`, plus four new suites. The two that matter most:

- **`reachability.test.tsx`** — the epic's central claim under test: every route behind a removed row still resolves. It parses `App.tsx`'s `<Route path>` set rather than rendering the tree (mocking every provider and lazy page would make the assertion close to tautological), with a count sanity check so a regex matching nothing fails rather than passes.
- **`useScrollRestoration.test.ts`** — the criterion most likely to regress silently, so it is tested directly rather than eyeballed. jsdom reports `0` for `scrollHeight`/`innerHeight`, so document geometry and rAF are stubbed and the restore is asserted on a real `window.scrollTo` call.

### Test Instructions

1. As an admin, open the drawer on desktop — 14 rows, no Circles / Notifications / User Settings / admin shortcuts, `Console` pinned at the foot.
2. Click `Console` → the drawer swaps to the five admin sections with "Back to library" on top. Navigate between two admin pages without returning to the hub.
3. On a 360px viewport at `/admin/settings`, confirm the drill-down list, the "Search settings" filter, and that scrolling down → opening a page → going back lands you where you left.
4. Switch circles from the top-bar chip; confirm the avatar menu no longer offers circles.

## Screenshots

Not captured — no browser in this session. The intended end state for all three breakpoints is drawn to scale in `docs/specs/assets/navigation-ia-mockups.html` (added in this PR); note the rail itself lands in #392, so tablet/desktop still show the drawer here, just carrying far fewer rows.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

**One honest interim regression:** on a 360px phone the toolbar was already at ~354px of its 360px budget (see `docs/audits/mobile-topbar-audit.md`), and the circle chip is net-new width there — the wordmark it "replaces" was already hidden below `sm`. The chip is the only shrinkable item in the row, so it truncates rather than overflowing, and the app shell can never be pushed sideways. This is transitional: #390 moves search out of the top bar into a tab and #392 deletes the hamburger, together returning ~80px.

**Not in this phase:** the navigation rail (#392). Tablet and desktop keep the drawer, simply carrying far fewer rows.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj

---
_Generated by [Claude Code](https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj)_