### PR TITLE
feat(web): Nav Phase 2 — the Review hub, one badged inbox for six queues

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -63,6 +63,8 @@ const DuplicateGroupPage = lazy(() => import('./pages/Duplicates/DuplicateGroupP
 const LocationSuggestionsPage = lazy(() => import('./pages/LocationSuggestions/LocationSuggestionsPage'));
 const LocationSuggestionRunRedirect = lazy(() => import('./pages/LocationSuggestions/LocationSuggestionRunRedirect'));
 const ReviewRunPage = lazy(() => import('./pages/Reviews/ReviewRunPage'));
+const ReviewHubPage = lazy(() => import('./pages/Reviews/ReviewHubPage'));
+const ReviewQueuePage = lazy(() => import('./pages/Reviews/ReviewQueuePage'));
 const ReviewInsightsPage = lazy(() => import('./pages/Insights/ReviewInsightsPage'));
 const ArchivePage = lazy(() => import('./pages/Archive/ArchivePage'));
 const TrashPage = lazy(() => import('./pages/Trash/TrashPage'));
@@ -180,6 +182,12 @@ function AppRoutes() {
                     when `features.memories` is off. */}
                 <Route path="/memories" element={<MemoriesPage />} />
                 <Route path="/memories/:id" element={<MemoryDetailPage />} />
+                {/* The Review hub (issue #390). It ADDS a namespace; it does not
+                    replace one — every queue's standalone route below still
+                    resolves, because bookmarks, the Home review banners and the
+                    `review_queue_*` notification links all point at them. */}
+                <Route path="/review" element={<ReviewHubPage />} />
+                <Route path="/review/:queue" element={<ReviewQueuePage />} />
                 <Route path="/bursts" element={<BurstsPage />} />
                 <Route path="/bursts/:id" element={<BurstGroupPage />} />
                 <Route path="/duplicates" element={<DuplicatesPage />} />

--- a/apps/web/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/web/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -1,24 +1,17 @@
 /**
- * Tests for the Library/Console Sidebar (issue #389, epic #388).
+ * Tests for the Library/Console Sidebar (issue #390, epic #388).
  *
- * The drawer now has exactly two modes, selected purely by `location.pathname`
- * (spec §3.2):
- *   - LIBRARY mode (any non-`/admin/*` route) renders the 14 primary rows.
- *   - CONSOLE mode (any `/admin/*` route) swaps the drawer's CONTENTS for the
- *     same permission-gated admin catalog `SettingsHubPage` renders, sourced
- *     from the single shared `config/adminSections.tsx` declaration, plus a
- *     "Back to library" affordance.
+ * Issue #390 collapses the five UTILITIES rows (Bursts, Duplicates, Location
+ * Suggestions, AI Enhancements, Workflows / Review Insights) into ONE badged
+ * "Review" row (spec §3.3 / §6.2 / §6.3). Library mode is now nine rows:
+ * Photos, Memories, Explore, Map, Albums, People, Archive, Trash, Review.
  *
- * Eight rows that used to live in the drawer are gone because each duplicates
- * chrome already on screen elsewhere (spec §1.2): Circles, Notifications,
- * User Settings (all now in the AppBar/UserMenu), and Job Queue / Worker
- * Nodes / Storage Insights / Public Sharing (now reachable only through
- * Console). This file asserts their absence explicitly, not just their
- * replacements' presence — a regression that silently reintroduces one of
- * them would otherwise pass every other assertion here.
+ * Console mode, aria-current handling, and the drawer plumbing are unchanged
+ * by this issue and are re-asserted here only to prove #390 didn't regress
+ * them, not because their logic moved.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, mockUser, mockAdminUser } from '../../utils/test-utils';
 import { Sidebar } from '../../../components/navigation/Sidebar';
@@ -52,10 +45,11 @@ vi.mock('../../../hooks/useWorkflowSubjects', () => ({
   useWorkflowsEnabled: vi.fn(),
 }));
 
-// The sidebar's "AI Enhancements" badge is the sole consumer of
-// GET /api/media/review-counts, and it only fires while the enhancer flag is
-// on (issue #204) — partial-mock the media service so these tests can assert
-// a request was (or was not) actually issued, not just what rendered.
+// The Review row's aggregate badge is the sole consumer of
+// GET /api/media/review-counts (via useReviewQueues -> useReviewCounts), and
+// it only fires while at least one counted queue feature is on (issue #204,
+// broadened by #390) — partial-mock the media service so these tests can
+// assert a request was (or was not) actually issued, not just what rendered.
 vi.mock('../../../services/media', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../services/media')>()),
   getReviewCounts: vi.fn(),
@@ -115,13 +109,13 @@ const ALL_ADMIN_PERMISSIONS = Array.from(
 // ---------------------------------------------------------------------------
 
 /**
- * Configure `useFeatureFlags` (drives both the AI Enhancements entry and,
- * transitively through the real `useMemoriesEnabled`, the Memories entry) and
+ * Configure `useFeatureFlags` (drives the Memories row and, transitively
+ * through `useReviewQueues`, the Review row's aggregate badge) and
  * `useWorkflowsEnabled`.
  *
  * `null` for either boolean means "flag not resolved yet" (hidden); a
  * boolean resolves it. `pendingEnhancements` seeds the review-counts response
- * consumed by the AI Enhancements badge; omit to leave that request
+ * consumed by the Review row's badge total; omit to leave that request
  * permanently in flight.
  */
 function mockFlags(options: {
@@ -172,7 +166,7 @@ function mockFlags(options: {
   }
 }
 
-/** All three optional flags resolved ON, for the "14 rows" catalog test. */
+/** All three optional flags resolved ON, for the "9 rows" catalog test. */
 function mockAllFlagsOn(pendingEnhancements = 0) {
   mockFlags({ pictureEnhancement: true, memories: true, workflows: true, pendingEnhancements });
 }
@@ -181,7 +175,7 @@ function mockAllFlagsOn(pendingEnhancements = 0) {
 // Shared row-name catalogs
 // ---------------------------------------------------------------------------
 
-/** The full 14-row Library catalog when every optional flag is enabled. */
+/** The full 9-row Library catalog when every optional flag is enabled. */
 const LIBRARY_ALL_FLAGS_ROWS = [
   'Photos',
   'Memories',
@@ -191,12 +185,7 @@ const LIBRARY_ALL_FLAGS_ROWS = [
   'People',
   'Archive',
   'Trash',
-  'Review Bursts',
-  'Review Duplicates',
-  'Review Insights',
-  'Location Suggestions',
-  'Workflows',
-  'AI Enhancements',
+  'Review',
 ];
 
 /** Rows that used to exist and must never reappear in Library mode. */
@@ -211,6 +200,20 @@ const REMOVED_LIBRARY_ROWS = [
   'Public Sharing',
 ];
 
+/**
+ * The five UTILITIES rows issue #390 collapsed into the single "Review" row.
+ * Their old labels (from the pre-#390 drawer) must never reappear as
+ * standalone Sidebar rows in Library mode.
+ */
+const REMOVED_UTILITIES_ROWS = [
+  'Review Bursts',
+  'Review Duplicates',
+  'Review Insights',
+  'Location Suggestions',
+  'Workflows',
+  'AI Enhancements',
+];
+
 describe('Sidebar', () => {
   const mockOnClose = vi.fn();
 
@@ -221,11 +224,11 @@ describe('Sidebar', () => {
   });
 
   // =========================================================================
-  // Library mode — the 14-row catalog (Required case 1)
+  // Library mode — the 9-row catalog
   // =========================================================================
 
   describe('Library mode', () => {
-    it('renders exactly the 14 expected rows with every flag on, and nothing else', () => {
+    it('renders exactly the 9 expected rows with every flag on, and nothing else', () => {
       setNonAdmin();
       mockAllFlagsOn();
 
@@ -250,6 +253,18 @@ describe('Sidebar', () => {
       });
     });
 
+    it('never renders the old UTILITIES rows (Bursts, Duplicates, Location Suggestions, Workflows, AI Enhancements) or a "Utilities" heading — they collapsed into the single Review row', () => {
+      setNonAdmin();
+      mockAllFlagsOn();
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      REMOVED_UTILITIES_ROWS.forEach((label) => {
+        expect(screen.queryByText(label)).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText('Utilities')).not.toBeInTheDocument();
+    });
+
     it('renders the same removed rows check for an admin viewer too (Library mode ignores role)', () => {
       setAdmin(ALL_ADMIN_PERMISSIONS);
       mockAllFlagsOn();
@@ -266,27 +281,58 @@ describe('Sidebar', () => {
       expect(screen.getByText('Console')).toBeInTheDocument();
     });
 
-    it('drops Memories, Workflows, and AI Enhancements when their flags are off/unresolved', () => {
+    it('drops Memories when its flag is off/unresolved, but keeps the other 8 rows', () => {
       setNonAdmin();
       mockFlags({ pictureEnhancement: false, memories: false, workflows: false });
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
       expect(screen.queryByText('Memories')).not.toBeInTheDocument();
-      expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
-      expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
 
-      // The 9 rows that are never flag-gated still render.
-      ['Photos', 'Explore', 'Map', 'Albums', 'People', 'Archive', 'Trash', 'Review Bursts', 'Review Duplicates', 'Review Insights', 'Location Suggestions'].forEach(
+      ['Photos', 'Explore', 'Map', 'Albums', 'People', 'Archive', 'Trash', 'Review'].forEach(
         (label) => {
           expect(screen.getByText(label)).toBeInTheDocument();
         },
       );
     });
+
+    // =======================================================================
+    // The Review row is unconditional (spec §6.3) — "do not regress" rules
+    // =======================================================================
+
+    describe('Review row — unconditional rendering (spec §6.3)', () => {
+      it('renders even when every review feature (bursts/duplicates/locations/enhancements/workflows) is off', () => {
+        setNonAdmin();
+        mockFlags({ pictureEnhancement: false, memories: false, workflows: false });
+
+        render(<Sidebar open={true} onClose={mockOnClose} />);
+
+        expect(screen.getByText('Review')).toBeInTheDocument();
+      });
+
+      it('renders even when every review feature is unresolved (null)', () => {
+        setNonAdmin();
+        mockFlags({ pictureEnhancement: null, memories: null, workflows: null });
+
+        render(<Sidebar open={true} onClose={mockOnClose} />);
+
+        expect(screen.getByText('Review')).toBeInTheDocument();
+      });
+
+      it('renders even when the aggregate pending count is zero', async () => {
+        setNonAdmin();
+        mockFlags({ pictureEnhancement: true, pendingEnhancements: 0 });
+
+        render(<Sidebar open={true} onClose={mockOnClose} />);
+
+        await waitFor(() => expect(mockGetReviewCounts).toHaveBeenCalled());
+        expect(screen.getByText('Review')).toBeInTheDocument();
+      });
+    });
   });
 
   // =========================================================================
-  // Console mode (Required cases 2-4)
+  // Console mode (unchanged by #390 — re-asserted as a non-regression check)
   // =========================================================================
 
   describe('Console mode', () => {
@@ -324,11 +370,6 @@ describe('Sidebar', () => {
       LIBRARY_ALL_FLAGS_ROWS.filter((label) => label !== 'Memories').forEach((label) => {
         expect(screen.queryByText(label)).not.toBeInTheDocument();
       });
-
-      // The Library "Memories" row specifically is confirmed absent by
-      // checking it isn't reachable via /memories (the admin card instead
-      // targets /admin/settings/memories) — see the Console navigation test
-      // for "Memories" -> "/admin/settings/memories".
     });
 
     it('never renders the Console mode-switch affordance while already in Console mode', () => {
@@ -423,7 +464,7 @@ describe('Sidebar', () => {
   });
 
   // =========================================================================
-  // aria-current (Required case 5, spec §7)
+  // aria-current="page"
   // =========================================================================
 
   describe('aria-current="page"', () => {
@@ -473,14 +514,24 @@ describe('Sidebar', () => {
       expect(insightsButton.classList.contains('Mui-selected')).toBe(true);
       expect(jobQueueButton.classList.contains('Mui-selected')).toBe(false);
     });
+
+    it('is set on the Review row when standing on one of the routes it owns', () => {
+      mockLocation.pathname = '/bursts';
+      setNonAdmin();
+
+      render(<Sidebar open={true} onClose={mockOnClose} />);
+
+      const reviewButton = screen.getByText('Review').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(reviewButton).toHaveAttribute('aria-current', 'page');
+    });
   });
 
   // =========================================================================
-  // Segment-boundary matching (Required case 6, spec §3.5)
+  // Segment-boundary matching (spec §3.5)
   // =========================================================================
 
-  describe('segment-boundary matching (owns())', () => {
-    it('activates no row at /reviewer (must not fuzzy-match "Review ..." rows)', () => {
+  describe('segment-boundary matching', () => {
+    it('activates no row at /reviewer (must not fuzzy-match the Review row)', () => {
       mockLocation.pathname = '/reviewer';
       setNonAdmin();
 
@@ -490,14 +541,14 @@ describe('Sidebar', () => {
       expect(selected).toHaveLength(0);
     });
 
-    it('does not activate "Review Bursts" at /burstsfoo', () => {
+    it('does not activate Review at /burstsfoo', () => {
       mockLocation.pathname = '/burstsfoo';
       setNonAdmin();
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      const burstsButton = screen.getByText('Review Bursts').closest('.MuiListItemButton-root') as HTMLElement;
-      expect(burstsButton.classList.contains('Mui-selected')).toBe(false);
+      const reviewButton = screen.getByText('Review').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(reviewButton.classList.contains('Mui-selected')).toBe(false);
     });
 
     it('activates Photos ONLY on an exact match at /', () => {
@@ -513,15 +564,41 @@ describe('Sidebar', () => {
       expect(selected).toHaveLength(1);
     });
 
-    it('activates a nested route via a genuine segment boundary (e.g. /bursts/some-id activates Review Bursts)', () => {
+    it('activates Review via a genuine segment boundary (e.g. /bursts/some-id)', () => {
       mockLocation.pathname = '/bursts/some-id';
       setNonAdmin();
 
       render(<Sidebar open={true} onClose={mockOnClose} />);
 
-      const burstsButton = screen.getByText('Review Bursts').closest('.MuiListItemButton-root') as HTMLElement;
-      expect(burstsButton.classList.contains('Mui-selected')).toBe(true);
+      const reviewButton = screen.getByText('Review').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(reviewButton.classList.contains('Mui-selected')).toBe(true);
     });
+  });
+
+  // =========================================================================
+  // The Review row owns nine route prefixes that don't resemble /review
+  // (spec §3.5) — a path-prefix match on the item's own path cannot express
+  // this, so it is driven by `resolveActiveDestination` instead. This is the
+  // whole point of the destination model, so cover several non-/review paths.
+  // =========================================================================
+
+  describe('Review row activation via resolveActiveDestination (spec §3.5)', () => {
+    it.each(['/review', '/bursts', '/bursts/some-id', '/workflows', '/review-insights'])(
+      'is the sole active row at %s',
+      (path) => {
+        mockLocation.pathname = path;
+        setNonAdmin();
+
+        const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
+
+        const reviewButton = screen.getByText('Review').closest('.MuiListItemButton-root') as HTMLElement;
+        expect(reviewButton.classList.contains('Mui-selected')).toBe(true);
+        expect(reviewButton).toHaveAttribute('aria-current', 'page');
+
+        const selected = container.querySelectorAll('.Mui-selected');
+        expect(selected).toHaveLength(1);
+      },
+    );
   });
 
   // =========================================================================
@@ -557,7 +634,7 @@ describe('Sidebar', () => {
   });
 
   // =========================================================================
-  // Navigation targets for a sample of rows
+  // Navigation targets for every Library row
   // =========================================================================
 
   describe('Navigation targets', () => {
@@ -569,10 +646,7 @@ describe('Sidebar', () => {
       ['People', '/people'],
       ['Archive', '/archive'],
       ['Trash', '/trash'],
-      ['Review Bursts', '/bursts'],
-      ['Review Duplicates', '/duplicates'],
-      ['Review Insights', '/review-insights'],
-      ['Location Suggestions', '/location-suggestions'],
+      ['Review', '/review'],
     ])('navigates to %s -> %s', async (label, path) => {
       setNonAdmin();
       render(<Sidebar open={true} onClose={mockOnClose} />);
@@ -584,42 +658,14 @@ describe('Sidebar', () => {
   });
 
   // =========================================================================
-  // AI Enhancements entry — flag gate + badge (issue #201/#204, preserved)
+  // Review row badge (issue #201/#204 precedent, re-pointed by #390 —
+  // the badge is no longer a distinct "AI Enhancements" row; it is the
+  // Review row's aggregate total, exercised here through the single
+  // pictureEnhancement flag for a deterministic, single-source count).
   // =========================================================================
 
-  describe('AI Enhancements entry', () => {
-    it('is hidden while the flag is unresolved', () => {
-      setNonAdmin();
-      mockFlags({ pictureEnhancement: null });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
-    });
-
-    it('is hidden when disabled', () => {
-      setNonAdmin();
-      mockFlags({ pictureEnhancement: false });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      expect(screen.queryByText('AI Enhancements')).not.toBeInTheDocument();
-    });
-
-    it('renders under Utilities and navigates to /enhancements when enabled', async () => {
-      setNonAdmin();
-      mockFlags({ pictureEnhancement: true });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const utilitiesList = screen.getByText('Utilities').closest('.MuiList-root') as HTMLElement;
-      expect(within(utilitiesList).getByText('AI Enhancements')).toBeInTheDocument();
-
-      fireEvent.click(screen.getByText('AI Enhancements').closest('.MuiListItemButton-root') as HTMLElement);
-      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/enhancements'));
-    });
-
-    it('renders the pending count as a badge', async () => {
+  describe('Review row badge', () => {
+    it('renders the pending count as a badge and in the accessible name', async () => {
       setNonAdmin();
       mockFlags({ pictureEnhancement: true, pendingEnhancements: 7 });
 
@@ -627,9 +673,12 @@ describe('Sidebar', () => {
       await waitFor(() => {
         expect(container.querySelector('.MuiBadge-badge')!.textContent).toBe('7');
       });
+
+      const reviewButton = screen.getByText('Review').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(reviewButton).toHaveAttribute('aria-label', 'Review, 7 items pending');
     });
 
-    it('caps the badge at 999+', async () => {
+    it('caps the visible badge at 999+ (the underlying count is unrounded elsewhere)', async () => {
       setNonAdmin();
       mockFlags({ pictureEnhancement: true, pendingEnhancements: 1500 });
 
@@ -639,22 +688,26 @@ describe('Sidebar', () => {
       });
     });
 
-    it('renders no badge when the pending count is zero', async () => {
+    it('renders no badge when the pending count is zero, and the accessible name carries no count phrase', async () => {
       setNonAdmin();
       mockFlags({ pictureEnhancement: true, pendingEnhancements: 0 });
 
       const { container } = render(<Sidebar open={true} onClose={mockOnClose} />);
       await waitFor(() => expect(mockGetReviewCounts).toHaveBeenCalled());
       expect(container.querySelector('.MuiBadge-badge')).toBeNull();
+
+      const reviewButton = screen.getByText('Review').closest('.MuiListItemButton-root') as HTMLElement;
+      expect(reviewButton).toHaveAttribute('aria-label', 'Review');
     });
   });
 
   // =========================================================================
-  // Review-counts request gating (issue #204, preserved)
+  // Review-counts request gating (issue #204, broadened by #390 to "any
+  // review feature enabled", re-pointed at the Review row's own wiring).
   // =========================================================================
 
   describe('Review-counts request gating', () => {
-    it('issues no request while the enhancer flag is unresolved or disabled', async () => {
+    it('issues no request while every review feature is unresolved or off', async () => {
       setNonAdmin();
       mockFlags({ pictureEnhancement: null });
       render(<Sidebar open={true} onClose={mockOnClose} />);
@@ -662,7 +715,7 @@ describe('Sidebar', () => {
       expect(mockGetReviewCounts).not.toHaveBeenCalled();
     });
 
-    it('requests counts for the active circle when enabled, and never calls the full dashboard', async () => {
+    it('requests counts for the active circle once a review feature is enabled, and never calls the full dashboard', async () => {
       setNonAdmin();
       mockFlags({ pictureEnhancement: true, pendingEnhancements: 3 });
 
@@ -676,7 +729,7 @@ describe('Sidebar', () => {
   });
 
   // =========================================================================
-  // Memories entry (issue #309, preserved)
+  // Memories entry (issue #309, preserved — unaffected by #390)
   // =========================================================================
 
   describe('Memories entry', () => {
@@ -703,39 +756,6 @@ describe('Sidebar', () => {
       expect(screen.getByText('Memories')).toBeInTheDocument();
       fireEvent.click(screen.getByText('Memories'));
       await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/memories'));
-    });
-  });
-
-  // =========================================================================
-  // Workflows entry
-  // =========================================================================
-
-  describe('Workflows entry', () => {
-    it('is hidden while unresolved', () => {
-      setNonAdmin();
-      mockFlags({ workflows: null });
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-      expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
-    });
-
-    it('is hidden when disabled', () => {
-      setNonAdmin();
-      mockFlags({ workflows: false });
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-      expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
-    });
-
-    it('renders under Utilities and navigates to /workflows when enabled', async () => {
-      setNonAdmin();
-      mockFlags({ workflows: true });
-
-      render(<Sidebar open={true} onClose={mockOnClose} />);
-
-      const utilitiesList = screen.getByText('Utilities').closest('.MuiList-root') as HTMLElement;
-      expect(within(utilitiesList).getByText('Workflows')).toBeInTheDocument();
-
-      fireEvent.click(screen.getByText('Workflows'));
-      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/workflows'));
     });
   });
 

--- a/apps/web/src/__tests__/components/review/ReviewQueueList.test.tsx
+++ b/apps/web/src/__tests__/components/review/ReviewQueueList.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Tests for ReviewQueueList (issue #390, spec §4.5).
+ *
+ * The one Review-inbox list rendered at the hub (and, from #392, the desktop
+ * context pane). `useReviewQueues` is mocked directly so each case can drive
+ * the resolved entry list without touching feature flags or the network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import { render } from '../../utils/test-utils';
+import { ReviewQueueList, reviewQueuePath } from '../../../components/review/ReviewQueueList';
+import { REVIEW_QUEUES, type ReviewQueueKey } from '../../../config/reviewQueues';
+import type { ResolvedReviewQueue } from '../../../hooks/useReviewQueues';
+
+vi.mock('../../../hooks/useReviewQueues', () => ({
+  useReviewQueues: vi.fn(),
+}));
+
+import { useReviewQueues } from '../../../hooks/useReviewQueues';
+
+const mockUseReviewQueues = vi.mocked(useReviewQueues);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build resolved entries from the real registry so labels/icons/paths stay
+ * in sync with the shipped config rather than being hand-duplicated here. */
+function buildEntries(
+  counts: Partial<Record<ReviewQueueKey, number | null>>,
+  enabledKeys: ReviewQueueKey[],
+): ResolvedReviewQueue[] {
+  return REVIEW_QUEUES.filter((def) => enabledKeys.includes(def.key)).map((def) => ({
+    ...def,
+    count: def.countKey ? (counts[def.key] ?? null) : null,
+  }));
+}
+
+const ALL_QUEUE_KEYS: ReviewQueueKey[] = ['bursts', 'duplicates', 'locations', 'enhancements'];
+const ALL_KEYS: ReviewQueueKey[] = [...ALL_QUEUE_KEYS, 'insights', 'automations'];
+/** Fixed registry order, per spec §4.5 requirement 2. */
+const REGISTRY_ORDER = REVIEW_QUEUES.map((d) => d.key);
+
+function mockResult(overrides: Partial<ReturnType<typeof useReviewQueues>>) {
+  mockUseReviewQueues.mockReturnValue({
+    entries: [],
+    counts: null,
+    totalPending: 0,
+    isLoading: false,
+    anyEnabled: true,
+    ...overrides,
+  });
+}
+
+describe('ReviewQueueList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Fixed registry order — never sorted by count
+  // =========================================================================
+
+  it('renders enabled entries in fixed registry order, unaffected by count changes', () => {
+    const entries1 = buildEntries(
+      { bursts: 4, duplicates: 6, locations: 2, enhancements: 0 },
+      ALL_KEYS,
+    );
+    mockResult({ entries: entries1, anyEnabled: true });
+
+    const { rerender } = render(<ReviewQueueList variant="hub" />);
+
+    const namesBefore = screen.getAllByRole('link').map((el) => el.getAttribute('aria-label'));
+    const keysBefore = REGISTRY_ORDER.filter((key) => ALL_KEYS.includes(key));
+    expect(namesBefore).toHaveLength(keysBefore.length);
+
+    // Wildly different counts, same set of enabled entries.
+    const entries2 = buildEntries(
+      { bursts: 0, duplicates: 1, locations: 99, enhancements: 3 },
+      ALL_KEYS,
+    );
+    mockResult({ entries: entries2, anyEnabled: true });
+    rerender(<ReviewQueueList variant="hub" />);
+
+    const namesAfter = screen.getAllByRole('link').map((el) => el.getAttribute('aria-label'));
+
+    // Extract the row KEY order from the aria-labels via their known labels,
+    // rather than the (count-dependent) full strings.
+    const labelToKey = new Map(REVIEW_QUEUES.map((d) => [d.label, d.key]));
+    const keyOrder = (labels: (string | null)[]) =>
+      labels.map((label) => {
+        const bareLabel = (label ?? '').split(',')[0];
+        return labelToKey.get(bareLabel);
+      });
+
+    expect(keyOrder(namesAfter)).toEqual(keyOrder(namesBefore));
+    expect(keyOrder(namesBefore)).toEqual(keysBefore);
+  });
+
+  // =========================================================================
+  // Drained queue reads as an em dash, never "0"
+  // =========================================================================
+
+  it('renders a drained queue as an em dash, not "0"', () => {
+    const entries = buildEntries({ bursts: 0, duplicates: 5 }, ['bursts', 'duplicates']);
+    mockResult({ entries, anyEnabled: true });
+
+    render(<ReviewQueueList variant="hub" />);
+
+    const burstsLink = screen.getByRole('link', { name: 'Bursts, none pending' });
+    expect(within(burstsLink).getByText('—')).toBeInTheDocument();
+    expect(within(burstsLink).queryByText('0')).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Accessible names carry the count
+  // =========================================================================
+
+  describe('accessible names', () => {
+    it('carries the count for a pending queue: "Bursts, 4 pending"', () => {
+      const entries = buildEntries({ bursts: 4 }, ['bursts']);
+      mockResult({ entries, anyEnabled: true });
+
+      render(<ReviewQueueList variant="hub" />);
+
+      expect(screen.getByRole('link', { name: 'Bursts, 4 pending' })).toBeInTheDocument();
+    });
+
+    it('reads "none pending" at zero', () => {
+      // A second, non-zero queue keeps this out of the all-clear state so the
+      // zero-count row itself is asserted, not the all-clear takeover.
+      const entries = buildEntries({ bursts: 0, duplicates: 5 }, ['bursts', 'duplicates']);
+      mockResult({ entries, anyEnabled: true });
+
+      render(<ReviewQueueList variant="hub" />);
+
+      expect(screen.getByRole('link', { name: 'Bursts, none pending' })).toBeInTheDocument();
+    });
+
+    it('secondary entries carry just their label, with no count phrasing', () => {
+      const entries = buildEntries({}, ['insights', 'automations']);
+      mockResult({ entries, anyEnabled: true });
+
+      render(<ReviewQueueList variant="hub" />);
+
+      expect(screen.getByRole('link', { name: 'Insights' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Automations' })).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Rows are real, focusable links
+  // =========================================================================
+
+  it('rows are real anchors with the correct href, and are keyboard-focusable', () => {
+    const entries = buildEntries({ bursts: 4 }, ['bursts']);
+    mockResult({ entries, anyEnabled: true });
+
+    render(<ReviewQueueList variant="hub" />);
+
+    const link = screen.getByRole('link', { name: 'Bursts, 4 pending' });
+    expect(link.tagName).toBe('A');
+    expect(link.getAttribute('href')).toBe(reviewQueuePath('bursts'));
+    expect(reviewQueuePath('bursts')).toBe('/review/bursts');
+
+    link.focus();
+    expect(link).toHaveFocus();
+  });
+
+  // =========================================================================
+  // All-clear state
+  // =========================================================================
+
+  describe('all-clear state', () => {
+    it('shows ONE all-clear state when every queue is drained, not four rows of 0', () => {
+      const entries = buildEntries(
+        { bursts: 0, duplicates: 0, locations: 0, enhancements: 0 },
+        ALL_KEYS,
+      );
+      mockResult({ entries, anyEnabled: true });
+
+      render(<ReviewQueueList variant="hub" />);
+
+      expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
+      ALL_QUEUE_KEYS.forEach((key) => {
+        const def = REVIEW_QUEUES.find((d) => d.key === key)!;
+        expect(screen.queryByRole('link', { name: new RegExp(`^${def.label}`) })).not.toBeInTheDocument();
+      });
+    });
+
+    it('still renders Insights and Automations below the all-clear state', () => {
+      const entries = buildEntries(
+        { bursts: 0, duplicates: 0, locations: 0, enhancements: 0 },
+        ALL_KEYS,
+      );
+      mockResult({ entries, anyEnabled: true });
+
+      render(<ReviewQueueList variant="hub" />);
+
+      expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Insights' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Automations' })).toBeInTheDocument();
+    });
+
+    it('does NOT show the all-clear state when a queue count has not loaded yet (null)', () => {
+      // bursts is drained, but duplicates has not resolved a count yet — this
+      // must not be mistaken for "drained too".
+      const entries = buildEntries({ bursts: 0, duplicates: null }, ['bursts', 'duplicates']);
+      mockResult({ entries, anyEnabled: true });
+
+      render(<ReviewQueueList variant="hub" />);
+
+      expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument();
+      // The unloaded row renders (as an em dash) but its accessible name
+      // carries no "none pending" claim — that would state the opposite of
+      // the truth while the request is still in flight.
+      const duplicatesLink = screen.getByRole('link', { name: 'Duplicates' });
+      expect(within(duplicatesLink).getByText('—')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Loading / all-disabled / no-queues states
+  // =========================================================================
+
+  it('shows a spinner while loading, and no rows', () => {
+    mockResult({ entries: [], isLoading: true, anyEnabled: true });
+
+    render(<ReviewQueueList variant="hub" />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows the all-disabled empty state when no review feature is enabled at all', () => {
+    mockResult({ entries: [], isLoading: false, anyEnabled: false });
+
+    render(<ReviewQueueList variant="hub" />);
+
+    expect(screen.getByText(/no review features are enabled/i)).toBeInTheDocument();
+  });
+
+  it('shows a "no queues enabled" message when only secondary entries resolve', () => {
+    const entries = buildEntries({}, ['insights', 'automations']);
+    mockResult({ entries, anyEnabled: true });
+
+    render(<ReviewQueueList variant="hub" />);
+
+    expect(screen.getByText(/no review queues are enabled/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Insights' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Automations' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/config/destinations.test.ts
+++ b/apps/web/src/__tests__/config/destinations.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the destination model (issue #390, epic #388, spec §3.5).
+ *
+ * The route-ownership guard mirrors `navigation/reachability.test.tsx`'s
+ * approach: it statically parses the ACTUAL `src/App.tsx` for its declared
+ * `<Route path="...">` set, rather than hand-maintaining a second "known
+ * routes" list here that could silently drift from the real router. That is
+ * what makes this a genuine regression guard — a future route addition that
+ * forgets to extend `DESTINATION_ROUTES` (or that collides with an existing
+ * prefix) fails this file, not just a manual QA pass.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  owns,
+  resolveActiveDestination,
+  DESTINATION_ROUTES,
+  UNOWNED_ROUTES,
+  type DestinationKey,
+} from '../../config/destinations';
+
+// ---------------------------------------------------------------------------
+// Parse the live App.tsx route table (same technique as reachability.test.tsx)
+// ---------------------------------------------------------------------------
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_TSX_PATH = resolve(HERE, '../../App.tsx');
+
+function extractRoutePaths(source: string): string[] {
+  const matches = source.matchAll(/<Route\s+path="([^"]+)"/g);
+  return Array.from(matches, (m) => m[1]);
+}
+
+/** `:param` segments carry no meaning for prefix ownership, but a concrete
+ * value keeps the fixture honest about what a real URL looks like. */
+function normalizeParams(path: string): string {
+  return path.replace(/:[^/]+/g, 'sample-id');
+}
+
+const appSource = readFileSync(APP_TSX_PATH, 'utf-8');
+const rawRoutePaths = Array.from(new Set(extractRoutePaths(appSource)));
+const normalizedRoutePaths = Array.from(new Set(rawRoutePaths.map(normalizeParams)));
+
+/** Every destination whose prefix table owns `path`, independent of the
+ * longest-prefix tie-break `resolveActiveDestination` applies — this is what
+ * lets the "at most one owner" assertion catch a genuine collision even when
+ * `resolveActiveDestination` would silently pick a winner. */
+function owningDestinations(path: string): DestinationKey[] {
+  return (Object.entries(DESTINATION_ROUTES) as [DestinationKey, readonly string[]][])
+    .filter(([, prefixes]) => prefixes.some((prefix) => owns(prefix, path)))
+    .map(([key]) => key);
+}
+
+describe('destinations config', () => {
+  // ===========================================================================
+  // Parser sanity check — guards the guard, same rationale as reachability.test.tsx
+  // ===========================================================================
+
+  it('parses a realistic number of routes out of App.tsx', () => {
+    expect(rawRoutePaths.length).toBeGreaterThan(40);
+  });
+
+  // ===========================================================================
+  // Required case 1: a route is owned by AT MOST one destination
+  // ===========================================================================
+
+  describe('route ownership — at most one destination per route', () => {
+    it.each(normalizedRoutePaths)('%s is owned by zero or one destination, never two', (path) => {
+      const owners = owningDestinations(path);
+      expect(owners.length).toBeLessThanOrEqual(1);
+    });
+
+    it('resolveActiveDestination never throws and agrees with the ownership count for every declared route', () => {
+      normalizedRoutePaths.forEach((path) => {
+        const owners = owningDestinations(path);
+        const resolved = resolveActiveDestination(path);
+        if (owners.length === 0) {
+          expect(resolved).toBeNull();
+        } else {
+          expect(resolved).toBe(owners[0]);
+        }
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Required case 3: specific routes resolve to null, asserted deliberately
+  // ===========================================================================
+
+  describe('UNOWNED_ROUTES resolve to no destination', () => {
+    it.each(UNOWNED_ROUTES)('%s resolves to null', (path) => {
+      expect(resolveActiveDestination(path)).toBeNull();
+    });
+
+    // Pinned individually too, so a future contributor cannot "fix" one of
+    // these into highlighting something arbitrary without this file noticing.
+    it.each(['/settings', '/profile', '/circles', '/notifications'])(
+      '%s resolves to null (not some other destination)',
+      (path) => {
+        expect(resolveActiveDestination(path)).toBeNull();
+      },
+    );
+  });
+
+  // ===========================================================================
+  // Required case 2: boundary matching
+  // ===========================================================================
+
+  describe('segment-boundary matching', () => {
+    it('/reviewer does NOT activate Review', () => {
+      expect(resolveActiveDestination('/reviewer')).not.toBe('review');
+      expect(resolveActiveDestination('/reviewer')).toBeNull();
+    });
+
+    it('/burstsfoo does NOT activate Review', () => {
+      expect(resolveActiveDestination('/burstsfoo')).not.toBe('review');
+      expect(resolveActiveDestination('/burstsfoo')).toBeNull();
+    });
+
+    it('/media-something does NOT activate Photos', () => {
+      expect(resolveActiveDestination('/media-something')).not.toBe('photos');
+      expect(resolveActiveDestination('/media-something')).toBeNull();
+    });
+
+    it('/ activates Photos, and ONLY on exact match', () => {
+      expect(resolveActiveDestination('/')).toBe('photos');
+      expect(resolveActiveDestination('/photos')).not.toBe('photos');
+    });
+
+    it('/review-insights activates Review via its OWN prefix — it is not a child of /review', () => {
+      // The subtle one: a bare `startsWith('/review')` would also match this,
+      // but `owns('/review', ...)` requires a `/` continuation, so it does NOT.
+      expect(owns('/review', '/review-insights')).toBe(false);
+      expect(resolveActiveDestination('/review-insights')).toBe('review');
+    });
+
+    it('/review-runs/x activates Review via its OWN prefix — it is not a child of /review', () => {
+      expect(owns('/review', '/review-runs/x')).toBe(false);
+      expect(resolveActiveDestination('/review-runs/x')).toBe('review');
+    });
+  });
+
+  // ===========================================================================
+  // Nested routes resolve to their parent destination
+  // ===========================================================================
+
+  describe('nested routes resolve to their parent', () => {
+    it.each([
+      ['/albums/sample-id', 'collections'],
+      ['/bursts/sample-id', 'review'],
+      ['/workflows/sample-id/runs/sample-id', 'review'],
+      ['/admin/settings/jobs', 'console'],
+    ] as const)('%s -> %s', (path, expected) => {
+      expect(resolveActiveDestination(path)).toBe(expected);
+    });
+  });
+
+  // ===========================================================================
+  // owns() — the primitive every rule above is built on
+  // ===========================================================================
+
+  describe('owns()', () => {
+    it('matches the exact prefix', () => {
+      expect(owns('/review', '/review')).toBe(true);
+    });
+
+    it('matches a child at a genuine segment boundary', () => {
+      expect(owns('/review', '/review/bursts')).toBe(true);
+    });
+
+    it('rejects a same-string-prefix that is not a segment child', () => {
+      expect(owns('/review', '/reviewer')).toBe(false);
+    });
+
+    it('"/" matches only the exact root, never every path', () => {
+      expect(owns('/', '/')).toBe(true);
+      expect(owns('/', '/anything')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/__tests__/hooks/useReviewCounts.test.ts
+++ b/apps/web/src/__tests__/hooks/useReviewCounts.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import { useReviewCounts } from '../../hooks/useReviewCounts';
+import {
+  useReviewCounts,
+  refreshReviewCounts,
+  __resetReviewCountsForTests,
+} from '../../hooks/useReviewCounts';
 import type { ReviewCountsResponse } from '../../types/media';
 
 // ---------------------------------------------------------------------------
@@ -64,6 +68,7 @@ function setCircle(id: string | null) {
 describe('useReviewCounts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetReviewCountsForTests();
   });
 
   // -------------------------------------------------------------------------
@@ -354,6 +359,125 @@ describe('useReviewCounts', () => {
       await waitFor(() => {
         expect(result.current.data?.pendingEnhancements).toBe(42);
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Shared refresh signal (issue #390, spec §4.5 requirement 1).
+  //
+  // More than one surface renders these counts at once — the Review hub's
+  // queue list and the sidebar's aggregate badge. `refreshReviewCounts()` is
+  // what keeps them from disagreeing: it bumps a module-level revision every
+  // mounted `useReviewCounts` instance observes, so a refresh triggered by ONE
+  // consumer refetches ALL of them together.
+  // -------------------------------------------------------------------------
+  describe('shared refresh signal', () => {
+    beforeEach(() => {
+      setCircle('circle-abc');
+      mockGetReviewCounts.mockResolvedValue(mockCounts);
+    });
+
+    it('refreshReviewCounts() triggers a refetch on a mounted, enabled instance', async () => {
+      const { result } = renderHook(() => useReviewCounts());
+
+      await waitFor(() => expect(result.current.data).not.toBeNull());
+      const callsBefore = mockGetReviewCounts.mock.calls.length;
+
+      act(() => {
+        refreshReviewCounts();
+      });
+
+      await waitFor(() => {
+        expect(mockGetReviewCounts.mock.calls.length).toBe(callsBefore + 1);
+      });
+    });
+
+    it('a single refreshReviewCounts() call refetches EVERY mounted instance, not just one', async () => {
+      const first = renderHook(() => useReviewCounts());
+      const second = renderHook(() => useReviewCounts());
+
+      await waitFor(() => expect(first.result.current.data).not.toBeNull());
+      await waitFor(() => expect(second.result.current.data).not.toBeNull());
+      const callsBefore = mockGetReviewCounts.mock.calls.length;
+
+      act(() => {
+        refreshReviewCounts();
+      });
+
+      // Both instances issued their own request — the shared piece is only
+      // the SIGNAL, not the data or the request itself (see the hook's header
+      // comment on what is deliberately not shared).
+      await waitFor(() => {
+        expect(mockGetReviewCounts.mock.calls.length).toBe(callsBefore + 2);
+      });
+    });
+
+    it('both instances converge on a value changed between the two fetches', async () => {
+      const a = renderHook(() => useReviewCounts());
+      const b = renderHook(() => useReviewCounts());
+
+      await waitFor(() => expect(a.result.current.data).toEqual(mockCounts));
+      await waitFor(() => expect(b.result.current.data).toEqual(mockCounts));
+
+      const updated = { ...mockCounts, pendingEnhancements: 99 };
+      mockGetReviewCounts.mockResolvedValue(updated);
+
+      act(() => {
+        refreshReviewCounts();
+      });
+
+      await waitFor(() => expect(a.result.current.data).toEqual(updated));
+      await waitFor(() => expect(b.result.current.data).toEqual(updated));
+    });
+
+    it('does NOT refetch a disabled instance — enabled: false still issues no request on a shared refresh', async () => {
+      const { result } = renderHook(() => useReviewCounts({ enabled: false }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(mockGetReviewCounts).not.toHaveBeenCalled();
+
+      act(() => {
+        refreshReviewCounts();
+      });
+
+      // Give any stray effect a chance to fire before asserting the negative.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockGetReviewCounts).not.toHaveBeenCalled();
+      expect(result.current.data).toBeNull();
+    });
+
+    it('a disabled instance ignores the signal even while an enabled sibling instance refetches', async () => {
+      const enabled = renderHook(() => useReviewCounts({ enabled: true }));
+      const disabled = renderHook(() => useReviewCounts({ enabled: false }));
+
+      await waitFor(() => expect(enabled.result.current.data).not.toBeNull());
+      const callsBefore = mockGetReviewCounts.mock.calls.length;
+
+      act(() => {
+        refreshReviewCounts();
+      });
+
+      await waitFor(() => {
+        expect(mockGetReviewCounts.mock.calls.length).toBe(callsBefore + 1);
+      });
+      expect(disabled.result.current.data).toBeNull();
+    });
+
+    it('__resetReviewCountsForTests() leaves the hook in a normal working state for the next test', async () => {
+      // Bump the revision a few times, then reset — a subsequent mount must
+      // still fetch exactly once on its own, with no residual pending signal
+      // from before the reset.
+      act(() => {
+        refreshReviewCounts();
+        refreshReviewCounts();
+      });
+      __resetReviewCountsForTests();
+      mockGetReviewCounts.mockClear();
+
+      const { result } = renderHook(() => useReviewCounts());
+
+      await waitFor(() => expect(result.current.data).toEqual(mockCounts));
+      expect(mockGetReviewCounts).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/__tests__/hooks/useReviewQueues.test.ts
+++ b/apps/web/src/__tests__/hooks/useReviewQueues.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for useReviewQueues (issue #390, spec §4.5).
+ *
+ * Resolves the `REVIEW_QUEUES` registry against live feature flags and the
+ * shared review-counts request. The three hooks it composes are mocked
+ * directly here — `useFeatureFlags`, `useWorkflowSubjects`, and
+ * `useReviewCounts` — so each case can drive the resolution logic without
+ * touching the network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReviewQueues } from '../../hooks/useReviewQueues';
+import type { ReviewCountsResponse } from '../../types/media';
+import type { PictureEnhancementPolicy } from '../../services/features';
+
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+}));
+vi.mock('../../hooks/useWorkflowSubjects', () => ({
+  useWorkflowsEnabled: vi.fn(),
+}));
+vi.mock('../../hooks/useReviewCounts', () => ({
+  useReviewCounts: vi.fn(),
+}));
+
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
+import { useWorkflowsEnabled } from '../../hooks/useWorkflowSubjects';
+import { useReviewCounts } from '../../hooks/useReviewCounts';
+
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
+const mockUseWorkflowsEnabled = vi.mocked(useWorkflowsEnabled);
+const mockUseReviewCounts = vi.mocked(useReviewCounts);
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+const FULL_COUNTS: ReviewCountsResponse = {
+  pendingBurstGroups: 4,
+  pendingDuplicateGroups: 6,
+  pendingLocationSuggestions: 2,
+  pendingEnhancements: 9,
+};
+
+function mockFeatureFlags(options: {
+  features?: Record<string, boolean> | null;
+  pictureEnhancement?: PictureEnhancementPolicy | null;
+  isLoading?: boolean;
+} = {}) {
+  const { features = null, pictureEnhancement = null, isLoading = false } = options;
+  mockUseFeatureFlags.mockReturnValue({
+    features,
+    pictureEnhancement,
+    isLoading,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+function enhancerPolicy(enabled: boolean): PictureEnhancementPolicy {
+  return { enabled, allowReplace: true, blockReplaceOnDownscale: false, model: 'gpt-image-1' };
+}
+
+function mockCounts(options: {
+  data?: ReviewCountsResponse | null;
+  isLoading?: boolean;
+} = {}) {
+  const { data = null, isLoading = false } = options;
+  mockUseReviewCounts.mockReturnValue({
+    data,
+    isLoading,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
+describe('useReviewQueues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCounts();
+  });
+
+  // =========================================================================
+  // Flag gating — the anti-flash rule
+  // =========================================================================
+
+  describe('flag gating', () => {
+    it('shows an entry only when its flag is === true', () => {
+      mockFeatureFlags({
+        features: { burstDetection: true, duplicateDetection: false, locationInference: true },
+      });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: FULL_COUNTS });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      const keys = result.current.entries.map((e) => e.key);
+      expect(keys).toContain('bursts');
+      expect(keys).toContain('locations');
+      expect(keys).not.toContain('duplicates');
+      expect(keys).not.toContain('automations');
+    });
+
+    it('hides an entry whose flag is unresolved (null), not just false', () => {
+      // `features` itself resolved (not loading), but simply lacks the key —
+      // the real shape of an outage/never-configured flag.
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(null);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      const keys = result.current.entries.map((e) => e.key);
+      expect(keys).not.toContain('bursts');
+      expect(keys).not.toContain('duplicates');
+      expect(keys).not.toContain('locations');
+      expect(keys).not.toContain('enhancements');
+      expect(keys).not.toContain('automations');
+    });
+
+    it('hides the enhancer entry when pictureEnhancement is null (unresolved)', () => {
+      mockFeatureFlags({ features: {}, pictureEnhancement: null });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries.map((e) => e.key)).not.toContain('enhancements');
+    });
+
+    it('shows the enhancer entry only when pictureEnhancement.enabled === true', () => {
+      mockFeatureFlags({ features: {}, pictureEnhancement: enhancerPolicy(true) });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: FULL_COUNTS });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries.map((e) => e.key)).toContain('enhancements');
+    });
+
+    it('shows automations only when useWorkflowsEnabled() === true', () => {
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(true);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries.map((e) => e.key)).toContain('automations');
+    });
+
+    it('insights always resolves — it carries no flag', () => {
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries.map((e) => e.key)).toContain('insights');
+    });
+
+    it('insights resolves even when every other feature is off/unresolved', () => {
+      mockFeatureFlags({ features: null, pictureEnhancement: null });
+      mockUseWorkflowsEnabled.mockReturnValue(null);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries[0].key).toBe('insights');
+    });
+  });
+
+  // =========================================================================
+  // totalPending
+  // =========================================================================
+
+  describe('totalPending', () => {
+    it('sums ONLY the enabled queue entries, even when the API returned a count for a disabled one', () => {
+      // Only bursts + duplicates enabled; locations and enhancements are off,
+      // but the counts payload (as if from a shared response) still carries
+      // numbers for all four.
+      mockFeatureFlags({ features: { burstDetection: true, duplicateDetection: true } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: FULL_COUNTS });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      // FULL_COUNTS.pendingBurstGroups(4) + pendingDuplicateGroups(6) = 10.
+      // Locations(2) and enhancements(9) must NOT contribute.
+      expect(result.current.totalPending).toBe(10);
+    });
+
+    it('is 0 when no queue-producing feature is enabled, even with insights/automations present', () => {
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(true);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.totalPending).toBe(0);
+    });
+
+    it('treats a not-yet-loaded count (null) as contributing 0, never NaN', () => {
+      mockFeatureFlags({ features: { burstDetection: true } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: null }); // still loading
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.totalPending).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // The counts request gate — the broadened form of the enhancer-only gate
+  // =========================================================================
+
+  describe('useReviewCounts gating', () => {
+    it('calls useReviewCounts with enabled: true when ANY counted queue feature is on', () => {
+      mockFeatureFlags({ features: { locationInference: true } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts();
+
+      renderHook(() => useReviewQueues());
+
+      expect(mockUseReviewCounts).toHaveBeenCalledWith({ enabled: true });
+    });
+
+    it('calls useReviewCounts with enabled: false when no counted queue feature is on, even with automations on', () => {
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(true); // automations only — carries no count
+      mockCounts();
+
+      renderHook(() => useReviewQueues());
+
+      expect(mockUseReviewCounts).toHaveBeenCalledWith({ enabled: false });
+    });
+
+    it('calls useReviewCounts with enabled: false when every flag is off/unresolved', () => {
+      mockFeatureFlags({ features: null, pictureEnhancement: null });
+      mockUseWorkflowsEnabled.mockReturnValue(null);
+      mockCounts();
+
+      renderHook(() => useReviewQueues());
+
+      expect(mockUseReviewCounts).toHaveBeenCalledWith({ enabled: false });
+    });
+  });
+
+  // =========================================================================
+  // count is null for the two secondary entries
+  // =========================================================================
+
+  describe('secondary entries carry no count', () => {
+    it('insights.count and automations.count are always null, even when counts data is loaded', () => {
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(true);
+      mockCounts({ data: FULL_COUNTS });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      const insights = result.current.entries.find((e) => e.key === 'insights');
+      const automations = result.current.entries.find((e) => e.key === 'automations');
+      expect(insights?.count).toBeNull();
+      expect(automations?.count).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // anyEnabled
+  // =========================================================================
+
+  describe('anyEnabled', () => {
+    it('is true whenever at least one entry (including insights) resolves', () => {
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.anyEnabled).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/__tests__/navigation/reachability.test.tsx
+++ b/apps/web/src/__tests__/navigation/reachability.test.tsx
@@ -68,6 +68,26 @@ const REQUIRED_REACHABLE_PATHS = [
   '/admin/settings/sharing', // was: drawer "Public Sharing" row -> now: Console > Operations > Public Sharing
 ];
 
+// Issue #390 (epic #388, spec §3.5 / §4.5 / §9) adds the Review hub. It ADDS a
+// namespace; it does not replace one. The epic's central claim is that
+// collapsing five UTILITIES rows into one badged "Review" row never makes
+// anything unreachable — every queue's pre-existing standalone route must
+// still resolve, because bookmarks, the Home review banners and the
+// `review_queue_*` notification links all point at those routes directly, not
+// at `/review/*`.
+const REVIEW_HUB_PATHS = ['/review', '/review/:queue'];
+
+// The six standalone routes ReviewQueuePage wraps (verbatim, never redirects)
+// — these existed before #390 and must survive it unchanged.
+const REVIEW_WRAPPED_STANDALONE_PATHS = [
+  '/bursts',
+  '/duplicates',
+  '/review-insights',
+  '/location-suggestions',
+  '/enhancements',
+  '/workflows',
+];
+
 describe('navigation reachability (issue #389)', () => {
   it('parses a realistic number of routes out of App.tsx (parser sanity check)', () => {
     // App.tsx currently declares 60+ routes. A number this low would mean the
@@ -116,6 +136,60 @@ describe('navigation reachability (issue #389)', () => {
 
     const layoutBlock = appSource.slice(layoutStart, fullBleedStart);
     REQUIRED_REACHABLE_PATHS.forEach((path) => {
+      expect(layoutBlock).toContain(`<Route path="${path}"`);
+    });
+  });
+});
+
+// ===========================================================================
+// The Review hub (issue #390, epic #388, spec §3.5 / §4.5 / §9)
+//
+// This is the epic's central claim, restated for this phase: `/review` is a
+// NEW namespace layered on top of the existing queue routes, never a
+// replacement for them. Sidebar.test.tsx already proves the five old
+// UTILITIES rows are gone from the drawer; this file's job is to prove that
+// removal didn't touch the router — every one of those six routes must still
+// resolve directly, exactly as before #390, alongside the two new hub routes.
+// ===========================================================================
+describe('navigation reachability — the Review hub (issue #390)', () => {
+  it.each(REVIEW_HUB_PATHS)('the new Review hub route %s exists in App.tsx', (path) => {
+    expect(routePathSet.has(path)).toBe(true);
+  });
+
+  it.each(REVIEW_WRAPPED_STANDALONE_PATHS)(
+    'the wrapped queue route %s still resolves on its own — the hub does not replace it',
+    (path) => {
+      expect(routePathSet.has(path)).toBe(true);
+    },
+  );
+
+  it('none of the eight Review-related paths are declared more than once', () => {
+    [...REVIEW_HUB_PATHS, ...REVIEW_WRAPPED_STANDALONE_PATHS].forEach((path) => {
+      const occurrences = routePaths.filter((p) => p === path).length;
+      expect(occurrences).toBe(1);
+    });
+  });
+
+  it('none of the six wrapped standalone routes redirect to /review — each still renders its own page', () => {
+    // A route that now merely forwards to the hub would technically satisfy
+    // "the path exists", but would defeat the whole point of wrapping rather
+    // than replacing. Pin that each is a real `<Route path="..." element={<...Page />}>`,
+    // not a `<Navigate to="/review" .../>`.
+    REVIEW_WRAPPED_STANDALONE_PATHS.forEach((path) => {
+      const match = appSource.match(
+        new RegExp(`<Route\\s+path="${path.replace('/', '\\/')}"\\s+element=\\{<([^\\s/>]+)`),
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).not.toBe('Navigate');
+    });
+  });
+
+  it('every Review-related required path sits inside the authenticated <Layout> route tree', () => {
+    const layoutStart = appSource.indexOf('<Route element={<Layout />}>');
+    const fullBleedStart = appSource.indexOf('<Route element={<Layout fullBleed />}>');
+    const layoutBlock = appSource.slice(layoutStart, fullBleedStart);
+
+    [...REVIEW_HUB_PATHS, ...REVIEW_WRAPPED_STANDALONE_PATHS].forEach((path) => {
       expect(layoutBlock).toContain(`<Route path="${path}"`);
     });
   });

--- a/apps/web/src/__tests__/pages/ReviewHubPage.test.tsx
+++ b/apps/web/src/__tests__/pages/ReviewHubPage.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for ReviewHubPage (issue #390, spec §3.1 / §4.5).
+ *
+ * Thin by design — the page contributes chrome, scroll restoration, and the
+ * count-invalidation-on-mount behavior around `ReviewQueueList`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { Routes, Route, Link as RouterLink } from 'react-router-dom';
+import { render } from '../utils/test-utils';
+import ReviewHubPage from '../../pages/Reviews/ReviewHubPage';
+import { __resetReviewCountsForTests } from '../../hooks/useReviewCounts';
+import { useReviewQueues } from '../../hooks/useReviewQueues';
+import type { ReviewCountsResponse } from '../../types/media';
+import type { PictureEnhancementPolicy } from '../../services/features';
+
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+}));
+vi.mock('../../hooks/useWorkflowSubjects', () => ({
+  useWorkflowsEnabled: vi.fn(),
+}));
+vi.mock('../../hooks/useScrollRestoration', () => ({
+  useScrollRestoration: vi.fn(),
+}));
+// The service layer, not the hook, so the count-refresh test drives the real
+// useReviewCounts / refreshReviewCounts machinery end to end.
+vi.mock('../../services/media', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/media')>()),
+  getReviewCounts: vi.fn(),
+}));
+
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
+import { useWorkflowsEnabled } from '../../hooks/useWorkflowSubjects';
+import { useScrollRestoration } from '../../hooks/useScrollRestoration';
+import { getReviewCounts } from '../../services/media';
+
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
+const mockUseWorkflowsEnabled = vi.mocked(useWorkflowsEnabled);
+const mockUseScrollRestoration = vi.mocked(useScrollRestoration);
+const mockGetReviewCounts = vi.mocked(getReviewCounts);
+
+function mockFlags(features: Record<string, boolean>, pictureEnhancement: PictureEnhancementPolicy | null = null) {
+  mockUseFeatureFlags.mockReturnValue({
+    features,
+    pictureEnhancement,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+function counts(overrides: Partial<ReviewCountsResponse> = {}): ReviewCountsResponse {
+  return {
+    pendingBurstGroups: 0,
+    pendingDuplicateGroups: 0,
+    pendingLocationSuggestions: 0,
+    pendingEnhancements: 0,
+    ...overrides,
+  };
+}
+
+describe('ReviewHubPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetReviewCountsForTests();
+    mockUseWorkflowsEnabled.mockReturnValue(false);
+  });
+
+  // =========================================================================
+  // Renders the list
+  // =========================================================================
+
+  it('renders the page heading and the queue list', async () => {
+    mockFlags({ duplicateDetection: true });
+    mockGetReviewCounts.mockResolvedValue(counts({ pendingDuplicateGroups: 3 }));
+
+    render(<ReviewHubPage />);
+
+    expect(screen.getByRole('heading', { name: 'Review' })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'Duplicates, 3 pending' })).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Navigating a row targets /review/<key>
+  // =========================================================================
+
+  it('a row links to /review/<key>', async () => {
+    mockFlags({ duplicateDetection: true });
+    mockGetReviewCounts.mockResolvedValue(counts({ pendingDuplicateGroups: 3 }));
+
+    render(<ReviewHubPage />);
+
+    const link = await screen.findByRole('link', { name: 'Duplicates, 3 pending' });
+    expect(link.getAttribute('href')).toBe('/review/duplicates');
+  });
+
+  // =========================================================================
+  // Scroll restoration
+  // =========================================================================
+
+  it('invokes scroll restoration under the "review-hub" key', () => {
+    mockFlags({});
+
+    render(<ReviewHubPage />);
+
+    expect(mockUseScrollRestoration).toHaveBeenCalledWith('review-hub');
+  });
+
+  // =========================================================================
+  // Count refresh on return — the criterion most likely to regress silently.
+  // =========================================================================
+
+  it('shows a fresh count on return rather than a cached one, driven through the real useReviewCounts', async () => {
+    mockFlags({ duplicateDetection: true });
+    // A persistent (not one-shot) resolved value for this "visit" — the page's
+    // own mount effect bumps the shared revision immediately, which causes an
+    // extra internal refetch on the same mount; a persistent value keeps the
+    // assertion about the SETTLED count robust to that, rather than pinning an
+    // exact call count.
+    mockGetReviewCounts.mockResolvedValue(counts({ pendingDuplicateGroups: 3 }));
+
+    function Harness() {
+      return (
+        <Routes>
+          <Route
+            path="/review"
+            element={
+              <>
+                <RouterLink to="/away">Leave</RouterLink>
+                <ReviewHubPage />
+              </>
+            }
+          />
+          <Route path="/away" element={<RouterLink to="/review">Return</RouterLink>} />
+        </Routes>
+      );
+    }
+
+    render(<Harness />, { wrapperOptions: { route: '/review' } });
+
+    expect(await screen.findByRole('link', { name: 'Duplicates, 3 pending' })).toBeInTheDocument();
+
+    // Something changed while the user was away.
+    mockGetReviewCounts.mockResolvedValue(counts({ pendingDuplicateGroups: 9 }));
+
+    fireEvent.click(screen.getByText('Leave'));
+    await waitFor(() => expect(screen.getByText('Return')).toBeInTheDocument());
+    // The hub is unmounted while away — its cached "3" is gone with it.
+    expect(screen.queryByRole('link', { name: /Duplicates/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Return'));
+
+    // The NEW value renders, not the stale "3".
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Duplicates, 9 pending' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link', { name: 'Duplicates, 3 pending' })).not.toBeInTheDocument();
+  });
+
+  it('mounting the hub bumps the shared revision so an already-mounted consumer refetches too', async () => {
+    mockFlags({ duplicateDetection: true });
+    mockGetReviewCounts.mockResolvedValue(counts({ pendingDuplicateGroups: 3 }));
+
+    // Simulate the sidebar's aggregate badge: a second, independently-mounted
+    // consumer of the same shared counts that stays mounted the whole time.
+    function Badge() {
+      const { totalPending } = useReviewQueues();
+      return <div data-testid="badge">{totalPending}</div>;
+    }
+
+    function Harness({ showHub }: { showHub: boolean }) {
+      return (
+        <>
+          <Badge />
+          {showHub && <ReviewHubPage />}
+        </>
+      );
+    }
+
+    const { rerender } = render(<Harness showHub={false} />);
+
+    await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('3'));
+
+    // The count changed server-side while only the badge was mounted.
+    mockGetReviewCounts.mockResolvedValue(counts({ pendingDuplicateGroups: 9 }));
+
+    rerender(<Harness showHub={true} />);
+
+    // The badge instance never unmounted, yet it picks up the new value —
+    // proof the hub's mount invalidation reaches every mounted consumer, not
+    // just its own internal list.
+    await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('9'));
+  });
+});

--- a/apps/web/src/__tests__/pages/ReviewQueuePage.test.tsx
+++ b/apps/web/src/__tests__/pages/ReviewQueuePage.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Tests for ReviewQueuePage (issue #390, spec §4.5).
+ *
+ * A WRAPPER, not a rewrite: each queue's existing standalone page is mounted
+ * verbatim inside `/review/:queue`. The six wrapped page modules are mocked
+ * to lightweight stubs so these tests exercise the wrapper's own logic
+ * (resolution, redirect, chain-to-next, back affordance) rather than each
+ * page's internals.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import { render } from '../utils/test-utils';
+import ReviewQueuePage from '../../pages/Reviews/ReviewQueuePage';
+import { REVIEW_QUEUES, type ReviewQueueKey } from '../../config/reviewQueues';
+import type { ResolvedReviewQueue } from '../../hooks/useReviewQueues';
+
+vi.mock('../../hooks/useReviewQueues', () => ({
+  useReviewQueues: vi.fn(),
+}));
+
+vi.mock('../../pages/Bursts/BurstsPage', () => ({
+  default: () => <div>BurstsPageStub</div>,
+}));
+vi.mock('../../pages/Duplicates/DuplicatesPage', () => ({
+  default: () => <div>DuplicatesPageStub</div>,
+}));
+vi.mock('../../pages/LocationSuggestions/LocationSuggestionsPage', () => ({
+  default: () => <div>LocationSuggestionsPageStub</div>,
+}));
+vi.mock('../../pages/Enhancements/EnhancementsPage', () => ({
+  default: () => <div>EnhancementsPageStub</div>,
+}));
+vi.mock('../../pages/Insights/ReviewInsightsPage', () => ({
+  default: () => <div>ReviewInsightsPageStub</div>,
+}));
+vi.mock('../../pages/Workflows/WorkflowListPage', () => ({
+  default: () => <div>WorkflowListPageStub</div>,
+}));
+
+import { useReviewQueues } from '../../hooks/useReviewQueues';
+
+const mockUseReviewQueues = vi.mocked(useReviewQueues);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildEntries(
+  counts: Partial<Record<ReviewQueueKey, number | null>>,
+  enabledKeys: ReviewQueueKey[],
+): ResolvedReviewQueue[] {
+  return REVIEW_QUEUES.filter((def) => enabledKeys.includes(def.key)).map((def) => ({
+    ...def,
+    count: def.countKey ? (counts[def.key] ?? null) : null,
+  }));
+}
+
+function mockResult(overrides: Partial<ReturnType<typeof useReviewQueues>>) {
+  mockUseReviewQueues.mockReturnValue({
+    entries: [],
+    counts: null,
+    totalPending: 0,
+    isLoading: false,
+    anyEnabled: true,
+    ...overrides,
+  });
+}
+
+function renderAt(path: string) {
+  return render(
+    <Routes>
+      <Route path="/review/:queue" element={<ReviewQueuePage />} />
+      <Route path="/review" element={<div>ReviewHubStub</div>} />
+    </Routes>,
+    { wrapperOptions: { route: path } },
+  );
+}
+
+describe('ReviewQueuePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Wraps the correct page
+  // =========================================================================
+
+  it('/review/duplicates renders the Duplicates page', async () => {
+    const entries = buildEntries({ duplicates: 4 }, ['duplicates']);
+    mockResult({ entries });
+
+    renderAt('/review/duplicates');
+
+    expect(await screen.findByText('DuplicatesPageStub')).toBeInTheDocument();
+  });
+
+  it('/review/bursts renders the Bursts page', async () => {
+    const entries = buildEntries({ bursts: 4 }, ['bursts']);
+    mockResult({ entries });
+
+    renderAt('/review/bursts');
+
+    expect(await screen.findByText('BurstsPageStub')).toBeInTheDocument();
+  });
+
+  it('/review/insights renders the Insights page (a secondary entry, no count)', async () => {
+    const entries = buildEntries({}, ['insights']);
+    mockResult({ entries });
+
+    renderAt('/review/insights');
+
+    expect(await screen.findByText('ReviewInsightsPageStub')).toBeInTheDocument();
+  });
+
+  it('/review/automations renders the Automations (workflows) page', async () => {
+    const entries = buildEntries({}, ['automations']);
+    mockResult({ entries });
+
+    renderAt('/review/automations');
+
+    expect(await screen.findByText('WorkflowListPageStub')).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Redirects
+  // =========================================================================
+
+  describe('redirects to /review', () => {
+    it('an unknown :queue segment redirects', async () => {
+      mockResult({ entries: buildEntries({ bursts: 4 }, ['bursts']) });
+
+      renderAt('/review/not-a-real-queue');
+
+      expect(await screen.findByText('ReviewHubStub')).toBeInTheDocument();
+    });
+
+    it('a queue whose feature is off (not in the resolved entries) redirects', async () => {
+      // `duplicates` is a real registry key, but not present in the resolved
+      // (enabled) entries — the feature is off.
+      mockResult({ entries: buildEntries({ bursts: 4 }, ['bursts']), isLoading: false });
+
+      renderAt('/review/duplicates');
+
+      expect(await screen.findByText('ReviewHubStub')).toBeInTheDocument();
+    });
+
+    it('does NOT redirect a disabled-looking queue while flags are still resolving — shows a spinner instead', () => {
+      mockResult({ entries: [], isLoading: true });
+
+      renderAt('/review/duplicates');
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByText('ReviewHubStub')).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Chain-to-next
+  // =========================================================================
+
+  describe('chain-to-next', () => {
+    it('shows "Next: N …" on a drained queue when another queue still has work, in registry order', async () => {
+      // bursts (current) drained; duplicates (next in registry order) has 5.
+      const entries = buildEntries({ bursts: 0, duplicates: 5 }, ['bursts', 'duplicates']);
+      mockResult({ entries });
+
+      renderAt('/review/bursts');
+
+      await screen.findByText('BurstsPageStub');
+      const next = screen.getByRole('link', { name: /Next:/ });
+      expect(next).toHaveTextContent('Next: 5 duplicates');
+      expect(next.getAttribute('href')).toBe('/review/duplicates');
+    });
+
+    it('wraps around to the front of the registry when the only remaining work is earlier in the order', async () => {
+      // Current = enhancements (last queue-group entry); only bursts (first
+      // in registry order) still has work — this can only be found by
+      // wrapping around past the end of the list.
+      const entries = buildEntries(
+        { bursts: 3, duplicates: 0, locations: 0, enhancements: 0 },
+        ['bursts', 'duplicates', 'locations', 'enhancements'],
+      );
+      mockResult({ entries });
+
+      renderAt('/review/enhancements');
+
+      await screen.findByText('EnhancementsPageStub');
+      const next = screen.getByRole('link', { name: /Next:/ });
+      expect(next).toHaveTextContent('Next: 3 bursts');
+      expect(next.getAttribute('href')).toBe('/review/bursts');
+    });
+
+    it('is suppressed when no other queue has remaining work', async () => {
+      const entries = buildEntries({ bursts: 0, duplicates: 0 }, ['bursts', 'duplicates']);
+      mockResult({ entries });
+
+      renderAt('/review/bursts');
+
+      await screen.findByText('BurstsPageStub');
+      expect(screen.queryByRole('link', { name: /Next:/ })).not.toBeInTheDocument();
+    });
+
+    it('never appears on a secondary entry, even when a real queue has pending work', async () => {
+      const entries = buildEntries({ bursts: 4 }, ['bursts', 'insights']);
+      mockResult({ entries });
+
+      renderAt('/review/insights');
+
+      await screen.findByText('ReviewInsightsPageStub');
+      expect(screen.queryByRole('link', { name: /Next:/ })).not.toBeInTheDocument();
+    });
+
+    it('is not shown while the current queue still has pending items', async () => {
+      const entries = buildEntries({ bursts: 4, duplicates: 5 }, ['bursts', 'duplicates']);
+      mockResult({ entries });
+
+      renderAt('/review/bursts');
+
+      await screen.findByText('BurstsPageStub');
+      expect(screen.queryByRole('link', { name: /Next:/ })).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Back affordance
+  // =========================================================================
+
+  it('a back affordance returns to /review', async () => {
+    const entries = buildEntries({ bursts: 4 }, ['bursts']);
+    mockResult({ entries });
+
+    renderAt('/review/bursts');
+
+    await screen.findByText('BurstsPageStub');
+    const back = screen.getByRole('link', { name: 'Back to Review' });
+    expect(back.getAttribute('href')).toBe('/review');
+  });
+});

--- a/apps/web/src/components/navigation/Sidebar.tsx
+++ b/apps/web/src/components/navigation/Sidebar.tsx
@@ -22,22 +22,16 @@ import {
   Groups as GroupsIcon,
   Explore as ExploreIcon,
   PhotoAlbum as AlbumIcon,
-  BurstMode as BurstModeIcon,
   Archive as ArchiveOutlinedIcon,
   Delete as DeleteOutlineIcon,
-  ContentCopy as ContentCopyIcon,
-  MyLocation as MyLocationIcon,
-  Insights as InsightsIcon,
-  AccountTree as AccountTreeIcon,
-  AutoFixHigh as AutoFixHighIcon,
+  FactCheck as FactCheckIcon,
   AutoAwesomeMotion as AutoAwesomeMotionIcon,
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { usePermissions } from '../../hooks/usePermissions';
-import { useWorkflowsEnabled } from '../../hooks/useWorkflowSubjects';
-import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useMemoriesEnabled } from '../../hooks/useMemoriesEnabled';
-import { useReviewCounts } from '../../hooks/useReviewCounts';
+import { useReviewQueues } from '../../hooks/useReviewQueues';
+import { resolveActiveDestination } from '../../config/destinations';
 import { ADMIN_HUB_PATH, visibleAdminSections } from '../../config/adminSections';
 
 interface SidebarProps {
@@ -51,6 +45,12 @@ interface NavItemDef {
   path: string;
   /** Optional pending-work count. Rendered as a badge only when > 0. */
   badgeCount?: number;
+  /**
+   * Accessible name override. Required wherever a badge carries meaning: a
+   * badge must never be the sole carrier of it (spec §7), so the count is
+   * spelled into the name — "Review, 12 items pending".
+   */
+  ariaLabel?: string;
 }
 
 const DRAWER_WIDTH = 240;
@@ -73,21 +73,14 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { isAdmin, hasPermission } = usePermissions();
-  const workflowsEnabled = useWorkflowsEnabled();
-  const { pictureEnhancement } = useFeatureFlags();
-  // The AI Enhancements badge is the sole consumer of these counts, and that
-  // entry only renders when the enhancer flag is on — so the hook is gated on
-  // the same condition and issues NO request while the flag is off or still
-  // loading (issue #204). `useReviewCounts` is keyed on the active circle, so
-  // when it IS enabled this is one small counts-only request per circle
-  // switch, not per navigation, and not the full dashboard payload.
-  const { data: reviewCounts } = useReviewCounts({
-    enabled: pictureEnhancement?.enabled === true,
-  });
-  const pendingEnhancements = reviewCounts?.pendingEnhancements ?? 0;
-  // Same module-level flag cache the enhancer entry above reads — this adds no
-  // second request. `=== true` for the same reason documented there: the entry
-  // must not flash in while the flags load, and a flags outage must hide it.
+  // The single aggregate badge for the whole Review inbox (issue #390). It sums
+  // only the ENABLED queues, and it observes the same refresh signal the hub
+  // list does — so the badge and the list refetch together and cannot end up
+  // showing two different numbers on one screen.
+  const { totalPending } = useReviewQueues();
+  // `=== true` (not a truthy check) so the entry does not flash in while the
+  // flag is still loading, and so a flags outage — which resolves to null rather
+  // than throwing — hides it instead of guessing.
   const memoriesEnabled = useMemoriesEnabled();
 
   // Console mode (spec §3.2): at any `/admin/*` route the drawer swaps its
@@ -119,28 +112,28 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     { label: 'Trash', icon: <DeleteOutlineIcon />, path: '/trash' },
   ];
 
-  const utilitiesItems: NavItemDef[] = [
-    { label: 'Review Bursts', icon: <BurstModeIcon />, path: '/bursts' },
-    { label: 'Review Duplicates', icon: <ContentCopyIcon />, path: '/duplicates' },
-    { label: 'Review Insights', icon: <InsightsIcon />, path: '/review-insights' },
-    { label: 'Location Suggestions', icon: <MyLocationIcon />, path: '/location-suggestions' },
-    ...(workflowsEnabled === true
-      ? [{ label: 'Workflows', icon: <AccountTreeIcon />, path: '/workflows' }]
-      : []),
-    // `=== true` (not a truthy check) so the entry does not flash in while the
-    // flag is still loading — `pictureEnhancement` is null until then, and
-    // useFeatureFlags degrades to null on failure rather than throwing.
-    ...(pictureEnhancement?.enabled === true
-      ? [
-          {
-            label: 'AI Enhancements',
-            icon: <AutoFixHighIcon />,
-            path: '/enhancements',
-            badgeCount: pendingEnhancements,
-          },
-        ]
-      : []),
-  ];
+  // Five UTILITIES rows collapse into ONE badged inbox (issue #390, spec §3.3).
+  // Six quiet rows read as furniture; one badge reads as work.
+  //
+  // It renders UNCONDITIONALLY — never hidden at a zero count, never hidden when
+  // the features are off (spec §6.3). Navigation that changes shape is worse
+  // than navigation that is slightly long: a user cannot find a feature they
+  // know exists, and cannot build muscle memory against a moving target. Keep
+  // the destination, drop the badge.
+  const reviewItem: NavItemDef = {
+    label: 'Review',
+    icon: <FactCheckIcon />,
+    path: '/review',
+    badgeCount: totalPending,
+    ariaLabel:
+      totalPending > 0 ? `Review, ${totalPending} items pending` : 'Review',
+  };
+
+  // Review owns nine route prefixes that do not resemble `/review` — standing at
+  // `/bursts` or `/workflows/:id` must still light this row up, which a
+  // path-prefix match on the item's own path cannot express (spec §3.5). The
+  // other rows keep the `owns` behaviour until #391 converts them.
+  const reviewActive = resolveActiveDestination(location.pathname) === 'review';
 
   // Console mode "invents no new admin IA" (spec §3.2) — these are the SAME
   // five permission-gated sections the hub renders, from the one shared
@@ -187,7 +180,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     active: activeOverride,
   }: {
     item: NavItemDef;
-    /** Escape hatch for Console mode, where nesting needs longest-prefix-wins. */
+    /**
+     * Explicit active state, for the two rows a path-prefix match on the item's
+     * own path cannot decide: Console mode (nesting needs longest-prefix-wins)
+     * and Review (it owns nine prefixes that do not resemble `/review`).
+     */
     active?: boolean;
   }) => {
     const active = activeOverride ?? owns(item.path, location.pathname);
@@ -199,6 +196,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           // explicit landmark (spec §7). Set here, once, so it holds in both
           // Library and Console mode.
           aria-current={active ? 'page' : undefined}
+          aria-label={item.ariaLabel}
           onClick={() => handleNavigate(item.path)}
           sx={{
             borderRadius: 1,
@@ -311,24 +309,15 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           ))}
         </List>
 
-        {/* UTILITIES section */}
-        <List
-          dense
-          disablePadding
-          subheader={
-            <ListSubheader disableSticky sx={subheaderSx}>
-              Utilities
-            </ListSubheader>
-          }
-        >
-          {utilitiesItems.map((item) => (
-            <NavItem key={item.path} item={item} />
-          ))}
+        {/* Review — one row, no subheader. A "Review" heading over a single
+            "Review" row would be pure chrome. */}
+        <List dense disablePadding sx={{ mt: 1 }}>
+          <NavItem item={reviewItem} active={reviewActive} />
         </List>
       </Box>
 
       {/* Console pinned at the foot, where User Settings used to sit. It is a
-          MODE affordance rather than one of the 14 rows — the epic counts it
+          MODE affordance rather than one of the nine rows — the epic counts it
           separately, which is why it lives below the divider. */}
       {isAdmin && (
         <>

--- a/apps/web/src/components/review/ReviewQueueList.tsx
+++ b/apps/web/src/components/review/ReviewQueueList.tsx
@@ -1,0 +1,240 @@
+/**
+ * The Review inbox, as a queue list — the one model at every breakpoint.
+ *
+ * Spec §4.5. Deliberately a standalone component rather than markup inside
+ * `ReviewHubPage`: issue #392 mounts THIS component as the desktop context pane,
+ * and a second implementation there would let count-refresh, row order and
+ * feature gating drift between the two surfaces that are supposed to be the same
+ * list at two sizes.
+ *
+ * Not tabs, and not a segmented control, at any width — see the rationale in
+ * `config/reviewQueues.tsx`.
+ */
+
+import {
+  Box,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { CheckCircleOutlined as CheckCircleOutlinedIcon } from '@mui/icons-material';
+import { Link as RouterLink } from 'react-router-dom';
+import { LoadingSpinner } from '../common/LoadingSpinner';
+import type { ReviewQueueKey } from '../../config/reviewQueues';
+import type { ResolvedReviewQueue } from '../../hooks/useReviewQueues';
+import { useReviewQueues } from '../../hooks/useReviewQueues';
+
+export interface ReviewQueueListProps {
+  /**
+   * `hub` is the full-width list on the hub page; `pane` is the denser
+   * treatment #392 will mount beside the queue on desktop. The difference is
+   * density only — the contents, order and gating are identical by design.
+   */
+  variant?: 'hub' | 'pane';
+  /** Fired in addition to (not instead of) navigation; #392 uses it to close/scroll. */
+  onNavigate?: (entry: ResolvedReviewQueue) => void;
+  /** Which entry is currently being viewed, for the pane's selected state. */
+  activeKey?: ReviewQueueKey | null;
+}
+
+/** The route a row points at. Rows always go through the hub's own namespace. */
+export function reviewQueuePath(key: ReviewQueueKey): string {
+  return `/review/${key}`;
+}
+
+/**
+ * A drained queue reads as an em dash, never "0" (spec §4.5 requirement 4).
+ * `null` — not applicable, or not loaded yet — reads the same way, since in both
+ * cases there is no number worth showing.
+ */
+function countLabel(count: number | null): string {
+  return count && count > 0 ? String(count) : '—';
+}
+
+/**
+ * The accessible name carries the count, because a badge must never be the sole
+ * carrier of meaning (spec §7). Secondary entries have no count to carry.
+ */
+function accessibleName(entry: ResolvedReviewQueue): string {
+  if (entry.countKey === null) return entry.label;
+  if (entry.count === null) return entry.label;
+  if (entry.count === 0) return `${entry.label}, none pending`;
+  return `${entry.label}, ${entry.count} pending`;
+}
+
+function QueueRow({
+  entry,
+  variant,
+  active,
+  onNavigate,
+}: {
+  entry: ResolvedReviewQueue;
+  variant: 'hub' | 'pane';
+  active: boolean;
+  onNavigate?: (entry: ResolvedReviewQueue) => void;
+}) {
+  const { Icon } = entry;
+  const pending = entry.count !== null && entry.count > 0;
+
+  return (
+    <ListItem disablePadding>
+      {/* A real link: focusable, middle-clickable, and it survives a keyboard
+          user tabbing the list — an onClick div would give up all three. */}
+      <ListItemButton
+        component={RouterLink}
+        to={reviewQueuePath(entry.key)}
+        selected={active}
+        aria-current={active ? 'page' : undefined}
+        aria-label={accessibleName(entry)}
+        onClick={() => onNavigate?.(entry)}
+        sx={{
+          borderRadius: 1,
+          py: variant === 'pane' ? 0.5 : 1,
+          // Every flex item needs an explicit floor: `min-width` defaults to
+          // `auto`, so a long label would otherwise set a hard min-content width
+          // on the whole column (issue #291).
+          minWidth: 0,
+        }}
+      >
+        <ListItemIcon sx={{ minWidth: variant === 'pane' ? 36 : 44 }}>
+          <Icon fontSize={variant === 'pane' ? 'small' : 'medium'} />
+        </ListItemIcon>
+        <ListItemText
+          primary={entry.label}
+          slotProps={{
+            primary: { variant: variant === 'pane' ? 'body2' : 'body1', noWrap: true },
+          }}
+          sx={{ minWidth: 0, my: 0 }}
+        />
+        {entry.countKey !== null && (
+          <Typography
+            component="span"
+            // The name above already says "4 pending"; announcing the bare
+            // numeral again would just be noise.
+            aria-hidden
+            variant={variant === 'pane' ? 'body2' : 'body1'}
+            sx={{
+              ml: 1,
+              flexShrink: 0,
+              fontVariantNumeric: 'tabular-nums',
+              fontWeight: pending ? 600 : 400,
+              color: pending ? 'text.primary' : 'text.disabled',
+            }}
+          >
+            {countLabel(entry.count)}
+          </Typography>
+        )}
+      </ListItemButton>
+    </ListItem>
+  );
+}
+
+export function ReviewQueueList({
+  variant = 'hub',
+  onNavigate,
+  activeKey = null,
+}: ReviewQueueListProps) {
+  const { entries, anyEnabled, isLoading } = useReviewQueues();
+
+  const queues = entries.filter((entry) => entry.group === 'queue');
+  const secondary = entries.filter((entry) => entry.group === 'secondary');
+
+  // Every queue drained. `count === 0` and not `!count`, so a queue whose count
+  // has not loaded (null) cannot masquerade as drained and flash the payoff
+  // state before the numbers arrive.
+  const allClear = queues.length > 0 && queues.every((entry) => entry.count === 0);
+
+  // Render nothing until BOTH the flags and the counts have answered. Each
+  // half has its own flash to avoid: a partially-resolved entry list pops rows
+  // in as flags land, and a resolved row with an unloaded count renders as an
+  // em dash — which in this list means "drained", i.e. it would state the
+  // opposite of the truth for as long as the request is in flight.
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  // Defensive: `insights` carries no feature flag, so today this cannot happen.
+  // It is kept because it is the correct response if that ever changes, and
+  // because the alternative — silently rendering an empty box — is unreadable.
+  if (!anyEnabled) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="body1" sx={{ mb: 0.5 }}>
+          No review features are enabled
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Bursts, duplicates, location suggestions and AI enhancements are turned
+          on by an administrator.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      {queues.length === 0 ? (
+        // Every queue-producing feature is off, but Insights/Automations below
+        // still resolve. Say so, rather than leaving a bare divider floating
+        // above them with nothing on the other side of it.
+        <Box sx={{ py: 3, px: 2, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            No review queues are enabled.
+          </Typography>
+        </Box>
+      ) : allClear ? (
+        // Not four rows of "0" — one confident state (spec §4.5 requirement 4).
+        // This is the payoff that makes clearing a backlog feel like something.
+        <Box sx={{ py: variant === 'pane' ? 3 : 6, px: 2, textAlign: 'center' }}>
+          <CheckCircleOutlinedIcon
+            color="success"
+            sx={{ fontSize: variant === 'pane' ? 32 : 48, mb: 1 }}
+          />
+          <Typography variant={variant === 'pane' ? 'subtitle1' : 'h6'} sx={{ mb: 0.5 }}>
+            You&apos;re all caught up
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Nothing waiting on you. New suggestions appear here after your next
+            import.
+          </Typography>
+        </Box>
+      ) : (
+        <List dense={variant === 'pane'} disablePadding>
+          {queues.map((entry) => (
+            <QueueRow
+              key={entry.key}
+              entry={entry}
+              variant={variant}
+              active={activeKey === entry.key}
+              onNavigate={onNavigate}
+            />
+          ))}
+        </List>
+      )}
+
+      {secondary.length > 0 && (
+        <>
+          {/* Insights is analytics and Automations is configuration — neither is
+              a queue, so both survive an empty inbox unchanged. */}
+          <Divider sx={{ my: 1 }} />
+          <List dense={variant === 'pane'} disablePadding>
+            {secondary.map((entry) => (
+              <QueueRow
+                key={entry.key}
+                entry={entry}
+                variant={variant}
+                active={activeKey === entry.key}
+                onNavigate={onNavigate}
+              />
+            ))}
+          </List>
+        </>
+      )}
+    </Box>
+  );
+}
+
+export default ReviewQueueList;

--- a/apps/web/src/config/destinations.ts
+++ b/apps/web/src/config/destinations.ts
@@ -1,0 +1,113 @@
+/**
+ * The destination model — canonical keys, route ownership, and active state.
+ *
+ * Spec §3.5. Collapsing 22 drawer rows into four destinations creates a problem
+ * the old navigation did not have: **a destination must light up for routes
+ * whose paths do not resemble it.** Standing at `/bursts` the active
+ * destination is Review, but `/bursts` does not start with `/review`. A
+ * `startsWith` on the item's own path — what `Sidebar` used to do — cannot
+ * express that, so the mapping is declared here instead of inferred.
+ *
+ * Two rules make the table trustworthy:
+ *
+ *  1. **A route is owned by at most one destination.** A test asserts this
+ *     against the live `App.tsx`, which is what keeps the table honest as
+ *     routes are added — it fails loudly the day someone adds a route and
+ *     forgets this file.
+ *  2. **Matching respects segment boundaries.** A bare `startsWith` would make
+ *     `/review` match `/reviewer` and `/bursts` match `/burstsfoo`. Note this
+ *     is also why `/review-insights` and `/review-runs` are enumerated
+ *     separately below rather than being covered by `/review`: under this rule
+ *     they are NOT children of it.
+ */
+
+export type DestinationKey = 'photos' | 'collections' | 'search' | 'review' | 'console';
+
+/**
+ * Does `prefix` own `path`? True when the path equals the prefix or continues
+ * with a `/`. `'/'` matches only itself — every path starts with it, so the
+ * root has to be exact or it would own the entire app.
+ */
+export function owns(prefix: string, path: string): boolean {
+  if (prefix === '/') return path === '/';
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+/**
+ * Route prefixes each destination owns. Child routes are covered by their
+ * parent prefix (`/albums/:albumId`, `/bursts/:id`, `/places/countries`, …) and
+ * do not need their own entries.
+ */
+export const DESTINATION_ROUTES: Record<DestinationKey, readonly string[]> = {
+  photos: ['/', '/media'],
+  collections: [
+    '/collections',
+    '/albums',
+    '/people',
+    '/places',
+    '/memories',
+    '/map',
+    '/archive',
+    '/trash',
+    '/tags',
+  ],
+  search: ['/search'],
+  review: [
+    '/review',
+    '/bursts',
+    '/duplicates',
+    '/review-insights',
+    '/location-suggestions',
+    '/enhancements',
+    '/workflows',
+    '/review-runs',
+    '/location-suggestion-runs',
+  ],
+  console: ['/admin'],
+};
+
+/**
+ * Routes deliberately owned by NO destination.
+ *
+ * These are reached from the top bar (avatar menu, circle chip, bell) or from
+ * outside the app entirely. **On these routes no destination renders as active,
+ * and that is correct rather than a bug** — highlighting an unrelated
+ * destination would be worse than highlighting none. Exported so a test can
+ * assert it explicitly, which is what stops a future contributor from "fixing"
+ * it into highlighting something arbitrary.
+ */
+export const UNOWNED_ROUTES: readonly string[] = [
+  '/settings',
+  '/profile',
+  '/circles',
+  '/notifications',
+  '/activate',
+  '/login',
+  '/auth/callback',
+  '/s/:token',
+];
+
+/**
+ * Which destination, if any, owns `pathname`.
+ *
+ * Longest prefix wins where prefixes overlap. They do not overlap today, but
+ * encoding the rule costs nothing and removes the question from every future
+ * addition to the table.
+ */
+export function resolveActiveDestination(pathname: string): DestinationKey | null {
+  let best: { key: DestinationKey; length: number } | null = null;
+
+  for (const [key, prefixes] of Object.entries(DESTINATION_ROUTES) as [
+    DestinationKey,
+    readonly string[],
+  ][]) {
+    for (const prefix of prefixes) {
+      if (!owns(prefix, pathname)) continue;
+      if (!best || prefix.length > best.length) {
+        best = { key, length: prefix.length };
+      }
+    }
+  }
+
+  return best?.key ?? null;
+}

--- a/apps/web/src/config/reviewQueues.tsx
+++ b/apps/web/src/config/reviewQueues.tsx
@@ -1,0 +1,141 @@
+/**
+ * The Review inbox registry — ONE declaration, several consumers.
+ *
+ * Spec §4.5. Review is **an inbox, not six parallel views**, and that
+ * distinction picks the component: the user's job is "clear the badge", not
+ * "visit Duplicates". So this is a list of queues with counts, at every
+ * breakpoint — never tabs. Three facts make tabs actively wrong here:
+ *
+ *  - Counts change as the user works; that IS the content. A tab bar buries it
+ *    in labels nobody is reading.
+ *  - It is 4 + 2, not 6 — four draining queues plus two entries that are not
+ *    queues at all (Insights is analytics, Automations is configuration).
+ *  - The entry count is VARIABLE, 1 to 6, depending on feature flags. A tab bar
+ *    whose width swings with configuration is the same spatial-memory failure
+ *    a horizontal scroll strip has; a list absorbs variable length natively.
+ *
+ * `ReviewQueueList` renders this on phone and tablet as the hub body, and issue
+ * #392 mounts the same component as the desktop context pane — which is why the
+ * registry is data rather than JSX baked into a page.
+ *
+ * **Order is FIXED and must never be sorted by count** (spec §4.5 requirement
+ * 2): rows that jump between visits are exactly the spatial-memory failure the
+ * list exists to avoid. The counts move; the rows do not.
+ */
+
+import type { SvgIconComponent } from '@mui/icons-material';
+import {
+  BurstMode as BurstModeIcon,
+  ContentCopy as ContentCopyIcon,
+  MyLocation as MyLocationIcon,
+  AutoFixHigh as AutoFixHighIcon,
+  Insights as InsightsIcon,
+  AccountTree as AccountTreeIcon,
+} from '@mui/icons-material';
+import type { ReviewCountsResponse } from '../types/media';
+
+/** Stable identifiers — also the `:queue` segment of `/review/:queue`. */
+export type ReviewQueueKey =
+  | 'bursts'
+  | 'duplicates'
+  | 'locations'
+  | 'enhancements'
+  | 'insights'
+  | 'automations';
+
+/**
+ * Which feature flag gates an entry.
+ *
+ * `null` means always available. These are resolved by `useReviewQueues`, which
+ * reads the SAME hooks `Sidebar` already uses — no new request is issued for
+ * this registry.
+ */
+export type ReviewQueueFlag =
+  | 'burstDetection'
+  | 'duplicateDetection'
+  | 'locationInference'
+  | 'pictureEnhancement'
+  | 'workflows'
+  | null;
+
+export interface ReviewQueueDef {
+  key: ReviewQueueKey;
+  label: string;
+  Icon: SvgIconComponent;
+  /** The pre-existing standalone route this entry wraps. Never redirected. */
+  path: string;
+  /**
+   * Which of `GET /api/media/review-counts`' four integers this entry drains,
+   * or `null` for the two entries that are not queues and carry no count.
+   */
+  countKey: keyof ReviewCountsResponse | null;
+  flag: ReviewQueueFlag;
+  /**
+   * `queue` entries drain and carry a count; `secondary` entries sit below a
+   * divider and are unaffected by an empty inbox.
+   */
+  group: 'queue' | 'secondary';
+}
+
+export const REVIEW_QUEUES: readonly ReviewQueueDef[] = [
+  {
+    key: 'bursts',
+    label: 'Bursts',
+    Icon: BurstModeIcon,
+    path: '/bursts',
+    countKey: 'pendingBurstGroups',
+    flag: 'burstDetection',
+    group: 'queue',
+  },
+  {
+    key: 'duplicates',
+    label: 'Duplicates',
+    Icon: ContentCopyIcon,
+    path: '/duplicates',
+    countKey: 'pendingDuplicateGroups',
+    flag: 'duplicateDetection',
+    group: 'queue',
+  },
+  {
+    key: 'locations',
+    label: 'Locations',
+    Icon: MyLocationIcon,
+    path: '/location-suggestions',
+    countKey: 'pendingLocationSuggestions',
+    flag: 'locationInference',
+    group: 'queue',
+  },
+  {
+    key: 'enhancements',
+    label: 'Enhancements',
+    Icon: AutoFixHighIcon,
+    path: '/enhancements',
+    countKey: 'pendingEnhancements',
+    flag: 'pictureEnhancement',
+    group: 'queue',
+  },
+  {
+    key: 'insights',
+    label: 'Insights',
+    Icon: InsightsIcon,
+    path: '/review-insights',
+    countKey: null,
+    flag: null,
+    group: 'secondary',
+  },
+  {
+    key: 'automations',
+    label: 'Automations',
+    Icon: AccountTreeIcon,
+    path: '/workflows',
+    countKey: null,
+    flag: 'workflows',
+    group: 'secondary',
+  },
+];
+
+/** Look an entry up by its `/review/:queue` segment. */
+export function findReviewQueue(key: string | undefined): ReviewQueueDef | null {
+  if (!key) return null;
+  return REVIEW_QUEUES.find((q) => q.key === key) ?? null;
+}

--- a/apps/web/src/hooks/useReviewCounts.ts
+++ b/apps/web/src/hooks/useReviewCounts.ts
@@ -1,19 +1,83 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useSyncExternalStore } from 'react';
 import type { ReviewCountsResponse } from '../types/media';
 import { getReviewCounts } from '../services/media';
 import { useCircle } from './useCircle';
 import { useIsMounted } from './useIsMounted';
+
+// ---------------------------------------------------------------------------
+// Module-level refresh signal
+//
+// WHY THE SIGNAL (issue #390, spec §4.5 requirement 1)
+// ---------------------------------------------------
+// More than one surface renders these counts at once: the Review hub's queue
+// list and the sidebar's aggregate Review badge, on the same screen. State was
+// per-instance, so refetching on the hub's mount would update the list while
+// the badge kept showing the number it loaded when the app booted — **the badge
+// and the list would disagree with each other in the same viewport**, which is
+// worse than either being stale alone, because it reads as a bug rather than as
+// lag.
+//
+// So "refresh the counts" is a module-level event rather than an instance
+// method: `refreshReviewCounts()` bumps a revision every mounted hook observes,
+// and every enabled instance refetches together.
+//
+// WHAT IS DELIBERATELY *NOT* SHARED
+// ---------------------------------
+// Only the signal. The data, the loading flag and the request itself stay
+// per-instance, so a refresh with two consumers mounted issues two requests.
+// That is accepted rather than deduped: `GET /api/media/review-counts` returns
+// four integers, and both a response CACHE and an in-flight SLOT were tried and
+// removed — each introduces module state that survives unmount, which buys one
+// avoided request in exchange for staleness a consumer cannot bust (cache) or a
+// slot a single hung request wedges shut (in-flight). Neither trade is worth it
+// at this payload size.
+//
+// Keeping the state per-instance is also what preserves `enabled: false` ⇒ no
+// request, `data: null`, which issue #204 depends on.
+// ---------------------------------------------------------------------------
+
+let revision = 0;
+const listeners = new Set<() => void>();
+
+function getRevision(): number {
+  return revision;
+}
+
+function subscribeRevision(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Invalidate the review counts everywhere they are rendered.
+ *
+ * Every mounted `useReviewCounts` refetches, so the hub list and the sidebar
+ * badge can never show two different numbers. Called on the Review hub's mount
+ * (spec §4.5 requirement 1: returning after clearing four bursts must not show
+ * a cached "4"), and by any caller's `refetch()`.
+ */
+export function refreshReviewCounts(): void {
+  revision += 1;
+  listeners.forEach((listener) => listener());
+}
+
+/** Test hatch: the revision outlives React unmounts by design. */
+export function __resetReviewCountsForTests(): void {
+  revision = 0;
+  listeners.clear();
+}
 
 interface UseReviewCountsOptions {
   /**
    * When false, the hook makes NO request and reports `data: null`.
    *
    * This exists because hooks cannot be called conditionally: a caller that
-   * only needs these counts behind a feature gate (e.g. the sidebar's AI
-   * Enhancements badge, gated on `features.pictureEnhancement`) must still
-   * call the hook unconditionally. Passing `enabled: false` is how it opts
-   * out of the network call without breaking the rules of hooks — see
-   * issue #204.
+   * only needs these counts behind a feature gate (e.g. the Review hub's queue
+   * list, gated on at least one review feature being enabled) must still call
+   * the hook unconditionally. Passing `enabled: false` is how it opts out of
+   * the network call without breaking the rules of hooks — see issue #204.
    *
    * Flipping this back to true (e.g. once a feature flag finishes loading)
    * triggers the fetch, since `enabled` participates in the effect deps.
@@ -47,22 +111,28 @@ export function useReviewCounts(
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isMounted = useIsMounted();
+  // Participating in the shared revision is what makes every consumer refetch
+  // together; it is read during render so it can be an effect dependency.
+  const rev = useSyncExternalStore(subscribeRevision, getRevision, getRevision);
 
-  const fetch = useCallback(async (circleId: string) => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await getReviewCounts(circleId);
-      if (!isMounted()) return;
-      setData(response);
-    } catch (err) {
-      if (!isMounted()) return;
-      const message = err instanceof Error ? err.message : 'Failed to load review counts';
-      setError(message);
-    } finally {
-      if (isMounted()) setIsLoading(false);
-    }
-  }, [isMounted]);
+  const fetch = useCallback(
+    async (circleId: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await getReviewCounts(circleId);
+        if (!isMounted()) return;
+        setData(response);
+      } catch (err) {
+        if (!isMounted()) return;
+        const message = err instanceof Error ? err.message : 'Failed to load review counts';
+        setError(message);
+      } finally {
+        if (isMounted()) setIsLoading(false);
+      }
+    },
+    [isMounted],
+  );
 
   useEffect(() => {
     if (!enabled || !activeCircleId) {
@@ -71,13 +141,17 @@ export function useReviewCounts(
       return;
     }
     void fetch(activeCircleId);
-  }, [enabled, activeCircleId, fetch]);
+    // `rev` is not used in the body — it is here precisely so a bump of the
+    // shared signal re-runs this effect and refetches.
+  }, [enabled, activeCircleId, fetch, rev]);
 
+  // Routed through the shared signal rather than fetching locally, so one
+  // caller's refresh refreshes every consumer — see the header comment. A
+  // disabled instance still issues no request of its own: its effect returns
+  // early regardless of the revision.
   const refetch = useCallback(() => {
-    if (enabled && activeCircleId) {
-      void fetch(activeCircleId);
-    }
-  }, [enabled, activeCircleId, fetch]);
+    refreshReviewCounts();
+  }, []);
 
   return { data, isLoading, error, refetch };
 }

--- a/apps/web/src/hooks/useReviewQueues.ts
+++ b/apps/web/src/hooks/useReviewQueues.ts
@@ -1,0 +1,107 @@
+/**
+ * Resolve the Review inbox registry against live feature flags and counts.
+ *
+ * One hook, several consumers (issue #390): the hub page's queue list, the
+ * sidebar's aggregate badge, and — from #392 — the desktop context pane. Having
+ * them read one resolver is what keeps the badge, the list and the pane from
+ * disagreeing about which queues exist or how many items are pending.
+ *
+ * It issues NO new request for the flags: `useFeatureFlags` and
+ * `useWorkflowsEnabled` are both module-level caches the sidebar already reads.
+ * The only network call is the counts one, and it is gated (below) so a
+ * deployment with every review feature off never makes it.
+ */
+
+import { useMemo } from 'react';
+import type { ReviewCountsResponse } from '../types/media';
+import type { ReviewQueueDef, ReviewQueueFlag } from '../config/reviewQueues';
+import { REVIEW_QUEUES } from '../config/reviewQueues';
+import { useFeatureFlags } from './useFeatureFlags';
+import { useWorkflowsEnabled } from './useWorkflowSubjects';
+import { useReviewCounts } from './useReviewCounts';
+
+export interface ResolvedReviewQueue extends ReviewQueueDef {
+  /**
+   * Pending items in this queue.
+   *
+   * `null` for the two `secondary` entries, which are not queues and carry no
+   * count — and also while the counts are still in flight, which is why a
+   * consumer must distinguish `null` from `0`: `0` is a genuinely drained queue
+   * (rendered as an em dash, and the trigger for the all-clear state), `null` is
+   * "not known yet" or "not applicable".
+   */
+  count: number | null;
+}
+
+export interface UseReviewQueuesResult {
+  /** Enabled entries only, in the registry's FIXED order — never sorted by count. */
+  entries: ResolvedReviewQueue[];
+  counts: ReviewCountsResponse | null;
+  /** Sum of the enabled queue counts — the aggregate badge on the Review destination. */
+  totalPending: number;
+  isLoading: boolean;
+  /** False when every entry is gated off, i.e. no review feature is enabled at all. */
+  anyEnabled: boolean;
+}
+
+export function useReviewQueues(): UseReviewQueuesResult {
+  const { features, pictureEnhancement, isLoading: flagsLoading } = useFeatureFlags();
+  const workflowsEnabled = useWorkflowsEnabled();
+
+  // `=== true` everywhere, never a truthy check — the same convention `Sidebar`
+  // documents: an entry must not flash in while the flags are still loading
+  // (every source is null until then), and a flags outage, which resolves to
+  // null rather than throwing, must HIDE the entry instead of guessing.
+  const isFlagEnabled = useMemo(() => {
+    return (flag: ReviewQueueFlag): boolean => {
+      if (flag === null) return true;
+      // Workflows has no entry in `features` — it is probed separately via
+      // `GET /workflows/subjects`, the only gate a non-admin can read for it.
+      if (flag === 'workflows') return workflowsEnabled === true;
+      // The enhancer's client policy is its own object, not a `features` key,
+      // and its `enabled` already folds in the env kill-switch server-side.
+      if (flag === 'pictureEnhancement') return pictureEnhancement?.enabled === true;
+      return features?.[flag] === true;
+    };
+  }, [features, pictureEnhancement, workflowsEnabled]);
+
+  const enabledDefs = useMemo(
+    () => REVIEW_QUEUES.filter((def) => isFlagEnabled(def.flag)),
+    [isFlagEnabled],
+  );
+
+  // The counts request is gated on at least one COUNTED queue being enabled.
+  // Insights and Automations resolve without counts, so a deployment running
+  // only those two must not pay for the request — this is the broadened form of
+  // the enhancer-only gate the sidebar used to apply (issue #204).
+  const anyQueueEnabled = enabledDefs.some((def) => def.countKey !== null);
+  const { data: counts, isLoading: countsLoading } = useReviewCounts({
+    enabled: anyQueueEnabled,
+  });
+
+  const entries = useMemo<ResolvedReviewQueue[]>(
+    () =>
+      enabledDefs.map((def) => ({
+        ...def,
+        count: def.countKey && counts ? counts[def.countKey] : null,
+      })),
+    [enabledDefs, counts],
+  );
+
+  // Only enabled queues contribute: a feature that is off must not inflate the
+  // badge with work the user has no surface to do.
+  const totalPending = entries.reduce((sum, entry) => sum + (entry.count ?? 0), 0);
+
+  return {
+    entries,
+    counts,
+    totalPending,
+    // `workflowsEnabled === null` means its probe has not resolved. It counts as
+    // loading so a deep link to `/review/automations` waits for the answer
+    // instead of being bounced to the hub as "disabled" a beat before the probe
+    // says otherwise.
+    isLoading:
+      flagsLoading || workflowsEnabled === null || (anyQueueEnabled && countsLoading),
+    anyEnabled: enabledDefs.length > 0,
+  };
+}

--- a/apps/web/src/pages/Reviews/ReviewHubPage.tsx
+++ b/apps/web/src/pages/Reviews/ReviewHubPage.tsx
@@ -1,0 +1,36 @@
+/**
+ * `/review` — the Review inbox (issue #390, spec §3.1 / §4.5).
+ *
+ * Thin by design: the list itself is `ReviewQueueList`, which #392 also mounts
+ * as the desktop context pane. This page contributes the page chrome, scroll
+ * restoration, and the count invalidation below.
+ */
+
+import { useEffect } from 'react';
+import { Box, Typography } from '@mui/material';
+import { ReviewQueueList } from '../../components/review/ReviewQueueList';
+import { refreshReviewCounts } from '../../hooks/useReviewCounts';
+import { useScrollRestoration } from '../../hooks/useScrollRestoration';
+
+export default function ReviewHubPage() {
+  useScrollRestoration('review-hub');
+
+  // Spec §4.5 requirement 1, and the criterion most likely to regress silently:
+  // clearing four bursts and coming back to a cached "4" destroys the only
+  // progress feedback the feature has. So the invalidation is explicit on every
+  // mount rather than incidental to some hook's lifecycle — and because it goes
+  // through the shared signal, the sidebar's aggregate badge moves with the
+  // list instead of contradicting it.
+  useEffect(() => {
+    refreshReviewCounts();
+  }, []);
+
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Review
+      </Typography>
+      <ReviewQueueList variant="hub" />
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Reviews/ReviewQueuePage.tsx
+++ b/apps/web/src/pages/Reviews/ReviewQueuePage.tsx
@@ -1,0 +1,139 @@
+/**
+ * `/review/:queue` — one queue inside the Review hub (issue #390).
+ *
+ * A WRAPPER, not a rewrite. Each queue's page is mounted verbatim; none of them
+ * is modified, and none of their standalone routes (`/bursts`, `/duplicates`, …)
+ * is removed or redirected. Bookmarks, the Home review banners and the
+ * `review_queue_*` notification links all point at those routes, and the epic's
+ * central claim is that nothing becomes unreachable.
+ *
+ * What this page adds around the wrapped content is the hub's two affordances:
+ * a way back, and chain-to-next.
+ */
+
+import { Suspense, lazy } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import {
+  ArrowBack as ArrowBackIcon,
+  ArrowForward as ArrowForwardIcon,
+} from '@mui/icons-material';
+import { Link as RouterLink, Navigate, useParams } from 'react-router-dom';
+import { LoadingSpinner } from '../../components/common/LoadingSpinner';
+import { reviewQueuePath } from '../../components/review/ReviewQueueList';
+import type { ReviewQueueKey } from '../../config/reviewQueues';
+import { REVIEW_QUEUES, findReviewQueue } from '../../config/reviewQueues';
+import type { ResolvedReviewQueue } from '../../hooks/useReviewQueues';
+import { useReviewQueues } from '../../hooks/useReviewQueues';
+
+// Lazily imported HERE rather than in `App.tsx` so opening `/review` does not
+// pull six unrelated page chunks in with it — only the queue actually opened is
+// fetched. Each is a zero-prop default export.
+const BurstsPage = lazy(() => import('../Bursts/BurstsPage'));
+const DuplicatesPage = lazy(() => import('../Duplicates/DuplicatesPage'));
+const LocationSuggestionsPage = lazy(
+  () => import('../LocationSuggestions/LocationSuggestionsPage'),
+);
+const EnhancementsPage = lazy(() => import('../Enhancements/EnhancementsPage'));
+const ReviewInsightsPage = lazy(() => import('../Insights/ReviewInsightsPage'));
+const WorkflowListPage = lazy(() => import('../Workflows/WorkflowListPage'));
+
+const QUEUE_PAGES: Record<ReviewQueueKey, React.ComponentType> = {
+  bursts: BurstsPage,
+  duplicates: DuplicatesPage,
+  locations: LocationSuggestionsPage,
+  enhancements: EnhancementsPage,
+  insights: ReviewInsightsPage,
+  automations: WorkflowListPage,
+};
+
+/**
+ * Registry labels are plural ("Duplicates"), which reads wrong at a count of
+ * one. Trimming the trailing "s" covers every label in the registry and is
+ * cheaper than carrying a second noun per entry.
+ */
+function pluralize(label: string, count: number): string {
+  const lower = label.toLowerCase();
+  return count === 1 && lower.endsWith('s') ? lower.slice(0, -1) : lower;
+}
+
+/**
+ * The next queue still holding work, in registry order, wrapping around and
+ * skipping the current one. Secondary entries are not queues and never qualify.
+ */
+function nextNonEmpty(
+  entries: ResolvedReviewQueue[],
+  currentKey: ReviewQueueKey,
+): ResolvedReviewQueue | null {
+  const order = REVIEW_QUEUES.map((def) => def.key);
+  const start = order.indexOf(currentKey);
+  if (start < 0) return null;
+
+  for (let step = 1; step <= order.length; step += 1) {
+    const key = order[(start + step) % order.length];
+    const entry = entries.find((candidate) => candidate.key === key);
+    if (entry && entry.group === 'queue' && entry.count !== null && entry.count > 0) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+export default function ReviewQueuePage() {
+  const { queue } = useParams<{ queue: string }>();
+  const { entries, isLoading } = useReviewQueues();
+
+  const def = findReviewQueue(queue);
+  // `entries` holds ENABLED entries only, so this resolves the unknown-key and
+  // feature-disabled cases with one lookup.
+  const entry = def ? entries.find((candidate) => candidate.key === def.key) ?? null : null;
+
+  if (!def) return <Navigate to="/review" replace />;
+  if (!entry) {
+    // Not enabled — but the flags may simply not have answered yet, and
+    // bouncing a deep link to the hub a beat before the answer arrives would be
+    // a bug the user experiences as a random redirect.
+    if (isLoading) return <LoadingSpinner />;
+    return <Navigate to="/review" replace />;
+  }
+
+  const QueueComponent = QUEUE_PAGES[entry.key];
+  const drained = entry.group === 'queue' && entry.count === 0;
+  const next = drained ? nextNonEmpty(entries, entry.key) : null;
+
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Button
+        component={RouterLink}
+        to="/review"
+        startIcon={<ArrowBackIcon />}
+        aria-label="Back to Review"
+        size="small"
+        sx={{ mb: 1 }}
+      >
+        Review
+      </Button>
+
+      <Suspense fallback={<LoadingSpinner />}>
+        <QueueComponent />
+      </Suspense>
+
+      {/* Chain-to-next (spec §4.5 requirement 3): having finished this queue,
+          offer the next one inline rather than making the user walk back to the
+          hub to discover it. The counts are already loaded, so it costs nothing. */}
+      {next && next.count !== null && (
+        <Box sx={{ mt: 3, display: 'flex', justifyContent: 'center', minWidth: 0 }}>
+          <Button
+            component={RouterLink}
+            to={reviewQueuePath(next.key)}
+            endIcon={<ArrowForwardIcon />}
+            variant="outlined"
+          >
+            <Typography component="span" variant="button" noWrap>
+              Next: {next.count} {pluralize(next.label, next.count)}
+            </Typography>
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 of epic #388. Five `UTILITIES` rows collapse into a single badged **Review** destination (**14 → 9 rows**). The hub *wraps* the pages that already exist — no page content is redesigned, and no existing route is deleted, moved, or redirected.

This is the destination worth defending: unlike the apps surveyed in the spec, MemoriaHub *generates work for its user*. That differentiator currently costs six quiet drawer rows which read as furniture. One badged inbox reads as work — and matches the actual rhythm, since these queues are empty most of the time and full immediately after an import.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #388
Fixes #390

## Changes Made

- **`/review` and `/review/:queue`** — added; the six standalone routes they wrap all keep resolving.
- **`ReviewQueueList` (new)** — the hub body, deliberately standalone because **#392 mounts this exact component as the desktop context pane.** A second implementation there would let count-refresh, ordering and gating drift between two surfaces meant to be the same list at two sizes.
- **`config/destinations.ts` (new)** — spec §3.5's route-ownership model with segment-boundary matching. This is what lets the single Review row light up at `/bursts` — a path that does not resemble it and that no `startsWith` on the row's own path could ever match.
- **`config/reviewQueues.tsx` (new)** — the six entries in fixed order, with their count keys and feature flags.
- **`useReviewCounts`** — the enabled gate broadened from "the enhancer only" to "any review feature", plus a module-level refresh **signal**.
- **`Sidebar`** — `UTILITIES` replaced by one badged `Review` row.

### It is a queue list, not tabs — at every breakpoint

An earlier draft of the issue specified six tabs; that was rejected on research and no tab bar is built here. Review is an inbox: the user's job is clearing the badge, not visiting Duplicates. Counts change as they work and *that is the content*, which a tab bar buries in labels. It is 4 draining queues + 2 non-queues rather than 6 peers. And the entry count is **variable, 1 to 6, with feature flags** — a tab bar whose width swings with configuration is a spatial-memory failure a list absorbs natively.

### Four details that decide whether it feels good

- **Counts refresh on return to the hub.** `useReviewCounts` gained a module-level refresh *signal* (not a cache), so the sidebar badge and the hub list refetch together and cannot show two different numbers on one screen.
- **Fixed row order, never sorted by count** — rows that jump between visits are the exact failure the list exists to avoid.
- **Chain-to-next** offers the next non-empty queue inline, from counts already loaded.
- **A drained queue reads as an em dash, never `0`**, and an all-drained inbox is one confident "You're all caught up" rather than four rows of zero. The all-clear check compares to zero rather than testing falsiness, so an unloaded (`null`) count cannot masquerade as drained and state the opposite of the truth while a request is in flight.

The Review row renders **unconditionally** — never hidden at zero, never hidden when features are off (spec §6.3). Keep the destination, drop the badge.

## Testing

- [x] Unit tests pass (`npm test`) — full `apps/web` suite: **237 files / 4784 tests green**
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — n/a (no runtime environment in this session; covered below)

Five new suites plus three updated. `Sidebar`'s UTILITIES-era cases were **rewritten, not deleted**. The three carrying the most weight:

- **`destinations.test.ts`** asserts spec §3.5 against the *live* `App.tsx`: every declared route resolves to exactly one destination or — for the deliberately unowned set — to none, and **no route is claimed by two**. It fails the day someone adds a route and forgets the table, and pins the subtle cases (`/reviewer` does not activate Review; `/review-insights` and `/review-runs` activate it via their *own* prefixes, not as children of `/review`).
- **`reachability.test.tsx`** grew the six wrapped routes — the epic's central claim is that nothing becomes unreachable.
- **The count-refresh case** drives the real hook through a mocked service, so serving a cached value genuinely fails it.

The old AI-Enhancements badge and counts-gating cases were re-pointed at the Review row: they had begun passing *coincidentally*, since the aggregate equals the enhancer count when the enhancer is the only enabled queue.

### Test Instructions

1. With bursts/duplicates/locations/enhancer enabled, confirm the drawer shows 9 rows with one badged **Review**.
2. Open `/review` → the queue list with counts; a drained queue shows `—`, not `0`.
3. Resolve a burst group, go back to `/review` → the count and the sidebar badge both drop.
4. Finish a queue with another non-empty → the "Next: N …" affordance appears and links there.
5. Drain everything → one "You're all caught up", with Insights and Automations still below it.
6. Stand at `/bursts/:id` → **Review** is the highlighted row.
7. Turn every review feature off → the Review row is still present, unbadged.

## Screenshots

Not captured — no browser in this session. The target is drawn to scale in `docs/specs/assets/navigation-ia-mockups.html` ("Review · a queue list" and "Review · all clear" frames).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

**One judgement call worth reviewing.** Module-level request de-duplication for `useReviewCounts` was attempted twice and removed both times: a TTL response cache made test outcomes depend on how fast the preceding test ran, and an in-flight-promise slot could wedge permanently on a never-settling request — a genuine production failure mode, not only a test artifact. What ships is the *signal* alone; data, loading and the request itself stay per-instance, which is what preserves `enabled: false` ⇒ no request (issue #204). The cost is two small counts-only requests when the hub and sidebar are both mounted; the benefit is that the badge and the list can never disagree.

**Sequencing:** until #392 lands, desktop gets the same hub-then-drill treatment as phone — correct, just not yet optimal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj

---
_Generated by [Claude Code](https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj)_