### PR TITLE
fix(web): restore search below 900px — /search now owns its own input

### DIFF
--- a/apps/web/src/__tests__/components/search/PageSearchBar.test.tsx
+++ b/apps/web/src/__tests__/components/search/PageSearchBar.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * Unit tests — PageSearchBar / PageSearchBarSection
+ *
+ * PageSearchBar is the regression guard's namesake component for production
+ * bug #400: it is the search input that lives IN `/search` itself, so the
+ * page is self-sufficient when `TopbarSearch` is gated out of the AppBar
+ * below `md`. Its behaviour intentionally mirrors `TopbarSearch` (see that
+ * component's test file for the sibling coverage on the toolbar entry point):
+ *   - Typing + Enter calls runAgentSearch with the trimmed query.
+ *   - Empty / whitespace-only input never calls runAgentSearch.
+ *   - No active circle disables the whole control.
+ *   - The Tune button opens SearchPanel with the active circleId; its
+ *     onSubmit wires to runDeterministicSearch and closes the panel.
+ *   - The clear (X) button appears only once there is text, and clears it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared BEFORE any import of the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../contexts/SearchContext', () => ({
+  useSearch: vi.fn(),
+  SearchProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+// A realistic minimal SearchRequest fixture used by the stubbed SearchPanel's
+// "Apply" button — mirrors TopbarSearch.test.tsx's fixture exactly.
+const FAKE_REQUEST = { circleId: 'circle-1', filters: { country: 'Costa Rica' } };
+
+// Stub SearchPanel: records the props it was opened with (so we can assert
+// circleId) and renders an "Apply" button that calls onSubmit when clicked.
+const searchPanelSpy = vi.fn();
+vi.mock('../../../components/search/SearchPanel', () => ({
+  SearchPanel: vi.fn((props: any) => {
+    searchPanelSpy(props);
+    return props.open ? (
+      <div data-testid="advanced-dialog">
+        <button onClick={() => props.onSubmit(FAKE_REQUEST)}>Apply</button>
+        <button onClick={props.onClose}>Cancel</button>
+      </div>
+    ) : null;
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { PageSearchBar, PageSearchBarSection } from '../../../components/search/PageSearchBar';
+import { useSearch } from '../../../contexts/SearchContext';
+import { useCircle } from '../../../hooks/useCircle';
+
+const mockUseSearch = vi.mocked(useSearch);
+const mockUseCircle = vi.mocked(useCircle);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultSearchMock() {
+  return {
+    messages: [],
+    results: null,
+    isSearching: false,
+    error: null,
+    searchRequest: null,
+    runAgentSearch: vi.fn(),
+    runDeterministicSearch: vi.fn(),
+    clearSearch: vi.fn(),
+  };
+}
+
+function defaultCircleMock() {
+  return {
+    activeCircle: { id: 'circle-1', name: 'My Circle' },
+    activeCircleId: 'circle-1',
+    activeCircleRole: 'circle_admin' as const,
+    circles: [],
+    loading: false,
+    setActiveCircle: vi.fn(),
+    refreshCircles: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PageSearchBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchPanelSpy.mockClear();
+    mockUseSearch.mockReturnValue(defaultSearchMock() as any);
+    mockUseCircle.mockReturnValue(defaultCircleMock() as any);
+  });
+
+  // -------------------------------------------------------------------------
+  // Rendering
+  // -------------------------------------------------------------------------
+  describe('rendering', () => {
+    it('renders a text input labelled "Search your photos"', () => {
+      render(<PageSearchBar />);
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+    });
+
+    it('renders an "Advanced search" button', () => {
+      render(<PageSearchBar />);
+
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+    });
+
+    it('the advanced search button announces it opens a dialog', () => {
+      render(<PageSearchBar />);
+
+      expect(
+        screen.getByRole('button', { name: /advanced search/i }),
+      ).toHaveAttribute('aria-haspopup', 'dialog');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Enter-to-submit
+  // -------------------------------------------------------------------------
+  describe('submitting via Enter', () => {
+    it('calls runAgentSearch with the trimmed typed text when Enter is pressed', async () => {
+      const runAgentSearch = vi.fn();
+      mockUseSearch.mockReturnValue({ ...defaultSearchMock(), runAgentSearch } as any);
+
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      const input = screen.getByRole('textbox', { name: /search your photos/i });
+      await user.type(input, '  vacation photos  {Enter}');
+
+      expect(runAgentSearch).toHaveBeenCalledWith('vacation photos');
+    });
+
+    it('does NOT call runAgentSearch for an empty query', async () => {
+      const runAgentSearch = vi.fn();
+      mockUseSearch.mockReturnValue({ ...defaultSearchMock(), runAgentSearch } as any);
+
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      const input = screen.getByRole('textbox', { name: /search your photos/i });
+      await user.type(input, '{Enter}');
+
+      expect(runAgentSearch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call runAgentSearch for a whitespace-only query', async () => {
+      const runAgentSearch = vi.fn();
+      mockUseSearch.mockReturnValue({ ...defaultSearchMock(), runAgentSearch } as any);
+
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      const input = screen.getByRole('textbox', { name: /search your photos/i });
+      await user.type(input, '   {Enter}');
+
+      expect(runAgentSearch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // No active circle — disabled control, submission is a no-op
+  // -------------------------------------------------------------------------
+  describe('no active circle', () => {
+    it('disables the text input', () => {
+      mockUseCircle.mockReturnValue({
+        ...defaultCircleMock(),
+        activeCircle: null,
+        activeCircleId: null,
+      } as any);
+
+      render(<PageSearchBar />);
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeDisabled();
+    });
+
+    it('disables the Advanced search button', () => {
+      mockUseCircle.mockReturnValue({
+        ...defaultCircleMock(),
+        activeCircle: null,
+        activeCircleId: null,
+      } as any);
+
+      render(<PageSearchBar />);
+
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeDisabled();
+    });
+
+    it('typing and pressing Enter does not call runAgentSearch', async () => {
+      const runAgentSearch = vi.fn();
+      mockUseCircle.mockReturnValue({
+        ...defaultCircleMock(),
+        activeCircle: null,
+        activeCircleId: null,
+      } as any);
+      mockUseSearch.mockReturnValue({ ...defaultSearchMock(), runAgentSearch } as any);
+
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      const input = screen.getByRole('textbox', { name: /search your photos/i });
+      // The input itself is disabled, so user-event cannot type into it —
+      // this in itself is the guarantee submission is unreachable. Fire the
+      // key event directly to prove the handler also declines to act, in
+      // case the disabled attribute is ever dropped from the markup.
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      expect(runAgentSearch).not.toHaveBeenCalled();
+    });
+
+    it('does not mount SearchPanel at all (no circleId to load facets with)', () => {
+      mockUseCircle.mockReturnValue({
+        ...defaultCircleMock(),
+        activeCircle: null,
+        activeCircleId: null,
+      } as any);
+
+      render(<PageSearchBar />);
+
+      expect(searchPanelSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Advanced search (SearchPanel) wiring
+  // -------------------------------------------------------------------------
+  describe('advanced search', () => {
+    it('opens SearchPanel with the active circleId when the Tune button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      await user.click(screen.getByRole('button', { name: /advanced search/i }));
+
+      expect(screen.getByTestId('advanced-dialog')).toBeInTheDocument();
+      expect(searchPanelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ open: true, circleId: 'circle-1' }),
+      );
+    });
+
+    it('calls runDeterministicSearch and closes the panel when SearchPanel submits', async () => {
+      const runDeterministicSearch = vi.fn();
+      mockUseSearch.mockReturnValue({
+        ...defaultSearchMock(),
+        runDeterministicSearch,
+      } as any);
+
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      await user.click(screen.getByRole('button', { name: /advanced search/i }));
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(runDeterministicSearch).toHaveBeenCalledWith(FAKE_REQUEST);
+      expect(screen.queryByTestId('advanced-dialog')).not.toBeInTheDocument();
+    });
+
+    it('closes the panel when Cancel/onClose fires', async () => {
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      await user.click(screen.getByRole('button', { name: /advanced search/i }));
+      expect(screen.getByTestId('advanced-dialog')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByTestId('advanced-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Clear button
+  // -------------------------------------------------------------------------
+  describe('clear button', () => {
+    it('does not render when the input is empty', () => {
+      render(<PageSearchBar />);
+
+      expect(screen.queryByRole('button', { name: /clear search/i })).not.toBeInTheDocument();
+    });
+
+    it('appears once the input has text', async () => {
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      await user.type(screen.getByRole('textbox', { name: /search your photos/i }), 'dogs');
+
+      expect(screen.getByRole('button', { name: /clear search/i })).toBeInTheDocument();
+    });
+
+    it('clears the input text when clicked', async () => {
+      const user = userEvent.setup();
+      render(<PageSearchBar />);
+
+      const input = screen.getByRole('textbox', { name: /search your photos/i });
+      await user.type(input, 'dogs');
+      await user.click(screen.getByRole('button', { name: /clear search/i }));
+
+      expect(input).toHaveValue('');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PageSearchBarSection — thin wrapper used at all four SearchPage mount sites
+// ---------------------------------------------------------------------------
+
+describe('PageSearchBarSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchPanelSpy.mockClear();
+    mockUseSearch.mockReturnValue(defaultSearchMock() as any);
+    mockUseCircle.mockReturnValue(defaultCircleMock() as any);
+  });
+
+  it('renders the same input and advanced-search trigger as PageSearchBar', () => {
+    render(<PageSearchBarSection />);
+
+    expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/pages/SearchPage.test.tsx
+++ b/apps/web/src/__tests__/pages/SearchPage.test.tsx
@@ -505,4 +505,133 @@ describe('SearchPage', () => {
       expect(screen.getByText('Grace')).toBeInTheDocument();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Capability guard — regression coverage for production bug #400.
+  //
+  // #392 gated TopbarSearch (the AppBar's search pill) to `md`+, on the
+  // rationale that Search moved to a bottom-bar destination. But `/search`
+  // had no input of its own, so below 900px there was NO way to run a
+  // search or open SearchPanel at all — every #392 test still passed
+  // because they all asserted CHROME ("TopbarSearch hidden below md"), never
+  // CAPABILITY ("can a user actually search from this page"). These tests
+  // assert capability directly, in every SearchPage branch, with no AppBar
+  // mounted — so they fail the way #400 failed if PageSearchBarSection is
+  // ever removed from a branch again.
+  // -------------------------------------------------------------------------
+  describe('Capability guard — search remains usable in every branch (regression for #400)', () => {
+    // None of these tests render AppBar/TopbarSearch — `render()` from
+    // test-utils mounts SearchPage bare, exactly like every test above. That
+    // is deliberate: the whole bug was the page silently depending on
+    // toolbar chrome it does not itself render, so proving the guard here
+    // must not accidentally lean on chrome either.
+    it('sanity check: this suite never mounts AppBar / TopbarSearch', () => {
+      render(<SearchPage />);
+      // TopbarSearch's own aria-label ("Open advanced search filters") is
+      // distinct from PageSearchBar's ("Advanced search") specifically so
+      // this assertion cannot be satisfied by the toolbar accidentally
+      // being present.
+      expect(
+        screen.queryByRole('button', { name: /open advanced search filters/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('branch: no active circle — a search input and advanced-search trigger are present (disabled)', () => {
+      mockUseCircle.mockReturnValue({
+        ...defaultCircleMock(),
+        activeCircle: null,
+        activeCircleId: null,
+      } as any);
+
+      render(<SearchPage />);
+
+      // Confirms we are really in the no-circle branch.
+      expect(screen.getByRole('alert').textContent).toMatch(/select a circle/i);
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+    });
+
+    it('branch: deterministic (advanced) results (searchRequest !== null) — search input and advanced trigger are present', () => {
+      mockUseSearch.mockReturnValue({
+        ...defaultSearchMock(),
+        searchRequest: { circleId: 'circle-1', filters: {} },
+      } as any);
+
+      render(<SearchPage />);
+
+      // Confirms we are really in the deterministic-results branch, and that
+      // the fix is additive — the gallery still renders alongside the bar.
+      expect(screen.getByTestId('media-gallery')).toBeInTheDocument();
+      expect(screen.getByText(/search results/i)).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+    });
+
+    it('branch: agentic results (results !== null) — search input and advanced trigger are present', () => {
+      mockUseSearch.mockReturnValue({
+        ...defaultSearchMock(),
+        results: {
+          items: [],
+          meta: { page: 1, pageSize: 20, totalItems: 3, totalPages: 1 },
+        },
+      } as any);
+
+      render(<SearchPage />);
+
+      // Confirms we are really in the agentic-results branch, and that
+      // existing content (the gallery, the result count) is undisturbed.
+      expect(screen.getByTestId('media-gallery')).toBeInTheDocument();
+      expect(screen.getByText(/3 results/i)).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+    });
+
+    it('branch: agentic search in flight (isSearching, results === null) — search input and advanced trigger are present', () => {
+      mockUseSearch.mockReturnValue({
+        ...defaultSearchMock(),
+        isSearching: true,
+        results: null,
+      } as any);
+
+      render(<SearchPage />);
+
+      // Confirms we are really in the isSearching branch.
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+    });
+
+    it('branch: default explore state (no request, no results, not searching) — search input and advanced trigger are present', () => {
+      // defaultSearchMock() is already searchRequest:null, results:null,
+      // isSearching:false — the explore branch.
+      render(<SearchPage />);
+
+      // Confirms we are really in the explore branch, and existing content
+      // (the Explore carousels) is undisturbed.
+      expect(screen.getByText('Countries')).toBeInTheDocument();
+      expect(screen.getByText('Regions')).toBeInTheDocument();
+      expect(screen.getByText('Cities')).toBeInTheDocument();
+      expect(screen.getByText('Tags')).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: /search your photos/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /advanced search/i })).toBeInTheDocument();
+    });
+
+    it('typing into the page search bar in the explore branch actually reaches runAgentSearch (end-to-end, not just presence)', async () => {
+      const runAgentSearch = vi.fn();
+      mockUseSearch.mockReturnValue({ ...defaultSearchMock(), runAgentSearch } as any);
+
+      const user = userEvent.setup();
+      render(<SearchPage />);
+
+      const input = screen.getByRole('textbox', { name: /search your photos/i });
+      await user.type(input, 'birthday party{Enter}');
+
+      expect(runAgentSearch).toHaveBeenCalledWith('birthday party');
+    });
+  });
 });

--- a/apps/web/src/components/navigation/AppBar.tsx
+++ b/apps/web/src/components/navigation/AppBar.tsx
@@ -197,14 +197,23 @@ export function AppBar() {
               <CircleChip />
 
               {/* Central search pill — `md` and up ONLY (spec §4.1 / §4.2).
-                  Below `md` Search is a bottom-bar destination, so a search
-                  field here would be a second entry point to the same place
-                  competing for the scarcest row in the app; removing it is what
-                  permanently resolves the ~354px-against-360px crowding the
-                  topbar audit documents, rather than tuning gaps a third time.
-                  At `md` and up the destination gives up its RAIL slot instead
-                  and is carried here, where there is width for a real input —
-                  see the header of `NavigationRail`. */}
+                  Below `md` this pill is absent, which frees the scarcest row in
+                  the app and permanently resolves the ~354px-against-360px
+                  crowding the topbar audit documents. At `md` and up the Search
+                  destination gives up its RAIL slot instead and is carried here,
+                  where there is width for a real input — see the header of
+                  `NavigationRail`.
+
+                  ⚠️ THIS GATE IS ONLY VALID BECAUSE `/search` OWNS ITS OWN INPUT.
+                  The tab is NOT by itself an equivalent replacement for this
+                  pill: `TopbarSearch` is the sole opener of `SearchPanel` and the
+                  sole free-text/agentic entry point in the toolbar, and issue
+                  #400 is the production outage that happened when this gate
+                  landed while `SearchPage` still only rendered results. What
+                  makes it correct now is `PageSearchBar`, mounted in all four
+                  `SearchPage` branches, which carries both capabilities. Do not
+                  remove that bar — deleting it silently recreates the outage
+                  below 900px, where this pill does not render at all. */}
               {isMd && <TopbarSearch />}
 
               {/* The flexible spacer that `TopbarSearch` used to supply.

--- a/apps/web/src/components/search/PageSearchBar.tsx
+++ b/apps/web/src/components/search/PageSearchBar.tsx
@@ -1,0 +1,182 @@
+/**
+ * PageSearchBar — the search input that lives IN the page, not in the toolbar.
+ *
+ * `TopbarSearch` is toolbar chrome and is gated to `md`+ (spec §4.1: below `md`
+ * Search is a bottom-bar destination rather than a top-bar field). That gate is
+ * only sound if the destination itself owns an equivalent input — otherwise the
+ * only entry point to free-text/agentic search AND the only opener of
+ * `SearchPanel` disappear below 900px, which is exactly the outage issue #400
+ * records. This component is that input: mounted by `SearchPage`, it makes
+ * `/search` self-sufficient at every breakpoint.
+ *
+ * It deliberately encapsulates BOTH search capabilities so a page that mounts it
+ * needs nothing else:
+ *   1. free-text / semantic / agentic search  → `runAgentSearch(query)`
+ *   2. advanced (deterministic) search        → `SearchPanel` → `runDeterministicSearch(req)`
+ *
+ * The submit / clear / advanced logic mirrors `TopbarSearch` exactly so the two
+ * entry points cannot drift in behaviour. `TopbarSearch` is intentionally left
+ * untouched — this is additive.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { Box, IconButton, InputBase, Paper, Tooltip } from '@mui/material';
+import {
+  Search as SearchIcon,
+  Tune as TuneIcon,
+  Close as ClearIcon,
+} from '@mui/icons-material';
+import { useCircle } from '../../hooks/useCircle';
+import { useSearch } from '../../contexts/SearchContext';
+import { SearchPanel } from './SearchPanel';
+
+export interface PageSearchBarProps {
+  /** Pre-fill the field (e.g. restoring the query behind a results view). */
+  initialQuery?: string;
+  /** Focus the input on mount. Off by default — a page-level autofocus on a
+   *  phone pops the keyboard over the content the user just navigated to. */
+  autoFocus?: boolean;
+}
+
+export function PageSearchBar({
+  initialQuery = '',
+  autoFocus = false,
+}: PageSearchBarProps) {
+  const { activeCircle, activeCircleId } = useCircle();
+  const { runAgentSearch, runDeterministicSearch } = useSearch();
+
+  const [input, setInput] = useState(initialQuery);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Same guard as TopbarSearch: an empty query or no active circle is a no-op,
+  // never an error state — SearchContext.runAgentSearch bails on both anyway.
+  const handleSubmit = useCallback(() => {
+    const q = input.trim();
+    if (!q || !activeCircle) return;
+    runAgentSearch(q);
+    // Keep the text so the user can see what they searched.
+  }, [input, activeCircle, runAgentSearch]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const handleClear = useCallback(() => {
+    setInput('');
+    inputRef.current?.focus();
+  }, []);
+
+  const handleAdvancedSubmit = useCallback(
+    (request: Parameters<typeof runDeterministicSearch>[0]) => {
+      runDeterministicSearch(request);
+      setAdvancedOpen(false);
+    },
+    [runDeterministicSearch],
+  );
+
+  const circleId = activeCircleId ?? '';
+
+  return (
+    <>
+      <Paper
+        elevation={0}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          // Full width of the page column, unlike the toolbar pill's capped
+          // maxWidth — here the field IS the page's primary affordance.
+          width: '100%',
+          // minWidth: 0 on every flex context per the issue #291 house rule, so
+          // a long value can never widen the app shell.
+          minWidth: 0,
+          px: 1,
+          py: 0.5,
+          // 48px comfortable touch target on phone, where this is the only
+          // way to search at all.
+          minHeight: 48,
+          borderRadius: 5,
+          bgcolor: 'action.hover',
+        }}
+      >
+        <IconButton
+          size="small"
+          onClick={handleSubmit}
+          disabled={!input.trim() || !activeCircle}
+          aria-label="Search"
+          sx={{ p: 0.75, flexShrink: 0, color: 'text.secondary' }}
+        >
+          <SearchIcon fontSize="small" />
+        </IconButton>
+
+        <InputBase
+          inputRef={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search your photos"
+          disabled={!activeCircle}
+          autoFocus={autoFocus}
+          inputProps={{ 'aria-label': 'Search your photos' }}
+          sx={{ flex: 1, minWidth: 0, fontSize: '0.95rem' }}
+        />
+
+        {input && (
+          <IconButton
+            size="small"
+            onClick={handleClear}
+            aria-label="Clear search"
+            sx={{ p: 0.5, flexShrink: 0, color: 'text.secondary' }}
+          >
+            <ClearIcon fontSize="small" />
+          </IconButton>
+        )}
+
+        {/* The ONLY opener of SearchPanel below `md`. Wrapped in a <span> so the
+            Tooltip still has a live event target while the button is disabled. */}
+        <Tooltip title="Advanced search">
+          <span style={{ display: 'flex', flexShrink: 0 }}>
+            <IconButton
+              size="small"
+              onClick={() => setAdvancedOpen(true)}
+              disabled={!activeCircle}
+              aria-label="Advanced search"
+              aria-haspopup="dialog"
+              sx={{ p: 0.75, color: 'text.secondary' }}
+            >
+              <TuneIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Paper>
+
+      {/* SearchPanel requires a real circleId to load its facets, so it is only
+          mounted once one exists — matching TopbarSearch. */}
+      {circleId && (
+        <SearchPanel
+          open={advancedOpen}
+          onClose={() => setAdvancedOpen(false)}
+          circleId={circleId}
+          onSubmit={handleAdvancedSubmit}
+        />
+      )}
+    </>
+  );
+}
+
+/** Convenience wrapper: the bar plus the vertical rhythm every SearchPage
+ *  branch wants above its own header row. Keeps the four mount sites identical. */
+export function PageSearchBarSection(props: PageSearchBarProps) {
+  return (
+    <Box sx={{ mb: 2, minWidth: 0 }}>
+      <PageSearchBar {...props} />
+    </Box>
+  );
+}

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -11,8 +11,11 @@
  * When neither is set (and no in-flight search), falls back to the Explore
  * browse rows (People / Places / Tags), which existed before.
  *
- * The search input lives in the AppBar TopbarSearch; this page only
- * renders output.
+ * The page owns its own search input (`PageSearchBar`), mounted at the top of
+ * ALL FOUR render branches below. That is load-bearing, not cosmetic: the
+ * AppBar's `TopbarSearch` is gated to `md`+ (spec §4.1), so below 900px this bar
+ * is the only entry point to free-text/agentic search AND the only opener of
+ * `SearchPanel`. Removing it from any branch re-creates the issue #400 outage.
  */
 
 import { useEffect, useState } from 'react';
@@ -40,6 +43,7 @@ import { MediaGallery } from '../components/media/MediaGallery';
 import { PersonAvatar } from '../components/people/PersonAvatar';
 import { useSearch } from '../contexts/SearchContext';
 import { ExploreCarousel } from '../components/search/ExploreCarousel';
+import { PageSearchBarSection } from '../components/search/PageSearchBar';
 import { renderLocationTile } from './Places/LocationTile';
 import type { ExploreLocationItem } from '../services/media';
 
@@ -211,6 +215,12 @@ export default function SearchPage() {
   if (!activeCircle) {
     return (
       <Box sx={{ p: { xs: 2, md: 3 } }}>
+        {/* Rendered (disabled — PageSearchBar derives that from the absent
+            circle) so the destination looks and measures the same before and
+            after a circle is picked, and the alert reads as an explanation of
+            the greyed-out field directly above it rather than as the whole
+            page. */}
+        <PageSearchBarSection />
         <Alert severity="info">Select a circle to search your photos.</Alert>
       </Box>
     );
@@ -223,6 +233,8 @@ export default function SearchPage() {
   if (searchRequest !== null) {
     return (
       <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1200, mx: 'auto' }}>
+        <PageSearchBarSection />
+
         {/* Header row */}
         <Box
           sx={{
@@ -270,6 +282,8 @@ export default function SearchPage() {
   if (results !== null || isSearching) {
     return (
       <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1200, mx: 'auto' }}>
+        <PageSearchBarSection />
+
         {/* Header row */}
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
           {results !== null ? (
@@ -324,6 +338,8 @@ export default function SearchPage() {
   // -------------------------------------------------------------------------
   return (
     <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 900, mx: 'auto' }}>
+      <PageSearchBarSection />
+
       {/* People */}
       {(peopleLoading || people.length > 0) && (
         <ExploreCarousel<PersonListItem>

--- a/docs/specs/navigation-ia.md
+++ b/docs/specs/navigation-ia.md
@@ -279,6 +279,12 @@ lg 1200`), which align closely with Material 3's compact / medium / expanded win
   [`docs/audits/mobile-topbar-audit.md`](../audits/mobile-topbar-audit.md) that toolbar
   already measures ~354 px against 360 px of viewport with the search pill present; removing
   it resolves that crowding permanently rather than tuning gaps again.
+  **Prerequisite:** a destination that replaces a piece of chrome MUST itself own the
+  equivalent capability *before* that chrome is gated away. `/search` therefore renders its
+  own search field (`PageSearchBar`, carrying both free-text/agentic search and the advanced
+  `SearchPanel`) in every one of its render branches. Issue #400 is the regression that
+  proved the rule: the pill was gated to `md`+ while `SearchPage` still only rendered
+  results, leaving every user below 900 px with no way to search at all.
 - **The circle chip replaces the wordmark.** On a phone, which circle you are in matters more
   than the app's name.
 - Review carries a dot indicator rather than a numeric badge at this size.


### PR DESCRIPTION
## Summary

**Production fix.** Below the `md` breakpoint (< 900px) there was no way to run any search — free-text, semantic/agentic, or advanced. Reported from production after the epic #388 deploy.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #400
Relates to #388, #392

## Changes Made

### What broke

`TopbarSearch` is the **sole entry point** to every search capability: its input calls `runAgentSearch` (free-text/semantic), and its Tune button is the **only** thing anywhere that opens `SearchPanel` (advanced search). #392 gated it to `md`+ on the rationale that Search had become a bottom-bar destination — but `/search` had no input of its own. `SearchPage` only consumed `useSearch()` results and referenced none of `runAgentSearch`, `runDeterministicSearch`, or `SearchPanel`.

Below 900px that shipped **a Search destination that cannot search.**

### The fix

**Not** dropping the `isMd` gate. That restores the toolbar pill while leaving `/search` unable to search — the symptom, not the hole.

Instead, **`PageSearchBar`** (new) gives the page both capabilities — the text input *and* the Tune button that opens `SearchPanel` — mounted in **all four** `SearchPage` branches (no-circle, deterministic results, agentic results, explore), so a user can start a new search from wherever they are and it never vanishes mid-task. Its submit/clear/advanced handlers mirror `TopbarSearch`'s so the two entry points cannot drift, and it reuses `useSearch`/`useCircle`: no new context, no new service call, no duplicated search logic.

`TopbarSearch` is **untouched**, and the `md`+ gate stays — it now rests on a premise that is finally true.

### Two comments that were actively misleading

- **`AppBar.tsx`** asserted the tab was an equivalent replacement. That confident wrong claim is a large part of why the gap survived review. It now states the invariant and warns that deleting the page bar silently recreates the outage below 900px.
- **`SearchPage`'s own header** said "the search input lives in the AppBar TopbarSearch; this page only renders output" — corrected to the same invariant.

### Spec §4.1

The spec said to pull the field out of the top bar because "Search is now a tab", and **never said the tab had to be able to search.** The implementation followed it faithfully into an outage, so §4.1 now records the prerequisite: a destination replacing a chrome affordance must *own* the equivalent capability.

## Testing

- [x] Unit tests pass (`npm test`) — targeted suite **11 files / 205 tests green**
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — `npm run build` green; behaviour verified by the capability tests below

**The tests guard capability, not chrome — that distinction is the actual lesson.** Every #392 test passed, and one of them asserts *"TopbarSearch is hidden below md"* — a **passing test that encodes the outage as intended behaviour**. `reachability.test.tsx` proved `/search` resolves; it just could not be used. None asked the only question that mattered: *can a user reach a search input from here?*

So `SearchPage` is now driven through all four branches by their real trigger conditions, each asserting a "Search your photos" textbox **and** an "Advanced search" trigger, plus that the branch's existing content is undisturbed. Two details give it teeth:

- It renders `SearchPage` with **no `AppBar` mounted**, and asserts `TopbarSearch`'s distinct aria-label is absent. The bug *was* the page silently depending on toolbar chrome, so a test leaving that chrome available could pass while the product is broken.
- One case types, presses Enter, and asserts `runAgentSearch` is reached — a working path, not merely a present input.

**Mutation-verified:** removing `PageSearchBarSection` from the explore branch fails the corresponding case with `Unable to find role="textbox"` — exactly how #400 presented.

### Test Instructions

1. In a viewport **narrower than 900px**, tap **Search** in the bottom bar → the page shows a search field and an "Advanced search" button.
2. Type a query, press Enter → agentic/semantic results render.
3. Tap **Advanced search** → `SearchPanel` opens; submitting runs a deterministic search.
4. Repeat with results already on screen and in the explore state — the bar is present in both.
5. At **≥900px**, confirm the top-bar pill still works exactly as before.

## Screenshots

Not captured — no browser in this session.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Honest framing: **#392 removed a working affordance and redirected users to a replacement never checked for the capability it was meant to provide**, and PR #397 described the tab as equivalent without verifying it. The spec carried the same unstated assumption, so both the code and the spec are corrected here — fixing only the code would leave the next implementer free to repeat it.

The `!activeCircle` branch renders the bar **disabled** rather than omitting it, so the destination looks and measures the same before and after a circle is picked, and the existing info alert reads as an explanation of the greyed-out field rather than as the whole page.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj

---
_Generated by [Claude Code](https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj)_