### PR TITLE
fix: dangling/stale linked-person links surface as raw 404s (#406)

### DIFF
--- a/apps/api/src/face/people.service.spec.ts
+++ b/apps/api/src/face/people.service.spec.ts
@@ -80,6 +80,8 @@ describe('PeopleService', () => {
   let mockUserAvatarService: {
     refreshAvatarsForPerson: jest.Mock;
     carryLinkedUsersOnMerge: jest.Mock;
+    unlinkUsersFromPerson: jest.Mock;
+    resetAvatarsAfterUnlink: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -128,6 +130,13 @@ describe('PeopleService', () => {
     mockUserAvatarService = {
       refreshAvatarsForPerson: jest.fn().mockResolvedValue(undefined),
       carryLinkedUsersOnMerge: jest.fn().mockResolvedValue(0),
+      // deletePerson's stale-link cleanup (issue #406). Default: nobody was
+      // linked to the deleted person, mirroring the pre-existing tests below
+      // that don't set up a linked user.
+      unlinkUsersFromPerson: jest
+        .fn()
+        .mockResolvedValue({ unlinkedUserIds: [], resetUserIds: [] }),
+      resetAvatarsAfterUnlink: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -1282,6 +1291,108 @@ describe('PeopleService', () => {
           data: expect.objectContaining({ action: 'person:delete', targetId: PERSON_ID }),
         }),
       );
+    });
+
+    // -----------------------------------------------------------------------
+    // Stale User.linkedPersonId cleanup (issue #406)
+    // -----------------------------------------------------------------------
+
+    it('calls userAvatarService.unlinkUsersFromPerson INSIDE the transaction', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([]);
+      mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+        (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+        (mockPrisma.person.update as jest.Mock).mockResolvedValue({});
+        (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
+        return cb(mockPrisma);
+      });
+
+      await service.deletePerson(PERSON_ID, USER_ID, PERMS);
+
+      // The tx-mock pattern here invokes the callback with `mockPrisma`
+      // itself standing in for `tx`, so this also proves the call happened
+      // as part of the transaction rather than after it.
+      expect(mockUserAvatarService.unlinkUsersFromPerson).toHaveBeenCalledWith(
+        mockPrisma,
+        PERSON_ID,
+      );
+    });
+
+    it('is a no-op on users when no one is linked to the deleted person', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([]);
+      mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+        (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+        (mockPrisma.person.update as jest.Mock).mockResolvedValue({});
+        (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
+        return cb(mockPrisma);
+      });
+      mockUserAvatarService.unlinkUsersFromPerson.mockResolvedValue({
+        unlinkedUserIds: [],
+        resetUserIds: [],
+      });
+
+      await service.deletePerson(PERSON_ID, USER_ID, PERMS);
+
+      expect(mockUserAvatarService.resetAvatarsAfterUnlink).not.toHaveBeenCalled();
+    });
+
+    it('resets the avatar (after commit) for every unlinked user whose avatarSource was person', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([]);
+      const callOrder: string[] = [];
+      mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+        (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+        (mockPrisma.person.update as jest.Mock).mockResolvedValue({});
+        (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
+        callOrder.push('transaction-start');
+        const result = await cb(mockPrisma);
+        callOrder.push('transaction-commit');
+        return result;
+      });
+      mockUserAvatarService.unlinkUsersFromPerson.mockImplementation(async () => {
+        callOrder.push('unlinkUsersFromPerson');
+        return { unlinkedUserIds: ['user-a', 'user-b'], resetUserIds: ['user-b'] };
+      });
+      mockUserAvatarService.resetAvatarsAfterUnlink.mockImplementation(async () => {
+        callOrder.push('resetAvatarsAfterUnlink');
+      });
+
+      await service.deletePerson(PERSON_ID, USER_ID, PERMS);
+
+      expect(mockUserAvatarService.resetAvatarsAfterUnlink).toHaveBeenCalledWith([
+        'user-b',
+      ]);
+      // unlinkUsersFromPerson ran inside the transaction; the avatar reset
+      // ran only after the transaction committed.
+      expect(callOrder).toEqual([
+        'transaction-start',
+        'unlinkUsersFromPerson',
+        'transaction-commit',
+        'resetAvatarsAfterUnlink',
+      ]);
+    });
+
+    it('leaves users with avatarSource upload/oauth alone (link cleared, avatar untouched)', async () => {
+      (mockPrisma.person.findUnique as jest.Mock).mockResolvedValue(makePerson());
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([]);
+      mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+        (mockPrisma.face.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+        (mockPrisma.person.update as jest.Mock).mockResolvedValue({});
+        (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
+        return cb(mockPrisma);
+      });
+      // Two users linked to this person: one 'upload'-sourced, one
+      // 'oauth'-sourced — unlinkUsersFromPerson reports both as unlinked but
+      // NEITHER needs an avatar reset.
+      mockUserAvatarService.unlinkUsersFromPerson.mockResolvedValue({
+        unlinkedUserIds: ['user-upload', 'user-oauth'],
+        resetUserIds: [],
+      });
+
+      await service.deletePerson(PERSON_ID, USER_ID, PERMS);
+
+      expect(mockUserAvatarService.resetAvatarsAfterUnlink).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/face/people.service.ts
+++ b/apps/api/src/face/people.service.ts
@@ -824,33 +824,50 @@ export class PeopleService {
     // Capture affected media items BEFORE the transaction releases faces to the unknown pool
     const deleteAffected = await this.fetchAffectedMediaItemsByPersonId(personId);
 
-    await this.prisma.$transaction(async (tx) => {
-      // 1. Release faces back to unknown pool
-      await tx.face.updateMany({
-        where: { personId },
-        data: { personId: null, manuallyAssigned: false },
-      });
+    const { unlinkedUserIds, resetUserIds } = await this.prisma.$transaction(
+      async (tx) => {
+        // 1. Release faces back to unknown pool
+        await tx.face.updateMany({
+          where: { personId },
+          data: { personId: null, manuallyAssigned: false },
+        });
 
-      // 2. Soft-delete person
-      await tx.person.update({
-        where: { id: personId },
-        data: {
-          deletedAt: new Date(),
-          coverFaceId: null, // clear FK
-        },
-      });
+        // 2. Soft-delete person
+        await tx.person.update({
+          where: { id: personId },
+          data: {
+            deletedAt: new Date(),
+            coverFaceId: null, // clear FK
+          },
+        });
 
-      // 3. Audit
-      await tx.auditEvent.create({
-        data: {
-          actorUserId: userId,
-          action: 'person:delete',
-          targetType: 'person',
-          targetId: personId,
-          meta: { circleId: person.circleId, name: person.name } as any,
-        },
-      });
-    });
+        // 3. Detach every account linked to the person being deleted
+        //    (issue #406) — a soft-delete does NOT trigger
+        //    User.linkedPersonId's `onDelete: SetNull` FK action (that only
+        //    fires on a genuine row delete), so the link would otherwise
+        //    dangle forever. Must run in THIS transaction so it can never be
+        //    left half-cleaned by a later failure. The avatar-state reset for
+        //    any actively 'person'-sourced account happens after commit —
+        //    see resetAvatarsAfterUnlink below.
+        const unlinkResult = await this.userAvatarService.unlinkUsersFromPerson(
+          tx,
+          personId,
+        );
+
+        // 4. Audit
+        await tx.auditEvent.create({
+          data: {
+            actorUserId: userId,
+            action: 'person:delete',
+            targetType: 'person',
+            targetId: personId,
+            meta: { circleId: person.circleId, name: person.name } as any,
+          },
+        });
+
+        return unlinkResult;
+      },
+    );
 
     // Re-enqueue auto-tagging for all media items that lost a person assignment
     await this.enqueueAutoTaggingForMediaItems(deleteAffected);
@@ -858,8 +875,22 @@ export class PeopleService {
     // Backup change feed: faces released to the unknown pool (issue #310)
     await this.mediaTouch.touchMediaItems(deleteAffected.map((m) => m.mediaItemId));
 
+    // Best-effort: fall any account that was actively displaying this
+    // now-deleted person's derived picture back to the OAuth picture
+    // (issue #406). Must run AFTER the transaction commits — it reaps
+    // storage bytes, which does not belong inside a DB transaction.
+    if (resetUserIds.length > 0) {
+      await this.userAvatarService.resetAvatarsAfterUnlink(resetUserIds);
+    }
+
     this.logger.log(
-      `Person ${personId} soft-deleted by user ${userId}; faces returned to unknown pool`,
+      `Person ${personId} soft-deleted by user ${userId}; faces returned to unknown pool` +
+        (unlinkedUserIds.length > 0
+          ? `; unlinked ${unlinkedUserIds.length} account(s) from the person` +
+            (resetUserIds.length > 0
+              ? ` (${resetUserIds.length} avatar reset to oauth)`
+              : '')
+          : ''),
     );
   }
 

--- a/apps/api/src/users/user-avatar.service.spec.ts
+++ b/apps/api/src/users/user-avatar.service.spec.ts
@@ -675,6 +675,249 @@ describe('UserAvatarService', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // unlinkUsersFromPerson() (issue #406)
+  // ---------------------------------------------------------------------------
+
+  describe('unlinkUsersFromPerson', () => {
+    it('clears linkedPersonId for every linked user and reports which need an avatar reset', async () => {
+      const tx = {
+        user: {
+          findMany: jest.fn().mockResolvedValue([
+            { id: 'user-a', avatarSource: UserAvatarSource.upload },
+            { id: 'user-b', avatarSource: UserAvatarSource.person },
+            { id: 'user-c', avatarSource: UserAvatarSource.oauth },
+          ]),
+          updateMany: jest.fn().mockResolvedValue({ count: 3 }),
+        },
+      };
+
+      const result = await service.unlinkUsersFromPerson(
+        tx as unknown as Prisma.TransactionClient,
+        PERSON_ID,
+      );
+
+      expect(result).toEqual({
+        unlinkedUserIds: ['user-a', 'user-b', 'user-c'],
+        resetUserIds: ['user-b'],
+      });
+      expect(tx.user.findMany).toHaveBeenCalledWith({
+        where: { linkedPersonId: PERSON_ID },
+        select: { id: true, avatarSource: true },
+      });
+      expect(tx.user.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['user-a', 'user-b', 'user-c'] } },
+        data: { linkedPersonId: null },
+      });
+    });
+
+    it('is a no-op when nobody is linked to the person', async () => {
+      const tx = {
+        user: {
+          findMany: jest.fn().mockResolvedValue([]),
+          updateMany: jest.fn(),
+        },
+      };
+
+      const result = await service.unlinkUsersFromPerson(
+        tx as unknown as Prisma.TransactionClient,
+        PERSON_ID,
+      );
+
+      expect(result).toEqual({ unlinkedUserIds: [], resetUserIds: [] });
+      expect(tx.user.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resetAvatarsAfterUnlink() (issue #406)
+  // ---------------------------------------------------------------------------
+
+  describe('resetAvatarsAfterUnlink', () => {
+    it('resets avatarSource/avatarStorageKey/avatarVersion/profileImageUrl and reaps the superseded object', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(
+        userRow({
+          id: 'user-b',
+          avatarSource: UserAvatarSource.person,
+          avatarStorageKey: 'avatars/user-b/old.jpg',
+          avatarVersion: 'v-old',
+          providerProfileImageUrl: 'https://provider.example/user-b.jpg',
+        }) as any,
+      );
+
+      await service.resetAvatarsAfterUnlink(['user-b']);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+      const writeArgs = mockPrisma.user.update.mock.calls[0][0] as any;
+      expect(writeArgs.where).toEqual({ id: 'user-b' });
+      expect(writeArgs.data).toMatchObject({
+        avatarSource: UserAvatarSource.oauth,
+        avatarStorageKey: null,
+        avatarVersion: null,
+        profileImageUrl: 'https://provider.example/user-b.jpg',
+      });
+      // linkedPersonId is untouched — clearing it is unlinkUsersFromPerson's
+      // job, inside the deletePerson transaction; this method only resets
+      // the avatar for the ids it's handed.
+      expect(writeArgs.data).not.toHaveProperty('linkedPersonId');
+
+      expect(provider.delete).toHaveBeenCalledWith('avatars/user-b/old.jpg');
+      expect(mockPrisma.storageObject.deleteMany).toHaveBeenCalledWith({
+        where: { storageKey: 'avatars/user-b/old.jpg' },
+      });
+    });
+
+    it('is fault-tolerant: one failing user does not stop the rest from being reset', async () => {
+      mockPrisma.user.findUnique.mockImplementation(
+        (args: any) =>
+          Promise.resolve(
+            userRow({ id: args.where.id, avatarSource: UserAvatarSource.person }),
+          ) as any,
+      );
+      mockPrisma.user.update.mockImplementation((args: any) => {
+        if (args.where.id === 'user-a') {
+          return Promise.reject(new Error('db unavailable'));
+        }
+        return Promise.resolve({ ...userRow(), ...args.data }) as any;
+      });
+
+      await expect(
+        service.resetAvatarsAfterUnlink(['user-a', 'user-b']),
+      ).resolves.toBeUndefined();
+
+      const updatedIds = mockPrisma.user.update.mock.calls.map(
+        (c: any[]) => c[0].where.id,
+      );
+      expect(updatedIds).toEqual(['user-a', 'user-b']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Stale-link backstop (issue #406): renderFromLinkedPerson /
+  // applyAvatarSource('person') both re-check liveness before rendering.
+  // ---------------------------------------------------------------------------
+
+  describe('stale linkedPersonId backstop', () => {
+    it('renderFromLinkedPerson: a soft-deleted linked person -> friendly error, no raw UUID, self-heals a person-sourced avatar', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(
+        userRow({
+          linkedPersonId: PERSON_ID,
+          avatarSource: UserAvatarSource.person,
+          avatarStorageKey: 'avatars/user-1/stale.jpg',
+          avatarVersion: 'v-stale',
+        }) as any,
+      );
+      mockPrisma.person.findUnique.mockResolvedValue(
+        personRow({ deletedAt: new Date('2026-01-01T00:00:00Z') }) as any,
+      );
+
+      let error: unknown;
+      try {
+        await service.renderFromLinkedPerson(USER_ID);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      const message = (error as BadRequestException).message;
+      expect(message).toMatch(/Your linked person no longer exists/);
+      // Never the raw internal message naming an internal UUID.
+      expect(message).not.toContain(PERSON_ID);
+      expect(message).not.toContain('not found');
+
+      // Self-heals: clears the link AND resets the avatar, since it was
+      // 'person'-sourced.
+      const writeArgs = mockPrisma.user.update.mock.calls.find(
+        (c: any[]) => c[0].data.linkedPersonId === null,
+      );
+      expect(writeArgs).toBeDefined();
+      expect(writeArgs![0].data).toMatchObject({
+        linkedPersonId: null,
+        avatarSource: UserAvatarSource.oauth,
+        avatarStorageKey: null,
+        avatarVersion: null,
+      });
+      expect(provider.delete).toHaveBeenCalledWith('avatars/user-1/stale.jpg');
+    });
+
+    it('renderFromLinkedPerson: leaves a non-person-sourced avatar alone while still clearing the stale link', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(
+        userRow({
+          linkedPersonId: PERSON_ID,
+          avatarSource: UserAvatarSource.upload,
+          avatarStorageKey: 'avatars/user-1/keep.jpg',
+          avatarVersion: 'v-keep',
+        }) as any,
+      );
+      // Fully gone (e.g. a hard delete elsewhere), not just soft-deleted.
+      mockPrisma.person.findUnique.mockResolvedValue(null);
+
+      await expect(service.renderFromLinkedPerson(USER_ID)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      const writeArgs = mockPrisma.user.update.mock.calls.find(
+        (c: any[]) => c[0].data.linkedPersonId === null,
+      );
+      expect(writeArgs).toBeDefined();
+      expect(writeArgs![0].data).not.toHaveProperty('avatarSource');
+      expect(writeArgs![0].data).not.toHaveProperty('avatarStorageKey');
+      expect(provider.delete).not.toHaveBeenCalled();
+    });
+
+    it('applyAvatarSource(person) via updateProfile hits the same backstop', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(
+        userRow({
+          linkedPersonId: PERSON_ID,
+          avatarSource: UserAvatarSource.person,
+        }) as any,
+      );
+      mockPrisma.person.findUnique.mockResolvedValue(
+        personRow({ deletedAt: new Date('2026-01-01T00:00:00Z') }) as any,
+      );
+
+      await expect(
+        service.updateProfile(requestUser(), {
+          avatarSource: UserAvatarSource.person,
+        } as any),
+      ).rejects.toThrow(/Your linked person no longer exists/);
+    });
+
+    it('a genuinely live linked person still renders normally (backstop does not false-positive)', async () => {
+      const source = await realJpeg(900, 900);
+      (prepareImageForProcessing as jest.Mock).mockResolvedValue({
+        buffer: source,
+        width: 900,
+        height: 900,
+      });
+
+      mockPrisma.user.findUnique.mockResolvedValue(
+        userRow({ linkedPersonId: PERSON_ID }) as any,
+      );
+      mockPrisma.person.findUnique.mockResolvedValue(
+        personRow({ profileMediaItemId: null, profileCrop: null, coverFaceId: null }) as any,
+      );
+      mockPrisma.face.findFirst.mockResolvedValue({
+        mediaItemId: 'media-3',
+        boundingBox: { x: 0.25, y: 0.25, w: 0.4, h: 0.4 },
+        frameThumbnailKey: null,
+      } as any);
+      mockPrisma.mediaItem.findUnique.mockResolvedValue({
+        type: 'photo',
+        deletedAt: null,
+        storageObject: {
+          storageKey: 'objects/media-3.jpg',
+          storageProvider: 's3',
+          bucket: 'bucket-1',
+          mimeType: 'image/jpeg',
+        },
+      } as any);
+
+      await expect(service.renderFromLinkedPerson(USER_ID)).resolves.toBeDefined();
+      expect(provider.upload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // uploadAvatar(): output contract — 512x512, EXIF/GPS stripped
   // ---------------------------------------------------------------------------
 

--- a/apps/api/src/users/user-avatar.service.spec.ts
+++ b/apps/api/src/users/user-avatar.service.spec.ts
@@ -307,7 +307,7 @@ describe('UserAvatarService', () => {
       );
     });
 
-    it('a non-member gets 404, NOT 403 (enumeration-resistant)', async () => {
+    it('a non-member gets 404, NOT 403 (enumeration-resistant), with an actionable message', async () => {
       mockPrisma.person.findUnique.mockResolvedValue(personRow() as any);
       circleMembership.assertCircleAccess.mockRejectedValueOnce(
         new ForbiddenException('You are not a member of this circle'),
@@ -319,26 +319,43 @@ describe('UserAvatarService', () => {
 
       await expect(promise).rejects.toBeInstanceOf(NotFoundException);
       await expect(promise).rejects.not.toBeInstanceOf(ForbiddenException);
+      await expect(promise).rejects.toThrow(
+        'This person is no longer available to link. They may have been removed, merged with another person, or you may no longer have access to their circle. Please pick again.',
+      );
     });
 
-    it('a soft-deleted person -> 404 without ever checking circle access', async () => {
+    it('a soft-deleted person -> 404 without ever checking circle access, with the same actionable message (issue #406)', async () => {
       mockPrisma.person.findUnique.mockResolvedValue(
         personRow({ deletedAt: new Date('2026-01-01T00:00:00Z') }) as any,
       );
 
-      await expect(
-        service.updateProfile(requestUser(), { linkedPersonId: PERSON_ID } as any),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      const promise = service.updateProfile(requestUser(), {
+        linkedPersonId: PERSON_ID,
+      } as any);
+
+      await expect(promise).rejects.toBeInstanceOf(NotFoundException);
+      // Same message as the non-member case above — the two causes remain
+      // indistinguishable to the caller, only the server log disambiguates.
+      await expect(promise).rejects.toThrow(
+        'This person is no longer available to link. They may have been removed, merged with another person, or you may no longer have access to their circle. Please pick again.',
+      );
+      // No longer a bare UUID with zero context (the pre-fix message).
+      await expect(promise).rejects.not.toThrow(`Person ${PERSON_ID} not found`);
 
       expect(circleMembership.assertCircleAccess).not.toHaveBeenCalled();
     });
 
-    it('a nonexistent person id -> 404 without ever checking circle access', async () => {
+    it('a nonexistent person id -> 404 without ever checking circle access, with the actionable message', async () => {
       mockPrisma.person.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.updateProfile(requestUser(), { linkedPersonId: 'no-such-person' } as any),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      const promise = service.updateProfile(requestUser(), {
+        linkedPersonId: 'no-such-person',
+      } as any);
+
+      await expect(promise).rejects.toBeInstanceOf(NotFoundException);
+      await expect(promise).rejects.toThrow(
+        'This person is no longer available to link. They may have been removed, merged with another person, or you may no longer have access to their circle. Please pick again.',
+      );
 
       expect(circleMembership.assertCircleAccess).not.toHaveBeenCalled();
     });

--- a/apps/api/src/users/user-avatar.service.ts
+++ b/apps/api/src/users/user-avatar.service.ts
@@ -61,6 +61,15 @@ export const AVATAR_ALLOWED_MIME_TYPES: readonly string[] = [
 /** Storage-key prefix. See the recursion-guard note on `storeAvatarObject`. */
 const AVATAR_KEY_PREFIX = 'avatars/';
 
+/**
+ * Client-facing message for `assertPersonLinkable` (issue #406). Deliberately
+ * generic — it must never reveal whether the person is missing/deleted or
+ * merely in a circle the caller cannot see (enumeration-resistance), while
+ * still giving the user something actionable instead of a bare UUID.
+ */
+const PERSON_UNLINKABLE_MESSAGE =
+  'This person is no longer available to link. They may have been removed, merged with another person, or you may no longer have access to their circle. Please pick again.';
+
 /** The columns `resolveAvatarUrl` reads. */
 const AVATAR_COLUMNS = {
   id: true,
@@ -994,6 +1003,17 @@ export class UserAvatarService {
    * member of — surfaces as 404, never 403: a 403 would confirm that the id
    * names a real person in a circle the caller cannot see, which is exactly the
    * enumeration the public-share and notification routes also refuse to allow.
+   *
+   * The thrown message is deliberately generic (issue #406) — it must never
+   * reveal WHICH of the two cases applied, only that linking cannot proceed.
+   * A concrete example of the "missing" case: the picker's client-side list
+   * goes stale between page load and the click (the person gets soft-deleted
+   * via `PeopleService.mergePeople`/`deletePerson` in that window), so a
+   * user who picked a real, visible option can still land here — a bare
+   * UUID in a raw NotFoundException gave them nothing to act on. Each throw
+   * site logs server-side first, at `warn` (an expected, user-triggerable
+   * condition, not a system fault), so the disambiguating detail the client
+   * never sees is still traceable from the logs.
    */
   private async assertPersonLinkable(
     user: RequestUser,
@@ -1005,7 +1025,10 @@ export class UserAvatarService {
     });
 
     if (!person || person.deletedAt) {
-      throw new NotFoundException(`Person ${personId} not found`);
+      this.logger.warn(
+        `assertPersonLinkable: person ${personId} not found or deleted (requested by user ${user.id})`,
+      );
+      throw new NotFoundException(PERSON_UNLINKABLE_MESSAGE);
     }
 
     try {
@@ -1015,9 +1038,14 @@ export class UserAvatarService {
         user.permissions,
         CircleRole.viewer,
       );
-    } catch {
+    } catch (err) {
+      this.logger.warn(
+        `assertPersonLinkable: circle access denied for person ${personId} (circle ${person.circleId}), user ${user.id}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       // Collapse Forbidden (and any circle-level NotFound) into a single 404.
-      throw new NotFoundException(`Person ${personId} not found`);
+      throw new NotFoundException(PERSON_UNLINKABLE_MESSAGE);
     }
   }
 

--- a/apps/api/src/users/user-avatar.service.ts
+++ b/apps/api/src/users/user-avatar.service.ts
@@ -331,6 +331,15 @@ export class UserAvatarService {
       );
     }
 
+    // Defense-in-depth backstop (issue #406): `deletePerson` clears
+    // linkedPersonId as part of deleting a person, but this re-checks
+    // liveness directly rather than trusting that every path that can make a
+    // person unusable has already done so (a race between two tabs, or any
+    // future deletion path). Throws a friendly, actionable message and
+    // self-heals instead of reaching renderPersonAvatar's raw
+    // NotFoundException naming an internal UUID.
+    await this.assertLinkedPersonLive(userId, user.linkedPersonId);
+
     await this.renderFromPersonAndStore(userId, user.linkedPersonId);
     return this.getProfile(userId);
   }
@@ -438,6 +447,79 @@ export class UserAvatarService {
     return count;
   }
 
+  /**
+   * Detach every account linked to a person that is being (or was just)
+   * soft-deleted (issue #406).
+   *
+   * `Person.deletedAt` is a soft-delete, so the `User.linkedPersonId ->
+   * Person.id` FK's `onDelete: SetNull` — which only fires on a genuine row
+   * delete — never runs, and the column would otherwise dangle forever.
+   * Called from INSIDE `PeopleService.deletePerson`'s transaction, on the
+   * `tx` passed in, mirroring `carryLinkedUsersOnMerge`'s shape: the clear
+   * MUST be atomic with the soft-delete itself, so a request that fails after
+   * this call can never leave the link half-cleaned.
+   *
+   * Only clears `linkedPersonId` here — it does NOT reset avatar state, since
+   * that write touches `profileImageUrl` (fine inside a transaction) but the
+   * superseded storage bytes must also be reaped, which talks to the storage
+   * provider and does not belong inside a DB transaction. Callers should pass
+   * the returned `resetUserIds` to `resetAvatarsAfterUnlink` AFTER the
+   * transaction commits.
+   */
+  async unlinkUsersFromPerson(
+    tx: Prisma.TransactionClient,
+    personId: string,
+  ): Promise<{ unlinkedUserIds: string[]; resetUserIds: string[] }> {
+    const linked = await tx.user.findMany({
+      where: { linkedPersonId: personId },
+      select: { id: true, avatarSource: true },
+    });
+
+    if (linked.length === 0) {
+      return { unlinkedUserIds: [], resetUserIds: [] };
+    }
+
+    const unlinkedUserIds = linked.map((u) => u.id);
+    const resetUserIds = linked
+      .filter((u) => u.avatarSource === UserAvatarSource.person)
+      .map((u) => u.id);
+
+    await tx.user.updateMany({
+      where: { id: { in: unlinkedUserIds } },
+      data: { linkedPersonId: null },
+    });
+
+    return { unlinkedUserIds, resetUserIds };
+  }
+
+  /**
+   * Best-effort avatar-state reset for the `resetUserIds` returned by
+   * `unlinkUsersFromPerson` — every account that was actively displaying a
+   * now-deleted person's derived picture falls back to the OAuth picture,
+   * using the exact same reset semantics `resetAvatarState` applies elsewhere
+   * (avatarSource -> oauth, avatarStorageKey -> null, avatarVersion -> null,
+   * profileImageUrl recomputed).
+   *
+   * MUST be called AFTER the caller's transaction has committed: it writes
+   * through `this.prisma` (not a `tx`) and reaps storage bytes, neither of
+   * which belongs inside a DB transaction. Mirrors `refreshAvatarsForPerson`'s
+   * fire-and-forget posture — a failure to reset one user's avatar must never
+   * fail (or partially undo) the person deletion that triggered it.
+   */
+  async resetAvatarsAfterUnlink(userIds: string[]): Promise<void> {
+    for (const userId of userIds) {
+      try {
+        await this.resetAvatarState(userId);
+      } catch (err) {
+        this.logger.warn(
+          `resetAvatarsAfterUnlink: avatar reset failed for user ${userId} (non-fatal): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Private — state writes
   // ---------------------------------------------------------------------------
@@ -515,6 +597,8 @@ export class UserAvatarService {
           'This account is not linked to a person yet. Link one first.',
         );
       }
+      // Defense-in-depth backstop (issue #406) — see renderFromLinkedPerson.
+      await this.assertLinkedPersonLive(userId, user.linkedPersonId);
       await this.renderFromPersonAndStore(userId, user.linkedPersonId);
       return;
     }
@@ -935,6 +1019,55 @@ export class UserAvatarService {
       // Collapse Forbidden (and any circle-level NotFound) into a single 404.
       throw new NotFoundException(`Person ${personId} not found`);
     }
+  }
+
+  /**
+   * Defense-in-depth backstop (issue #406) for the two entry points that
+   * actually READ a person to render bytes — `renderFromLinkedPerson` and
+   * `applyAvatarSource`'s `'person'` branch — as opposed to
+   * `describeLinkedPerson`, which only ever DESCRIBES the link for a GET.
+   *
+   * `PeopleService.deletePerson` clears `linkedPersonId` for every linked
+   * account as part of the delete itself, so this should normally never fire.
+   * It exists for whatever that cleanup doesn't (yet) cover — a race between
+   * two tabs, or a future way for a person to become unusable without going
+   * through `deletePerson` — and it self-heals exactly like that cleanup
+   * does: clears the stale link, and falls an actively `'person'`-sourced
+   * avatar back to `'oauth'`, so the affordance is consistently disabled on
+   * the client's next `GET /api/users/me/profile` instead of failing the same
+   * way forever. Throws a friendly, actionable message rather than
+   * `renderPersonAvatar`'s raw `NotFoundException` naming an internal UUID.
+   */
+  private async assertLinkedPersonLive(
+    userId: string,
+    personId: string,
+  ): Promise<void> {
+    const person = await this.prisma.person.findUnique({
+      where: { id: personId },
+      select: { deletedAt: true },
+    });
+
+    if (person && !person.deletedAt) return;
+
+    const current = await this.loadAvatarColumns(userId);
+    const wasPersonSourced = current.avatarSource === UserAvatarSource.person;
+
+    if (wasPersonSourced) {
+      const previousStorageKey = current.avatarStorageKey;
+      await this.writeAvatarState(userId, {
+        linkedPersonId: null,
+        avatarSource: UserAvatarSource.oauth,
+        avatarStorageKey: null,
+        avatarVersion: null,
+      });
+      await this.deleteAvatarObject(previousStorageKey);
+    } else {
+      await this.writeAvatarState(userId, { linkedPersonId: null });
+    }
+
+    throw new BadRequestException(
+      'Your linked person no longer exists. Please link a different person.',
+    );
   }
 
   /**

--- a/apps/web/src/__tests__/components/user/LinkedPersonCard.test.tsx
+++ b/apps/web/src/__tests__/components/user/LinkedPersonCard.test.tsx
@@ -356,6 +356,67 @@ describe('LinkedPersonCard', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Regression coverage for issue #406 — the picker self-heals after a link
+  // attempt, since `onLinkChange` swallows its own errors and this component
+  // has no way to tell success from failure.
+  // -------------------------------------------------------------------------
+  describe('picker refresh after a link attempt (issue #406)', () => {
+    it('re-fetches the people list after onLinkChange resolves, dropping a since-invalidated option', async () => {
+      mockUseFeatureFlags.mockReturnValue(
+        flagsResult({ features: { faceRecognition: true } }),
+      );
+      mockListPeople.mockResolvedValue({
+        items: [
+          {
+            id: 'person-1',
+            name: 'Grandma',
+            isUnlabeled: false,
+            faceCount: 12,
+            coverFace: null,
+            profileMediaItemId: null,
+            profileCrop: null,
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+            favorite: false,
+          },
+        ],
+        meta: { page: 1, pageSize: 100, totalItems: 1, totalPages: 1 },
+      });
+      // The component cannot distinguish a successful link from a failed one
+      // — `onLinkChange` (`ProfilePage.handleLinkChange`) catches internally
+      // and never rethrows — so mocking it to simply resolve exercises both
+      // cases identically from this component's point of view.
+      const onLinkChange = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<LinkedPersonCard profile={makeProfile()} onLinkChange={onLinkChange} />);
+
+      const input = await screen.findByLabelText(/Find a person/i);
+
+      const callsAfterMount = mockListPeople.mock.calls.length;
+      expect(callsAfterMount).toBeGreaterThan(0);
+
+      await user.click(input);
+      const option = await screen.findByText('Grandma');
+      await user.click(option);
+
+      const linkButton = screen.getByRole('button', { name: /Link this person/i });
+      await user.click(linkButton);
+
+      await waitFor(() => {
+        expect(onLinkChange).toHaveBeenCalledWith('person-1');
+      });
+
+      // The load-bearing assertion: after the link attempt settles, the
+      // picker refreshes its data instead of leaving a stale option
+      // retryable forever.
+      await waitFor(() => {
+        expect(mockListPeople.mock.calls.length).toBeGreaterThan(callsAfterMount);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Unlink affordance
   // -------------------------------------------------------------------------
   describe('unlink affordance', () => {

--- a/apps/web/src/components/user/LinkedPersonCard.tsx
+++ b/apps/web/src/components/user/LinkedPersonCard.tsx
@@ -213,6 +213,14 @@ export function LinkedPersonCard({
       setSelected(null);
     } finally {
       setSubmitting(false);
+      // `onLinkChange` swallows its own errors (see the prop doc), so this
+      // component genuinely cannot tell success from failure here. Re-fetch
+      // regardless: on success it picks up the newly-linked person's fresh
+      // data, and on failure — e.g. the selected person was merged/deleted
+      // by face-clustering between page load and this click (issue #406) —
+      // it drops the now-invalid option so the exact same failing selection
+      // can't be retried indefinitely.
+      void loadPeople();
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes #406 — `/profile` could show a raw, internal `Person <uuid> not found` alert whenever a user's linked `Person` link went stale, across **two distinct code paths** found via a real screen-recording repro:

1. **Render-time**: an already-linked `Person` gets soft-deleted (`DELETE /api/people/:id`) after the link was made; nothing ever cleaned up the dangling `User.linkedPersonId`, and re-rendering the avatar from it kept failing identically forever.
2. **Link-time**: the "Linked person" picker's list goes stale (e.g. the selected person gets merged into another record via `PeopleService.mergePeople`, which soft-deletes the merge source) between page load and the moment the user clicks "Link this person" — confirmed by frame-by-frame analysis of a screen recording showing the field reset and error appear immediately after a valid-looking selection was submitted.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #406

## Changes Made

**Render-time path:**
- `PeopleService.deletePerson` (soft-delete) now clears `User.linkedPersonId` for any account linked to the person being deleted, inside the same transaction as the face-release/soft-delete/audit steps — mirroring what `mergePeople` already does via `carryLinkedUsersOnMerge`.
- New `UserAvatarService.unlinkUsersFromPerson(tx, personId)` / `resetAvatarsAfterUnlink(userIds)` — transactional link clear + best-effort post-commit avatar reset to `oauth` for accounts whose `avatarSource` was `'person'`.
- Defense-in-depth backstop in `renderFromLinkedPerson` / `applyAvatarSource`'s `'person'` branch: re-check the linked person's liveness before rendering, self-heal a stale link if found, and throw an actionable message instead of the raw `NotFoundException`.

**Link-time path:**
- `UserAvatarService.assertPersonLinkable` (called from `PATCH /api/users/me/profile { linkedPersonId }`) now throws an actionable message instead of a bare UUID — still collapsing "person missing/deleted" and "no circle access" into one message (enumeration-resistance preserved), with `logger.warn(...)` at each throw site so the real cause is traceable server-side.
- `LinkedPersonCard.tsx` now refreshes its people list after every link attempt (success or failure), so a since-invalidated option can't be retried indefinitely.

Test coverage added across `people.service.spec.ts`, `user-avatar.service.spec.ts`, and `LinkedPersonCard.test.tsx` for all of the above.

## Testing

- [x] Unit tests pass (`npm test`) — 219+33/33 in the directly affected backend spec files; frontend `LinkedPersonCard.test.tsx` passing; 679 passed / 0 failed across the broader `users/`+`face/` suites
- [x] Type checks pass (`npx tsc --noEmit`, both `apps/api` and `apps/web`)
- [ ] E2E tests pass (if applicable)
- [ ] Manual testing completed

### Test Instructions

1. Link a user's account to a `Person`, set picture source to "My linked person".
2. In another session, delete that `Person` from the People page → confirm the avatar quietly reverts to the Google picture, no raw UUID error.
3. On the picker, select a person, then (in another session) merge that person into another before clicking "Link this person" → confirm the error message is actionable, not a bare UUID, and the picker no longer offers that option afterward.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
