### PR TITLE
fix(web): match the app shell by its logo, unbreaking main

### DIFF
--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -13,14 +13,23 @@ describe('App', () => {
     );
 
     // The MSW handler for /api/auth/me returns a valid user, so the app renders
-    // the authenticated layout. Wait for the application name in the AppBar.
+    // the authenticated layout. Wait for the brand in the AppBar.
     await waitFor(
       () => {
-        // MemoriaHub title is always rendered in the AppBar regardless of route
+        // The brand is the logo IMAGE at every breakpoint; the wordmark beside
+        // it is gated on `isDesktopBrand` (AppBar.tsx) and so does not render
+        // under jsdom, where that breakpoint query resolves false. Match the
+        // logo by its alt text — `queryByText` cannot see an `alt` attribute,
+        // which is exactly why this assertion broke when the navigation
+        // overhaul (#394-#403) replaced the always-on text title.
+        const appLogo = screen.queryByAltText(/MemoriaHub/i);
+        // Still accept the wordmark, so the test keeps passing at a desktop
+        // breakpoint (or if the gating is ever relaxed) rather than silently
+        // depending on the wordmark being absent.
         const appTitle = screen.queryByText(/MemoriaHub/i);
         // Fallback: if auth is still loading, login page elements may appear first
         const loginText = screen.queryByText(/sign in/i);
-        expect(appTitle || loginText).toBeTruthy();
+        expect(appLogo || appTitle || loginText).toBeTruthy();
       },
       { timeout: 5000 }
     );


### PR DESCRIPTION
## Summary

`main` is currently red. `App.test.tsx` fails on a clean checkout of `origin/main` (`3d127a0`) with nothing else applied, so every open PR inherits a failing `Build & Test` that masks real regressions.

Found while investigating CI on #409, whose own diff is unrelated and passes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #410

## Root cause

The smoke test asserted the shell had rendered by looking for the app name as **text**:

```ts
const appTitle = screen.queryByText(/MemoriaHub/i);
const loginText = screen.queryByText(/sign in/i);
expect(appTitle || loginText).toBeTruthy();
```

The navigation overhaul (#394–#403) restructured the brand in `components/navigation/AppBar.tsx`. The logo is now always an image, and the wordmark renders only at a desktop breakpoint:

```tsx
<Box component="img" src={appLogo} alt={APP_NAME} … />
{isDesktopBrand && <Typography …>{APP_NAME}</Typography>}
```

Under jsdom that breakpoint query resolves false, so the wordmark never renders and the only "MemoriaHub" left in the tree is the logo's `alt` attribute — which `queryByText` cannot match. The user is authenticated, so there was no "sign in" fallback either, and the assertion failed on `null`.

The failure DOM showed the AppBar, circle chip, upload button, notifications bell and theme toggle all present. **The app was never broken** — the assertion had simply stopped describing how the brand renders.

## Changes Made

- Match the logo by its `alt` text, which is the always-rendered brand element.
- Keep the wordmark and login-page arms of the `||`, so the test still passes at a desktop breakpoint or if the gating is later relaxed, rather than silently depending on the wordmark being absent.
- Comment why `queryByText` cannot see the logo, so the next person to touch the brand knows what this assertion is pinned to.

The test still fails if the shell genuinely does not render — all three arms are absent when `App` crashes, so this is not weakened into a tautology.

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Type checks pass (`npm run typecheck`)

Verified failing **before** and passing **after** on a clean `origin/main` checkout:

```
before  Test Files  1 failed (1)     Tests  1 failed (1)
after   Test Files  1 passed (1)     Tests  1 passed (1)
```

CI's own summary on #409 reported this as the only failing test in the suite (`1 failed | 248 passed (249)`), so this single fix should restore main to green.

### Test Instructions

```bash
git checkout --detach origin/main
cd apps/web && npx vitest run src/__tests__/App.test.tsx   # fails
git checkout claude/memoriahub-issue-410-fix-app-shell-test
cd apps/web && npx vitest run src/__tests__/App.test.tsx   # passes
```

## Additional Notes

This fixes the assertion, not the breakpoint gating, which is deliberate product behaviour per the AppBar's own comments (the wordmark is decorative and yields to the circle chip and search pill in the medium band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCMUKgEkxdM25YPGCyfJCc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCMUKgEkxdM25YPGCyfJCc)_