### PR TITLE
fix(web): show a review queue that has pending work, even when its flag is off

### DIFF
--- a/apps/web/src/__tests__/components/review/FeatureDisabledNotice.test.tsx
+++ b/apps/web/src/__tests__/components/review/FeatureDisabledNotice.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tests for FeatureDisabledNotice (issue #404).
+ *
+ * Two things are pinned here:
+ *
+ *  1. THE COMPONENT'S OWN CONTRACT — given `hasExistingWork` and the caller's
+ *     admin status, does it show the right copy and the right settings link.
+ *     `FeatureDisabledNotice` carries NO flag-reading logic of its own; it is
+ *     a dumb banner every page mounts conditionally.
+ *
+ *  2. THE GATE EVERY PAGE APPLIES before mounting it —
+ *     `features !== null && features.<flag> !== true` — via a small local
+ *     harness that reproduces the exact expression documented in the
+ *     component's own header comment (and duplicated identically at each of
+ *     the three call sites). `DuplicatesPage.test.tsx` / `BurstsPage.test.tsx`
+ *     / `LocationSuggestionsPage.test.tsx` each separately pin this same gate
+ *     against their real page; this harness pins the EXPRESSION ITSELF, once,
+ *     isolated from three pages' worth of unrelated setup — a "helpful"
+ *     simplification to `features?.<flag> === false` (which would start
+ *     claiming a feature is disabled during a flags OUTAGE, since an outage
+ *     resolves `features` to `null` rather than throwing) fails here even if
+ *     a page-specific case is ever weakened or skipped.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render, mockAdminUser, mockUser } from '../../utils/test-utils';
+import { FeatureDisabledNotice } from '../../../components/review/FeatureDisabledNotice';
+import { useFeatureFlags } from '../../../hooks/useFeatureFlags';
+
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+}));
+
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
+
+function mockFlags(features: Record<string, boolean> | null, isLoading = false) {
+  mockUseFeatureFlags.mockReturnValue({
+    features,
+    pictureEnhancement: null,
+    isLoading,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+/**
+ * Reproduces the exact gate `DuplicatesPage` (and its two siblings) applies:
+ *   const featureDisabled = features !== null && features.duplicateDetection !== true;
+ *   {featureDisabled && <FeatureDisabledNotice ... />}
+ */
+function GatedNotice({ flag }: { flag: string }) {
+  const { features } = useFeatureFlags();
+  const disabled = features !== null && features[flag] !== true;
+  return disabled ? (
+    <FeatureDisabledNotice
+      featureLabel="Duplicate detection"
+      settingsPath="/admin/settings/duplicates"
+      hasExistingWork={false}
+    />
+  ) : null;
+}
+
+describe('FeatureDisabledNotice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // The page gate: features !== null && features.<flag> !== true
+  // =========================================================================
+
+  describe('the page gate', () => {
+    it('renders when the flag has loaded and is explicitly false', () => {
+      mockFlags({ duplicateDetection: false });
+
+      render(<GatedNotice flag="duplicateDetection" />);
+
+      expect(screen.getByText(/duplicate detection is turned off/i)).toBeInTheDocument();
+    });
+
+    it('renders when the flag has loaded but the key is simply absent', () => {
+      // The real shape a never-configured flag takes: `features` resolved to
+      // an object, but that object has no entry for this flag at all.
+      mockFlags({});
+
+      render(<GatedNotice flag="duplicateDetection" />);
+
+      expect(screen.getByText(/duplicate detection is turned off/i)).toBeInTheDocument();
+    });
+
+    it('does NOT render when the flag has loaded and is true', () => {
+      mockFlags({ duplicateDetection: true });
+
+      render(<GatedNotice flag="duplicateDetection" />);
+
+      expect(screen.queryByText(/is turned off/i)).not.toBeInTheDocument();
+    });
+
+    it('does NOT render while flags are still loading (features is null, isLoading true)', () => {
+      mockFlags(null, true);
+
+      render(<GatedNotice flag="duplicateDetection" />);
+
+      expect(screen.queryByText(/is turned off/i)).not.toBeInTheDocument();
+    });
+
+    it('does NOT render on a flags OUTAGE — features resolves to null, never treated as "everything is disabled"', () => {
+      // The deliberate departure from the `=== true` convention, documented
+      // in FeatureDisabledNotice.tsx: a failed GET /api/features must HIDE
+      // the banner, not claim the feature is off. That claim would be a lie
+      // the user has no way to distinguish from a real admin-configured
+      // toggle, and it is the one most likely to be "corrected" later into
+      // `features?.duplicateDetection === false`, which gets this exact case
+      // wrong.
+      mockFlags(null, false);
+
+      render(<GatedNotice flag="duplicateDetection" />);
+
+      expect(screen.queryByText(/is turned off/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Copy varies on hasExistingWork
+  // =========================================================================
+
+  describe('copy', () => {
+    it('tells the user their existing items are still reviewable when hasExistingWork is true', () => {
+      render(
+        <FeatureDisabledNotice
+          featureLabel="Duplicate detection"
+          settingsPath="/admin/settings/duplicates"
+          hasExistingWork
+        />,
+      );
+
+      expect(
+        screen.getByText(/items found earlier are listed below and can still be reviewed/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/no new items will appear here/i)).not.toBeInTheDocument();
+    });
+
+    it('tells the user nothing new will ever appear when hasExistingWork is false', () => {
+      render(
+        <FeatureDisabledNotice
+          featureLabel="Duplicate detection"
+          settingsPath="/admin/settings/duplicates"
+          hasExistingWork={false}
+        />,
+      );
+
+      expect(screen.getByText(/no new items will appear here/i)).toBeInTheDocument();
+      expect(screen.queryByText(/still be reviewed/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Settings link — admin only
+  // =========================================================================
+
+  describe('settings link', () => {
+    it('renders for an admin, pointed at the caller-supplied settingsPath', () => {
+      render(
+        <FeatureDisabledNotice
+          featureLabel="Duplicate detection"
+          settingsPath="/admin/settings/duplicates"
+          hasExistingWork={false}
+        />,
+        { wrapperOptions: { user: mockAdminUser } },
+      );
+
+      const link = screen.getByRole('link', { name: /open settings/i });
+      expect(link).toHaveAttribute('href', '/admin/settings/duplicates');
+      expect(screen.getByText(/turn it back on in the feature settings/i)).toBeInTheDocument();
+    });
+
+    it('does not render for a non-admin, and points them at an administrator instead', () => {
+      render(
+        <FeatureDisabledNotice
+          featureLabel="Duplicate detection"
+          settingsPath="/admin/settings/duplicates"
+          hasExistingWork={false}
+        />,
+        { wrapperOptions: { user: mockUser } },
+      );
+
+      expect(screen.queryByRole('link', { name: /open settings/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/an administrator can turn it back on/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/__tests__/hooks/useReviewQueues.test.ts
+++ b/apps/web/src/__tests__/hooks/useReviewQueues.test.ts
@@ -7,11 +7,21 @@
  * `useReviewCounts` — so each case can drive the resolution logic without
  * touching the network.
  */
+import { createElement } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { useReviewQueues } from '../../hooks/useReviewQueues';
+import { ReviewQueueList } from '../../components/review/ReviewQueueList';
 import type { ReviewCountsResponse } from '../../types/media';
 import type { PictureEnhancementPolicy } from '../../services/features';
+
+// This is a `.ts` file (not `.tsx`), so the loading-state integration test
+// below builds its element tree with `createElement` rather than JSX —
+// deliberate, not an oversight.
+function reviewQueueListTree() {
+  return createElement(MemoryRouter, null, createElement(ReviewQueueList, { variant: 'hub' }));
+}
 
 vi.mock('../../hooks/useFeatureFlags', () => ({
   useFeatureFlags: vi.fn(),
@@ -85,7 +95,11 @@ describe('useReviewQueues', () => {
   // =========================================================================
 
   describe('flag gating', () => {
-    it('shows an entry only when its flag is === true', () => {
+    it('resolves a queue whose flag is OFF but which still has pending residual work (issue #404 — the production regression)', () => {
+      // The exact reported shape: duplicateDetection is off, but the server
+      // still reports 6 pending duplicate groups (an earlier run, or the
+      // admin backfill). Pure flag gating hid this row; the fix resolves it
+      // anyway because there is real, reachable work behind it.
       mockFeatureFlags({
         features: { burstDetection: true, duplicateDetection: false, locationInference: true },
       });
@@ -97,8 +111,50 @@ describe('useReviewQueues', () => {
       const keys = result.current.entries.map((e) => e.key);
       expect(keys).toContain('bursts');
       expect(keys).toContain('locations');
-      expect(keys).not.toContain('duplicates');
+      expect(keys).toContain('duplicates');
+      const duplicates = result.current.entries.find((e) => e.key === 'duplicates');
+      expect(duplicates?.count).toBe(FULL_COUNTS.pendingDuplicateGroups);
+      // `automations` carries no count key at all — off is off for it.
       expect(keys).not.toContain('automations');
+    });
+
+    it('does NOT resolve a queue whose flag is off AND whose count is 0 — the residual clause is not a blanket un-gate', () => {
+      // Without this, a deployment that never turned duplicateDetection on
+      // would carry a permanently dead row forever: the fix is "resolve when
+      // there is real work", never "always resolve regardless of the flag".
+      mockFeatureFlags({ features: { duplicateDetection: false } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: { ...FULL_COUNTS, pendingDuplicateGroups: 0 } });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries.map((e) => e.key)).not.toContain('duplicates');
+    });
+
+    it('resolves a queue whose flag is ON regardless of its count, including the count: 0 drained state', () => {
+      mockFeatureFlags({ features: { burstDetection: true } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: { ...FULL_COUNTS, pendingBurstGroups: 0 } });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      const bursts = result.current.entries.find((e) => e.key === 'bursts');
+      expect(bursts).toBeDefined();
+      expect(bursts?.count).toBe(0);
+    });
+
+    it('never resolves a SECONDARY entry on residual work — secondary entries stay purely flag-gated', () => {
+      // automations is off; the counts payload is fully loaded and non-zero
+      // everywhere it applies. Secondary entries carry no countKey at all
+      // (count is always null for them), so there is nothing a residual
+      // clause could key off even if one were mistakenly extended to them.
+      mockFeatureFlags({ features: {} });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: FULL_COUNTS });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.entries.map((e) => e.key)).not.toContain('automations');
     });
 
     it('hides an entry whose flag is unresolved (null), not just false', () => {
@@ -170,18 +226,25 @@ describe('useReviewQueues', () => {
   // =========================================================================
 
   describe('totalPending', () => {
-    it('sums ONLY the enabled queue entries, even when the API returned a count for a disabled one', () => {
-      // Only bursts + duplicates enabled; locations and enhancements are off,
-      // but the counts payload (as if from a shared response) still carries
-      // numbers for all four.
-      mockFeatureFlags({ features: { burstDetection: true, duplicateDetection: true } });
+    it('sums every RESOLVED entry — enabled ones and residual (flag-off, count>0) ones alike — never an excluded (flag-off, count 0) one', () => {
+      // bursts is enabled; duplicates is off but has residual work (resolves,
+      // counts); locations and enhancements are off AND drained (excluded,
+      // contribute nothing).
+      mockFeatureFlags({
+        features: { burstDetection: true, duplicateDetection: false, locationInference: false },
+      });
       mockUseWorkflowsEnabled.mockReturnValue(false);
-      mockCounts({ data: FULL_COUNTS });
+      mockCounts({
+        data: {
+          pendingBurstGroups: 4,
+          pendingDuplicateGroups: 6,
+          pendingLocationSuggestions: 0,
+          pendingEnhancements: 0,
+        },
+      });
 
       const { result } = renderHook(() => useReviewQueues());
 
-      // FULL_COUNTS.pendingBurstGroups(4) + pendingDuplicateGroups(6) = 10.
-      // Locations(2) and enhancements(9) must NOT contribute.
       expect(result.current.totalPending).toBe(10);
     });
 
@@ -206,38 +269,42 @@ describe('useReviewQueues', () => {
   });
 
   // =========================================================================
-  // The counts request gate — the broadened form of the enhancer-only gate
+  // The counts request is now UNCONDITIONAL (issue #404) — the old
+  // flag-derived `enabled` gate is gone entirely, because that gate was the
+  // chicken-and-egg at the root of the bug: with every queue flag off, no
+  // request fired, no counts arrived, and residual work could never be
+  // discovered in the one configuration where it mattered most.
   // =========================================================================
 
-  describe('useReviewCounts gating', () => {
-    it('calls useReviewCounts with enabled: true when ANY counted queue feature is on', () => {
+  describe('useReviewCounts is called unconditionally', () => {
+    it('calls useReviewCounts with no arguments when a counted queue feature is on', () => {
       mockFeatureFlags({ features: { locationInference: true } });
       mockUseWorkflowsEnabled.mockReturnValue(false);
       mockCounts();
 
       renderHook(() => useReviewQueues());
 
-      expect(mockUseReviewCounts).toHaveBeenCalledWith({ enabled: true });
+      expect(mockUseReviewCounts).toHaveBeenCalledWith();
     });
 
-    it('calls useReviewCounts with enabled: false when no counted queue feature is on, even with automations on', () => {
+    it('still calls useReviewCounts with no arguments when no counted queue feature is on, even with automations on', () => {
       mockFeatureFlags({ features: {} });
       mockUseWorkflowsEnabled.mockReturnValue(true); // automations only — carries no count
       mockCounts();
 
       renderHook(() => useReviewQueues());
 
-      expect(mockUseReviewCounts).toHaveBeenCalledWith({ enabled: false });
+      expect(mockUseReviewCounts).toHaveBeenCalledWith();
     });
 
-    it('calls useReviewCounts with enabled: false when every flag is off/unresolved', () => {
+    it('still calls useReviewCounts with no arguments when every flag is off/unresolved — this is exactly what makes residual-work discovery possible', () => {
       mockFeatureFlags({ features: null, pictureEnhancement: null });
       mockUseWorkflowsEnabled.mockReturnValue(null);
       mockCounts();
 
       renderHook(() => useReviewQueues());
 
-      expect(mockUseReviewCounts).toHaveBeenCalledWith({ enabled: false });
+      expect(mockUseReviewCounts).toHaveBeenCalledWith();
     });
   });
 
@@ -272,6 +339,73 @@ describe('useReviewQueues', () => {
       const { result } = renderHook(() => useReviewQueues());
 
       expect(result.current.anyEnabled).toBe(true);
+    });
+
+    it('reflects entries.length > 0 directly, including a residual (flag-off) entry', () => {
+      mockFeatureFlags({ features: { duplicateDetection: false } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: { ...FULL_COUNTS, pendingDuplicateGroups: 6 } });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.anyEnabled).toBe(result.current.entries.length > 0);
+      expect(result.current.anyEnabled).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // No-flash (issue #404): counts must not settle a beat after flags do.
+  //
+  // Before this fix, `isLoading` derived from `anyQueueEnabled && countsLoading`
+  // — so with every queue flag off, the counts half of the loading state was
+  // ignored entirely. A residual row could then only appear by POPPING IN
+  // after `ReviewQueueList` had already rendered a list without it: the flags
+  // settle first (fast, cached), `isLoading` goes false immediately, the list
+  // renders with whatever `entries` looks like when `counts` is still `null`
+  // (no residual rows resolve on a null count), and only THEN does the counts
+  // request resolve and grow the list a row.
+  //
+  // A test that renders once, awaits everything, and checks the final state
+  // cannot see this: the settled result is the SAME correct list either way.
+  // Only observing the list DURING the gap between "flags known" and "counts
+  // known" — and confirming it renders NOTHING (not a partial list) — proves
+  // `isLoading` is actually gating on both.
+  // =========================================================================
+
+  describe('no premature settling while counts are still in flight', () => {
+    it('useReviewQueues reports isLoading: true while counts have not resolved, even though flags already have', () => {
+      mockFeatureFlags({ features: { duplicateDetection: false } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      // The counts promise has not resolved yet: `data` is still null and the
+      // hook is still reporting `isLoading: true` for this instance.
+      mockCounts({ data: null, isLoading: true });
+
+      const { result } = renderHook(() => useReviewQueues());
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('ReviewQueueList shows its loading state while counts are in flight, then renders the complete list once — never a list that later grows the residual row', () => {
+      mockFeatureFlags({ features: { duplicateDetection: false } });
+      mockUseWorkflowsEnabled.mockReturnValue(false);
+      mockCounts({ data: null, isLoading: true });
+
+      const { rerender } = render(reviewQueueListTree());
+
+      // Mid-flight: a spinner, and — the property a "settled-state-only" test
+      // cannot see — NO rows at all, not even a partial list missing the
+      // eventual residual row.
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+      // The counts promise settles: duplicateDetection is off, but 6 pending
+      // duplicate groups are reported — the residual case from the
+      // regression above.
+      mockCounts({ data: { ...FULL_COUNTS, pendingDuplicateGroups: 6 }, isLoading: false });
+      rerender(reviewQueueListTree());
+
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Duplicates, 6 pending' })).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/pages/BurstsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/BurstsPage.test.tsx
@@ -56,6 +56,10 @@ vi.mock('../../hooks/useSystemSettings', () => ({
   useSystemSettings: vi.fn(),
 }));
 
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+}));
+
 vi.mock('../../hooks/useBursts', () => ({
   useBurstGroups: vi.fn(),
   useBurstGroupDetail: vi.fn(),
@@ -88,6 +92,7 @@ import BurstGroupPage from '../../pages/Bursts/BurstGroupPage';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useCircle } from '../../hooks/useCircle';
 import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useBurstGroups, useBurstGroupDetail } from '../../hooks/useBursts';
 import { ApiError } from '../../services/api';
 import type { BurstGroupSummary, BurstGroupDetail } from '../../services/bursts';
@@ -95,6 +100,7 @@ import type { BurstGroupSummary, BurstGroupDetail } from '../../services/bursts'
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseCircle = vi.mocked(useCircle);
 const mockUseSystemSettings = vi.mocked(useSystemSettings);
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
 const mockUseBurstGroups = vi.mocked(useBurstGroups);
 const mockUseBurstGroupDetail = vi.mocked(useBurstGroupDetail);
 
@@ -196,6 +202,26 @@ function makeSystemSettingsHook(
   };
 }
 
+/**
+ * Default matches the real MSW `GET /api/features` handler's response
+ * (`{ features: {} }`) so tests that don't care about the flag keep behaving
+ * exactly as they did before `useFeatureFlags` was mocked directly here —
+ * `burstDetection` is absent, so the feature-off banner (issue #404) shows
+ * by default just as it did under the real network round trip.
+ */
+function makeFeatureFlagsHook(
+  overrides: Partial<ReturnType<typeof useFeatureFlags>> = {},
+): ReturnType<typeof useFeatureFlags> {
+  return {
+    features: {},
+    pictureEnhancement: null,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 function makeSummary(id = 'group-1'): BurstGroupSummary {
   return {
     id,
@@ -267,6 +293,7 @@ describe('BurstsPage', () => {
     mockUsePermissions.mockReturnValue(makePermissions(false));
     mockUseCircle.mockReturnValue(makeCircleContext());
     mockUseSystemSettings.mockReturnValue(makeSystemSettingsHook());
+    mockUseFeatureFlags.mockReturnValue(makeFeatureFlagsHook());
     mockUseBurstGroups.mockReturnValue(makeBurstGroupsHook());
   });
 
@@ -856,6 +883,41 @@ describe('BurstsPage', () => {
       const call = fetchGroups.mock.calls[0][0];
       expect(call).not.toHaveProperty('sortBy');
       expect(call).not.toHaveProperty('sortOrder');
+    });
+  });
+
+  describe('feature-disabled banner (issue #404)', () => {
+    it('renders the banner above the existing groups when the flag is off — the groups still render', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        makeFeatureFlagsHook({ features: { burstDetection: false } }),
+      );
+      mockUseBurstGroups.mockReturnValue(
+        makeBurstGroupsHook({ items: [makeSummary('g-1'), makeSummary('g-2')] }),
+      );
+
+      render(<BurstsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/burst detection is turned off/i)).toBeInTheDocument();
+      });
+      // Above the content, never instead of it — the groups are still real,
+      // still resolvable, and are exactly why the page has to stay reachable.
+      const photoLabels = screen.getAllByText(/5 photos/i);
+      expect(photoLabels.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not render the banner when the flag is on', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        makeFeatureFlagsHook({ features: { burstDetection: true } }),
+      );
+      mockUseBurstGroups.mockReturnValue(makeBurstGroupsHook({ items: [makeSummary('g-1')] }));
+
+      render(<BurstsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/review bursts/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/burst detection is turned off/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/pages/DuplicatesPage.test.tsx
+++ b/apps/web/src/__tests__/pages/DuplicatesPage.test.tsx
@@ -38,6 +38,10 @@ vi.mock('../../hooks/useSystemSettings', () => ({
   useSystemSettings: vi.fn(),
 }));
 
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+}));
+
 vi.mock('../../hooks/useDuplicates', () => ({
   useDuplicateGroups: vi.fn(),
 }));
@@ -60,6 +64,7 @@ import DuplicatesPage from '../../pages/Duplicates/DuplicatesPage';
 import { useCircle } from '../../hooks/useCircle';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useDuplicateGroups } from '../../hooks/useDuplicates';
 import { ApiError } from '../../services/api';
 import type { DuplicateGroupSummary } from '../../services/duplicates';
@@ -67,6 +72,7 @@ import type { DuplicateGroupSummary } from '../../services/duplicates';
 const mockUseCircle = vi.mocked(useCircle);
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseSystemSettings = vi.mocked(useSystemSettings);
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
 const mockUseDuplicateGroups = vi.mocked(useDuplicateGroups);
 
 // ---------------------------------------------------------------------------
@@ -167,6 +173,26 @@ function makeSystemSettingsHook(autoResolveThreshold = 60): ReturnType<typeof us
   };
 }
 
+/**
+ * Default matches the real MSW `GET /api/features` handler's response
+ * (`{ features: {} }`) so tests that don't care about the flag keep behaving
+ * exactly as they did before `useFeatureFlags` was mocked directly here —
+ * `duplicateDetection` is absent, so the feature-off banner (issue #404)
+ * shows by default just as it did under the real network round trip.
+ */
+function makeFeatureFlagsHook(
+  overrides: Partial<ReturnType<typeof useFeatureFlags>> = {},
+): ReturnType<typeof useFeatureFlags> {
+  return {
+    features: {},
+    pictureEnhancement: null,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 function makeSummary(
   id = 'group-1',
   kind: DuplicateGroupSummary['kind'] = 'exact_variant',
@@ -192,6 +218,7 @@ describe('DuplicatesPage', () => {
     mockUseCircle.mockReturnValue(makeCircleContext());
     mockUsePermissions.mockReturnValue(makePermissions(false));
     mockUseSystemSettings.mockReturnValue(makeSystemSettingsHook());
+    mockUseFeatureFlags.mockReturnValue(makeFeatureFlagsHook());
     mockUseDuplicateGroups.mockReturnValue(makeDuplicateGroupsHook());
   });
 
@@ -772,6 +799,43 @@ describe('DuplicatesPage', () => {
       const call = fetchGroups.mock.calls[0][0];
       expect(call).not.toHaveProperty('sortBy');
       expect(call).not.toHaveProperty('sortOrder');
+    });
+  });
+
+  describe('feature-disabled banner (issue #404)', () => {
+    it('renders the banner above the existing groups when the flag is off — the groups still render', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        makeFeatureFlagsHook({ features: { duplicateDetection: false } }),
+      );
+      mockUseDuplicateGroups.mockReturnValue(
+        makeDuplicateGroupsHook({ items: [makeSummary('g-1'), makeSummary('g-2')] }),
+      );
+
+      render(<DuplicatesPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/duplicate detection is turned off/i)).toBeInTheDocument();
+      });
+      // Above the content, never instead of it — real, resolvable groups are
+      // exactly why the page has to stay reachable with the flag off.
+      const photoLabels = screen.getAllByText(/2 photos/i);
+      expect(photoLabels.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not render the banner when the flag is on', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        makeFeatureFlagsHook({ features: { duplicateDetection: true } }),
+      );
+      mockUseDuplicateGroups.mockReturnValue(
+        makeDuplicateGroupsHook({ items: [makeSummary('g-1')] }),
+      );
+
+      render(<DuplicatesPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/review duplicates/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/duplicate detection is turned off/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/pages/LocationSuggestionsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/LocationSuggestionsPage.test.tsx
@@ -66,6 +66,10 @@ vi.mock('../../hooks/useSystemSettings', () => ({
   useSystemSettings: vi.fn(),
 }));
 
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+}));
+
 vi.mock('../../hooks/useLocationSuggestions', () => ({
   useLocationSuggestions: vi.fn(),
 }));
@@ -130,6 +134,7 @@ import LocationSuggestionsPage from '../../pages/LocationSuggestions/LocationSug
 import { useCircle } from '../../hooks/useCircle';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useLocationSuggestions } from '../../hooks/useLocationSuggestions';
 import { startLocationAcceptRun, startLocationRejectRun } from '../../services/locationSuggestionRuns';
 import { searchPlaces, reverseGeocode } from '../../services/media';
@@ -139,6 +144,7 @@ import type { LocationSuggestionSummary } from '../../services/locationSuggestio
 const mockUseCircle = vi.mocked(useCircle);
 const mockUsePermissions = vi.mocked(usePermissions);
 const mockUseSystemSettings = vi.mocked(useSystemSettings);
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
 const mockUseLocationSuggestions = vi.mocked(useLocationSuggestions);
 const mockStartLocationAcceptRun = vi.mocked(startLocationAcceptRun);
 const mockStartLocationRejectRun = vi.mocked(startLocationRejectRun);
@@ -229,6 +235,26 @@ function makeLocationSuggestionsHook(
   } as unknown as ReturnType<typeof useLocationSuggestions>;
 }
 
+/**
+ * Default matches the real MSW `GET /api/features` handler's response
+ * (`{ features: {} }`) so tests that don't care about the flag keep behaving
+ * exactly as they did before `useFeatureFlags` was mocked directly here —
+ * `locationInference` is absent, so the feature-off banner (issue #404)
+ * shows by default just as it did under the real network round trip.
+ */
+function makeFeatureFlagsHook(
+  overrides: Partial<ReturnType<typeof useFeatureFlags>> = {},
+): ReturnType<typeof useFeatureFlags> {
+  return {
+    features: {},
+    pictureEnhancement: null,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 function makeSuggestion(overrides: Partial<LocationSuggestionSummary> = {}): LocationSuggestionSummary {
   return {
     id: 'suggestion-1',
@@ -262,6 +288,7 @@ describe('LocationSuggestionsPage', () => {
     mockUseCircle.mockReturnValue(makeCircleContext());
     mockUsePermissions.mockReturnValue(makePermissions(false));
     mockUseSystemSettings.mockReturnValue(makeSystemSettingsHook());
+    mockUseFeatureFlags.mockReturnValue(makeFeatureFlagsHook());
     mockUseLocationSuggestions.mockReturnValue(makeLocationSuggestionsHook());
     mockSearchPlaces.mockResolvedValue([]);
     mockReverseGeocode.mockResolvedValue({
@@ -955,6 +982,43 @@ describe('LocationSuggestionsPage', () => {
       const call = fetchSuggestions.mock.calls[0][0];
       expect(call).not.toHaveProperty('sortBy');
       expect(call).not.toHaveProperty('sortOrder');
+    });
+  });
+
+  describe('feature-disabled banner (issue #404)', () => {
+    it('renders the banner above the existing suggestions when the flag is off — the suggestions still render', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        makeFeatureFlagsHook({ features: { locationInference: false } }),
+      );
+      mockUseLocationSuggestions.mockReturnValue(
+        makeLocationSuggestionsHook({ items: [makeSuggestion({ id: 's-1' }), makeSuggestion({ id: 's-2' })] }),
+      );
+
+      render(<LocationSuggestionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/location inference is turned off/i)).toBeInTheDocument();
+      });
+      // Above the content, never instead of it — the suggestions are still
+      // real and still acceptable, which is exactly why the page has to stay
+      // reachable with the flag off.
+      expect(screen.getAllByTestId('location-mini-map')).toHaveLength(2);
+    });
+
+    it('does not render the banner when the flag is on', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        makeFeatureFlagsHook({ features: { locationInference: true } }),
+      );
+      mockUseLocationSuggestions.mockReturnValue(
+        makeLocationSuggestionsHook({ items: [makeSuggestion()] }),
+      );
+
+      render(<LocationSuggestionsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Location Suggestions')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/location inference is turned off/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/__tests__/pages/ReviewQueuePage.test.tsx
+++ b/apps/web/src/__tests__/pages/ReviewQueuePage.test.tsx
@@ -145,6 +145,26 @@ describe('ReviewQueuePage', () => {
       expect(await screen.findByText('ReviewHubStub')).toBeInTheDocument();
     });
 
+    it('a queue whose feature is off but which has residual pending work stays reachable — it does NOT redirect (issue #404 knock-on)', async () => {
+      // The exact contrast with the case directly above: `duplicates` is
+      // still off, but `useReviewQueues` (issue #404) now resolves a queue
+      // entry whenever the server reports real pending work behind it,
+      // regardless of the flag — so `entries` contains `duplicates` here even
+      // though its flag is off. `ReviewQueuePage` does not know or care WHY
+      // an entry is present; it only asks whether `entries` contains it. That
+      // single lookup is what makes `/review/duplicates` stop bouncing to the
+      // hub for a deployment with residual duplicate groups and the feature
+      // toggled off — no change to this file's own resolution logic was
+      // needed for that to fall out.
+      const entries = buildEntries({ duplicates: 6 }, ['duplicates']);
+      mockResult({ entries, isLoading: false });
+
+      renderAt('/review/duplicates');
+
+      expect(await screen.findByText('DuplicatesPageStub')).toBeInTheDocument();
+      expect(screen.queryByText('ReviewHubStub')).not.toBeInTheDocument();
+    });
+
     it('does NOT redirect a disabled-looking queue while flags are still resolving — shows a spinner instead', () => {
       mockResult({ entries: [], isLoading: true });
 

--- a/apps/web/src/components/review/FeatureDisabledNotice.tsx
+++ b/apps/web/src/components/review/FeatureDisabledNotice.tsx
@@ -1,0 +1,80 @@
+/**
+ * "This review feature is turned off" — the banner the three queue pages show
+ * when their global feature flag is disabled (issue #404).
+ *
+ * WHY A BANNER AND NOT A GUARD
+ * ----------------------------
+ * `BurstsPage`, `DuplicatesPage` and `LocationSuggestionsPage` have never had a
+ * feature gate of their own: with the flag off they still fetch, still list
+ * whatever groups exist, and still resolve them. Groups created while the flag
+ * was on — or by an admin backfill — stay in the database and stay actionable.
+ * A route guard or a redirect would therefore take a WORKING page away from a
+ * user with real work waiting, which is the bug this issue is fixing one level
+ * up in the navigation. So the page stays reachable and stays fully functional;
+ * the only thing added is an honest explanation.
+ *
+ * It sits ABOVE the existing content rather than replacing it, for the same
+ * reason: the residual groups are exactly what the user came for. Replacing the
+ * list would hide them behind the very message that says they exist.
+ *
+ * Without this, a disabled feature rendered an empty list VISUALLY IDENTICAL to
+ * "nothing pending" — the page said "No duplicate groups to review" when the
+ * truth was "nothing is looking for them".
+ */
+
+import { Alert, AlertTitle, Box, Button, Typography } from '@mui/material';
+import { Settings as SettingsIcon } from '@mui/icons-material';
+import { Link as RouterLink } from 'react-router-dom';
+import { usePermissions } from '../../hooks/usePermissions';
+
+export interface FeatureDisabledNoticeProps {
+  /** Sentence-case feature name, e.g. "Duplicate detection". */
+  featureLabel: string;
+  /** Admin settings route that owns this feature's global toggle. */
+  settingsPath: string;
+  /**
+   * Whether the page currently has groups on screen. It changes what the user
+   * needs to be told: with items, the point is "these are still yours to
+   * review"; without, the point is "nothing new will ever appear".
+   */
+  hasExistingWork: boolean;
+}
+
+export function FeatureDisabledNotice({
+  featureLabel,
+  settingsPath,
+  hasExistingWork,
+}: FeatureDisabledNoticeProps) {
+  // Read here rather than at each call site: the link is only useful to someone
+  // who can actually follow it, and every caller would otherwise repeat the
+  // same check.
+  const { isAdmin } = usePermissions();
+
+  return (
+    <Alert severity="info" sx={{ mb: 2 }}>
+      <AlertTitle>{featureLabel} is turned off</AlertTitle>
+      <Typography variant="body2" component="p">
+        {hasExistingWork
+          ? 'Nothing new is being detected, but the items found earlier are listed below and can still be reviewed.'
+          : 'Nothing new is being detected, so no new items will appear here.'}{' '}
+        {isAdmin
+          ? 'Turn it back on in the feature settings.'
+          : 'An administrator can turn it back on.'}
+      </Typography>
+      {isAdmin && (
+        <Box sx={{ mt: 1 }}>
+          <Button
+            component={RouterLink}
+            to={settingsPath}
+            size="small"
+            startIcon={<SettingsIcon />}
+          >
+            Open settings
+          </Button>
+        </Box>
+      )}
+    </Alert>
+  );
+}
+
+export default FeatureDisabledNotice;

--- a/apps/web/src/hooks/useReviewQueues.ts
+++ b/apps/web/src/hooks/useReviewQueues.ts
@@ -8,8 +8,24 @@
  *
  * It issues NO new request for the flags: `useFeatureFlags` and
  * `useWorkflowsEnabled` are both module-level caches the sidebar already reads.
- * The only network call is the counts one, and it is gated (below) so a
- * deployment with every review feature off never makes it.
+ * The only network call is the counts one.
+ *
+ * RESOLUTION RULE — enabled OR has pending work (issue #404)
+ * ---------------------------------------------------------
+ * A `queue` entry resolves when its feature flag is on **or** the server says it
+ * still holds pending items. Pure flag gating (the #390 behaviour) hid a row
+ * whose queue was full: `MediaService.computeReviewCounts` reports
+ * `pendingDuplicateGroups` UNCONDITIONALLY — it is not feature-gated — and
+ * `DuplicatesPage` (like `BurstsPage` and `LocationSuggestionsPage`) renders and
+ * works with the flag off, so the row was hiding a working page from a user who
+ * had real work waiting. Groups created while the flag was on, or by
+ * `POST /api/admin/duplicates/backfill`, stay resolvable in `duplicate_groups`
+ * forever; gating them away orphans them. These three rows were ungated
+ * entirely before #390, and spec §6.3 already states the principle: *keep the
+ * destination, drop the badge*.
+ *
+ * `secondary` entries (Insights, Automations) keep PURE flag gating — they carry
+ * no count, so "has pending work" is not a question that can be asked of them.
  */
 
 import { useMemo } from 'react';
@@ -34,13 +50,18 @@ export interface ResolvedReviewQueue extends ReviewQueueDef {
 }
 
 export interface UseReviewQueuesResult {
-  /** Enabled entries only, in the registry's FIXED order — never sorted by count. */
+  /** Resolved entries only, in the registry's FIXED order — never sorted by count. */
   entries: ResolvedReviewQueue[];
   counts: ReviewCountsResponse | null;
-  /** Sum of the enabled queue counts — the aggregate badge on the Review destination. */
+  /**
+   * Sum of the resolved queue counts — the aggregate badge on the Review
+   * destination. Residual work behind a disabled flag COUNTS: the row is
+   * reachable and the page acts on it, so hiding it from the badge would be the
+   * same bug one level up.
+   */
   totalPending: number;
   isLoading: boolean;
-  /** False when every entry is gated off, i.e. no review feature is enabled at all. */
+  /** False when nothing resolves at all — no flag on and no residual work. */
   anyEnabled: boolean;
 }
 
@@ -65,43 +86,73 @@ export function useReviewQueues(): UseReviewQueuesResult {
     };
   }, [features, pictureEnhancement, workflowsEnabled]);
 
-  const enabledDefs = useMemo(
-    () => REVIEW_QUEUES.filter((def) => isFlagEnabled(def.flag)),
-    [isFlagEnabled],
-  );
-
-  // The counts request is gated on at least one COUNTED queue being enabled.
-  // Insights and Automations resolve without counts, so a deployment running
-  // only those two must not pay for the request — this is the broadened form of
-  // the enhancer-only gate the sidebar used to apply (issue #204).
-  const anyQueueEnabled = enabledDefs.some((def) => def.countKey !== null);
-  const { data: counts, isLoading: countsLoading } = useReviewCounts({
-    enabled: anyQueueEnabled,
-  });
+  // The counts request is now UNGATED (issue #404) — `useReviewCounts` still
+  // makes no request without an active circle, and that is the only condition
+  // left on it.
+  //
+  // It has to be. The resolution rule below asks "does this queue hold pending
+  // work?", and the previous gate derived `enabled` from the flag-enabled set —
+  // so with every queue flag off, no request fired, no counts arrived, and
+  // residual work could never be discovered. The row could not appear precisely
+  // in the configuration where it most needed to. That is a genuine
+  // chicken-and-egg, not an ordering bug, and the only way out is to stop asking
+  // the flags for permission to ask the server.
+  //
+  // Paying for it unconditionally is justified: the Review destination itself
+  // renders unconditionally and always wants an aggregate badge, so its counts
+  // are needed unconditionally. `GET /api/media/review-counts` is the
+  // purpose-built counts-only endpoint issue #204 created for exactly this shape
+  // of caller — four integers, no thumbnail signing, no dashboard payload.
+  // #204's concern was avoiding the FULL dashboard response, not this call.
+  //
+  // NOTE: `useReviewCounts`'s own `enabled` option and its `enabled: false` ⇒
+  // no-request contract are untouched. Only this call site stopped passing it.
+  const { data: counts, isLoading: countsLoading } = useReviewCounts();
 
   const entries = useMemo<ResolvedReviewQueue[]>(
     () =>
-      enabledDefs.map((def) => ({
+      REVIEW_QUEUES.map((def) => ({
         ...def,
         count: def.countKey && counts ? counts[def.countKey] : null,
-      })),
-    [enabledDefs, counts],
+      })).filter((entry) => {
+        if (isFlagEnabled(entry.flag)) return true;
+        // Residual work keeps a queue row alive even with its feature off. Not
+        // applied to `secondary` entries: they have no count, so `count` is
+        // always null there and this branch would be dead anyway — spelling the
+        // group check out keeps that a stated rule rather than an accident of
+        // the registry's current shape.
+        return entry.group === 'queue' && (entry.count ?? 0) > 0;
+      }),
+    [isFlagEnabled, counts],
   );
 
-  // Only enabled queues contribute: a feature that is off must not inflate the
-  // badge with work the user has no surface to do.
   const totalPending = entries.reduce((sum, entry) => sum + (entry.count ?? 0), 0);
 
   return {
     entries,
     counts,
     totalPending,
+    // Three things must have answered before a consumer may render, and the
+    // third is new in #404.
+    //
     // `workflowsEnabled === null` means its probe has not resolved. It counts as
     // loading so a deep link to `/review/automations` waits for the answer
     // instead of being bounced to the hub as "disabled" a beat before the probe
     // says otherwise.
-    isLoading:
-      flagsLoading || workflowsEnabled === null || (anyQueueEnabled && countsLoading),
-    anyEnabled: enabledDefs.length > 0,
+    //
+    // `countsLoading` is now UNCONDITIONAL (it used to be `anyQueueEnabled &&
+    // countsLoading`). Counts settle after flags, and a residual row exists only
+    // once the counts arrive — so gating on the flags alone would render the
+    // list, then pop an extra row in a beat later. Holding the existing loading
+    // state until both halves have settled makes the list render ONCE, complete.
+    // Safe against a stuck spinner: with no active circle `useReviewCounts`
+    // reports `isLoading: false` immediately, and it always clears the flag in an
+    // unconditional `finally`.
+    isLoading: flagsLoading || workflowsEnabled === null || countsLoading,
+    // Still meaningful, just measured against what actually resolved rather than
+    // against the flag-enabled set: false means nothing at all is reachable
+    // here — no flag on AND no residual work — which is the condition the
+    // all-disabled empty state describes.
+    anyEnabled: entries.length > 0,
   };
 }

--- a/apps/web/src/pages/Bursts/BurstsPage.tsx
+++ b/apps/web/src/pages/Bursts/BurstsPage.tsx
@@ -31,7 +31,9 @@ import { useNavigate, useSearchParams, Link as RouterLink } from 'react-router-d
 import { useCircle } from '../../hooks/useCircle';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useBurstGroups } from '../../hooks/useBursts';
+import { FeatureDisabledNotice } from '../../components/review/FeatureDisabledNotice';
 import { GroupBulkResolveToolbar } from '../../components/review/GroupBulkResolveToolbar';
 import { SelectionCheckboxOverlay } from '../../components/review/SelectionCheckboxOverlay';
 import { ConfidenceMeter } from '../../components/review/ConfidenceMeter';
@@ -156,6 +158,11 @@ export default function BurstsPage() {
   const { activeCircle, activeCircleId } = useCircle();
   const { hasPermission, isAdmin } = usePermissions();
   const { settings } = useSystemSettings();
+  // See `DuplicatesPage` for the inversion rule: a LOADED flag record that does
+  // not say `true` means off; still-loading and a flags outage (`features:
+  // null`) must both stay silent rather than claim the feature is disabled.
+  const { features } = useFeatureFlags();
+  const featureDisabled = features !== null && features.burstDetection !== true;
   const {
     items,
     meta,
@@ -331,6 +338,16 @@ export default function BurstsPage() {
           </Tooltip>
         )}
       </Box>
+
+      {/* Feature-off notice (issue #404). Above the content, never instead of
+          it: any groups below are still real and still resolvable. */}
+      {featureDisabled && (
+        <FeatureDisabledNotice
+          featureLabel="Burst detection"
+          settingsPath="/admin/settings/bursts"
+          hasExistingWork={items.length > 0}
+        />
+      )}
 
       {/* Sort control */}
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>

--- a/apps/web/src/pages/Duplicates/DuplicatesPage.tsx
+++ b/apps/web/src/pages/Duplicates/DuplicatesPage.tsx
@@ -32,7 +32,9 @@ import { useNavigate, useSearchParams, Link as RouterLink } from 'react-router-d
 import { useCircle } from '../../hooks/useCircle';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useDuplicateGroups } from '../../hooks/useDuplicates';
+import { FeatureDisabledNotice } from '../../components/review/FeatureDisabledNotice';
 import { GroupBulkResolveToolbar } from '../../components/review/GroupBulkResolveToolbar';
 import { SelectionCheckboxOverlay } from '../../components/review/SelectionCheckboxOverlay';
 import { ConfidenceMeter } from '../../components/review/ConfidenceMeter';
@@ -188,6 +190,14 @@ export default function DuplicatesPage() {
   const { activeCircle, activeCircleId } = useCircle();
   const { hasPermission, isAdmin } = usePermissions();
   const { settings } = useSystemSettings();
+  // The `=== true` flag convention, inverted with care. Two states must NOT
+  // show the notice: still loading, and a flags outage — `useFeatureFlags`
+  // resolves a failure to `features: null` rather than throwing, and telling a
+  // user their feature is off because a request failed would be a lie printed
+  // in an Alert. So the notice requires a LOADED flag record that does not say
+  // `true`; an absent key inside a loaded record does mean off.
+  const { features } = useFeatureFlags();
+  const featureDisabled = features !== null && features.duplicateDetection !== true;
   const {
     items,
     meta,
@@ -361,6 +371,17 @@ export default function DuplicatesPage() {
           </Tooltip>
         )}
       </Box>
+
+      {/* Feature-off notice (issue #404). Above the content, never instead of
+          it: any groups below are still real, still resolvable, and are exactly
+          why this page must stay reachable with the flag off. */}
+      {featureDisabled && (
+        <FeatureDisabledNotice
+          featureLabel="Duplicate detection"
+          settingsPath="/admin/settings/duplicates"
+          hasExistingWork={items.length > 0}
+        />
+      )}
 
       {/* Resolve-above-threshold actions */}
       {items.length > 0 && (

--- a/apps/web/src/pages/LocationSuggestions/LocationSuggestionsPage.tsx
+++ b/apps/web/src/pages/LocationSuggestions/LocationSuggestionsPage.tsx
@@ -32,7 +32,9 @@ import { useNavigate, useSearchParams, Link as RouterLink } from 'react-router-d
 import { useCircle } from '../../hooks/useCircle';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useSystemSettings } from '../../hooks/useSystemSettings';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { useLocationSuggestions } from '../../hooks/useLocationSuggestions';
+import { FeatureDisabledNotice } from '../../components/review/FeatureDisabledNotice';
 import {
   startLocationAcceptRun,
   startLocationRejectRun,
@@ -245,6 +247,11 @@ export default function LocationSuggestionsPage() {
   const { activeCircle, activeCircleId } = useCircle();
   const { isAdmin } = usePermissions();
   const { settings } = useSystemSettings();
+  // See `DuplicatesPage` for the inversion rule: a LOADED flag record that does
+  // not say `true` means off; still-loading and a flags outage (`features:
+  // null`) must both stay silent rather than claim the feature is disabled.
+  const { features } = useFeatureFlags();
+  const featureDisabled = features !== null && features.locationInference !== true;
   const { items, meta, isLoading, error, fetchSuggestions, accept, reject, actingIds } =
     useLocationSuggestions();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -432,6 +439,16 @@ export default function LocationSuggestionsPage() {
           </Button>
         </Box>
       </Box>
+
+      {/* Feature-off notice (issue #404). Above the content, never instead of
+          it: any suggestions below are still real and still acceptable. */}
+      {featureDisabled && (
+        <FeatureDisabledNotice
+          featureLabel="Location inference"
+          settingsPath="/admin/settings/location-inference"
+          hasExistingWork={items.length > 0}
+        />
+      )}
 
       {actionError && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setActionError(null)}>

--- a/docs/specs/navigation-ia.md
+++ b/docs/specs/navigation-ia.md
@@ -500,6 +500,20 @@ than adding one, and makes the phone and desktop treatments the same model at tw
    caught up" rather than six rows of "0". A drained queue in the list reads as an em dash,
    not a zero.
 
+**Feature gating — enabled OR holding pending work (issue #404).** A queue row renders when
+its feature flag is on **or** the queue still holds pending items. Pure flag gating was
+wrong on three counts. The pages behind these rows have **no feature gate of their own**:
+`BurstsPage`, `DuplicatesPage` and `LocationSuggestionsPage` render, list and resolve
+normally with the flag off, so the row was hiding a working page. The server does not gate
+the numbers either — `computeReviewCounts` returns all four counts unconditionally — so the
+old rule discarded work the API had already reported, in the row *and* in the aggregate
+badge. And groups created while the flag was on, or by an admin backfill, stay in the
+database and stay resolvable; gating them away orphans them with no route in. These three
+rows were ungated entirely before this hub existed, and §6.3 already states the principle:
+**keep the destination, drop the badge.** The two `secondary` entries keep pure flag gating,
+having no count to ask the question of. A page whose feature is off says so in a banner
+above its content — never instead of it, and never as a redirect.
+
 **Deliberately deferred:** a *unified* review stream — one swipeable card deck mixing all
 four queues — would be the more ambitious answer, but each queue has a genuinely different
 decision UI (pick-the-best-of-N for bursts, confirm-a-map-pin for locations, accept/reject a


### PR DESCRIPTION
## Summary

**Production fix.** Duplicates was missing from `/review` while Bursts showed 234. Immediate cause: `features.duplicateDetection` is off (the default) and #390 hides a queue row whose flag is off — **but that gating was itself a regression.** Those rows were **ungated** before #390 (verified at `b7fdd76`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #404
Relates to #388, #390

## Changes Made

### Why this was worse than a hidden menu row

1. **`DuplicatesPage` / `BurstsPage` / `LocationSuggestionsPage` have no feature gate of their own** — they render and work when reached directly. The nav gate was hiding *working pages*.
2. **The server reported the work and the client discarded it.** `computeReviewCounts` returns `pendingDuplicateGroups` unconditionally, but the client summed only flag-enabled entries — so pending groups were invisible in the row **and** the aggregate badge. No signal anywhere.
3. **Existing groups were orphaned.** Rows from an earlier run or `POST /api/admin/duplicates/backfill` stay in `duplicate_groups` and stay resolvable, but became unreachable from navigation the moment an admin switched the flag off.

It also contradicted spec §6.3 — *"users cannot find a feature they know exists… keep the destination, drop the badge"* — applied to the Review destination but never carried down to the rows.

### The rule

A queue row resolves when its feature is **enabled OR it has pending work**, and `totalPending` includes those rows. Flag off **plus zero pending still renders nothing**, so this is not a revert: deployments that never enabled a feature keep a clean hub.

### Two traps that had to be solved together, or the fix is cosmetic

- **The counts request was gated on the flag-enabled set**, so with every queue flag off no request fired, no counts arrived, and residual work could never be discovered — precisely where it mattered. The gate is dropped at this one call site: the Review destination renders unconditionally and always wants an aggregate badge, so its counts are needed unconditionally, and `review-counts` is the four-integer endpoint #204 built for exactly this. **`useReviewCounts`'s own `enabled` option is untouched** — `enabled: false` ⇒ no request still holds for every other caller.
- **Counts settle after flags**, so a residual row would have popped in a beat late. `countsLoading` now folds into `isLoading` unconditionally, so the list holds its spinner until both settle and renders once, complete.

### Page disabled states

The three pages gain a banner **above** their content, never replacing it — the residual groups are exactly what the user came for, so hiding them behind a message saying they exist would defeat the purpose. Copy varies on whether work is present; the settings link renders only for an admin who can follow it.

Its flag read is `features !== null && flag !== true`, **deliberately not** the codebase's usual `=== true`: `useFeatureFlags` resolves an *outage* to `null`, and telling someone their feature is disabled because a request failed would be a lie.

### Verified rather than assumed

The implementer flagged that Enhancements might differ, since its drawer *is* flag-gated unlike the three group pages. Checked server-side: **only `startEnhance` is flag-gated** — `listEnhancements`, `getEnhancement`, `applyEnhancement` and discard are not. An existing *ready* enhancement can still be applied or discarded with the feature off, so the flag blocks creating new work (correct) without stranding decisions already waiting. Including it in the rule is right.

## Testing

- [x] Unit tests pass (`npm test`) — **17 files / 388 tests green** (baseline 361 passed / 5 failed)
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — `npm run build` green

**One of the rewritten tests asserted the bug outright** — it mocked `duplicateDetection: false` *with six pending groups* and expected no row. That is the production report, encoded as intended behaviour. It is the same failure mode as #392's *"TopbarSearch is hidden below md"* and its breakpoint fixtures: **three regressions from this epic have now been guarded by tests that asserted the implementation's assumptions back at it.**

Cases carrying the weight:
- Flag off + pending work ⇒ row resolves, count renders, badge includes it — the production case, covering Duplicates by name.
- **Flag off + zero pending ⇒ no row** — what distinguishes this from a plain revert.
- Secondary entries keep **pure** flag gating; a count must never resurrect them.
- `useReviewCounts` called with no argument even when every flag is off — the mechanism residual discovery depends on, pinned rather than left implicit.
- **No premature settling:** driven with an unresolved counts promise, asserting the loading state then one complete render — a test checking only the settled state cannot catch a late-growing row.
- `FeatureDisabledNotice` stays silent while flags load **and on an outage**, tested in isolation since that is the assertion most likely to be "corrected" into a bug.
- `/review/duplicates` no longer bounces to the hub when residual work exists behind a disabled flag.

**Mutation-verified:** reverting the residual-work clause fails **3 of 21**, including the no-flash guard — confirming that guard exercises the new rule rather than passing incidentally.

### Test Instructions

1. With Near-Duplicate Detection **off** and pending duplicate groups present: `/review` shows the Duplicates row with its count, and the Review badge includes it.
2. Open `/duplicates` — an info banner explains the feature is off, **and the groups still render below it**.
3. With the feature off and **zero** pending groups: no Duplicates row (not a dead em-dash row).
4. Turn the feature on: row present regardless of count; drained shows an em dash.
5. Confirm the row does not appear a beat after the list renders.

## Screenshots

Not captured — no browser in this session.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Third production bug from epic #388 (after #400 and #402) with the identical shape: **a spec instruction implemented exactly as written, with the product consequence never checked.** Here §4.5 said "a disabled row is not rendered" — obviously right in isolation, and nobody asked what happens to a deployment holding real pending work behind a flag an admin later switched off. §4.5 is corrected accordingly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj

---
_Generated by [Claude Code](https://claude.ai/code/session_01D82rKxk4TVDhsUNnepB4fj)_