### PR TITLE
feat(api): world-class API documentation — Scalar UI, tag groups, session auth, self-documenting RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,101 @@ jobs:
       - run: npm run test:ci --workspace=api
       - run: npm run test:ci --workspace=web
 
+  openapi:
+    name: OpenAPI Spec
+    runs-on: ubuntu-latest
+    # No `needs: build` — same rationale as cli-test below: this runs
+    # concurrently and adds no wall-clock time to an all-green workflow.
+    env:
+      NODE_ENV: test
+    steps:
+      # Full history so the base branch can be checked out for the spec diff.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      # Same rationale as the build job: apps/api imports
+      # @memoriahub/enrichment-compute by subpath against its git-ignored dist/.
+      - run: npm run build --workspace=@memoriahub/enrichment-compute
+
+      - run: npx prisma generate
+        working-directory: apps/api
+
+      # The dump script boots the app in Nest's preview mode: every module is
+      # loaded and every controller's metadata read, but no provider is
+      # instantiated — so this needs no database, no object storage, and no
+      # credentials, and starts no cron or worker loops.
+      - name: Generate the spec
+        run: npm run openapi:dump
+
+      - name: Lint the spec
+        run: npm run openapi:lint
+
+      - name: Type-check the dump script
+        run: npm run openapi:typecheck --workspace=api
+
+      # A breaking API change should be visible in review rather than found by a
+      # client. The base spec is produced from a worktree of the base branch that
+      # borrows this checkout's installed node_modules and generated Prisma
+      # client, so no second `npm ci` is needed.
+      #
+      # Best-effort by construction: a base branch that predates this job cannot
+      # dump a spec at all, and dependency drift between the branches can make
+      # the borrowed modules wrong. Both outcomes report "skipped" rather than
+      # failing a PR over a diff that is informational.
+      - name: Diff the spec against the base branch
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          git worktree add --detach /tmp/base "origin/${{ github.base_ref }}" || {
+            echo "Could not check out the base branch; skipping spec diff." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+          ln -s "$GITHUB_WORKSPACE/node_modules" /tmp/base/node_modules
+          cp -r packages/enrichment-compute/dist /tmp/base/packages/enrichment-compute/dist
+
+          if ! (cd /tmp/base && npm run openapi:dump >/tmp/base-dump.log 2>&1); then
+            {
+              echo "### OpenAPI spec diff skipped"
+              echo
+              echo 'The base branch could not produce a spec (it may predate this job, or its'
+              echo 'dependencies differ from this branch). The generated spec is attached as an'
+              echo 'artifact.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if diff -u /tmp/base/openapi.json openapi.json > /tmp/spec.diff; then
+            echo "No OpenAPI changes in this PR." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "### OpenAPI spec changes"
+            echo
+            echo "<details><summary>$(grep -c '^[+-]' /tmp/spec.diff) changed lines</summary>"
+            echo
+            echo '```diff'
+            # Bounded: a job summary is capped at 1 MiB, and a full 1 MB spec
+            # rewrite would blow past it and lose the summary entirely.
+            head -c 60000 /tmp/spec.diff
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openapi.json
+          path: openapi.json
+
   cli-test:
     name: CLI Build & Test
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ worktrees/
 *.tgz
 .cache/
 nul
+openapi.json

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,62 @@
+# =============================================================================
+# Spectral ruleset for apps/api's OpenAPI document (epic #414, phase 7)
+# =============================================================================
+#
+# Run in CI against the dumped spec:
+#
+#     npm run openapi:lint
+#
+# The point is to stop the spec rotting: a new endpoint with no operation id, a
+# tag nobody declared, or a duplicated operation id fails the build rather than
+# quietly degrading the reference page.
+#
+# Rules are tuned rather than accepted wholesale, and every override records why
+# — an unexplained `off` is how a lint config stops meaning anything.
+# =============================================================================
+
+extends: ['spectral:oas']
+
+rules:
+  # --- The guarantees the reference page depends on ---------------------------
+
+  # Operation ids are the generated-SDK method names, so a missing or duplicated
+  # one is a real defect rather than a style nit.
+  operation-operationId: error
+  operation-operationId-unique: error
+  operation-operationId-valid-in-url: error
+
+  # A tag no `tags` entry declares renders ungrouped and undescribed — exactly
+  # the state this epic set out to fix, so it must not be reachable again.
+  operation-tags: error
+  operation-tag-defined: error
+  tag-description: error
+  openapi-tags-uniqueness: error
+
+  info-contact: error
+  info-description: error
+  oas3-api-servers: error
+
+  # --- Deliberately relaxed ---------------------------------------------------
+
+  # `tags` is ordered by product area (see src/openapi/tags.ts) and that order is
+  # what `x-tagGroups` renders. Alphabetical would throw the taxonomy away.
+  openapi-tags-alphabetical: off
+
+  # Prose per operation is worth having but is not uniformly present yet, and the
+  # generated "Requires:" line means no guarded operation is ever description-less.
+  # Kept visible as a warning rather than blocking.
+  operation-description: warn
+
+  # This project ships no license metadata; adding a claim just to satisfy a lint
+  # rule would be worse than omitting it.
+  info-license: off
+  license-url: off
+
+  # `ErrorDto` is referenced only from the `default` response the document pass
+  # writes, and several DTOs exist to be `$ref`'d from hand-written schemas.
+  # Worth seeing, not worth failing on.
+  oas3-unused-component: warn
+
+  # Examples are being added over time; a DTO without one should not block a build.
+  oas3-valid-media-example: warn
+  oas3-valid-schema-example: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **API documentation overhaul (epic #414)** — `/api/docs` is now a branded, interactive [Scalar](https://scalar.com) reference in place of the scaffold's unconfigured Swagger UI, and `/api/openapi.json` is a valid OpenAPI **3.1** document. See the [API Documentation spec](docs/specs/api-documentation.md).
+  - **Branding and orientation** — "MemoriaHub API" at the deployed build's real version (was "Enterprise App API" at a hardcoded `1.0`), a same-origin server, and a Markdown getting-started guide covering the four ways to get a token, the response envelope, both pagination styles, the error shape, and the two-layer permission model.
+  - **Taxonomy** — every tag declared once with a description and a deliberate order, grouped into `x-tagGroups` sidebar sections. The three coexisting admin-tag conventions (`Admin - X`, `Admin — X`, `Admin: X`) are normalized to `Admin: X`.
+  - **One-click session auth** — signed in to MemoriaHub in the same browser, the page authorizes itself from your refresh cookie before mounting the client; no token to copy, and a reload re-authorizes. PATs (`pat_…`) and node credentials (`nod_…`) are documented as first-class schemes, offered on the operations that actually accept them.
+  - **Self-documenting RBAC** — every guarded operation states its required role, permissions, and per-circle role, generated from the same `@Auth()` decorator the guards read.
+  - **Accurate response shapes** — the global `TransformInterceptor` wraps every JSON response in `{ data, meta }`, so almost every `@ApiResponse({ type: Dto })` described a shape the server never sends. The document now applies the same wrapper the interceptor does.
+  - **OpenAPI 3.1** — required by zod v4's JSON Schema 2020-12 output, which 3.0 rejected. `nullable: true` is rewritten to `type: [..., "null"]`, since 3.1 removed the keyword and a consumer that ignores it generates non-nullable fields.
+  - **Quality gates** — `npm run openapi:dump` / `openapi:lint`, a Spectral ruleset, and a CI job that lints the spec and posts a diff against the base branch on pull requests.
+
+### Fixed
+
+- **15 controllers advertised an undefined `bearer` security scheme** — `@ApiBearerAuth()` was called with no scheme name, so the docs page's Authorize dialog had nothing to attach to those operations and a reader who had authorized still got `401` from every one of them. They now name the existing `JWT-auth` scheme. No guard changed.
+- **Several published schemas contradicted the wire** — `GET /api/users?isActive=` was documented as a boolean though it is a query string parsed into one; the device-session pagination parameters carried numeric examples on an implicitly-string schema; and `displayName`, `profileImageUrl` and the three share `expiresAt` fields published `type: object` because `string | null` reflects as `Object` without an explicit `type`.
+
 ### Removed
 
 - **v0 server-side media backup** — The Admin-triggered S3-to-API-server-disk replication feature has been removed entirely, superseded by epic #308's node-based Local Media Backup (`/api/nodes/:id/backup/*`), which mirrors original bytes to a *separate* machine incrementally, with sha256 verification, sidecars, a SQLite catalog, and restore. The v0 feature was also non-functional in practice: it ran the whole copy inside the `POST` request (504 behind nginx's 60s `proxy_read_timeout`), only wrote run history on completion (so history was always empty), resolved the boot-env `STORAGE_PROVIDER` rather than each object's own provider, and could copy files onto themselves under `STORAGE_PROVIDER=local`. Removed surface area:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ If the diff feels “big,” you waited too long. **Split the work and commit so
 ## Architecture Principles
 
 1. **Separation of Concerns**: UI handles presentation only; API handles all business logic and authorization
-2. **Same-Origin Hosting**: UI at `/`, API at `/api`, Swagger at `/api/docs`
+2. **Same-Origin Hosting**: UI at `/`, API at `/api`, API reference at `/api/docs`, OpenAPI document at `/api/openapi.json`
 3. **Security by Default**: All API endpoints require authentication unless explicitly public
 4. **API-First**: All business logic resides in the API layer
 
@@ -269,7 +269,7 @@ cd apps/api && npm run prisma:migrate
 ## Service URLs (Development)
 
 - **Application**: http://localhost:3535 (via Nginx)
-- **Swagger UI**: http://localhost:3535/api/docs
+- **API Reference (Scalar)**: http://localhost:3535/api/docs — see the [API Documentation spec](docs/specs/api-documentation.md)
 - **Uptrace**: http://localhost:14318 (when otel stack running)
 
 ## API Endpoints (MVP)
@@ -1466,6 +1466,7 @@ The `maintenance.*` namespace (no dedicated admin settings-page panel as of this
 ## Feature Specifications
 
 Detailed specs live under `docs/specs/`:
+- [API Documentation](docs/specs/api-documentation.md) — the Scalar reference at `/api/docs` and the OpenAPI 3.1 document at `/api/openapi.json`: the tag taxonomy and `x-tagGroups` sidebar, RBAC requirements generated from `@Auth()` metadata (and why that is a document pass rather than a decorator), the `{ data: … }` envelope pass that mirrors the global `TransformInterceptor` instead of editing ~70 controllers, the 3.0-`nullable`-to-3.1-union rewrite the version switch made necessary, one-click session pre-authorization and the two constraints that forced a hand-written page template, and the Spectral/CI/test gates that stop the spec rotting
 - [Enrichment Queue](docs/specs/enrichment-queue.md) — worker lifecycle, retry, priority, adding new handlers
 - [Face Recognition](docs/specs/face-recognition.md) — face detection (photos + videos), video frame sampling, cross-frame dedup, recognition, clustering, people management, global feature toggle, global admin backfill
 - [AI Auto-Tagging](docs/specs/auto-tagging.md) — vocabulary-driven vision model tagging, description generation, global feature toggle, global admin backfill, embedding step

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Off by default (`features.memories`) — an admin turns it on in Admin Settings,
 - **User Management**: Admin interface for managing users, role assignments, and allowlist
 - **Settings Framework**: System-wide and per-user settings with type-safe schemas (includes `activeCircleId`)
 - **Observability**: OpenTelemetry instrumentation with traces, metrics, and structured logging
-- **API Documentation**: Swagger/OpenAPI documentation at `/api/docs`
+- **API Documentation**: Interactive Scalar API reference at `/api/docs`, OpenAPI 3.1 document at `/api/openapi.json`
 - **Same-Origin Architecture**: Frontend and API served from the same host via Nginx reverse proxy
 
 ### Planned Capabilities
@@ -148,7 +148,7 @@ exit
 
 - **Frontend**: http://localhost:3535
 - **API**: http://localhost:3535/api
-- **Swagger Docs**: http://localhost:3535/api/docs
+- **API Reference**: http://localhost:3535/api/docs
 
 ### 6. First Login
 
@@ -287,7 +287,10 @@ MemoriaHub/
 
 ## API Documentation
 
-Interactive API documentation is available at `/api/docs` when running the application.
+An interactive Scalar API reference is available at `/api/docs` when running the application, with
+the OpenAPI 3.1 document at `/api/openapi.json`. If you are signed in to MemoriaHub in the same
+browser, the page authorizes itself from your session — no token to copy. See the
+[API Documentation spec](docs/specs/api-documentation.md).
 
 ### Key Endpoints
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,7 +27,9 @@
     "prisma:studio": "node scripts/prisma-env.js studio",
     "prisma:seed": "node scripts/prisma-env.js db seed",
     "prisma:push": "node scripts/prisma-env.js db push",
-    "db:test": "node scripts/test-db-connection.js"
+    "db:test": "node scripts/test-db-connection.js",
+    "openapi:dump": "ts-node -P scripts/tsconfig.json --transpile-only scripts/dump-openapi.ts",
+    "openapi:typecheck": "tsc -p scripts/tsconfig.json"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",

--- a/apps/api/scripts/dump-openapi.ts
+++ b/apps/api/scripts/dump-openapi.ts
@@ -1,0 +1,64 @@
+// =============================================================================
+// Dump the OpenAPI document to a file (epic #414, phase 7)
+// =============================================================================
+//
+// Used by CI to lint the spec with Spectral and to diff it against the base
+// branch, so a breaking API change is visible in review rather than discovered
+// by a client.
+//
+// Run with:  npm run openapi:dump --workspace=api -- [outfile]
+//
+// NOTE ON PREVIEW MODE
+// -----------------------------------------------------------------------------
+// The app is created with `preview: true`, which loads every module and reads
+// every controller's metadata WITHOUT instantiating providers. That is what lets
+// this run on a bare CI checkout: no database, no object storage, no AI
+// credentials, no cron or worker loops started, nothing to tear down. The
+// document is produced from decorator metadata, which preview mode has in full.
+//
+// `NODE_ENV` is forced to production so the dumped spec is the one a deployment
+// publishes — in particular, without the non-production `Test Authentication`
+// routes.
+// =============================================================================
+
+process.env.NODE_ENV = 'production';
+
+import { writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { mkdirSync } from 'fs';
+import { NestFactory } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { AppModule } from '../src/app.module';
+import { fastifyAdapterOptions } from '../src/common/fastify-setup';
+import { createOpenApiDocument } from '../src/openapi/document';
+
+async function main(): Promise<void> {
+  const outfile = resolve(process.argv[2] ?? 'openapi.json');
+
+  // The adapter has to be supplied explicitly: this app runs on Fastify, and
+  // without it Nest falls back to looking for @nestjs/platform-express.
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(fastifyAdapterOptions()),
+    { preview: true, logger: false },
+  );
+
+  const document = createOpenApiDocument(app);
+  await app.close();
+
+  mkdirSync(dirname(outfile), { recursive: true });
+  // Two-space indentation and a trailing newline so a `git diff` between two
+  // dumps is line-oriented and readable, rather than one enormous line.
+  writeFileSync(outfile, `${JSON.stringify(document, null, 2)}\n`, 'utf8');
+
+  const operations = Object.values(document.paths ?? {}).reduce(
+    (total, pathItem) => total + Object.keys(pathItem ?? {}).length,
+    0,
+  );
+  process.stdout.write(`Wrote ${outfile} (${operations} operations)\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exit(1);
+});

--- a/apps/api/scripts/tsconfig.json
+++ b/apps/api/scripts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    // The API tsconfig is scoped to `src/`, so a script that imports from `src`
+    // sits outside its rootDir and tsc refuses to infer one. Widening the root
+    // to the workspace and emitting nothing keeps these one-off scripts
+    // type-checked under the same settings as the app they import.
+    "rootDir": "..",
+    "noEmit": true,
+    "declaration": false,
+    // The base config turns on declaration maps, which tsc rejects once
+    // `declaration` is off.
+    "declarationMap": false,
+    "incremental": false
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/apps/api/src/app.module.spec.ts
+++ b/apps/api/src/app.module.spec.ts
@@ -1,0 +1,28 @@
+import { testOnlyModules } from './app.module';
+import { TestAuthModule } from './test-auth/test-auth.module';
+
+/**
+ * `TestAuthModule` mints tokens with no OAuth round-trip. A controller that is
+ * not registered is invisible to `SwaggerModule.createDocument`, so this gate is
+ * what keeps those routes out of a production API document as well as out of a
+ * production process — worth asserting directly rather than inferring from the
+ * absence of a tag in a test-environment document.
+ */
+describe('testOnlyModules', () => {
+  const saved = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = saved;
+  });
+
+  it('registers the test auth module outside production', () => {
+    process.env.NODE_ENV = 'development';
+    expect(testOnlyModules()).toEqual([TestAuthModule]);
+  });
+
+  it('registers nothing in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(testOnlyModules()).toEqual([]);
+  });
+});

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { Module, MiddlewareConsumer, NestModule, DynamicModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { EventEmitterModule } from '@nestjs/event-emitter';
@@ -54,6 +54,23 @@ import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { MaintenanceGuard } from './common/maintenance/maintenance.guard';
 
 import configuration from './config/configuration';
+
+/**
+ * Modules registered only outside production.
+ *
+ * `TestAuthModule` mints tokens without a real OAuth round-trip, so it must
+ * never exist in a production process — and, because a controller that is not
+ * registered is invisible to `SwaggerModule.createDocument`, keeping it out of
+ * the module list is also what keeps its routes out of the published API
+ * document.
+ *
+ * Extracted from the inline conditional so that fact is directly testable.
+ * `main.ts` additionally refuses to boot when `TEST_AUTH_ENABLED=true` in
+ * production, but nothing asserted the module gate itself.
+ */
+export function testOnlyModules(): NonNullable<DynamicModule['imports']> {
+  return process.env.NODE_ENV !== 'production' ? [TestAuthModule] : [];
+}
 
 @Module({
   imports: [
@@ -116,7 +133,7 @@ import configuration from './config/configuration';
     DbBackupModule,
 
     // Test modules (non-production only)
-    ...(process.env.NODE_ENV !== 'production' ? [TestAuthModule] : []),
+    ...testOnlyModules(),
   ],
   providers: [
     // Global validation pipe (Zod)

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -213,7 +213,7 @@ export class AuthController {
   @Get('me')
   @AllowDuringMaintenance()
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Get current user',
     description: 'Returns information about the currently authenticated user',
@@ -285,7 +285,7 @@ export class AuthController {
   @Post('logout')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiBearerAuth()
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Logout',
     description: 'Logout endpoint and revoke refresh token',
@@ -320,7 +320,7 @@ export class AuthController {
   @Post('logout-all')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiBearerAuth()
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Logout from all devices',
     description: 'Revoke all refresh tokens for the current user',

--- a/apps/api/src/auth/decorators/auth.decorator.ts
+++ b/apps/api/src/auth/decorators/auth.decorator.ts
@@ -1,19 +1,62 @@
 import { applyDecorators, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiUnauthorizedResponse, ApiForbiddenResponse } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiExtension,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { RolesGuard } from '../guards/roles.guard';
 import { PermissionsGuard } from '../guards/permissions.guard';
 import { Roles } from './roles.decorator';
 import { Permissions } from './permissions.decorator';
 import { RoleName, PermissionName } from '../../common/constants/roles.constants';
+import { ErrorDto } from '../../common/dto/error.dto';
+
+/**
+ * Per-circle role ranks, lowest first. Independent of the system role: an
+ * authenticated call must satisfy the system permission AND the circle role.
+ */
+export type CircleRoleName = 'viewer' | 'collaborator' | 'circle_admin';
 
 interface AuthOptions {
   roles?: RoleName[];
   permissions?: PermissionName[];
+  /**
+   * Minimum per-circle role the route enforces, for documentation only.
+   *
+   * There is no per-circle guard to derive this from — circle membership is
+   * checked inside the services, which the decorator cannot see — so it is
+   * declared here when a route has one. Omitting it means "this route is not
+   * circle-scoped", not "any member may call it".
+   */
+  circleRole?: CircleRoleName;
 }
 
 /**
- * Combined auth decorator that applies JWT, roles, and permissions guards
+ * The vendor extension `@Auth()` stamps onto each operation.
+ *
+ * Read back out of the OpenAPI document by `applyRbacDocs()` (see
+ * `src/openapi/rbac-docs.ts`), which renders it into the operation description.
+ * Going through the document rather than the Nest container is what keeps the
+ * generated line honest: it is derived from the same decorator call the guards
+ * are configured by, so a permission change edits the docs by construction.
+ */
+export const RBAC_EXTENSION_KEY = 'x-rbac';
+
+export interface RbacExtension {
+  authenticated: true;
+  /** Caller needs ANY of these system roles. Empty means no role requirement. */
+  roles: RoleName[];
+  /** Caller needs ALL of these permissions. Empty means no permission requirement. */
+  permissions: PermissionName[];
+  /** Minimum per-circle role, when the route is circle-scoped. */
+  circleRole?: CircleRoleName;
+}
+
+/**
+ * Combined auth decorator that applies JWT, roles, and permissions guards, and
+ * documents what it just enforced.
  *
  * @example
  * // Just authentication
@@ -25,15 +68,29 @@ interface AuthOptions {
  * // With permissions (user needs ALL permissions)
  * @Auth({ permissions: [PERMISSIONS.USERS_READ] })
  *
- * // Combined
- * @Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.SYSTEM_SETTINGS_WRITE] })
+ * // Combined, and circle-scoped
+ * @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE], circleRole: 'collaborator' })
  */
 export function Auth(options: AuthOptions = {}) {
+  const rbac: RbacExtension = {
+    authenticated: true,
+    roles: options.roles ?? [],
+    permissions: options.permissions ?? [],
+    ...(options.circleRole ? { circleRole: options.circleRole } : {}),
+  };
+
   const decorators = [
     UseGuards(JwtAuthGuard, RolesGuard, PermissionsGuard),
     ApiBearerAuth('JWT-auth'),
-    ApiUnauthorizedResponse({ description: 'Unauthorized - Invalid or missing token' }),
-    ApiForbiddenResponse({ description: 'Forbidden - Insufficient permissions' }),
+    ApiExtension(RBAC_EXTENSION_KEY, rbac),
+    ApiUnauthorizedResponse({
+      description: 'Missing, malformed, or expired bearer token.',
+      type: ErrorDto,
+    }),
+    ApiForbiddenResponse({
+      description: 'Authenticated, but the caller lacks a required role, permission, or circle role.',
+      type: ErrorDto,
+    }),
   ];
 
   if (options.roles && options.roles.length > 0) {

--- a/apps/api/src/auth/dto/auth-user.dto.ts
+++ b/apps/api/src/auth/dto/auth-user.dto.ts
@@ -28,6 +28,7 @@ export class CurrentUserDto {
   email!: string;
 
   @ApiProperty({
+    type: String,
     example: 'John Doe',
     description: 'Display name (computed from override or provider)',
     nullable: true,
@@ -35,6 +36,7 @@ export class CurrentUserDto {
   displayName!: string | null;
 
   @ApiProperty({
+    type: String,
     example: 'https://example.com/avatar.jpg',
     description: 'Profile image URL (computed from override or provider)',
     nullable: true,

--- a/apps/api/src/burst/admin-burst.controller.ts
+++ b/apps/api/src/burst/admin-burst.controller.ts
@@ -25,7 +25,7 @@ const adminBurstBackfillSchema = z.object({
 }).prefault({});
 class AdminBurstBackfillDto extends createZodDto(adminBurstBackfillSchema) {}
 
-@ApiTags('Admin — Bursts')
+@ApiTags('Admin: Bursts')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/bursts')
 export class AdminBurstController {

--- a/apps/api/src/burst/burst.controller.ts
+++ b/apps/api/src/burst/burst.controller.ts
@@ -29,7 +29,7 @@ import { BulkResolveBurstThresholdDto } from './dto/bulk-resolve-burst-threshold
 import { BulkDismissBurstThresholdDto } from './dto/bulk-dismiss-burst-threshold.dto';
 
 @ApiTags('Bursts')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('media')
 export class BurstController {
   constructor(private readonly burstService: BurstService) {}

--- a/apps/api/src/common/decorators/api-data-response.decorator.ts
+++ b/apps/api/src/common/decorators/api-data-response.decorator.ts
@@ -1,0 +1,97 @@
+import { Type, applyDecorators } from '@nestjs/common';
+import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger';
+import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+
+/**
+ * Pagination style a listing endpoint uses. See the `meta` shapes below —
+ * `GET /api/media` is the one endpoint that supports both, selected by whether
+ * the caller sends `page`.
+ */
+export type DataResponseMeta = 'offset' | 'keyset';
+
+export interface ApiDataResponseOptions {
+  status?: number;
+  description?: string;
+  /** Wrap the model in an array: `{ data: [T] }`. */
+  isArray?: boolean;
+  /** Emit a sibling `meta` object alongside `data`. */
+  meta?: DataResponseMeta;
+}
+
+const OFFSET_META_SCHEMA = {
+  type: 'object',
+  description: 'Offset pagination. Backed by a `COUNT(*)`, so it can report a total.',
+  required: ['page', 'pageSize', 'totalItems', 'totalPages'],
+  properties: {
+    page: { type: 'integer', description: 'One-based page number.', example: 1 },
+    pageSize: { type: 'integer', example: 50 },
+    totalItems: { type: 'integer', example: 1284 },
+    totalPages: { type: 'integer', example: 26 },
+  },
+} as const;
+
+const KEYSET_META_SCHEMA = {
+  type: 'object',
+  description:
+    'Keyset pagination. Runs no count query; pass `nextCursor` back as `cursor` to fetch the ' +
+    'following page.',
+  required: ['pageSize', 'nextCursor', 'hasMore'],
+  properties: {
+    pageSize: { type: 'integer', example: 50 },
+    nextCursor: {
+      type: 'string',
+      nullable: true,
+      description: 'Opaque cursor for the next page, or null when the last page has been reached.',
+    },
+    hasMore: { type: 'boolean', example: true },
+  },
+} as const;
+
+/**
+ * Documents a response that wraps its payload in the `{ data: … }` envelope.
+ *
+ * Exists because the two were routinely out of sync: a handler returning
+ * `{ data: { providers: [...] } }` documented with `@ApiResponse({ type: Dto })`
+ * advertises the bare inner object, so a generated client, a Postman import, or
+ * anyone reading the sample gets a shape the server never sends. Declaring the
+ * envelope once, here, removes the opportunity to describe it wrongly.
+ *
+ * Use plain `@ApiResponse` for the handful of endpoints that genuinely return
+ * an unwrapped body — the point is accuracy, not uniformity.
+ *
+ * @example
+ * @ApiDataResponse(AuthProvidersResponseDto, { description: 'Enabled providers' })
+ *
+ * @example
+ * @ApiDataResponse(MediaItemDto, { isArray: true, meta: 'keyset' })
+ */
+export function ApiDataResponse(
+  model: Type<unknown>,
+  options: ApiDataResponseOptions = {},
+) {
+  const { status = 200, description, isArray = false, meta } = options;
+
+  const dataSchema = isArray
+    ? { type: 'array' as const, items: { $ref: getSchemaPath(model) } }
+    : { $ref: getSchemaPath(model) };
+
+  const properties: Record<string, unknown> = { data: dataSchema };
+  const required = ['data'];
+
+  if (meta) {
+    properties.meta = meta === 'offset' ? OFFSET_META_SCHEMA : KEYSET_META_SCHEMA;
+    required.push('meta');
+  }
+
+  return applyDecorators(
+    ApiExtraModels(model),
+    ApiResponse({
+      status,
+      description,
+      // Cast because `SchemaObject.properties` is typed against @nestjs/swagger's
+      // own node types, which the plain JSON-Schema literals above satisfy
+      // structurally but cannot be inferred as.
+      schema: { type: 'object', required, properties } as SchemaObject,
+    }),
+  );
+}

--- a/apps/api/src/common/dto/error.dto.ts
+++ b/apps/api/src/common/dto/error.dto.ts
@@ -1,0 +1,89 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * The one error body this API ever returns.
+ *
+ * `HttpExceptionFilter` rebuilds every error response from a fixed key
+ * allowlist, so this class is not an approximation of the wire format — it is
+ * the complete set of keys that can appear. In particular a custom top-level
+ * field on a thrown `HttpException` payload is silently dropped; endpoint-
+ * specific data belongs under {@link details}.
+ *
+ * Kept as an `@ApiProperty` class rather than a zod DTO because nothing
+ * validates it — it is documentation-only, produced by the filter and never
+ * parsed on the way in.
+ */
+export class ErrorDto {
+  @ApiProperty({
+    description: 'HTTP status code, repeated in the body so a logged payload is self-describing.',
+    example: 409,
+  })
+  statusCode!: number;
+
+  @ApiProperty({
+    description:
+      'Stable machine-readable code derived from the status. Prefer branching on this over ' +
+      'matching `message`, which is prose and may change.',
+    example: 'CONFLICT',
+    enum: [
+      'BAD_REQUEST',
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'NOT_FOUND',
+      'CONFLICT',
+      'UNPROCESSABLE_ENTITY',
+      'TOO_MANY_REQUESTS',
+      'INTERNAL_ERROR',
+      'ERROR',
+    ],
+  })
+  code!: string;
+
+  @ApiProperty({
+    description: 'Human-readable description of what went wrong.',
+    example: 'A backup is already running',
+  })
+  message!: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Endpoint-specific structured data — the only place a custom field survives the exception ' +
+      'filter. Shape varies by endpoint and is documented on the operation that returns it.',
+    example: { activeRunId: '3f1b0c5e-9f7a-4a2d-8f1e-2b6c9d0a4e77' },
+  })
+  details?: unknown;
+
+  @ApiPropertyOptional({
+    description:
+      'OAuth 2.0 / RFC 8628 error code, forwarded verbatim. Present only on the device-authorization ' +
+      'routes and on the maintenance-mode 503 (where it is `maintenance`).',
+    example: 'authorization_pending',
+  })
+  error?: string;
+
+  @ApiPropertyOptional({
+    description: 'OAuth 2.0 / RFC 8628 human-readable error description, forwarded verbatim.',
+    example: 'The authorization request is still pending',
+  })
+  error_description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Maintenance-mode 503 only: when maintenance was enabled. Null if unknown.',
+    type: String,
+    nullable: true,
+    example: '2026-08-12T04:37:58.000Z',
+  })
+  startedAt?: string | null;
+
+  @ApiProperty({
+    description: 'When the error was produced, ISO 8601 UTC.',
+    example: '2026-08-12T04:37:58.000Z',
+  })
+  timestamp!: string;
+
+  @ApiProperty({
+    description: 'Request path that produced the error.',
+    example: '/api/admin/db-backup/runs',
+  })
+  path!: string;
+}

--- a/apps/api/src/db-backup/db-backup.controller.ts
+++ b/apps/api/src/db-backup/db-backup.controller.ts
@@ -59,7 +59,7 @@ import {
  * routine while restoring one renames the live database and restarts the
  * process.
  */
-@ApiTags('Admin - Database Backup')
+@ApiTags('Admin: Database Backup')
 @Controller('admin/db-backup')
 export class DatabaseBackupController {
   constructor(

--- a/apps/api/src/dedup/admin-duplicate.controller.ts
+++ b/apps/api/src/dedup/admin-duplicate.controller.ts
@@ -38,7 +38,7 @@ class AdminDuplicateConfidenceBackfillDto extends createZodDto(
   adminDuplicateConfidenceBackfillSchema,
 ) {}
 
-@ApiTags('Admin — Duplicates')
+@ApiTags('Admin: Duplicates')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/duplicates')
 export class AdminDuplicateController {

--- a/apps/api/src/dedup/duplicate.controller.ts
+++ b/apps/api/src/dedup/duplicate.controller.ts
@@ -29,7 +29,7 @@ import { BulkResolveDuplicateThresholdDto } from './dto/bulk-resolve-duplicate-t
 import { BulkDismissDuplicateThresholdDto } from './dto/bulk-dismiss-duplicate-threshold.dto';
 
 @ApiTags('Duplicates')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('media')
 export class DuplicateController {
   constructor(private readonly duplicateService: DuplicateService) {}

--- a/apps/api/src/dedup/review-insights.controller.ts
+++ b/apps/api/src/dedup/review-insights.controller.ts
@@ -7,7 +7,7 @@ import { PERMISSIONS } from '../common/constants/roles.constants';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 
 @ApiTags('Review Insights')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('media')
 export class ReviewInsightsController {
   constructor(private readonly reviewInsights: ReviewInsightsService) {}

--- a/apps/api/src/device-auth/device-auth.controller.ts
+++ b/apps/api/src/device-auth/device-auth.controller.ts
@@ -194,12 +194,14 @@ export class DeviceAuthController {
   @ApiQuery({
     name: 'page',
     required: false,
+    type: Number,
     description: 'Page number',
     example: 1,
   })
   @ApiQuery({
     name: 'limit',
     required: false,
+    type: Number,
     description: 'Page size',
     example: 10,
   })

--- a/apps/api/src/doctor/doctor.controller.ts
+++ b/apps/api/src/doctor/doctor.controller.ts
@@ -13,7 +13,7 @@ import { DoctorReport } from './doctor.types';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { PERMISSIONS, ROLES } from '../common/constants/roles.constants';
 
-@ApiTags('Admin - Doctor')
+@ApiTags('Admin: Doctor')
 @Controller('admin/doctor')
 export class DoctorController {
   constructor(private readonly doctorService: DoctorService) {}

--- a/apps/api/src/enhancement/admin-enhancement.controller.ts
+++ b/apps/api/src/enhancement/admin-enhancement.controller.ts
@@ -10,7 +10,7 @@ import { ROLES, PERMISSIONS } from '../common/constants/roles.constants';
  * system-settings read permission (no new scope), Admin role.
  */
 @ApiTags('Admin: AI Picture Enhancer')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('admin/ai/enhance')
 export class AdminEnhancementController {
   constructor(private readonly service: MediaEnhancementService) {}

--- a/apps/api/src/enhancement/media-enhancement.controller.ts
+++ b/apps/api/src/enhancement/media-enhancement.controller.ts
@@ -33,7 +33,7 @@ import {
 } from './dto/list-enhancements-query.dto';
 
 @ApiTags('Picture Enhancement')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('media')
 export class MediaEnhancementController {
   constructor(private readonly service: MediaEnhancementService) {}

--- a/apps/api/src/enrichment/enrichment-admin.controller.ts
+++ b/apps/api/src/enrichment/enrichment-admin.controller.ts
@@ -76,7 +76,7 @@ export class ResetStuckDto extends createZodDto(resetStuckSchema) {}
 // Controller
 // ---------------------------------------------------------------------------
 
-@ApiTags('Admin - Jobs')
+@ApiTags('Admin: Job Queue')
 @Controller('admin/jobs')
 export class EnrichmentAdminController {
   constructor(private readonly adminService: EnrichmentAdminService) {}

--- a/apps/api/src/face/admin-face-backfill.controller.ts
+++ b/apps/api/src/face/admin-face-backfill.controller.ts
@@ -31,7 +31,7 @@ const adminFaceBackfillSchema = z.object({
 }).prefault({});
 class AdminFaceBackfillDto extends createZodDto(adminFaceBackfillSchema) {}
 
-@ApiTags('Admin — Face Recognition')
+@ApiTags('Admin: Face Recognition')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/face')
 export class AdminFaceBackfillController {

--- a/apps/api/src/geo/geocode-admin.controller.ts
+++ b/apps/api/src/geo/geocode-admin.controller.ts
@@ -19,7 +19,7 @@ const backfillGeoSchema = z.object({
 }).prefault({});
 class BackfillGeoDto extends createZodDto(backfillGeoSchema) {}
 
-@ApiTags('Admin - Geocode')
+@ApiTags('Admin: Geocode')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/geocode')
 export class GeocodeAdminController {

--- a/apps/api/src/insights/insights.controller.ts
+++ b/apps/api/src/insights/insights.controller.ts
@@ -34,7 +34,7 @@ export interface InsightsRefreshDto {
 // Controller
 // ---------------------------------------------------------------------------
 
-@ApiTags('Admin - Insights')
+@ApiTags('Admin: Storage Insights')
 @Controller('admin/insights')
 export class InsightsController {
   constructor(private readonly insightsService: InsightsService) {}

--- a/apps/api/src/location-groups/location-groups-admin.controller.ts
+++ b/apps/api/src/location-groups/location-groups-admin.controller.ts
@@ -12,7 +12,7 @@ import { RebuildLocationGroupsDto } from './dto/location-group.dto';
  * Split from `LocationGroupsController` only because the route prefix differs;
  * both reuse the same Admin-only `geo_settings:*` pair (no new permission).
  */
-@ApiTags('Admin - Location Groups')
+@ApiTags('Admin: Location Groups')
 @Controller('admin/location-groups')
 export class LocationGroupsAdminController {
   constructor(private readonly service: LocationGroupsService) {}

--- a/apps/api/src/location-inference/admin-location-inference.controller.ts
+++ b/apps/api/src/location-inference/admin-location-inference.controller.ts
@@ -17,7 +17,7 @@ const adminLocationInferenceBackfillSchema = z.object({
 }).prefault({});
 class AdminLocationInferenceBackfillDto extends createZodDto(adminLocationInferenceBackfillSchema) {}
 
-@ApiTags('Admin — Location Inference')
+@ApiTags('Admin: Location Inference')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/location-inference')
 export class AdminLocationInferenceController {

--- a/apps/api/src/location-inference/location-suggestion.controller.ts
+++ b/apps/api/src/location-inference/location-suggestion.controller.ts
@@ -22,7 +22,7 @@ import { AcceptLocationSuggestionDto } from './dto/accept-location-suggestion.dt
 import { BulkResolveLocationSuggestionsDto } from './dto/bulk-resolve-location-suggestions.dto';
 
 @ApiTags('Location Inference')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('media')
 export class LocationSuggestionController {
   constructor(

--- a/apps/api/src/location-inference/runs/location-suggestion-runs.controller.ts
+++ b/apps/api/src/location-inference/runs/location-suggestion-runs.controller.ts
@@ -37,7 +37,7 @@ import { ListLocationSuggestionRunItemsQueryDto } from '../dto/list-location-sug
  * Prefer `/api/review-runs/:id` for new clients.
  */
 @ApiTags('Location Suggestion Runs (deprecated)')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('location-suggestion-runs')
 export class LocationSuggestionRunsController {
   constructor(private readonly runService: ReviewRunService) {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,12 +6,17 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from '@nestjs/common';
 import fastifyCookie from '@fastify/cookie';
 import multipart from '@fastify/multipart';
 import { AppModule } from './app.module';
 import { fastifyAdapterOptions } from './common/fastify-setup';
+import { createOpenApiDocument } from './openapi/document';
+import { renderDocsPage } from './openapi/docs-page';
+import { resolveApiVersion } from './openapi/version';
+
+const OPENAPI_JSON_PATH = '/api/openapi.json';
+const DOCS_PATH = '/api/docs';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -57,32 +62,36 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // Swagger/OpenAPI setup
-  const config = new DocumentBuilder()
-    .setTitle('Enterprise App API')
-    .setDescription('API documentation for the Enterprise App Foundation')
-    .setVersion('1.0')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        description: 'Enter JWT token',
-      },
-      'JWT-auth',
-    )
-    .build();
-
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document, {
-    jsonDocumentUrl: 'api/openapi.json',
+  // ---------------------------------------------------------------------------
+  // OpenAPI: the spec at /api/openapi.json, the Scalar reference at /api/docs
+  // ---------------------------------------------------------------------------
+  // Served as two raw Fastify routes rather than through `SwaggerModule.setup`,
+  // because the docs page is our own template (see `openapi/docs-page.ts` for
+  // why) and `setup` would additionally mount the stock Swagger UI on the same
+  // path. Registering directly also keeps both routes outside the Nest guard
+  // pipeline — matching what `SwaggerModule.setup` already did, and keeping the
+  // reference readable during maintenance mode.
+  const version = resolveApiVersion();
+  const document = createOpenApiDocument(app);
+  const docsPage = renderDocsPage({
+    title: 'MemoriaHub API Reference',
+    version,
+    specUrl: OPENAPI_JSON_PATH,
   });
+
+  const fastify = app.getHttpAdapter().getInstance();
+  fastify.get(OPENAPI_JSON_PATH, (_req, reply) =>
+    reply.type('application/json').send(document),
+  );
+  for (const path of [DOCS_PATH, `${DOCS_PATH}/`]) {
+    fastify.get(path, (_req, reply) => reply.type('text/html').send(docsPage));
+  }
 
   const port = process.env.PORT || 3000;
   await app.listen(port, '0.0.0.0');
 
   logger.log(`Application running on port ${port}`);
-  logger.log(`Swagger UI available at /api/docs`);
+  logger.log(`API reference available at ${DOCS_PATH} (spec: ${OPENAPI_JSON_PATH})`);
 }
 
 bootstrap();

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -12,11 +12,11 @@ import multipart from '@fastify/multipart';
 import { AppModule } from './app.module';
 import { fastifyAdapterOptions } from './common/fastify-setup';
 import { createOpenApiDocument } from './openapi/document';
-import { renderDocsPage } from './openapi/docs-page';
-import { resolveApiVersion } from './openapi/version';
-
-const OPENAPI_JSON_PATH = '/api/openapi.json';
-const DOCS_PATH = '/api/docs';
+import {
+  DOCS_PATH,
+  OPENAPI_JSON_PATH,
+  registerDocsRoutes,
+} from './openapi/register-docs-routes';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -62,30 +62,9 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // ---------------------------------------------------------------------------
-  // OpenAPI: the spec at /api/openapi.json, the Scalar reference at /api/docs
-  // ---------------------------------------------------------------------------
-  // Served as two raw Fastify routes rather than through `SwaggerModule.setup`,
-  // because the docs page is our own template (see `openapi/docs-page.ts` for
-  // why) and `setup` would additionally mount the stock Swagger UI on the same
-  // path. Registering directly also keeps both routes outside the Nest guard
-  // pipeline — matching what `SwaggerModule.setup` already did, and keeping the
-  // reference readable during maintenance mode.
-  const version = resolveApiVersion();
-  const document = createOpenApiDocument(app);
-  const docsPage = renderDocsPage({
-    title: 'MemoriaHub API Reference',
-    version,
-    specUrl: OPENAPI_JSON_PATH,
-  });
-
-  const fastify = app.getHttpAdapter().getInstance();
-  fastify.get(OPENAPI_JSON_PATH, (_req, reply) =>
-    reply.type('application/json').send(document),
-  );
-  for (const path of [DOCS_PATH, `${DOCS_PATH}/`]) {
-    fastify.get(path, (_req, reply) => reply.type('text/html').send(docsPage));
-  }
+  // OpenAPI: the spec at /api/openapi.json, the Scalar reference at /api/docs.
+  // See openapi/register-docs-routes.ts for why these are raw Fastify routes.
+  registerDocsRoutes(app, createOpenApiDocument(app));
 
   const port = process.env.PORT || 3000;
   await app.listen(port, '0.0.0.0');

--- a/apps/api/src/media/media-reprocess.controller.ts
+++ b/apps/api/src/media/media-reprocess.controller.ts
@@ -34,7 +34,7 @@ const reprocessFailedBodySchema = z.object({
 
 export class ReprocessFailedBodyDto extends createZodDto(reprocessFailedBodySchema) {}
 
-@ApiTags('Admin - Media')
+@ApiTags('Admin: Media Recovery')
 @Controller('admin/media')
 export class MediaReprocessController {
   constructor(

--- a/apps/api/src/media/trash-empty/trash-empty-runs.controller.ts
+++ b/apps/api/src/media/trash-empty/trash-empty-runs.controller.ts
@@ -29,7 +29,7 @@ import { ListTrashEmptyRunItemsQueryDto } from './dto/list-trash-empty-run-items
  * cancel requires media:delete + per-circle circle_admin.
  */
 @ApiTags('Trash Empty Runs')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('trash-empty-runs')
 export class TrashEmptyRunsController {
   constructor(private readonly runService: TrashEmptyRunService) {}

--- a/apps/api/src/memories/admin/admin-memories.controller.ts
+++ b/apps/api/src/memories/admin/admin-memories.controller.ts
@@ -39,7 +39,7 @@ const adminMemoriesBackfillSchema = z
   .prefault({});
 class AdminMemoriesBackfillDto extends createZodDto(adminMemoriesBackfillSchema) {}
 
-@ApiTags('Admin — Memories')
+@ApiTags('Admin: Memories')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/memories')
 export class AdminMemoriesController {

--- a/apps/api/src/memories/digest/public-memory-digest.controller.ts
+++ b/apps/api/src/memories/digest/public-memory-digest.controller.ts
@@ -117,7 +117,13 @@ export class PublicMemoryDigestController {
    */
   @Get('digest-image/:token')
   @Public()
-  @ApiOperation({ summary: 'Stream a digest cover thumbnail (no auth required)' })
+  @ApiOperation({
+    summary: 'Stream a digest cover thumbnail (no auth required)',
+    description:
+      'Serves the cover image embedded in a Memories digest email. Authorized by an HMAC-signed ' +
+      'capability token in the path rather than a session, because an email client cannot carry ' +
+      'one; the token encodes the single image it grants and expires.',
+  })
   @ApiParam({ name: 'token', description: 'HMAC-signed digest image token' })
   @ApiResponse({ status: 200, description: 'Thumbnail bytes (JPEG)' })
   @ApiResponse({ status: 404, description: 'Invalid, expired, or unknown token' })
@@ -200,7 +206,14 @@ export class PublicMemoryDigestController {
    */
   @Get('digest-unsubscribe/:token')
   @Public()
-  @ApiOperation({ summary: 'Digest unsubscribe confirmation page (no auth required)' })
+  @ApiOperation({
+    summary: 'Digest unsubscribe confirmation page (no auth required)',
+    description:
+      'Renders the one-click unsubscribe confirmation for a Memories digest. Like the cover ' +
+      'image above, it is authorized by an HMAC-signed capability token so a recipient can opt ' +
+      'out without logging in. The POST form of this route is the RFC 8058 endpoint mail ' +
+      'clients call directly.',
+  })
   @ApiParam({ name: 'token', description: 'HMAC-signed unsubscribe token' })
   @ApiResponse({ status: 200, description: 'HTML confirmation page' })
   @ApiResponse({ status: 404, description: 'Invalid or expired token' })

--- a/apps/api/src/metadata/admin-metadata.controller.ts
+++ b/apps/api/src/metadata/admin-metadata.controller.ts
@@ -25,7 +25,7 @@ const adminMetadataBackfillSchema = z.object({
 }).prefault({});
 class AdminMetadataBackfillDto extends createZodDto(adminMetadataBackfillSchema) {}
 
-@ApiTags('Admin — Metadata')
+@ApiTags('Admin: Metadata')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/metadata')
 export class AdminMetadataController {

--- a/apps/api/src/nodes/node-backup.controller.ts
+++ b/apps/api/src/nodes/node-backup.controller.ts
@@ -26,7 +26,7 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { PERMISSIONS } from '../common/constants/roles.constants';
 
-@ApiTags('Nodes - Backup')
+@ApiTags('Nodes: Backup')
 @Controller('nodes/:id/backup')
 @Auth({ permissions: [PERMISSIONS.JOBS_WRITE] })
 export class NodeBackupController {

--- a/apps/api/src/nodes/nodes-admin.controller.ts
+++ b/apps/api/src/nodes/nodes-admin.controller.ts
@@ -22,7 +22,7 @@ import { Auth } from '../auth/decorators/auth.decorator';
 import { PERMISSIONS, ROLES } from '../common/constants/roles.constants';
 import { AdminNodeCredentialListItemDto } from './dto/node-credential-response.dto';
 
-@ApiTags('Admin - Nodes')
+@ApiTags('Admin: Worker Nodes')
 @Controller('admin/nodes')
 export class NodesAdminController {
   constructor(

--- a/apps/api/src/openapi/data-envelope.spec.ts
+++ b/apps/api/src/openapi/data-envelope.spec.ts
@@ -1,0 +1,122 @@
+import { applyDataEnvelope } from './data-envelope';
+import { MutableDocument } from './types';
+
+function documentWith(
+  responses: Record<string, unknown>,
+  schemas: Record<string, unknown> = {},
+): MutableDocument {
+  return {
+    components: { schemas },
+    paths: { '/api/thing': { get: { responses } } },
+  };
+}
+
+function schemaOf(doc: MutableDocument, status: string): Record<string, unknown> | undefined {
+  const op = (doc.paths!['/api/thing'] as Record<string, { responses: Record<string, unknown> }>)
+    .get;
+  const response = op.responses[status] as {
+    content?: Record<string, { schema?: Record<string, unknown> }>;
+  };
+  return response.content?.['application/json']?.schema;
+}
+
+const jsonResponse = (schema: Record<string, unknown>) => ({
+  description: 'ok',
+  content: { 'application/json': { schema } },
+});
+
+describe('applyDataEnvelope', () => {
+  it('wraps a 2xx JSON response in the envelope the global interceptor produces', () => {
+    const doc = documentWith(
+      { '200': jsonResponse({ $ref: '#/components/schemas/Thing' }) },
+      { Thing: { type: 'object', properties: { id: { type: 'string' } } } },
+    );
+    applyDataEnvelope(doc);
+
+    expect(schemaOf(doc, '200')).toEqual({
+      type: 'object',
+      required: ['data'],
+      properties: {
+        data: { $ref: '#/components/schemas/Thing' },
+        meta: expect.objectContaining({ type: 'object' }),
+      },
+    });
+  });
+
+  it('leaves error responses alone — the exception filter bypasses interceptors', () => {
+    const doc = documentWith({
+      '404': jsonResponse({ $ref: '#/components/schemas/ErrorDto' }),
+      default: jsonResponse({ $ref: '#/components/schemas/ErrorDto' }),
+    });
+    applyDataEnvelope(doc);
+
+    expect(schemaOf(doc, '404')).toEqual({ $ref: '#/components/schemas/ErrorDto' });
+    expect(schemaOf(doc, 'default')).toEqual({ $ref: '#/components/schemas/ErrorDto' });
+  });
+
+  it('leaves a schemaless response alone — that is the byte-proxy and 204 case', () => {
+    const doc = documentWith({ '204': { description: 'No content' } });
+    expect(() => applyDataEnvelope(doc)).not.toThrow();
+    expect(schemaOf(doc, '204')).toBeUndefined();
+  });
+
+  it('does not double-wrap a schema that already declares data', () => {
+    const already = {
+      type: 'object',
+      properties: { data: { type: 'string' } },
+    };
+    const doc = documentWith({ '200': jsonResponse(already) });
+    applyDataEnvelope(doc);
+
+    expect(schemaOf(doc, '200')).toEqual(already);
+  });
+
+  it('follows a $ref before deciding, so an envelope DTO is not wrapped twice', () => {
+    const doc = documentWith(
+      { '200': jsonResponse({ $ref: '#/components/schemas/Envelope' }) },
+      { Envelope: { type: 'object', properties: { data: { type: 'string' } } } },
+    );
+    applyDataEnvelope(doc);
+
+    expect(schemaOf(doc, '200')).toEqual({ $ref: '#/components/schemas/Envelope' });
+  });
+
+  it('leaves composed schemas alone rather than guessing at their shape', () => {
+    const composed = { allOf: [{ $ref: '#/components/schemas/A' }] };
+    const doc = documentWith({ '200': jsonResponse(composed) });
+    applyDataEnvelope(doc);
+
+    expect(schemaOf(doc, '200')).toEqual(composed);
+  });
+
+  it('leaves an unresolvable $ref alone', () => {
+    const doc = documentWith({ '200': jsonResponse({ $ref: '#/components/schemas/Missing' }) });
+    applyDataEnvelope(doc);
+
+    expect(schemaOf(doc, '200')).toEqual({ $ref: '#/components/schemas/Missing' });
+  });
+
+  it('only touches application/json', () => {
+    const doc: MutableDocument = {
+      components: { schemas: {} },
+      paths: {
+        '/api/thing': {
+          get: {
+            responses: {
+              '200': {
+                description: 'bytes',
+                content: { 'image/jpeg': { schema: { type: 'string', format: 'binary' } } },
+              },
+            },
+          },
+        },
+      },
+    };
+    applyDataEnvelope(doc);
+
+    const op = (doc.paths!['/api/thing'] as Record<string, { responses: Record<string, unknown> }>)
+      .get;
+    const response = op.responses['200'] as { content: Record<string, { schema: unknown }> };
+    expect(response.content['image/jpeg'].schema).toEqual({ type: 'string', format: 'binary' });
+  });
+});

--- a/apps/api/src/openapi/data-envelope.ts
+++ b/apps/api/src/openapi/data-envelope.ts
@@ -1,0 +1,115 @@
+// =============================================================================
+// The `{ data: … }` response envelope (epic #414, phase 6)
+// =============================================================================
+//
+// The response-shape audit turned up something bigger than the handful of
+// endpoints the epic named: `TransformInterceptor` is registered as a GLOBAL
+// `APP_INTERCEPTOR`, and it wraps every handler return value in
+// `{ data, meta: { timestamp } }` unless the handler already returned an object
+// carrying a `data` key.
+//
+// So the drift was not "a few controllers document the inner type" — it was
+// nearly every controller, because `@ApiResponse({ type: Dto })` describes what
+// the handler returns and the interceptor changes that afterwards. Fixing it by
+// editing ~70 controllers would be a large, error-prone sweep that the next new
+// endpoint immediately reopens.
+//
+// Applying the same transformation to the document that the interceptor applies
+// to the response closes it permanently: a handler documented as returning
+// `Dto` is published as `{ data: Dto }`, and a handler that already returns
+// `{ data: Dto }` is published unchanged, exactly mirroring the interceptor's
+// own passthrough rule.
+//
+// WHAT IS DELIBERATELY LEFT ALONE
+//   * Non-2xx responses — errors are written by `HttpExceptionFilter` straight
+//     to the reply, bypassing every interceptor, so they are NOT enveloped.
+//   * Responses with no `application/json` schema — `204`, redirects, and the
+//     byte-proxy / SSE / CSV-export routes that take `@Res()` and write the
+//     reply themselves. None of those declare a JSON schema, so skipping
+//     schemaless responses is exactly the right filter and needs no allowlist.
+//   * Schemas that already carry a `data` property, resolved through `$ref`.
+// =============================================================================
+
+import { MutableDocument, forEachOperation } from './types';
+
+type SchemaLike = Record<string, unknown>;
+
+const META_SCHEMA = {
+  type: 'object',
+  description:
+    'Present when the endpoint supplies it (pagination) or when the global response interceptor ' +
+    'adds it (`{ timestamp }`). Not every response carries one.',
+  additionalProperties: true,
+} as const;
+
+/**
+ * Wraps every documented 2xx JSON response in the envelope the global
+ * interceptor produces.
+ */
+export function applyDataEnvelope(document: MutableDocument): MutableDocument {
+  const schemas = ((document.components as SchemaLike | undefined)?.schemas ??
+    {}) as Record<string, SchemaLike>;
+
+  forEachOperation(document, (operation) => {
+    for (const [status, response] of Object.entries(operation.responses ?? {})) {
+      if (!/^2\d\d$/.test(status)) continue;
+
+      const json = (response as SchemaLike | undefined)?.['content'] as
+        | Record<string, { schema?: SchemaLike }>
+        | undefined;
+      const media = json?.['application/json'];
+      const schema = media?.schema;
+      if (!media || !schema) continue;
+
+      if (declaresDataProperty(schema, schemas)) continue;
+
+      media.schema = {
+        type: 'object',
+        required: ['data'],
+        properties: { data: schema, meta: META_SCHEMA },
+      };
+    }
+  });
+
+  return document;
+}
+
+/**
+ * Whether a schema already describes the envelope.
+ *
+ * `$ref` is followed one level into `components.schemas`, because a DTO named
+ * for the whole envelope (`{ data: … }` as a single declared type) is
+ * indistinguishable from an inner type until it is resolved — and double-
+ * wrapping one would publish `{ data: { data: … } }`, a shape the server never
+ * sends.
+ *
+ * Anything that is not a plain object schema or a resolvable local `$ref`
+ * (`allOf`, `oneOf`, an external ref) is treated as "unknown", and unknown
+ * schemas are left untouched rather than guessed at.
+ */
+function declaresDataProperty(
+  schema: SchemaLike,
+  schemas: Record<string, SchemaLike>,
+  depth = 0,
+): boolean {
+  if (depth > 2) return true; // Cyclic or unexpectedly deep: do not touch it.
+
+  const ref = schema['$ref'];
+  if (typeof ref === 'string') {
+    const name = ref.startsWith('#/components/schemas/')
+      ? ref.slice('#/components/schemas/'.length)
+      : null;
+    const target = name ? schemas[name] : undefined;
+    // An unresolvable ref is "unknown" — report true so the caller skips it.
+    return target ? declaresDataProperty(target, schemas, depth + 1) : true;
+  }
+
+  if (schema['allOf'] || schema['oneOf'] || schema['anyOf']) return true;
+
+  const properties = schema['properties'];
+  if (properties && typeof properties === 'object') {
+    return 'data' in (properties as Record<string, unknown>);
+  }
+
+  return false;
+}

--- a/apps/api/src/openapi/description.ts
+++ b/apps/api/src/openapi/description.ts
@@ -1,0 +1,153 @@
+// =============================================================================
+// The `info.description` Markdown shown at the top of /api/docs (epic #414)
+// =============================================================================
+//
+// This is the getting-started guide. It is baked into the OpenAPI document
+// rather than written on a separate page so that it travels with the spec:
+// anyone who downloads `/api/openapi.json`, imports it into Postman, or
+// generates an SDK from it gets the same orientation the docs page shows.
+//
+// Keep it task-shaped (how do I get a token, what does a response look like,
+// how do I page) rather than a feature tour — the tag sections below it are the
+// feature tour.
+// =============================================================================
+
+/**
+ * Builds the Markdown intro.
+ *
+ * @param version resolved application version, echoed so a reader can tell
+ *   which build they are pointed at without cross-checking `info.version`.
+ */
+export function buildApiDescription(version: string): string {
+  return `
+The HTTP API behind **MemoriaHub** — a self-hosted family photo and video library with
+AI enrichment, face recognition, semantic search, curated memories, and a distributed
+worker fleet.
+
+This page is generated from the running server (build \`${version}\`), so it always matches the
+deployment you are pointed at. The machine-readable document is at
+[\`/api/openapi.json\`](/api/openapi.json).
+
+---
+
+## Getting a token
+
+Every route is authenticated unless it is explicitly marked **Public**. There are four ways
+to obtain a bearer token, in rough order of how often you will want each.
+
+### 1. Your browser session (fastest, for exploring these docs)
+
+If you are already signed in to MemoriaHub in this browser, press **Authorize with my session**
+at the top of this page. It calls \`POST /api/auth/refresh\` with your existing refresh cookie
+and loads the returned access token into the client below. Nothing to copy or paste, and the
+authorization survives a reload.
+
+Access tokens are short-lived (15 minutes by default). If calls start returning \`401\`, press the
+button again.
+
+### 2. Personal access token — scripts and automation
+
+Mint a \`pat_…\` token via \`POST /api/pat\` (or the web UI) and send it as
+\`Authorization: Bearer pat_…\`. A PAT carries the full permission set of the user that created it
+and is accepted on every authenticated route, so treat it like a password. Revoke with
+\`DELETE /api/pat/{id}\`.
+
+### 3. Node credential — worker fleet only
+
+A \`nod_…\` credential authenticates like a PAT but is accepted **only** on \`/api/nodes/*\`. That
+restriction is the point: a worker running unattended on someone else's hardware cannot reach
+media, settings, or admin routes even if its credential leaks, and even if its owner is an Admin.
+Mint with \`POST /api/node-credentials\`.
+
+### 4. Device authorization grant — CLI and TV-style clients
+
+For a machine that cannot open a browser, use the RFC 8628 flow: \`POST /api/auth/device/code\`
+to get a user code, show it to the user, and poll \`POST /api/auth/device/token\` until they
+approve it at \`/activate\`. The CLI's \`memoriahub login\` does exactly this.
+
+---
+
+## Response shape
+
+Most endpoints wrap their payload in a \`data\` envelope:
+
+\`\`\`json
+{ "data": { "id": "…", "name": "…" } }
+\`\`\`
+
+Paginated endpoints add a sibling \`meta\`. Which pagination style you get depends on the endpoint,
+and one endpoint — \`GET /api/media\` — supports **both**, selected by whether you send \`page\`:
+
+- **Offset** (send \`page\`) — \`meta: { page, pageSize, totalItems, totalPages }\`. Backed by a
+  \`COUNT(*)\`, so it is the more expensive of the two. Use it when you need a total.
+- **Keyset** (omit \`page\`, send \`cursor\`) — \`meta: { pageSize, nextCursor, hasMore }\`. No count
+  query. Pass the previous response's \`nextCursor\` back as \`cursor\`. Use it for infinite scroll
+  and for anything walking a large library.
+
+A handful of older endpoints return their payload unwrapped. The response schema shown for each
+operation is authoritative.
+
+---
+
+## Errors
+
+Every error passes through one filter and comes back in one shape:
+
+\`\`\`json
+{
+  "statusCode": 409,
+  "code": "CONFLICT",
+  "message": "A backup is already running",
+  "details": { "activeRunId": "…" },
+  "timestamp": "2026-08-12T04:37:58.000Z",
+  "path": "/api/admin/db-backup/runs"
+}
+\`\`\`
+
+Endpoint-specific structured data always lives under \`details\` — the filter rebuilds the body from
+a fixed key allowlist, so a custom top-level field would be dropped before it reached you.
+
+\`503\` with \`"error": "maintenance"\` means an administrator has put the deployment into maintenance
+mode; a \`Retry-After\` header accompanies it.
+
+---
+
+## Permissions
+
+Authorization is two independent layers, and an authenticated call must satisfy **both**.
+
+**System permissions** are granted through system roles — Admin, Contributor, Viewer — and are
+named \`resource:action\` (\`media:read\`, \`jobs:write\`, \`db_backup:restore\`). Every operation in
+this document states the permissions it requires; those lines are generated from the same
+\`@Auth()\` decorator the guards read, so they cannot drift from what the server enforces.
+
+**Per-circle roles** govern which circle you may act in, independently of your system role:
+
+| Role | Can |
+| --- | --- |
+| \`viewer\` | Browse and download media in the circle |
+| \`collaborator\` | Everything a viewer can, plus upload, tag, and organize |
+| \`circle_admin\` | Everything a collaborator can, plus manage members and delete the circle |
+
+So \`media:write\` alone is not enough to modify a photo — you also need at least \`collaborator\` in
+that photo's circle. Holding \`circles:manage_any\`, \`media:read_any\`, or \`media:write_any\` (Admin)
+bypasses the per-circle check entirely.
+
+---
+
+## Conventions
+
+- All timestamps are ISO 8601 in UTC.
+- All ids are UUIDs unless documented otherwise.
+- Byte counts are returned as **strings**, not numbers — they are 64-bit values and would lose
+  precision or fail to serialize as JSON numbers.
+- \`204 No Content\` responses have no body.
+- The API is served same-origin under \`/api\`; this document's server is \`/\`.
+
+## Further reading
+
+Architecture and feature specifications live in the repository under
+[\`docs/specs/\`](https://github.com/marinoscar/MemoriaHub/tree/main/docs/specs) — including the
+enrichment queue, distributed worker nodes, search, workflows, memories, and public sharing.
+`.trim();
+}

--- a/apps/api/src/openapi/docs-page.spec.ts
+++ b/apps/api/src/openapi/docs-page.spec.ts
@@ -1,0 +1,84 @@
+import { SECURITY_SCHEMES } from './document';
+import {
+  DEFAULT_SCALAR_CDN,
+  SESSION_SECURITY_SCHEME,
+  renderDocsPage,
+} from './docs-page';
+
+const options = {
+  title: 'MemoriaHub API Reference',
+  version: '1.2.3',
+  specUrl: '/api/openapi.json',
+};
+
+describe('renderDocsPage', () => {
+  it('names the session scheme the document actually declares', () => {
+    // These live in separate modules on purpose — docs-page renders a string and
+    // must not pull the document builder (and Nest) in with it — so the coupling
+    // is asserted here instead of enforced by an import.
+    expect(SESSION_SECURITY_SCHEME).toBe(SECURITY_SCHEMES.JWT_AUTH);
+  });
+
+  it('points the reference at the canonical spec rather than inlining it', () => {
+    const html = renderDocsPage(options);
+    expect(html).toContain('"url":"/api/openapi.json"');
+    expect(html).toContain('href="/api/openapi.json"');
+  });
+
+  it('loads the reference bundle from the default CDN', () => {
+    expect(renderDocsPage(options)).toContain(`<script src="${DEFAULT_SCALAR_CDN}">`);
+  });
+
+  it('lets an air-gapped deployment point the bundle somewhere else', () => {
+    const html = renderDocsPage({ ...options, cdn: 'https://assets.internal/scalar.js' });
+    expect(html).toContain('<script src="https://assets.internal/scalar.js">');
+    expect(html).not.toContain(DEFAULT_SCALAR_CDN);
+  });
+
+  it('honours API_DOCS_CDN', () => {
+    const previous = process.env.API_DOCS_CDN;
+    process.env.API_DOCS_CDN = 'https://cdn.example.test/bundle.js';
+    try {
+      expect(renderDocsPage(options)).toContain('https://cdn.example.test/bundle.js');
+    } finally {
+      if (previous === undefined) delete process.env.API_DOCS_CDN;
+      else process.env.API_DOCS_CDN = previous;
+    }
+  });
+
+  describe('one-click session auth', () => {
+    const html = renderDocsPage(options);
+
+    it('exchanges the refresh cookie for an access token', () => {
+      expect(html).toContain("fetch('/api/auth/refresh'");
+      // The cookie is path-scoped to /api/auth, so it rides along only with
+      // credentials: 'include'. Without this the whole feature silently no-ops.
+      expect(html).toContain("credentials: 'include'");
+    });
+
+    it('pre-authorizes the client before mounting it', () => {
+      const fetchAt = html.indexOf('fetchSessionToken');
+      const mountAt = html.indexOf('createApiReference');
+      expect(fetchAt).toBeGreaterThan(-1);
+      expect(fetchAt).toBeLessThan(mountAt);
+      expect(html).toContain('preferredSecurityScheme');
+    });
+
+    it('tells a signed-out reader what to do instead of failing silently', () => {
+      expect(html).toContain('Not signed in');
+    });
+  });
+
+  describe('escaping', () => {
+    it('escapes interpolated text into the markup', () => {
+      const html = renderDocsPage({ ...options, version: '<img src=x onerror=alert(1)>' });
+      expect(html).not.toContain('<img src=x');
+      expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    });
+
+    it('cannot be broken out of by a value containing a closing script tag', () => {
+      const html = renderDocsPage({ ...options, specUrl: '/spec</script><script>evil()' });
+      expect(html).not.toContain('</script><script>evil()');
+    });
+  });
+});

--- a/apps/api/src/openapi/docs-page.ts
+++ b/apps/api/src/openapi/docs-page.ts
@@ -1,0 +1,199 @@
+// =============================================================================
+// The /api/docs page (epic #414, phases 3 and 4)
+// =============================================================================
+//
+// Renders the Scalar API reference: a searchable sectioned sidebar, a built-in
+// request client, generated code samples, and dark mode — replacing the stock
+// Swagger UI that shipped with the scaffold.
+//
+// WHY THIS TEMPLATE INSTEAD OF `@scalar/nestjs-api-reference`
+// -----------------------------------------------------------------------------
+// That package renders a fixed template whose last statement is the
+// `Scalar.createApiReference(...)` call. The one-click session auth below has to
+// resolve a token BEFORE that call, so it can be handed to Scalar as
+// pre-authorization rather than poked into Scalar's internal store afterwards.
+// The token cannot be resolved server-side either: the refresh cookie is scoped
+// to `path=/api/auth` and is therefore never sent to `/api/docs`. So the fetch
+// must happen in the browser, before mount — which is exactly the seam the
+// packaged template does not expose. Sixty lines of template we control beats
+// string-surgery on generated HTML.
+//
+// The reference bundle is loaded from a CDN, matching Scalar's own default.
+// `API_DOCS_CDN` overrides it, which is the escape hatch for an air-gapped
+// deployment that wants to self-host the bundle behind its own nginx.
+// =============================================================================
+
+/** Where the standalone Scalar bundle is loaded from. */
+export const DEFAULT_SCALAR_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference';
+
+export interface DocsPageOptions {
+  /** Browser tab title. */
+  title: string;
+  /** Application version, shown in the header bar. */
+  version: string;
+  /** Path the spec is fetched from, relative to the app root. */
+  specUrl: string;
+  /** Override for the reference bundle URL. */
+  cdn?: string;
+}
+
+/**
+ * A 📸 favicon as a data URI.
+ *
+ * Inline rather than a served file so the docs page has no second request and
+ * no dependency on static-asset routing, which differs between the dev server
+ * and the nginx-fronted deployment.
+ */
+const FAVICON =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">' +
+      '<text y=".9em" font-size="90">📸</text></svg>',
+  );
+
+/**
+ * Renders the complete docs page.
+ *
+ * Every interpolated value is either JSON-serialized or HTML-escaped; the two
+ * inline scripts additionally guard against a `</script` sequence closing the
+ * block early, which is the one way a JSON literal can break out of one.
+ */
+export function renderDocsPage(options: DocsPageOptions): string {
+  const cdn = options.cdn || process.env.API_DOCS_CDN || DEFAULT_SCALAR_CDN;
+
+  const scalarConfig = {
+    url: options.specUrl,
+    theme: 'default',
+    // Dark mode follows the OS by default, with Scalar's own toggle left
+    // visible so a reader can override it — same posture as the app itself.
+    hideDarkModeToggle: false,
+    layout: 'modern',
+    // Ordering is already deliberate in `tags.ts`; re-sorting here would throw
+    // that away and render the sections alphabetically.
+    defaultOpenAllTags: false,
+    hideModels: false,
+    searchHotKey: 'k',
+  };
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(options.title)}</title>
+    <link rel="icon" href="${FAVICON}" />
+    <style>
+      body { margin: 0; }
+      #mh-authbar {
+        display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+        padding: 8px 16px; font: 13px/1.4 ui-sans-serif, system-ui, -apple-system, sans-serif;
+        background: #11131e; color: #e7e7e7; border-bottom: 1px solid rgba(255,255,255,.12);
+      }
+      #mh-authbar strong { font-weight: 600; }
+      #mh-authbar .mh-version { color: #8e93a8; }
+      #mh-authbar .mh-spacer { flex: 1 1 auto; }
+      #mh-authbar button {
+        font: inherit; cursor: pointer; padding: 5px 12px; border-radius: 6px;
+        border: 1px solid rgba(255,255,255,.2); background: #2f354a; color: inherit;
+      }
+      #mh-authbar button:hover { background: #3c435c; }
+      #mh-status::before { content: '●'; margin-right: 6px; }
+      #mh-status.mh-ok { color: #30beb0; }
+      #mh-status.mh-warn { color: #ffc90d; }
+      #mh-status.mh-pending { color: #8e93a8; }
+    </style>
+  </head>
+  <body>
+    <div id="mh-authbar">
+      <strong>MemoriaHub API</strong>
+      <span class="mh-version">${escapeHtml(options.version)}</span>
+      <span class="mh-spacer"></span>
+      <span id="mh-status" class="mh-pending">Checking your session…</span>
+      <button id="mh-auth" type="button">Authorize with my session</button>
+      <a href="${escapeHtml(options.specUrl)}" style="color:#2cb6f6">openapi.json</a>
+    </div>
+    <div id="app"></div>
+    <script src="${escapeHtml(cdn)}"></script>
+    <script>
+      (function () {
+        var CONFIG = ${jsonForScript(scalarConfig)};
+        var SCHEME = ${jsonForScript(SESSION_SECURITY_SCHEME)};
+        var statusEl = document.getElementById('mh-status');
+        var buttonEl = document.getElementById('mh-auth');
+
+        function setStatus(text, kind) {
+          statusEl.textContent = text;
+          statusEl.className = 'mh-' + kind;
+        }
+
+        // Exchanges the browser's refresh cookie for a short-lived access
+        // token. \`credentials: 'include'\` is required even same-origin here:
+        // the cookie is path-scoped to /api/auth, so it rides along only
+        // because this request targets that path.
+        function fetchSessionToken() {
+          return fetch('/api/auth/refresh', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { Accept: 'application/json' },
+          })
+            .then(function (res) { return res.ok ? res.json() : null; })
+            .then(function (body) { return (body && body.accessToken) || null; })
+            .catch(function () { return null; });
+        }
+
+        function mount(token) {
+          var config = Object.assign({}, CONFIG);
+          if (token) {
+            var schemes = {};
+            schemes[SCHEME] = { token: token };
+            config.authentication = { preferredSecurityScheme: SCHEME, securitySchemes: schemes };
+            setStatus('Authorized with your session', 'ok');
+          } else {
+            setStatus('Not signed in — sign in to MemoriaHub, then reload', 'warn');
+          }
+          window.Scalar.createApiReference('#app', config);
+        }
+
+        // Re-authorizing means re-mounting, and re-mounting cleanly is what a
+        // reload already does. The auto-fetch on load is what makes the button
+        // rarely necessary: land on this page signed in and the client below is
+        // already authorized.
+        buttonEl.addEventListener('click', function () { window.location.reload(); });
+
+        fetchSessionToken().then(mount);
+      })();
+    </script>
+  </body>
+</html>
+`;
+}
+
+/**
+ * Kept in sync with `SECURITY_SCHEMES.JWT_AUTH` by the assertion in
+ * `docs-page.spec.ts` — importing it here would drag the whole document
+ * builder (and Nest) into a module that only renders a string.
+ */
+export const SESSION_SECURITY_SCHEME = 'JWT-auth';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * JSON for embedding inside a `<script>` block.
+ *
+ * `JSON.stringify` alone is not safe there: a `</script` inside any string
+ * value ends the block, and `<!--` starts an HTML comment. Both are escaped
+ * into equivalent JSON that the parser reads identically.
+ */
+function jsonForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}

--- a/apps/api/src/openapi/document.ts
+++ b/apps/api/src/openapi/document.ts
@@ -18,9 +18,10 @@ import { ErrorDto } from '../common/dto/error.dto';
 import { RBAC_EXTENSION_KEY } from '../auth/decorators/auth.decorator';
 import { applyDataEnvelope } from './data-envelope';
 import { buildApiDescription } from './description';
+import { applyNullableFor31 } from './nullable';
 import { applyRbacDocs } from './rbac-docs';
 import { OPENAPI_TAGS, OPENAPI_TAG_GROUPS } from './tags';
-import { MutableDocument, forEachOperation } from './types';
+import { DocOperation, MutableDocument, forEachOperation } from './types';
 import { resolveApiVersion } from './version';
 
 /** Security scheme names. `JWT_AUTH` is referenced by name from `@Auth()`. */
@@ -50,6 +51,12 @@ export function buildOpenApiConfig(version: string = resolveApiVersion()) {
     .setTitle('MemoriaHub API')
     .setDescription(buildApiDescription(version))
     .setVersion(version)
+    // OpenAPI 3.1, not the 3.0 default. zod v4 emits JSON Schema 2020-12, which
+    // 3.1 adopts wholesale and 3.0 rejects — under 3.0 the zod-derived DTOs
+    // published numeric `exclusiveMinimum` and `propertyNames` keywords that are
+    // invalid there, so a schema-validating consumer (or Spectral) rightly
+    // failed on them. Scalar renders 3.1 natively.
+    .setOpenAPIVersion('3.1.0')
     .setContact('MemoriaHub', 'https://github.com/marinoscar/MemoriaHub', '')
     .setExternalDoc(
       'Architecture and feature specifications',
@@ -95,7 +102,18 @@ export function buildOpenApiConfig(version: string = resolveApiVersion()) {
     builder.addTag(tag.name, tag.description);
   }
 
-  return builder.build();
+  const config = builder.build();
+
+  // `setContact` takes all three fields positionally, so an omitted email is an
+  // empty string — which is not a valid `email`, and a schema-validating
+  // consumer rejects the whole document over it. A contact with a name and a URL
+  // is perfectly valid; fabricating an address to satisfy the field would be
+  // worse than not having one.
+  if (config.info.contact && !config.info.contact.email) {
+    delete (config.info.contact as { email?: string }).email;
+  }
+
+  return config;
 }
 
 /**
@@ -139,6 +157,9 @@ export function enrichOpenApiDocument<T extends MutableDocument>(document: T): T
   applyDataEnvelope(document);
   applyDefaultErrorResponse(document);
   applyTagGroups(document);
+  // Last: every earlier pass may introduce schemas of its own, and this one has
+  // to see all of them.
+  applyNullableFor31(document);
   return document;
 }
 
@@ -156,6 +177,22 @@ export function buildOperationId(controllerKey: string, methodKey: string): stri
 }
 
 /**
+ * Whether an operation requires a bearer token.
+ *
+ * Two signals, because two things put one there. `@Auth()` stamps `x-rbac`,
+ * which is the richer marker. A handful of routes instead compose
+ * `@UseGuards(JwtAuthGuard)` with a bare `@ApiBearerAuth('JWT-auth')` — mostly
+ * on the auth controller itself, where the RBAC guards would have nothing to
+ * check — and those are just as authenticated.
+ */
+export function isAuthenticatedOperation(operation: DocOperation): boolean {
+  if (operation[RBAC_EXTENSION_KEY] !== undefined) return true;
+  return (operation.security ?? []).some(
+    (entry) => SECURITY_SCHEMES.JWT_AUTH in entry,
+  );
+}
+
+/**
  * Adds the PAT and node-credential schemes to operations they actually work on.
  *
  * `@Auth()` can only declare the session scheme, because that is the one it
@@ -170,7 +207,7 @@ export function buildOperationId(controllerKey: string, methodKey: string): stri
  */
 function applyAlternativeAuthSchemes(document: MutableDocument): void {
   forEachOperation(document, (operation, path) => {
-    if (operation[RBAC_EXTENSION_KEY] === undefined) return;
+    if (!isAuthenticatedOperation(operation)) return;
 
     const security = (operation.security ??= []);
     const has = (name: string) => security.some((entry) => name in entry);
@@ -215,7 +252,22 @@ function applyDefaultErrorResponse(document: MutableDocument): void {
  * Emits `x-tagGroups`, the vendor extension Scalar and Redoc read to render a
  * sectioned sidebar. Renderers without support fall back to the flat `tags`
  * array, which `buildOpenApiConfig` emits in the same order.
+ *
+ * Tags no operation uses are pruned from both. The taxonomy is declared for the
+ * whole application, but not every module is registered in every environment —
+ * `Test Authentication` exists only outside production — and a declared-but-
+ * unused tag renders as an empty sidebar section. Pruning is what makes one
+ * static taxonomy correct in both environments.
  */
 function applyTagGroups(document: MutableDocument): void {
-  document['x-tagGroups'] = OPENAPI_TAG_GROUPS;
+  const used = new Set<string>();
+  forEachOperation(document, (operation) => {
+    for (const tag of operation.tags ?? []) used.add(tag);
+  });
+
+  document.tags = OPENAPI_TAGS.filter((tag) => used.has(tag.name));
+  document['x-tagGroups'] = OPENAPI_TAG_GROUPS.map((group) => ({
+    name: group.name,
+    tags: group.tags.filter((tag) => used.has(tag)),
+  })).filter((group) => group.tags.length > 0);
 }

--- a/apps/api/src/openapi/document.ts
+++ b/apps/api/src/openapi/document.ts
@@ -1,0 +1,221 @@
+// =============================================================================
+// OpenAPI document construction (epic #414)
+// =============================================================================
+//
+// Everything that shapes `/api/openapi.json` lives here rather than in
+// `main.ts`, for one concrete reason: the spec is now asserted by tests and
+// dumped by a CI script, and neither of those can boot a listening server. A
+// pure `buildOpenApiConfig()` / `createOpenApiDocument(app)` pair can be called
+// from a test harness, from `scripts/dump-openapi.ts`, and from `main.ts`
+// alike, so the document CI lints is the document users get.
+// =============================================================================
+
+import type { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import type { OpenAPIObject } from '@nestjs/swagger';
+import { cleanupOpenApiDoc } from 'nestjs-zod';
+import { ErrorDto } from '../common/dto/error.dto';
+import { RBAC_EXTENSION_KEY } from '../auth/decorators/auth.decorator';
+import { applyDataEnvelope } from './data-envelope';
+import { buildApiDescription } from './description';
+import { applyRbacDocs } from './rbac-docs';
+import { OPENAPI_TAGS, OPENAPI_TAG_GROUPS } from './tags';
+import { MutableDocument, forEachOperation } from './types';
+import { resolveApiVersion } from './version';
+
+/** Security scheme names. `JWT_AUTH` is referenced by name from `@Auth()`. */
+export const SECURITY_SCHEMES = {
+  JWT_AUTH: 'JWT-auth',
+  PAT_AUTH: 'PAT-auth',
+  NODE_CREDENTIAL: 'Node-credential',
+} as const;
+
+/**
+ * Routes a `nod_` credential is accepted on.
+ *
+ * Deliberately narrow, and it must stay in step with the credential guard: a
+ * node credential is rejected everywhere else, so advertising it on another
+ * path would document an authentication that cannot work.
+ */
+const NODE_CREDENTIAL_PATH = /^(?:\/api)?\/nodes(?:\/|$)/;
+
+/**
+ * The `DocumentBuilder` configuration.
+ *
+ * @param version resolved application version; injectable so a test can assert
+ *   the shape without depending on what the build happens to be stamped with.
+ */
+export function buildOpenApiConfig(version: string = resolveApiVersion()) {
+  const builder = new DocumentBuilder()
+    .setTitle('MemoriaHub API')
+    .setDescription(buildApiDescription(version))
+    .setVersion(version)
+    .setContact('MemoriaHub', 'https://github.com/marinoscar/MemoriaHub', '')
+    .setExternalDoc(
+      'Architecture and feature specifications',
+      'https://github.com/marinoscar/MemoriaHub/tree/main/docs',
+    )
+    // Same-origin: the UI is served at `/`, this API under `/api`, so a
+    // relative server URL is correct for every deployment without templating.
+    .addServer('/', 'This deployment (same-origin)')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description:
+          'Short-lived session access token from `POST /api/auth/refresh` or the OAuth callback. ' +
+          'On this page, use "Authorize with my session" to load one automatically.',
+      },
+      SECURITY_SCHEMES.JWT_AUTH,
+    )
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        description:
+          'Personal access token (`pat_…`) from `POST /api/pat`. Long-lived, carries the full ' +
+          'permission set of the user that minted it, and is accepted on every authenticated route.',
+      },
+      SECURITY_SCHEMES.PAT_AUTH,
+    )
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        description:
+          'Worker-node credential (`nod_…`) from `POST /api/node-credentials`. Accepted **only** on ' +
+          '`/api/nodes/*` — it cannot reach media, settings, or admin routes even when its owner is ' +
+          'an Admin.',
+      },
+      SECURITY_SCHEMES.NODE_CREDENTIAL,
+    );
+
+  for (const tag of OPENAPI_TAGS) {
+    builder.addTag(tag.name, tag.description);
+  }
+
+  return builder.build();
+}
+
+/**
+ * Builds the finished document: Nest's introspection, then the five passes that
+ * turn it into something worth reading.
+ */
+export function createOpenApiDocument(app: INestApplication): OpenAPIObject {
+  const document = SwaggerModule.createDocument(app, buildOpenApiConfig(), {
+    // Namespaced but readable: `media_listMedia`, not `MediaController_listMedia`.
+    // Stable across refactors that do not rename the controller or handler, which
+    // is what makes generated SDK method names survive a release.
+    operationIdFactory: buildOperationId,
+    // ErrorDto is only ever referenced from a `$ref` this file writes, so it
+    // would otherwise never be emitted into `components.schemas`.
+    extraModels: [ErrorDto],
+  });
+
+  // nestjs-zod's recommended post-processing for zod-derived DTOs: resolves the
+  // placeholder schemas `createZodDto` leaves behind into real JSON Schema.
+  const cleaned = cleanupOpenApiDoc(document);
+
+  // `OpenAPIObject` has no index signature, so it is not structurally a
+  // `MutableDocument` even though every field the passes touch is present.
+  // Widening here is the one place that conversion happens.
+  enrichOpenApiDocument(cleaned as unknown as MutableDocument);
+
+  return cleaned;
+}
+
+/**
+ * The post-processing passes, split out from `createOpenApiDocument` so they can
+ * be exercised against a hand-built document without booting an application.
+ */
+export function enrichOpenApiDocument<T extends MutableDocument>(document: T): T {
+  applyRbacDocs(document);
+  applyAlternativeAuthSchemes(document);
+  // Order matters: the envelope pass targets 2xx JSON responses only, and the
+  // error pass writes a `default` response — running the envelope first keeps
+  // the two from ever meeting, but relying on that would be fragile, so the
+  // envelope pass filters on the status code explicitly as well.
+  applyDataEnvelope(document);
+  applyDefaultErrorResponse(document);
+  applyTagGroups(document);
+  return document;
+}
+
+/**
+ * `AdminMemoriesController.backfill` → `adminMemories_backfill`.
+ *
+ * Keeps the controller as a namespace (so two `list` handlers cannot collide)
+ * while dropping the noise a generator would otherwise bake into every method
+ * name. Uniqueness is asserted in `openapi.spec.ts`.
+ */
+export function buildOperationId(controllerKey: string, methodKey: string): string {
+  const namespace = controllerKey.replace(/Controller$/, '');
+  const lowerFirst = namespace.charAt(0).toLowerCase() + namespace.slice(1);
+  return `${lowerFirst}_${methodKey}`;
+}
+
+/**
+ * Adds the PAT and node-credential schemes to operations they actually work on.
+ *
+ * `@Auth()` can only declare the session scheme, because that is the one it
+ * names. But a PAT authenticates every authenticated route, and a `nod_`
+ * credential authenticates `/api/nodes/*` — both facts the docs should state.
+ * Deriving them here from the path and the `x-rbac` marker keeps the claim
+ * accurate as routes are added, where a hand-applied `@ApiSecurity()` would
+ * quietly go stale.
+ *
+ * Multiple entries in an operation's `security` array are alternatives (OR), so
+ * appending never tightens a requirement.
+ */
+function applyAlternativeAuthSchemes(document: MutableDocument): void {
+  forEachOperation(document, (operation, path) => {
+    if (operation[RBAC_EXTENSION_KEY] === undefined) return;
+
+    const security = (operation.security ??= []);
+    const has = (name: string) => security.some((entry) => name in entry);
+
+    if (!has(SECURITY_SCHEMES.PAT_AUTH)) {
+      security.push({ [SECURITY_SCHEMES.PAT_AUTH]: [] });
+    }
+    if (NODE_CREDENTIAL_PATH.test(path) && !has(SECURITY_SCHEMES.NODE_CREDENTIAL)) {
+      security.push({ [SECURITY_SCHEMES.NODE_CREDENTIAL]: [] });
+    }
+  });
+}
+
+/**
+ * Attaches the shared error envelope as each operation's `default` response.
+ *
+ * A `default` rather than an enumerated 400/404/409 list per operation: every
+ * error from every route passes through one `HttpExceptionFilter` and comes
+ * back in one shape, so `default` states exactly that — without asserting on
+ * each route's behalf which statuses it can produce, which nobody could keep
+ * true across 70 controllers.
+ *
+ * Operations that document a specific status keep it; this only fills the gap.
+ */
+function applyDefaultErrorResponse(document: MutableDocument): void {
+  forEachOperation(document, (operation) => {
+    const responses = (operation.responses ??= {});
+    if (responses.default) return;
+
+    responses.default = {
+      description:
+        'Error. Every failure is rendered by the shared exception filter into this envelope; ' +
+        'endpoint-specific data appears under `details`.',
+      content: {
+        'application/json': { schema: { $ref: '#/components/schemas/ErrorDto' } },
+      },
+    };
+  });
+}
+
+/**
+ * Emits `x-tagGroups`, the vendor extension Scalar and Redoc read to render a
+ * sectioned sidebar. Renderers without support fall back to the flat `tags`
+ * array, which `buildOpenApiConfig` emits in the same order.
+ */
+function applyTagGroups(document: MutableDocument): void {
+  document['x-tagGroups'] = OPENAPI_TAG_GROUPS;
+}

--- a/apps/api/src/openapi/nullable.spec.ts
+++ b/apps/api/src/openapi/nullable.spec.ts
@@ -1,0 +1,76 @@
+import { applyNullableFor31 } from './nullable';
+import { MutableDocument } from './types';
+
+describe('applyNullableFor31', () => {
+  it('widens a typed schema into a union', () => {
+    const doc: MutableDocument = {
+      components: { schemas: { A: { type: 'string', nullable: true } } },
+    };
+    applyNullableFor31(doc);
+
+    expect((doc.components as never as { schemas: { A: unknown } }).schemas.A).toEqual({
+      type: ['string', 'null'],
+    });
+  });
+
+  it('rewrites inline parameter and response schemas too, not only components', () => {
+    const doc: MutableDocument = {
+      paths: {
+        '/api/thing': {
+          get: {
+            parameters: [{ name: 'q', schema: { type: 'integer', nullable: true } }],
+            responses: {
+              '200': {
+                content: { 'application/json': { schema: { type: 'boolean', nullable: true } } },
+              },
+            },
+          },
+        },
+      },
+    };
+    applyNullableFor31(doc);
+
+    expect(JSON.stringify(doc)).not.toContain('nullable');
+    expect(JSON.stringify(doc)).toContain('["integer","null"]');
+    expect(JSON.stringify(doc)).toContain('["boolean","null"]');
+  });
+
+  it('adds null to an existing type union without duplicating it', () => {
+    const doc: MutableDocument = {
+      components: { schemas: { A: { type: ['string', 'null'], nullable: true } } },
+    };
+    applyNullableFor31(doc);
+
+    expect((doc.components as never as { schemas: { A: { type: string[] } } }).schemas.A.type)
+      .toEqual(['string', 'null']);
+  });
+
+  it('turns a nullable $ref into a one-of, the only form 3.1 honours', () => {
+    const doc: MutableDocument = {
+      components: {
+        schemas: { A: { $ref: '#/components/schemas/B', nullable: true } },
+      },
+    };
+    applyNullableFor31(doc);
+
+    expect((doc.components as never as { schemas: { A: unknown } }).schemas.A).toEqual({
+      oneOf: [{ $ref: '#/components/schemas/B' }, { type: 'null' }],
+    });
+  });
+
+  it('drops the keyword when there is nothing to widen', () => {
+    const doc: MutableDocument = { components: { schemas: { A: { nullable: true } } } };
+    applyNullableFor31(doc);
+
+    expect((doc.components as never as { schemas: { A: unknown } }).schemas.A).toEqual({});
+  });
+
+  it('terminates on a cyclic document', () => {
+    const schema: Record<string, unknown> = { type: 'string', nullable: true };
+    schema.self = schema;
+    const doc: MutableDocument = { components: { schemas: { A: schema } } };
+
+    expect(() => applyNullableFor31(doc)).not.toThrow();
+    expect(schema.nullable).toBeUndefined();
+  });
+});

--- a/apps/api/src/openapi/nullable.ts
+++ b/apps/api/src/openapi/nullable.ts
@@ -1,0 +1,83 @@
+// =============================================================================
+// OpenAPI 3.0 `nullable` → 3.1 type union (epic #414, phase 7)
+// =============================================================================
+//
+// The document is published as OpenAPI 3.1, because zod v4 emits JSON Schema
+// 2020-12 and 3.0 rejects several of its keywords outright.
+//
+// But `@nestjs/swagger`'s `@ApiProperty({ nullable: true })` still emits the
+// 3.0 spelling — a sibling `nullable: true` next to `type` — and 3.1 removed
+// that keyword entirely. A 3.1 consumer does not "mostly ignore" it: it reads
+// `type: "string"` and generates a non-nullable field, so a client is wrong
+// about exactly the values most likely to break it.
+//
+// 3.1's spelling is a type union, `type: ["string", "null"]`, which is what this
+// pass rewrites to. It runs over the whole document rather than being fixed at
+// ~28 `@ApiProperty` call sites, because the next one written will use the 3.0
+// spelling too — `nullable` is what the decorator's own types document.
+// =============================================================================
+
+import { MutableDocument } from './types';
+
+type SchemaLike = Record<string, unknown>;
+
+/**
+ * Rewrites every `nullable: true` in the document into a 3.1 type union.
+ *
+ * Walks the whole document rather than just `components.schemas`: inline
+ * parameter and response schemas carry the keyword too.
+ */
+export function applyNullableFor31(document: MutableDocument): MutableDocument {
+  walk(document as SchemaLike, new Set());
+  return document;
+}
+
+function walk(node: unknown, seen: Set<object>): void {
+  if (!node || typeof node !== 'object') return;
+  if (seen.has(node as object)) return;
+  seen.add(node as object);
+
+  if (Array.isArray(node)) {
+    for (const item of node) walk(item, seen);
+    return;
+  }
+
+  const schema = node as SchemaLike;
+  if (schema.nullable === true) {
+    rewrite(schema);
+  }
+
+  for (const value of Object.values(schema)) walk(value, seen);
+}
+
+function rewrite(schema: SchemaLike): void {
+  const type = schema.type;
+
+  if (typeof type === 'string') {
+    schema.type = type === 'null' ? type : [type, 'null'];
+    delete schema.nullable;
+    return;
+  }
+
+  if (Array.isArray(type)) {
+    if (!type.includes('null')) type.push('null');
+    delete schema.nullable;
+    return;
+  }
+
+  // No `type` to widen — the schema is a bare `$ref`, a composition, or
+  // untyped. 3.1 expresses "this or null" as a one-of, which is also the only
+  // form that works alongside a `$ref` (a `$ref` sibling is ignored in 3.0 and
+  // merged in 3.1, so neither spelling of a sibling keyword is dependable).
+  const ref = schema.$ref;
+  if (typeof ref === 'string') {
+    delete schema.$ref;
+    schema.oneOf = [{ $ref: ref }, { type: 'null' }];
+    delete schema.nullable;
+    return;
+  }
+
+  // Nothing meaningful to rewrite into; drop the keyword rather than leave a
+  // 3.0-only field in a 3.1 document.
+  delete schema.nullable;
+}

--- a/apps/api/src/openapi/rbac-docs.spec.ts
+++ b/apps/api/src/openapi/rbac-docs.spec.ts
@@ -1,0 +1,106 @@
+import { RBAC_EXTENSION_KEY } from '../auth/decorators/auth.decorator';
+import { applyRbacDocs, describeRequirements, REQUIREMENTS_MARKER } from './rbac-docs';
+import { DocOperation, MutableDocument } from './types';
+
+function operation(rbac?: unknown, description?: string): DocOperation {
+  return {
+    ...(description !== undefined ? { description } : {}),
+    ...(rbac !== undefined ? { [RBAC_EXTENSION_KEY]: rbac } : {}),
+  };
+}
+
+describe('describeRequirements', () => {
+  it('says nothing about an operation with no @Auth() metadata', () => {
+    expect(describeRequirements(operation())).toBeNull();
+  });
+
+  it('reports authentication-only routes as such', () => {
+    const line = describeRequirements(
+      operation({ authenticated: true, roles: [], permissions: [] }),
+    );
+    expect(line).toBe(`${REQUIREMENTS_MARKER} authentication only — any signed-in user may call this.`);
+  });
+
+  it('names a single permission', () => {
+    const line = describeRequirements(
+      operation({ authenticated: true, roles: [], permissions: ['users:read'] }),
+    );
+    expect(line).toBe(`${REQUIREMENTS_MARKER} authentication, plus permission \`users:read\`.`);
+  });
+
+  it('joins multiple permissions with "and", because the guard requires all of them', () => {
+    const line = describeRequirements(
+      operation({
+        authenticated: true,
+        roles: [],
+        permissions: ['media:read', 'search:use'],
+      }),
+    );
+    expect(line).toContain('permissions `media:read` and `search:use`');
+  });
+
+  it('presents multiple roles as alternatives, because the guard requires any of them', () => {
+    const line = describeRequirements(
+      operation({ authenticated: true, roles: ['admin', 'contributor'], permissions: [] }),
+    );
+    expect(line).toContain('any of the system roles `admin`, `contributor`');
+  });
+
+  it('combines role, permission and circle role in one sentence', () => {
+    const line = describeRequirements(
+      operation({
+        authenticated: true,
+        roles: ['admin'],
+        permissions: ['media:write'],
+        circleRole: 'collaborator',
+      }),
+    );
+    expect(line).toBe(
+      `${REQUIREMENTS_MARKER} authentication, plus system role \`admin\`, ` +
+        'permission `media:write` and per-circle role `collaborator` or higher.',
+    );
+  });
+});
+
+describe('applyRbacDocs', () => {
+  function documentWith(op: DocOperation): MutableDocument {
+    return { paths: { '/api/thing': { get: op } } };
+  }
+
+  it('appends to a hand-written description instead of replacing it', () => {
+    const doc = documentWith(
+      operation({ authenticated: true, roles: [], permissions: ['users:read'] }, 'Lists things.'),
+    );
+    applyRbacDocs(doc);
+
+    const description = (doc.paths!['/api/thing'] as { get: DocOperation }).get.description!;
+    expect(description).toContain('Lists things.');
+    expect(description).toContain('`users:read`');
+  });
+
+  it('is idempotent, so re-running never stacks duplicate blocks', () => {
+    const doc = documentWith(
+      operation({ authenticated: true, roles: [], permissions: ['users:read'] }),
+    );
+    applyRbacDocs(doc);
+    applyRbacDocs(doc);
+
+    const description = (doc.paths!['/api/thing'] as { get: DocOperation }).get.description!;
+    expect(description.match(/\*\*Requires:\*\*/g)).toHaveLength(1);
+  });
+
+  it('ignores non-operation keys on a path item', () => {
+    const doc: MutableDocument = {
+      paths: {
+        '/api/thing': {
+          parameters: [{ name: 'id', in: 'path' }],
+          get: operation({ authenticated: true, roles: [], permissions: [] }),
+        },
+      },
+    };
+    expect(() => applyRbacDocs(doc)).not.toThrow();
+    expect((doc.paths!['/api/thing'] as Record<string, unknown>).parameters).toEqual([
+      { name: 'id', in: 'path' },
+    ]);
+  });
+});

--- a/apps/api/src/openapi/rbac-docs.ts
+++ b/apps/api/src/openapi/rbac-docs.ts
@@ -44,10 +44,17 @@ export function describeRequirements(operation: DocOperation): string | null {
   const rbac = operation[RBAC_EXTENSION_KEY] as RbacExtension | undefined;
 
   if (!rbac || rbac.authenticated !== true) {
-    // No `@Auth()` on this handler. It is either `@Public()` or guarded by
-    // something bespoke; either way there is no decorator metadata to render,
-    // and inventing a claim about it would be worse than saying nothing.
-    return null;
+    // No `@Auth()` on this handler. A few routes — chiefly on the auth
+    // controller — instead compose `@UseGuards(JwtAuthGuard)` with a bare
+    // `@ApiBearerAuth(...)`, where the RBAC guards would have nothing to check.
+    // Those declare a security requirement and nothing more, which is exactly
+    // what the authentication-only line says.
+    //
+    // Everything else is `@Public()` or guarded by something bespoke: no
+    // decorator metadata to render, and inventing a claim about it would be
+    // worse than saying nothing.
+    const declaresSecurity = (operation.security ?? []).length > 0;
+    return declaresSecurity ? authenticationOnly() : null;
   }
 
   const clauses: string[] = [];
@@ -73,10 +80,14 @@ export function describeRequirements(operation: DocOperation): string | null {
   }
 
   if (clauses.length === 0) {
-    return `${REQUIREMENTS_MARKER} authentication only — any signed-in user may call this.`;
+    return authenticationOnly();
   }
 
   return `${REQUIREMENTS_MARKER} authentication, plus ${joinClauses(clauses)}.`;
+}
+
+function authenticationOnly(): string {
+  return `${REQUIREMENTS_MARKER} authentication only — any signed-in user may call this.`;
 }
 
 function code(value: string): string {

--- a/apps/api/src/openapi/rbac-docs.ts
+++ b/apps/api/src/openapi/rbac-docs.ts
@@ -1,0 +1,89 @@
+import { RBAC_EXTENSION_KEY, RbacExtension } from '../auth/decorators/auth.decorator';
+import { DocOperation, MutableDocument, forEachOperation } from './types';
+
+/**
+ * Marker prepended to every generated requirements line.
+ *
+ * Serves two purposes: it is the visible label a reader sees, and it makes the
+ * pass idempotent — an operation whose description already contains it is left
+ * alone, so running the enrichment twice (a test, a re-created document) can
+ * never stack duplicate blocks.
+ */
+export const REQUIREMENTS_MARKER = '**Requires:**';
+
+/**
+ * Renders the `x-rbac` extension stamped by `@Auth()` into each operation's
+ * description.
+ *
+ * This runs over the finished document rather than inside the decorator on
+ * purpose. A decorator that wrote `description` directly would race the
+ * controller's own `@ApiOperation({ description })` — decorators evaluate
+ * bottom-up and `@nestjs/swagger` merges operation metadata shallowly, so
+ * whichever ran last would silently clobber the other. Post-processing appends
+ * instead, so hand-written prose and generated requirements coexist.
+ */
+export function applyRbacDocs(document: MutableDocument): MutableDocument {
+  forEachOperation(document, (operation) => {
+    const line = describeRequirements(operation);
+    if (!line) return;
+
+    const existing = operation.description ?? '';
+    if (existing.includes(REQUIREMENTS_MARKER)) return;
+
+    operation.description = existing ? `${existing}\n\n${line}` : line;
+  });
+
+  return document;
+}
+
+/**
+ * The one-line requirements sentence for an operation, or `null` when the
+ * operation is something this pass has nothing to say about.
+ */
+export function describeRequirements(operation: DocOperation): string | null {
+  const rbac = operation[RBAC_EXTENSION_KEY] as RbacExtension | undefined;
+
+  if (!rbac || rbac.authenticated !== true) {
+    // No `@Auth()` on this handler. It is either `@Public()` or guarded by
+    // something bespoke; either way there is no decorator metadata to render,
+    // and inventing a claim about it would be worse than saying nothing.
+    return null;
+  }
+
+  const clauses: string[] = [];
+  const roles = rbac.roles ?? [];
+  const permissions = rbac.permissions ?? [];
+
+  if (roles.length === 1) {
+    clauses.push(`system role ${code(roles[0])}`);
+  } else if (roles.length > 1) {
+    clauses.push(`any of the system roles ${roles.map(code).join(', ')}`);
+  }
+
+  if (permissions.length === 1) {
+    clauses.push(`permission ${code(permissions[0])}`);
+  } else if (permissions.length > 1) {
+    // The guard requires ALL of them, so join with "and" rather than a bare
+    // comma list that reads as alternatives.
+    clauses.push(`permissions ${permissions.map(code).join(' and ')}`);
+  }
+
+  if (rbac.circleRole) {
+    clauses.push(`per-circle role ${code(rbac.circleRole)} or higher`);
+  }
+
+  if (clauses.length === 0) {
+    return `${REQUIREMENTS_MARKER} authentication only — any signed-in user may call this.`;
+  }
+
+  return `${REQUIREMENTS_MARKER} authentication, plus ${joinClauses(clauses)}.`;
+}
+
+function code(value: string): string {
+  return `\`${value}\``;
+}
+
+function joinClauses(clauses: string[]): string {
+  if (clauses.length === 1) return clauses[0];
+  return `${clauses.slice(0, -1).join(', ')} and ${clauses[clauses.length - 1]}`;
+}

--- a/apps/api/src/openapi/register-docs-routes.ts
+++ b/apps/api/src/openapi/register-docs-routes.ts
@@ -1,0 +1,49 @@
+import type { NestFastifyApplication } from '@nestjs/platform-fastify';
+import type { OpenAPIObject } from '@nestjs/swagger';
+import { renderDocsPage } from './docs-page';
+import { resolveApiVersion } from './version';
+
+/** Canonical machine-readable document. */
+export const OPENAPI_JSON_PATH = '/api/openapi.json';
+/** Interactive reference. */
+export const DOCS_PATH = '/api/docs';
+
+/**
+ * Registers the two documentation routes on the Fastify instance.
+ *
+ * Raw Fastify routes rather than `SwaggerModule.setup`, for two reasons: the
+ * page is our own template (see `docs-page.ts` for why), and `setup` would
+ * additionally mount the stock Swagger UI on the same path.
+ *
+ * Registering directly also keeps both routes outside the Nest guard pipeline —
+ * matching what `SwaggerModule.setup` already did, and keeping the reference
+ * readable during maintenance mode, which is exactly when an operator is most
+ * likely to want it.
+ *
+ * Lives here rather than inline in `main.ts` so it can be exercised against a
+ * test application; `main.ts` itself is excluded from coverage and cannot be
+ * booted by a spec.
+ */
+export function registerDocsRoutes(
+  app: NestFastifyApplication,
+  document: OpenAPIObject,
+  version: string = resolveApiVersion(),
+): void {
+  const page = renderDocsPage({
+    title: 'MemoriaHub API Reference',
+    version,
+    specUrl: OPENAPI_JSON_PATH,
+  });
+
+  const fastify = app.getHttpAdapter().getInstance();
+
+  fastify.get(OPENAPI_JSON_PATH, (_req, reply) =>
+    reply.type('application/json').send(document),
+  );
+
+  // Both spellings: a reader who types the path with a trailing slash should
+  // not get a 404 from the one page whose job is to orient them.
+  for (const path of [DOCS_PATH, `${DOCS_PATH}/`]) {
+    fastify.get(path, (_req, reply) => reply.type('text/html').send(page));
+  }
+}

--- a/apps/api/src/openapi/tags.ts
+++ b/apps/api/src/openapi/tags.ts
@@ -1,0 +1,451 @@
+// =============================================================================
+// OpenAPI tag taxonomy (epic #414, phase 2)
+// =============================================================================
+//
+// The single declaration of every `@ApiTags(...)` name used in this API, its
+// human description, and which sidebar section it belongs to.
+//
+// Two rules this file exists to enforce:
+//
+//   1. ONE admin-tag naming convention. The codebase previously carried three
+//      separators at once (`Admin - X`, `Admin — X`, `Admin: X`), which the
+//      renderer sorted as three unrelated families. `Admin: X` is now the only
+//      accepted form, asserted by `openapi.spec.ts`.
+//
+//   2. NO undeclared and NO orphaned tags. A tag used by a controller but not
+//      listed here would render with no description and land outside every
+//      group; a tag listed here but used by nobody would render an empty
+//      section. Both are failed assertions in `openapi.spec.ts` rather than
+//      something a reviewer has to notice.
+//
+// Ordering is deliberate: `TAG_GROUPS` is emitted verbatim as `x-tagGroups`,
+// and the flattened tag order becomes the document's `tags` array, which is
+// what a renderer falls back to when it has no group support.
+// =============================================================================
+
+export interface OpenApiTag {
+  /** Must match the controller's `@ApiTags(...)` argument byte-for-byte. */
+  name: string;
+  /** One or two sentences. Rendered under the section heading in the sidebar. */
+  description: string;
+}
+
+export interface OpenApiTagGroup {
+  name: string;
+  tags: OpenApiTag[];
+}
+
+/**
+ * Sidebar sections, in render order.
+ *
+ * A group is a product area, not a module boundary — `Media` and `Storage` live
+ * together because a caller uploading a photo touches both, even though they are
+ * separate Nest modules.
+ */
+export const TAG_GROUPS: OpenApiTagGroup[] = [
+  {
+    name: 'Authentication & Access',
+    tags: [
+      {
+        name: 'Authentication',
+        description:
+          'Google OAuth sign-in, access-token refresh, logout, and the current-user lookup. ' +
+          'Start here: every other section assumes a bearer token obtained through one of these routes.',
+      },
+      {
+        name: 'Device Authorization',
+        description:
+          'RFC 8628 device authorization grant — how the CLI and the Android app obtain a token on a ' +
+          'machine that cannot open a browser, plus management of the resulting device sessions.',
+      },
+      {
+        name: 'Personal Access Tokens',
+        description:
+          'Long-lived `pat_` bearer credentials for scripts and automation. A PAT carries the full ' +
+          'permission set of the user that minted it and is accepted on every authenticated route.',
+      },
+      {
+        name: 'Allowlist',
+        description:
+          'Pre-authorized email addresses. Access is allowlist-gated: an email absent from this list ' +
+          'cannot complete OAuth sign-in at all. Admin only.',
+      },
+      {
+        name: 'Test Authentication',
+        description:
+          'Token minting for automated tests. Registered only when `NODE_ENV !== "production"`, so ' +
+          'these routes are absent from a production document entirely.',
+      },
+    ],
+  },
+  {
+    name: 'Account & Circles',
+    tags: [
+      {
+        name: 'Users',
+        description:
+          'User administration (Admin) plus the caller\'s own profile and avatar. The `/users/me/*` ' +
+          'routes are self-scoped and need authentication only — no permission.',
+      },
+      {
+        name: 'User Settings',
+        description:
+          'The caller\'s own JSONB settings document: theme, notification preferences, per-table ' +
+          'layouts, and Memories preferences. PATCH merges; PUT replaces.',
+      },
+      {
+        name: 'Circles',
+        description:
+          'Family circles — the unit of media ownership and sharing. Every media route is scoped to a ' +
+          'circle the caller is a member of, at one of three per-circle roles.',
+      },
+      {
+        name: 'Features',
+        description:
+          'Client-visible feature flags for the calling user. Authentication only, no permission, so ' +
+          'non-admin members can resolve gated UI affordances without a 403.',
+      },
+    ],
+  },
+  {
+    name: 'Media Library',
+    tags: [
+      {
+        name: 'Media',
+        description:
+          'The core library: listing and filtering media, albums, bulk mutations, archive and trash, ' +
+          'the map and explore surfaces, geo lookups, and per-item edits.',
+      },
+      {
+        name: 'Storage',
+        description:
+          'Raw object lifecycle beneath the media library — resumable and simple uploads, signed ' +
+          'downloads, metadata, and deletion.',
+      },
+      {
+        name: 'Metadata',
+        description: 'On-demand re-extraction of EXIF, dimensions, geocode, and video-probe data for one item.',
+      },
+      {
+        name: 'Trash Empty Runs',
+        description:
+          'Progress for the asynchronous "empty trash" run started from a circle, which hard-deletes ' +
+          'every trashed item in the background rather than in the request.',
+      },
+    ],
+  },
+  {
+    name: 'AI & Enrichment',
+    tags: [
+      {
+        name: 'Tagging',
+        description: 'Per-item AI auto-tagging status and reruns.',
+      },
+      {
+        name: 'Tag Labels',
+        description:
+          'The global tag vocabulary the vision model is allowed to draw from, including CSV ' +
+          'import/export. Admin only.',
+      },
+      {
+        name: 'Picture Enhancement',
+        description:
+          'AI photo enhancement: start a run, poll it, then keep-both / replace / discard. Nothing is ' +
+          'ever applied without an explicit human decision.',
+      },
+      {
+        name: 'Bursts',
+        description:
+          'Burst-photo review queue — groups of near-identical rapid-fire shots, with a suggested best ' +
+          'copy. Non-destructive until resolved.',
+      },
+      {
+        name: 'Duplicates',
+        description:
+          'Near-duplicate review queue built on CLIP visual similarity and perceptual hashing. Catches ' +
+          're-shared and recompressed copies that exact-hash dedup cannot.',
+      },
+      {
+        name: 'Review Insights',
+        description: 'Per-circle aggregate of burst and duplicate review activity.',
+      },
+      {
+        name: 'Review Runs',
+        description:
+          'The shared asynchronous engine behind every bulk review action (bursts, duplicates, and ' +
+          'location suggestions): counters, per-item outcomes, and cancellation.',
+      },
+      {
+        name: 'Location Inference',
+        description:
+          'GPS coordinates inferred for photos that have none, by interpolating from chronologically ' +
+          'nearby same-device photos that do. Reviewed before it sticks, unless high-confidence.',
+      },
+      {
+        name: 'Location Suggestion Runs (deprecated)',
+        description:
+          'Deprecated aliases for the Review Runs routes, kept so existing clients keep working. Use ' +
+          '`/api/review-runs/*` instead.',
+      },
+      {
+        name: 'Location Groups',
+        description:
+          'Admin-curated canonical place names that merge many raw geocoder spellings ' +
+          '("Heredia", "Provincia de Heredia") into one browsable entry per tier.',
+      },
+    ],
+  },
+  {
+    name: 'People & Faces',
+    tags: [
+      {
+        name: 'People',
+        description:
+          'Person records within a circle: clustering unknown faces, assigning and merging, hiding, ' +
+          'and permanently purging biometric rows.',
+      },
+      {
+        name: 'Face Detection',
+        description: 'Detected faces on a single media item, their status, and per-item reruns.',
+      },
+    ],
+  },
+  {
+    name: 'Search',
+    tags: [
+      {
+        name: 'Search',
+        description:
+          'Deterministic filter search, optional semantic (vector) ranking, and the streaming agentic ' +
+          'search endpoint that drives the conversational UI.',
+      },
+    ],
+  },
+  {
+    name: 'Memories',
+    tags: [
+      {
+        name: 'Memories',
+        description:
+          'Auto-curated collections — On This Day, trips, per-person highlights, themes, seasonal, and ' +
+          'year in review — plus per-user seen/hidden/favorite state.',
+      },
+    ],
+  },
+  {
+    name: 'Workflows',
+    tags: [
+      {
+        name: 'Workflows',
+        description:
+          'Rule-based media automation on a Subject · Trigger · If · Then model: define, preview, and ' +
+          'run automations over a circle\'s library.',
+      },
+      {
+        name: 'Workflow Runs',
+        description: 'Execution history for a workflow: counters, per-item outcomes, approval, and cancellation.',
+      },
+    ],
+  },
+  {
+    name: 'Sharing & Public',
+    tags: [
+      {
+        name: 'Sharing',
+        description: 'Create, list, expire, and revoke public share links for a media item or an album.',
+      },
+      {
+        name: 'Public Sharing',
+        description:
+          'Unauthenticated share consumption. Media bytes are proxied by the API — a storage URL is ' +
+          'never exposed — and revoked, expired, or trashed targets return an indistinguishable 404.',
+      },
+      {
+        name: 'Public Memories',
+        description:
+          'Unauthenticated endpoints backing the Memories email digest: cover-image bytes and one-click ' +
+          'unsubscribe, each gated by an HMAC-signed capability token rather than a session.',
+      },
+    ],
+  },
+  {
+    name: 'Notifications',
+    tags: [
+      {
+        name: 'Notifications',
+        description:
+          'The in-app notification center: paginated inbox, unread badge count, and read / dismiss / ' +
+          'delete. Every route is scoped to the calling user.',
+      },
+    ],
+  },
+  {
+    name: 'Worker Nodes',
+    tags: [
+      {
+        name: 'Nodes',
+        description:
+          'The worker-node data plane: register, heartbeat, claim jobs, renew leases, and submit ' +
+          'results. Media bytes move directly between the node and object storage over presigned URLs.',
+      },
+      {
+        name: 'Nodes: Backup',
+        description:
+          'Local media backup — the incremental change feed, acknowledgement checkpoints, and run ' +
+          'lifecycle a node uses to pull-mirror a circle\'s original bytes onto its own disk.',
+      },
+      {
+        name: 'Node Credentials',
+        description:
+          'Durable `nod_` bearer credentials. Least-privilege by construction: accepted **only** on ' +
+          '`/api/nodes/*`, so a leaked worker credential can never reach media, settings, or admin routes.',
+      },
+    ],
+  },
+  {
+    name: 'Configuration',
+    tags: [
+      {
+        name: 'System Settings',
+        description: 'The global settings document — every feature flag and tuning parameter. Admin only.',
+      },
+      {
+        name: 'AI Settings',
+        description:
+          'AI provider credentials (encrypted at rest), connectivity tests, model listing, and which ' +
+          'provider/model serves each AI feature.',
+      },
+      {
+        name: 'Face Settings',
+        description: 'Face-recognition provider configuration, connectivity tests, and biometric erasure.',
+      },
+      {
+        name: 'Geo Settings',
+        description: 'Reverse-geocoding provider selection and credentials.',
+      },
+      {
+        name: 'Email Settings',
+        description: 'Transactional email provider (SES or SMTP), masked credentials, and test sends.',
+      },
+      {
+        name: 'Storage Settings',
+        description:
+          'Object-storage providers, connectivity tests, active-provider selection, and copy-only ' +
+          'migration between providers.',
+      },
+    ],
+  },
+  {
+    name: 'Admin & Operations',
+    tags: [
+      {
+        name: 'Health',
+        description:
+          'Liveness and readiness probes. Liveness stays 200 during maintenance mode; readiness ' +
+          'reports 503 so a load balancer drains the instance.',
+      },
+      {
+        name: 'Maintenance',
+        description:
+          'App-wide maintenance mode. The persisted flag survives the restart it was enabled for; a ' +
+          '`MAINTENANCE_MODE` environment override is the break-glass in both directions.',
+      },
+      {
+        name: 'Admin: Job Queue',
+        description:
+          'The shared enrichment job queue: stats, listing, retry, stuck-job recovery, and the ' +
+          'on-demand insights/ETA aggregate.',
+      },
+      {
+        name: 'Admin: Doctor',
+        description:
+          'On-demand configuration health sweep across every subsystem, running live provider ' +
+          'connectivity checks. Nothing is persisted.',
+      },
+      {
+        name: 'Admin: Storage Insights',
+        description: 'Precomputed global storage metrics and the manual refresh trigger.',
+      },
+      {
+        name: 'Admin: Media Recovery',
+        description:
+          'Recovery for storage objects orphaned mid-pipeline or permanently failed, plus missing ' +
+          'thumbnail repair.',
+      },
+      {
+        name: 'Admin: Database Backup',
+        description:
+          'PostgreSQL backup and restore: schedule, run history, signed downloads, and the scratch-' +
+          'database restore with its two rollback modes. Backs up the database, not media files.',
+      },
+      {
+        name: 'Admin: Worker Nodes',
+        description: 'Fleet-wide node health, per-node job counts, and credential revocation across all owners.',
+      },
+      {
+        name: 'Admin: Workflows',
+        description: 'Cross-circle workflow oversight: stats, every workflow and run, force-disable, force-cancel.',
+      },
+      {
+        name: 'Admin: Face Recognition',
+        description: 'App-wide face-detection and auto-archive backfills across every circle.',
+      },
+      {
+        name: 'Admin: Tagging',
+        description: 'App-wide AI auto-tagging backfill across every circle.',
+      },
+      {
+        name: 'Admin: Metadata',
+        description: 'App-wide metadata re-extraction backfill across every circle.',
+      },
+      {
+        name: 'Admin: Bursts',
+        description: 'App-wide burst-detection backfill across every circle.',
+      },
+      {
+        name: 'Admin: Duplicates',
+        description: 'App-wide duplicate-detection backfill, CLIP model status, and confidence backfill.',
+      },
+      {
+        name: 'Admin: Location Inference',
+        description: 'App-wide location-inference sweep across every eligible circle.',
+      },
+      {
+        name: 'Admin: Location Groups',
+        description: 'Rebuild of the derived canonical location columns across the whole library.',
+      },
+      {
+        name: 'Admin: Geocode',
+        description: 'App-wide reverse-geocode backfill for every media item carrying GPS coordinates.',
+      },
+      {
+        name: 'Admin: Social Media Detection',
+        description: 'App-wide social-media video detection backfill and OCR model status.',
+      },
+      {
+        name: 'Admin: Memories',
+        description: 'Sharded library-wide Memories backfill, per circle or across every circle.',
+      },
+      {
+        name: 'Admin: AI Picture Enhancer',
+        description: 'Readiness status for the AI Picture Enhancer: feature flag, provider, model, and credential.',
+      },
+    ],
+  },
+];
+
+/** Every declared tag, flattened in group order. */
+export const OPENAPI_TAGS: OpenApiTag[] = TAG_GROUPS.flatMap((group) => group.tags);
+
+/**
+ * The `x-tagGroups` value emitted into the document.
+ *
+ * A vendor extension rather than a standard field: OpenAPI has no concept of
+ * tag sections, so every renderer that supports them (Scalar, Redoc) reads this
+ * key. Renderers that don't simply fall back to the flat `tags` array, which is
+ * why that array is emitted in the same order.
+ */
+export const OPENAPI_TAG_GROUPS = TAG_GROUPS.map((group) => ({
+  name: group.name,
+  tags: group.tags.map((tag) => tag.name),
+}));

--- a/apps/api/src/openapi/types.ts
+++ b/apps/api/src/openapi/types.ts
@@ -1,0 +1,65 @@
+// =============================================================================
+// Minimal structural types for post-processing the generated document
+// =============================================================================
+//
+// `@nestjs/swagger` exports `OpenAPIObject` from its root but not
+// `OperationObject`, and reaching into `@nestjs/swagger/dist/interfaces/...` to
+// get it couples this code to that package's build layout.
+//
+// The passes in this directory read and write a handful of fields on operations
+// and add vendor extensions, so a structural type with an index signature is
+// both sufficient and more honest than the package's own — whose `responses` is
+// required, which the generated object does not always satisfy mid-pass.
+// =============================================================================
+
+export interface DocOperation {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags?: string[];
+  responses?: Record<string, unknown>;
+  /** Entries are alternatives (OR), not a conjunction. */
+  security?: Array<Record<string, string[]>>;
+  /** Vendor extensions, including the `x-rbac` stamped by `@Auth()`. */
+  [key: string]: unknown;
+}
+
+export type DocPathItem = Record<string, DocOperation | unknown>;
+
+export interface MutableDocument {
+  paths?: Record<string, DocPathItem | undefined>;
+  [key: string]: unknown;
+}
+
+/** HTTP methods an OpenAPI path item may carry, in spec order. */
+export const HTTP_METHODS = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+] as const;
+
+/**
+ * Visits every operation in the document.
+ *
+ * Shared by the post-processing passes so the "which keys on a path item are
+ * operations" question is answered in exactly one place — `parameters` and
+ * `servers` are siblings of the methods and must not be treated as operations.
+ */
+export function forEachOperation(
+  document: MutableDocument,
+  visit: (operation: DocOperation, path: string, method: string) => void,
+): void {
+  for (const [path, pathItem] of Object.entries(document.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+    for (const method of HTTP_METHODS) {
+      const operation = (pathItem as Record<string, unknown>)[method];
+      if (!operation || typeof operation !== 'object') continue;
+      visit(operation as DocOperation, path, method);
+    }
+  }
+}

--- a/apps/api/src/openapi/version.spec.ts
+++ b/apps/api/src/openapi/version.spec.ts
@@ -1,0 +1,38 @@
+import { resolveApiVersion } from './version';
+
+describe('resolveApiVersion', () => {
+  const saved = {
+    app: process.env.APP_VERSION,
+    npm: process.env.npm_package_version,
+  };
+
+  afterEach(() => {
+    restore('APP_VERSION', saved.app);
+    restore('npm_package_version', saved.npm);
+  });
+
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  it('prefers the version the deploy pipeline stamped on the image', () => {
+    process.env.APP_VERSION = '2.7.0';
+    process.env.npm_package_version = '1.0.0';
+    expect(resolveApiVersion()).toBe('2.7.0');
+  });
+
+  it('falls back to the npm script environment', () => {
+    delete process.env.APP_VERSION;
+    process.env.npm_package_version = '1.4.2';
+    expect(resolveApiVersion()).toBe('1.4.2');
+  });
+
+  it('finds package.json when neither variable is set', () => {
+    delete process.env.APP_VERSION;
+    delete process.env.npm_package_version;
+    // A bare `node dist/main` has neither variable, which is the case that
+    // would otherwise publish a version of "0.0.0" to every reader.
+    expect(resolveApiVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/apps/api/src/openapi/version.ts
+++ b/apps/api/src/openapi/version.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+/**
+ * Version stamped into `info.version`.
+ *
+ * Resolution order, and why:
+ *
+ *  1. `APP_VERSION` — set by the deploy pipeline on the built image. This is the
+ *     only source that knows about a release tag, so it wins.
+ *  2. `npm_package_version` — set when the process was started through an npm
+ *     script, which covers local `start:dev`.
+ *  3. `apps/api/package.json`, found by walking up from this file. `require`ing
+ *     it directly is not an option: `resolveJsonModule` is off, and the
+ *     relative depth differs between `src/` under ts-jest and `dist/` under
+ *     `node dist/main`. Walking up finds it from either.
+ *
+ * Never throws — a docs page is not worth failing a boot over, so an
+ * unresolvable version degrades to `'0.0.0'`.
+ */
+export function resolveApiVersion(): string {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION;
+  if (process.env.npm_package_version) return process.env.npm_package_version;
+
+  let dir = __dirname;
+  // Bounded walk: deep enough to escape `dist/openapi`, short enough that a
+  // stray package.json far up the tree (the monorepo root) is still reachable
+  // but a runaway loop is not possible.
+  for (let depth = 0; depth < 6; depth += 1) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+        version?: unknown;
+      };
+      if (typeof parsed.version === 'string' && parsed.version.length > 0) {
+        return parsed.version;
+      }
+    } catch {
+      // Not this directory — keep walking.
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return '0.0.0';
+}

--- a/apps/api/src/review-runs/review-runs.controller.ts
+++ b/apps/api/src/review-runs/review-runs.controller.ts
@@ -34,7 +34,7 @@ import { ListReviewRunItemsQueryDto } from './dto/list-review-run-items-query.dt
  * cancel requires media:write + per-circle collaborator.
  */
 @ApiTags('Review Runs')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('review-runs')
 export class ReviewRunsController {
   constructor(private readonly runService: ReviewRunService) {}

--- a/apps/api/src/share/dto/bulk-share.dto.ts
+++ b/apps/api/src/share/dto/bulk-share.dto.ts
@@ -32,6 +32,7 @@ export class BulkShareDto {
   action!: BulkShareAction;
 
   @ApiPropertyOptional({
+    type: String,
     description: 'New expiration datetime; null clears expiration. Required when action is set_expiration.',
     nullable: true,
   })

--- a/apps/api/src/share/dto/create-share.dto.ts
+++ b/apps/api/src/share/dto/create-share.dto.ts
@@ -34,6 +34,7 @@ export class CreateShareDto {
   albumId?: string;
 
   @ApiPropertyOptional({
+    type: String,
     description: 'ISO 8601 expiration datetime; null or omitted means never expires',
     example: '2026-12-31T23:59:59Z',
     nullable: true,

--- a/apps/api/src/share/dto/update-share.dto.ts
+++ b/apps/api/src/share/dto/update-share.dto.ts
@@ -3,6 +3,7 @@ import { IsDateString, IsOptional, ValidateIf } from 'class-validator';
 
 export class UpdateShareDto {
   @ApiProperty({
+    type: String,
     description: 'New expiration datetime; null clears expiration (never expires)',
     example: '2026-12-31T23:59:59Z',
     nullable: true,

--- a/apps/api/src/share/public-share.controller.ts
+++ b/apps/api/src/share/public-share.controller.ts
@@ -35,7 +35,14 @@ export class PublicShareController {
    */
   @Get(':token')
   @Public()
-  @ApiOperation({ summary: 'Get public share info (no auth required)' })
+  @ApiOperation({
+    summary: 'Get public share info (no auth required)',
+    description:
+      'Returns a metadata-stripped view of a shared media item or album: media type and ' +
+      'dimensions only, never EXIF, location, owner, or a storage URL. A revoked, expired, or ' +
+      'trashed target returns the same generic 404 as an unknown token, so a token cannot be ' +
+      'probed for existence.',
+  })
   @ApiParam({ name: 'token', description: 'Share token' })
   @ApiResponse({
     status: 200,
@@ -91,7 +98,14 @@ export class PublicShareController {
    */
   @Get(':token/media/:idx')
   @Public()
-  @ApiOperation({ summary: 'Proxy media bytes (no auth required)' })
+  @ApiOperation({
+    summary: 'Proxy media bytes (no auth required)',
+    description:
+      'Streams the shared file through the API — the storage URL is never exposed. Video ' +
+      'responses honour Range requests (206). `variant=thumb` returns the thumbnail for album ' +
+      'grids. Note that bytes are the raw original: EXIF embedded in the file, including GPS, ' +
+      'is NOT stripped.',
+  })
   @ApiParam({ name: 'token', description: 'Share token' })
   @ApiParam({ name: 'idx', description: 'Zero-based item index', type: Number })
   @ApiQuery({ name: 'variant', required: false, enum: ['original', 'thumb'] })

--- a/apps/api/src/social-media/admin-social-media.controller.ts
+++ b/apps/api/src/social-media/admin-social-media.controller.ts
@@ -37,7 +37,7 @@ class AdminSocialMediaBackfillDto extends createZodDto(
   adminSocialMediaBackfillSchema,
 ) {}
 
-@ApiTags('Admin — Social Media Detection')
+@ApiTags('Admin: Social Media Detection')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/social-media')
 export class AdminSocialMediaController {

--- a/apps/api/src/tagging/admin-tagging.controller.ts
+++ b/apps/api/src/tagging/admin-tagging.controller.ts
@@ -26,7 +26,7 @@ const adminBackfillSchema = z.object({
 }).prefault({});
 class AdminBackfillDto extends createZodDto(adminBackfillSchema) {}
 
-@ApiTags('Admin — Tagging')
+@ApiTags('Admin: Tagging')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin/tagging')
 export class AdminTaggingController {

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -36,7 +36,7 @@ export class UsersController {
   @ApiQuery({ name: 'pageSize', required: false, type: Number })
   @ApiQuery({ name: 'search', required: false, type: String })
   @ApiQuery({ name: 'role', required: false, type: String })
-  @ApiQuery({ name: 'isActive', required: false, type: Boolean })
+  @ApiQuery({ name: 'isActive', required: false, enum: ['true', 'false'] })
   @ApiQuery({ name: 'sortBy', required: false, enum: ['email', 'createdAt', 'updatedAt'] })
   @ApiQuery({ name: 'sortOrder', required: false, enum: ['asc', 'desc'] })
   @ApiResponse({ status: 200, description: 'Paginated user list' })

--- a/apps/api/src/workflows/admin/workflows-admin.controller.ts
+++ b/apps/api/src/workflows/admin/workflows-admin.controller.ts
@@ -34,7 +34,7 @@ import { ListAdminWorkflowRunsQueryDto } from './dto/list-admin-workflow-runs-qu
  * mirroring the admin jobs/nodes controllers.
  */
 @ApiTags('Admin: Workflows')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('admin')
 export class WorkflowsAdminController {
   constructor(private readonly adminService: WorkflowsAdminService) {}

--- a/apps/api/src/workflows/admin/workflows-admin.controller.ts
+++ b/apps/api/src/workflows/admin/workflows-admin.controller.ts
@@ -33,7 +33,7 @@ import { ListAdminWorkflowRunsQueryDto } from './dto/list-admin-workflow-runs-qu
  * system_settings:write and the runaway-run cancel requires jobs:write —
  * mirroring the admin jobs/nodes controllers.
  */
-@ApiTags('Admin - Workflows')
+@ApiTags('Admin: Workflows')
 @ApiBearerAuth()
 @Controller('admin')
 export class WorkflowsAdminController {

--- a/apps/api/src/workflows/runs/workflow-runs.controller.ts
+++ b/apps/api/src/workflows/runs/workflow-runs.controller.ts
@@ -31,7 +31,7 @@ import { ListRunItemsQueryDto } from './dto/list-run-items-query.dto';
  * per-circle viewer; approve/cancel require media:write + collaborator.
  */
 @ApiTags('Workflow Runs')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('workflow-runs')
 export class WorkflowRunsController {
   constructor(private readonly runService: WorkflowRunService) {}

--- a/apps/api/src/workflows/workflows.controller.ts
+++ b/apps/api/src/workflows/workflows.controller.ts
@@ -40,7 +40,7 @@ import { ListRunsQueryDto } from './runs/dto/list-runs-query.dto';
  * (per-circle roles are enforced in the service, mirroring bulk-media ops).
  */
 @ApiTags('Workflows')
-@ApiBearerAuth()
+@ApiBearerAuth('JWT-auth')
 @Controller('workflows')
 export class WorkflowsController {
   constructor(

--- a/apps/api/test/helpers/test-app.helper.ts
+++ b/apps/api/test/helpers/test-app.helper.ts
@@ -77,6 +77,19 @@ export interface TestAppOptions {
    * Set to false only for true E2E tests that need a real database
    */
   useMockDatabase?: boolean;
+
+  /**
+   * Hook to register raw Fastify routes, called after the global prefix is set
+   * and BEFORE `app.init()`.
+   *
+   * The timing is the whole point. Fastify refuses to accept a route once its
+   * root plugin has booted ("Root plugin has already booted"), and `app.init()`
+   * boots it — so a spec that registers a route after `createTestApp` returns
+   * cannot work at all. `main.ts` registers the documentation routes at exactly
+   * this point in its own boot sequence, so a spec using this hook is exercising
+   * the same ordering the server uses.
+   */
+  registerRoutes?: (app: NestFastifyApplication) => void;
 }
 
 /**
@@ -125,6 +138,9 @@ export async function createTestApp(
   app.setGlobalPrefix('api');
   // Note: ZodValidationPipe is already registered globally via APP_PIPE in AppModule
   // Do NOT add a standard ValidationPipe here as it conflicts with Zod DTOs
+
+  // Must precede init(): see `registerRoutes` on TestAppOptions.
+  options.registerRoutes?.(app);
 
   await app.init();
   await app.getHttpAdapter().getInstance().ready();

--- a/apps/api/test/openapi/docs-routes.spec.ts
+++ b/apps/api/test/openapi/docs-routes.spec.ts
@@ -1,0 +1,75 @@
+import { createTestApp, closeTestApp, TestContext } from '../helpers/test-app.helper';
+import { createOpenApiDocument } from '../../src/openapi/document';
+import {
+  DOCS_PATH,
+  OPENAPI_JSON_PATH,
+  registerDocsRoutes,
+} from '../../src/openapi/register-docs-routes';
+
+/**
+ * Exercises the two routes end to end, over the same Fastify instance `main.ts`
+ * registers them on.
+ *
+ * Worth its own suite because these are raw Fastify routes rather than Nest
+ * controllers: nothing else in the test surface would notice if the path, the
+ * content type, or the registration order broke.
+ */
+describe('documentation routes', () => {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    context = await createTestApp({
+      // Registered before init(), the same point in the boot sequence main.ts
+      // uses — Fastify refuses new routes once its root plugin has booted.
+      registerRoutes: (app) =>
+        registerDocsRoutes(app, createOpenApiDocument(app), '9.9.9'),
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await closeTestApp(context);
+  });
+
+  describe(OPENAPI_JSON_PATH, () => {
+    it('serves the document as JSON', async () => {
+      const response = await context.app.inject({ method: 'GET', url: OPENAPI_JSON_PATH });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('application/json');
+
+      const body = response.json();
+      expect(body.openapi).toBe('3.1.0');
+      expect(body.info.title).toBe('MemoriaHub API');
+      expect(Object.keys(body.paths).length).toBeGreaterThan(100);
+    });
+  });
+
+  describe(DOCS_PATH, () => {
+    it('serves the reference as HTML', async () => {
+      const response = await context.app.inject({ method: 'GET', url: DOCS_PATH });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('text/html');
+      expect(response.body).toContain('<title>MemoriaHub API Reference</title>');
+      expect(response.body).toContain('createApiReference');
+    });
+
+    it('answers on the trailing-slash spelling too', async () => {
+      const response = await context.app.inject({ method: 'GET', url: `${DOCS_PATH}/` });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('points at the spec rather than inlining it, so the page stays small', async () => {
+      const response = await context.app.inject({ method: 'GET', url: DOCS_PATH });
+
+      expect(response.body).toContain(OPENAPI_JSON_PATH);
+      // The spec is ~1 MB; inlining it would be the obvious regression here.
+      expect(response.body.length).toBeLessThan(20_000);
+    });
+
+    it('reaches the reader without a bearer token — it is how they get one', async () => {
+      const response = await context.app.inject({ method: 'GET', url: DOCS_PATH });
+      expect(response.statusCode).toBe(200);
+    });
+  });
+});

--- a/apps/api/test/openapi/openapi-document.spec.ts
+++ b/apps/api/test/openapi/openapi-document.spec.ts
@@ -1,5 +1,9 @@
 import { createTestApp, closeTestApp, TestContext } from '../helpers/test-app.helper';
-import { createOpenApiDocument, SECURITY_SCHEMES } from '../../src/openapi/document';
+import {
+  createOpenApiDocument,
+  isAuthenticatedOperation,
+  SECURITY_SCHEMES,
+} from '../../src/openapi/document';
 import { OPENAPI_TAGS, OPENAPI_TAG_GROUPS } from '../../src/openapi/tags';
 import { REQUIREMENTS_MARKER } from '../../src/openapi/rbac-docs';
 import { RBAC_EXTENSION_KEY } from '../../src/auth/decorators/auth.decorator';
@@ -58,6 +62,22 @@ describe('OpenAPI document', () => {
       expect(document.servers).toEqual([
         expect.objectContaining({ url: '/' }),
       ]);
+    });
+
+    it('publishes OpenAPI 3.1, which zod v4 schemas require', () => {
+      expect(document.openapi).toBe('3.1.0');
+    });
+
+    it('carries no 3.0-only `nullable` keyword, which a 3.1 consumer would ignore', () => {
+      // Ignoring it means generating a non-nullable field — wrong about exactly
+      // the values most likely to break a client.
+      expect(JSON.stringify(document)).not.toContain('"nullable"');
+    });
+
+    it('omits the contact email rather than publishing an invalid empty one', () => {
+      const contact = (document.info as { contact?: Record<string, unknown> }).contact;
+      expect(contact).toBeDefined();
+      expect(contact).not.toHaveProperty('email');
     });
 
     it('documents the getting-started essentials in the description', () => {
@@ -143,6 +163,8 @@ describe('OpenAPI document', () => {
   describe('self-documenting RBAC', () => {
     const guarded = () =>
       operations.filter(({ operation }) => operation[RBAC_EXTENSION_KEY] !== undefined);
+    const authenticated = () =>
+      operations.filter(({ operation }) => isAuthenticatedOperation(operation));
 
     it('guards a substantial share of the surface', () => {
       expect(guarded().length).toBeGreaterThan(150);
@@ -169,6 +191,16 @@ describe('OpenAPI document', () => {
       expect(withProse).toBeDefined();
     });
 
+    it('states requirements on routes guarded by JwtAuthGuard alone too', () => {
+      // A few auth-controller routes compose `@UseGuards(JwtAuthGuard)` with a
+      // bare `@ApiBearerAuth(...)` rather than `@Auth()`; they are still
+      // authenticated and must still say so.
+      const silent = authenticated()
+        .filter(({ operation }) => !(operation.description ?? '').includes(REQUIREMENTS_MARKER))
+        .map(({ path, method }) => `${method} ${path}`);
+      expect(silent).toEqual([]);
+    });
+
     it('leaves public operations alone', () => {
       const providers = operations.find(
         ({ path, method }) => path === '/api/auth/providers' && method === 'get',
@@ -190,9 +222,9 @@ describe('OpenAPI document', () => {
       );
     });
 
-    it('offers session and PAT auth as alternatives on every guarded operation', () => {
+    it('offers session and PAT auth as alternatives on every authenticated operation', () => {
       const missing = operations
-        .filter(({ operation }) => operation[RBAC_EXTENSION_KEY] !== undefined)
+        .filter(({ operation }) => isAuthenticatedOperation(operation))
         .filter(({ operation }) => {
           const names = (operation.security ?? []).flatMap((entry) => Object.keys(entry));
           return (
@@ -209,8 +241,7 @@ describe('OpenAPI document', () => {
         const names = (operation.security ?? []).flatMap((entry) => Object.keys(entry));
         const offered = names.includes(SECURITY_SCHEMES.NODE_CREDENTIAL);
         const isNodeRoute = /^\/api\/nodes(\/|$)/.test(path);
-        const guarded = operation[RBAC_EXTENSION_KEY] !== undefined;
-        expect(offered).toBe(isNodeRoute && guarded);
+        expect(offered).toBe(isNodeRoute && isAuthenticatedOperation(operation));
       }
     });
   });
@@ -236,7 +267,7 @@ describe('OpenAPI document', () => {
       expect(missing).toEqual([]);
     });
 
-    it('documents 401 and 403 on guarded operations', () => {
+    it('documents 401 and 403 on operations guarded by @Auth()', () => {
       const missing = operations
         .filter(({ operation }) => operation[RBAC_EXTENSION_KEY] !== undefined)
         .filter(({ operation }) => !operation.responses?.['401'] || !operation.responses?.['403'])

--- a/apps/api/test/openapi/openapi-document.spec.ts
+++ b/apps/api/test/openapi/openapi-document.spec.ts
@@ -1,0 +1,261 @@
+import { createTestApp, closeTestApp, TestContext } from '../helpers/test-app.helper';
+import { createOpenApiDocument, SECURITY_SCHEMES } from '../../src/openapi/document';
+import { OPENAPI_TAGS, OPENAPI_TAG_GROUPS } from '../../src/openapi/tags';
+import { REQUIREMENTS_MARKER } from '../../src/openapi/rbac-docs';
+import { RBAC_EXTENSION_KEY } from '../../src/auth/decorators/auth.decorator';
+import { DocOperation, forEachOperation, MutableDocument } from '../../src/openapi/types';
+
+/**
+ * Boots the real AppModule once and asserts the document it produces.
+ *
+ * These are the guardrails the epic asked for: a spec that can silently rot is
+ * the failure mode this whole feature exists to remove, so every claim the docs
+ * page makes about itself (one admin-tag convention, no orphan tags, generated
+ * RBAC lines, an error envelope everywhere) is checked here rather than by a
+ * reviewer noticing.
+ */
+describe('OpenAPI document', () => {
+  let context: TestContext;
+  let document: MutableDocument;
+  let operations: Array<{ path: string; method: string; operation: DocOperation }>;
+
+  beforeAll(async () => {
+    context = await createTestApp();
+    document = createOpenApiDocument(context.app) as unknown as MutableDocument;
+
+    operations = [];
+    forEachOperation(document, (operation, path, method) => {
+      operations.push({ path, method, operation });
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await closeTestApp(context);
+  });
+
+  it('produces a non-trivial document', () => {
+    expect(operations.length).toBeGreaterThan(200);
+  });
+
+  describe('branding and metadata', () => {
+    it('is titled after this product, not the scaffold it came from', () => {
+      const info = document.info as { title: string; version: string; description: string };
+      expect(info.title).toBe('MemoriaHub API');
+      expect(info.description).toContain('MemoriaHub');
+    });
+
+    it('carries no trace of the "Enterprise App" template', () => {
+      expect(JSON.stringify(document)).not.toMatch(/Enterprise App/i);
+    });
+
+    it('reports a real version rather than the hardcoded 1.0', () => {
+      const { version } = document.info as { version: string };
+      expect(version).not.toBe('1.0');
+      expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it('declares a same-origin server so the built-in client targets this deployment', () => {
+      expect(document.servers).toEqual([
+        expect.objectContaining({ url: '/' }),
+      ]);
+    });
+
+    it('documents the getting-started essentials in the description', () => {
+      const { description } = document.info as { description: string };
+      // Each of these is a question a first-time caller has to answer before
+      // they can make a single successful request.
+      expect(description).toContain('pat_');
+      expect(description).toContain('nod_');
+      expect(description).toContain('RFC 8628');
+      expect(description).toContain('nextCursor');
+      expect(description).toContain('circle_admin');
+    });
+  });
+
+  describe('tag taxonomy', () => {
+    const usedTags = (): Set<string> => {
+      const tags = new Set<string>();
+      for (const { operation } of operations) {
+        for (const tag of operation.tags ?? []) tags.add(tag);
+      }
+      return tags;
+    };
+
+    it('uses exactly one admin-tag naming convention', () => {
+      const offenders = [...usedTags()].filter((tag) => /^Admin\s*[-—]/.test(tag));
+      expect(offenders).toEqual([]);
+    });
+
+    it('declares every tag an operation actually uses', () => {
+      const declared = new Set(OPENAPI_TAGS.map((tag) => tag.name));
+      const undeclared = [...usedTags()].filter((tag) => !declared.has(tag));
+      expect(undeclared).toEqual([]);
+    });
+
+    it('has no declared tag that no operation uses', () => {
+      const used = usedTags();
+      const orphaned = OPENAPI_TAGS.map((tag) => tag.name).filter((tag) => !used.has(tag));
+      expect(orphaned).toEqual([]);
+    });
+
+    it('gives every declared tag a description', () => {
+      const undescribed = (document.tags as Array<{ name: string; description?: string }>)
+        .filter((tag) => !tag.description)
+        .map((tag) => tag.name);
+      expect(undescribed).toEqual([]);
+    });
+
+    it('places every tag in exactly one x-tagGroup', () => {
+      const grouped = OPENAPI_TAG_GROUPS.flatMap((group) => group.tags);
+      expect(new Set(grouped).size).toBe(grouped.length);
+      expect(new Set(grouped)).toEqual(new Set(OPENAPI_TAGS.map((tag) => tag.name)));
+      expect(document['x-tagGroups']).toEqual(OPENAPI_TAG_GROUPS);
+    });
+  });
+
+  describe('operation ids', () => {
+    it('gives every operation a namespaced id', () => {
+      const missing = operations
+        .filter(({ operation }) => !operation.operationId)
+        .map(({ path, method }) => `${method} ${path}`);
+      expect(missing).toEqual([]);
+    });
+
+    it('keeps operation ids unique, so a generated SDK has no colliding methods', () => {
+      const seen = new Map<string, string>();
+      const collisions: string[] = [];
+      for (const { path, method, operation } of operations) {
+        const id = operation.operationId as string;
+        const previous = seen.get(id);
+        if (previous) collisions.push(`${id}: ${previous} and ${method} ${path}`);
+        else seen.set(id, `${method} ${path}`);
+      }
+      expect(collisions).toEqual([]);
+    });
+
+    it('drops the "Controller" noise a generator would otherwise bake into names', () => {
+      const ids = operations.map(({ operation }) => operation.operationId as string);
+      expect(ids.some((id) => /Controller_/.test(id))).toBe(false);
+      expect(ids).toContain('auth_getProviders');
+    });
+  });
+
+  describe('self-documenting RBAC', () => {
+    const guarded = () =>
+      operations.filter(({ operation }) => operation[RBAC_EXTENSION_KEY] !== undefined);
+
+    it('guards a substantial share of the surface', () => {
+      expect(guarded().length).toBeGreaterThan(150);
+    });
+
+    it('states the requirements of every guarded operation in its description', () => {
+      const silent = guarded()
+        .filter(({ operation }) => !(operation.description ?? '').includes(REQUIREMENTS_MARKER))
+        .map(({ path, method }) => `${method} ${path}`);
+      expect(silent).toEqual([]);
+    });
+
+    it('names the actual permission a guarded operation requires', () => {
+      const usersList = operations.find(
+        ({ path, method }) => path === '/api/users' && method === 'get',
+      );
+      expect(usersList?.operation.description).toContain('`users:read`');
+    });
+
+    it('appends to the hand-written description rather than replacing it', () => {
+      const withProse = guarded().find(({ operation }) =>
+        (operation.description ?? '').split(REQUIREMENTS_MARKER)[0].trim().length > 0,
+      );
+      expect(withProse).toBeDefined();
+    });
+
+    it('leaves public operations alone', () => {
+      const providers = operations.find(
+        ({ path, method }) => path === '/api/auth/providers' && method === 'get',
+      );
+      expect(providers?.operation.description ?? '').not.toContain(REQUIREMENTS_MARKER);
+    });
+  });
+
+  describe('authentication schemes', () => {
+    it('documents all three bearer credentials', () => {
+      const schemes = (document.components as { securitySchemes: Record<string, unknown> })
+        .securitySchemes;
+      expect(Object.keys(schemes).sort()).toEqual(
+        [
+          SECURITY_SCHEMES.JWT_AUTH,
+          SECURITY_SCHEMES.NODE_CREDENTIAL,
+          SECURITY_SCHEMES.PAT_AUTH,
+        ].sort(),
+      );
+    });
+
+    it('offers session and PAT auth as alternatives on every guarded operation', () => {
+      const missing = operations
+        .filter(({ operation }) => operation[RBAC_EXTENSION_KEY] !== undefined)
+        .filter(({ operation }) => {
+          const names = (operation.security ?? []).flatMap((entry) => Object.keys(entry));
+          return (
+            !names.includes(SECURITY_SCHEMES.JWT_AUTH) ||
+            !names.includes(SECURITY_SCHEMES.PAT_AUTH)
+          );
+        })
+        .map(({ path, method }) => `${method} ${path}`);
+      expect(missing).toEqual([]);
+    });
+
+    it('offers the node credential on /api/nodes routes and nowhere else', () => {
+      for (const { path, operation } of operations) {
+        const names = (operation.security ?? []).flatMap((entry) => Object.keys(entry));
+        const offered = names.includes(SECURITY_SCHEMES.NODE_CREDENTIAL);
+        const isNodeRoute = /^\/api\/nodes(\/|$)/.test(path);
+        const guarded = operation[RBAC_EXTENSION_KEY] !== undefined;
+        expect(offered).toBe(isNodeRoute && guarded);
+      }
+    });
+  });
+
+  describe('error envelope', () => {
+    it('publishes the shared ErrorDto schema', () => {
+      const schemas = (document.components as { schemas: Record<string, unknown> }).schemas;
+      expect(schemas.ErrorDto).toBeDefined();
+    });
+
+    it('documents the envelope as the default response on every operation', () => {
+      const missing = operations
+        .filter(({ operation }) => {
+          const fallback = operation.responses?.default as
+            | { content?: Record<string, { schema?: { $ref?: string } }> }
+            | undefined;
+          return (
+            fallback?.content?.['application/json']?.schema?.$ref !==
+            '#/components/schemas/ErrorDto'
+          );
+        })
+        .map(({ path, method }) => `${method} ${path}`);
+      expect(missing).toEqual([]);
+    });
+
+    it('documents 401 and 403 on guarded operations', () => {
+      const missing = operations
+        .filter(({ operation }) => operation[RBAC_EXTENSION_KEY] !== undefined)
+        .filter(({ operation }) => !operation.responses?.['401'] || !operation.responses?.['403'])
+        .map(({ path, method }) => `${method} ${path}`);
+      expect(missing).toEqual([]);
+    });
+  });
+
+  describe('response envelope accuracy', () => {
+    it('documents GET /api/auth/providers with the { data } wrapper the handler returns', () => {
+      const providers = operations.find(
+        ({ path, method }) => path === '/api/auth/providers' && method === 'get',
+      );
+      const schema = (
+        providers?.operation.responses?.['200'] as {
+          content?: Record<string, { schema?: { properties?: Record<string, unknown> } }>;
+        }
+      )?.content?.['application/json']?.schema;
+      expect(schema?.properties).toHaveProperty('data');
+    });
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -2928,17 +2928,30 @@ GET  /admin/insights         → refresh.state === "idle"     (done; metrics upd
 
 ---
 
-## Swagger/OpenAPI Documentation
+## Interactive API Reference
 
-Interactive API documentation with request/response examples is available at:
+A [Scalar](https://scalar.com) API reference is served same-origin at `/api/docs`
+(development: http://localhost:3535/api/docs), with the machine-readable OpenAPI
+3.1 document at `/api/openapi.json`. See the
+[API Documentation spec](specs/api-documentation.md) for how it is built.
 
-**Development:** http://localhost:3535/api/docs
+The reference gives you:
+- A sidebar grouped into product sections (`x-tagGroups`), each tag described
+- A built-in request client with generated code samples (curl, JS, Python, …)
+- Full-text search over every operation (`k`)
+- The permissions each operation requires, generated from the `@Auth()` decorator
+  the guards are configured by — so they cannot drift from what is enforced
+- Dark mode following your OS setting
 
-The Swagger UI allows you to:
-- Explore all endpoints
-- View request/response schemas
-- Test API calls directly from the browser
-- Authenticate with JWT tokens
+**Authorizing takes no copy-paste.** If you are signed in to MemoriaHub in the
+same browser, the page exchanges your refresh cookie for an access token on load
+and pre-authorizes the client; the header bar shows the result, and the
+**Authorize with my session** button re-runs it. Personal access tokens (`pat_…`)
+and node credentials (`nod_…`) are documented as first-class alternatives, and
+the reference page offers whichever schemes an operation actually accepts.
+
+The reference bundle is loaded from a CDN by default. An air-gapped deployment
+can self-host it and point the page at its own copy with `API_DOCS_CDN`.
 
 ---
 

--- a/docs/specs/api-documentation.md
+++ b/docs/specs/api-documentation.md
@@ -1,0 +1,241 @@
+# API Documentation
+
+> Epic [#414](https://github.com/marinoscar/MemoriaHub/issues/414). Implemented in
+> `apps/api/src/openapi/`.
+
+The interactive API reference at `/api/docs` and the OpenAPI document at
+`/api/openapi.json`: how they are built, which decisions are load-bearing, and
+what stops them rotting.
+
+---
+
+## 1. What was wrong
+
+`/api/docs` shipped as the scaffold left it. The document was titled
+**"Enterprise App API"** at a hardcoded version `1.0`, rendered by an
+unconfigured stock Swagger UI over roughly 65 tags in no order, with three
+admin-tag naming conventions coexisting (`Admin - X`, `Admin — X`, `Admin: X`)
+so the sidebar read as three unrelated families. There was no way to obtain a
+token from the page: Google OAuth is a browser redirect Swagger UI cannot drive,
+and the PAT and device flows existed but were undocumented as auth options.
+
+Two problems were less visible and more damaging:
+
+- **Fifteen controllers called `@ApiBearerAuth()` with no scheme name**, which
+  emits `security: [{ bearer: [] }]` against a scheme the document never
+  defined. Not cosmetic: an undefined scheme gives the Authorize dialog nothing
+  to attach, so a reader who had authorized still got `401` from every one of
+  those operations.
+- **Almost every documented response shape was wrong.** `TransformInterceptor`
+  is a global `APP_INTERCEPTOR` that wraps every handler return value in
+  `{ data, meta }`, while `@ApiResponse({ type: Dto })` describes what the
+  handler returns — so the published schema was consistently one level off from
+  the wire.
+
+---
+
+## 2. Shape of the solution
+
+Everything that shapes the document lives in `apps/api/src/openapi/`, not in
+`main.ts`. The reason is concrete: the spec is now asserted by tests and dumped
+by a CI script, and neither can boot a listening server. A pure
+`buildOpenApiConfig()` / `createOpenApiDocument(app)` pair is callable from the
+test harness, from `scripts/dump-openapi.ts`, and from `main.ts` alike — so the
+document CI lints is the document users get.
+
+| File | Responsibility |
+| --- | --- |
+| `document.ts` | `DocumentBuilder` config, security schemes, operation ids, and the pass pipeline |
+| `description.ts` | The Markdown getting-started guide baked into `info.description` |
+| `tags.ts` | Every tag name, its description, and its `x-tagGroups` section |
+| `rbac-docs.ts` | Renders the `x-rbac` extension into operation descriptions |
+| `data-envelope.ts` | Applies the `{ data: … }` wrapper the global interceptor produces |
+| `nullable.ts` | Rewrites 3.0 `nullable` into 3.1 type unions |
+| `docs-page.ts` | The Scalar page, including one-click session pre-authorization |
+| `version.ts` | Resolves the application version |
+| `types.ts` | Structural types and the shared operation walker |
+
+`createOpenApiDocument` runs Nest's introspection, then `cleanupOpenApiDoc`
+(nestjs-zod's recommended post-processing, so zod DTOs emit real JSON Schema),
+then five passes in a fixed order.
+
+---
+
+## 3. Self-documenting RBAC
+
+`@Auth()` already knows the roles and permissions it is about to enforce. It now
+records them as an `x-rbac` vendor extension, and `applyRbacDocs` renders that
+into the operation description:
+
+> **Requires:** authentication, plus system role `admin`, permission
+> `media:write` and per-circle role `collaborator` or higher.
+
+**Why metadata plus a later pass, rather than writing the description in the
+decorator.** Decorators evaluate bottom-up and `@nestjs/swagger` merges
+operation metadata shallowly. A decorator that set `description` directly would
+race the controller's own `@ApiOperation({ description })`, and whichever ran
+last would silently clobber the other. Post-processing appends, so hand-written
+prose and generated requirements coexist. The pass is idempotent: an operation
+whose description already carries the marker is skipped.
+
+**Per-circle roles are declared, not inferred.** There is no per-circle guard to
+read — membership is checked inside the services — so `@Auth({ circleRole })`
+exists to state it where a route enforces one. It is opt-in per route rather
+than derived, which is the honest position: the decorator cannot know.
+
+A handful of routes (chiefly on the auth controller) compose
+`@UseGuards(JwtAuthGuard)` with a bare `@ApiBearerAuth('JWT-auth')` instead of
+`@Auth()`, because the RBAC guards would have nothing to check. Those declare a
+security requirement and nothing more, and get the authentication-only line.
+
+---
+
+## 4. The `{ data: … }` envelope
+
+The audit found the drift was structural rather than a handful of endpoints, so
+the fix is structural too: `applyDataEnvelope` performs on the document exactly
+the transformation `TransformInterceptor` performs on the response.
+
+A handler documented as returning `Dto` is published as `{ data: Dto }`. A
+handler that already returns `{ data: Dto }` is published unchanged — mirroring
+the interceptor's own passthrough rule, which skips any object already carrying
+a `data` key.
+
+Deliberately untouched:
+
+- **Non-2xx responses.** `HttpExceptionFilter` writes errors straight to the
+  reply, bypassing every interceptor, so they are not enveloped.
+- **Responses with no `application/json` schema** — `204`, redirects, and the
+  byte-proxy / SSE / CSV-export routes that take `@Res()` and write the reply
+  themselves. None declares a JSON schema, so filtering on that is exactly the
+  right rule and needs no allowlist to maintain.
+- **Schemas that already declare `data`**, resolved one level through `$ref` —
+  double-wrapping one would publish `{ data: { data: … } }`.
+
+Editing ~70 controllers instead would have been a large, error-prone sweep that
+the next new endpoint immediately reopens. `ApiDataResponse(Dto)` exists for
+declaring the envelope explicitly where that reads better, but the pass is what
+makes the whole surface correct.
+
+---
+
+## 5. OpenAPI 3.1, and the `nullable` trap it opens
+
+The document is published as **3.1**, not the 3.0 default: zod v4 emits JSON
+Schema 2020-12, which 3.1 adopts wholesale and 3.0 rejects. Under 3.0 the
+zod-derived DTOs published numeric `exclusiveMinimum` and `propertyNames`
+keywords that are invalid there.
+
+Switching versions leaves one gap. `@ApiProperty({ nullable: true })` emits the
+3.0 spelling — a sibling `nullable: true` next to `type` — and 3.1 removed that
+keyword. A 3.1 consumer does not "mostly ignore" it: it reads `type: "string"`
+and generates a non-nullable field, wrong about exactly the values most likely
+to break a client.
+
+`applyNullableFor31` rewrites every occurrence into 3.1's spelling,
+`type: ["string", "null"]`, and a nullable `$ref` into a `oneOf` (the only form
+3.1 honours, since a `$ref` sibling keyword is ignored in 3.0 and merged in
+3.1 — neither dependable). It walks the whole document rather than being fixed
+at each `@ApiProperty` call site, because the next one written will use the 3.0
+spelling too: that is what the decorator's own types document.
+
+---
+
+## 6. The reference page
+
+`/api/docs` serves a [Scalar](https://scalar.com) reference: sectioned
+searchable sidebar, built-in request client, generated code samples, dark mode,
+native OpenAPI 3.1. `/api/openapi.json` remains the canonical machine-readable
+document; the page fetches it rather than inlining it, so the HTML stays small.
+
+Both are registered as raw Fastify routes rather than through
+`SwaggerModule.setup`, which would additionally mount the stock Swagger UI on
+the same path. Registering directly also keeps them outside the Nest guard
+pipeline — matching what `SwaggerModule.setup` already did, and keeping the
+reference readable during maintenance mode.
+
+### 6.1 One-click session auth
+
+Landing on `/api/docs` while signed in leaves the client already authorized. The
+page `POST`s to `/api/auth/refresh` with `credentials: 'include'`, and hands the
+returned access token to Scalar as pre-authorization before mounting it. A
+reload re-runs it, which is what makes authorization survive one.
+
+Two constraints shaped this:
+
+- **It cannot be done server-side.** The refresh cookie is scoped to
+  `path=/api/auth` and is therefore never sent to `/api/docs`. The exchange has
+  to happen in the browser.
+- **It cannot be done after mount.** Handing Scalar a token as configuration is
+  clean; poking it into Scalar's internal store afterwards is not. So the fetch
+  must complete *before* `createApiReference` is called — which is precisely the
+  seam `@scalar/nestjs-api-reference`'s fixed template does not expose, since its
+  last statement is that call. Hence a small template of our own rather than
+  string-surgery on generated HTML.
+
+### 6.2 Which schemes an operation offers
+
+`@Auth()` can only name the session scheme. But a PAT authenticates every
+authenticated route, and a `nod_` credential authenticates `/api/nodes/*` —
+both facts a reader needs. `applyAlternativeAuthSchemes` derives them from the
+path and the guard marker, so the claim stays accurate as routes are added,
+where a hand-applied `@ApiSecurity()` would quietly go stale. Multiple entries
+in `security` are alternatives, so appending never tightens a requirement.
+
+### 6.3 The CDN
+
+The Scalar bundle loads from a CDN, matching Scalar's own default. For a
+self-hosted product that is a real constraint, so `API_DOCS_CDN` points the page
+at a self-hosted copy; the page is otherwise unchanged.
+
+---
+
+## 7. Quality gates
+
+**Tag taxonomy.** `tags.ts` is the single declaration of every tag. Two rules
+are asserted rather than reviewed: one admin-tag convention (`Admin: X`), and no
+undeclared or orphaned tags — a tag a controller uses but nobody declares
+renders undescribed and ungrouped, and a tag nobody uses renders an empty
+section. Tags no operation uses are pruned from `tags` and `x-tagGroups`, which
+is what lets one static taxonomy be correct in both environments: the
+`Test Authentication` module is registered only outside production.
+
+**Operation ids.** `buildOperationId` produces `media_listMedia` rather than
+Nest's default `MediaController_listMedia` — the controller stays a namespace,
+so two `list` handlers cannot collide, without the noise a generator would bake
+into every SDK method name. Uniqueness is asserted.
+
+**Tests.** `test/openapi/openapi-document.spec.ts` boots the real `AppModule`
+and asserts the finished document; `src/openapi/*.spec.ts` cover the pure passes.
+
+**CI.** `scripts/dump-openapi.ts` writes the document to a file, booting the app
+in Nest's **preview mode** — every module loaded and every controller's metadata
+read, no provider instantiated — so it runs on a bare checkout with no database,
+no credentials, and no cron or worker loops started. `NODE_ENV` is forced to
+production so the dumped spec is the one a deployment publishes.
+
+The `openapi` CI job generates the spec, lints it with Spectral (errors fail the
+build; the ruleset in `.spectral.yaml` records a reason for every override), and
+on a pull request posts a diff against the base branch into the job summary. The
+diff is best-effort by construction — it borrows the checkout's `node_modules`
+for the base worktree, which dependency drift can invalidate — and never fails a
+PR over information.
+
+Locally:
+
+```bash
+npm run openapi:dump    # writes ./openapi.json
+npm run openapi:lint    # Spectral
+```
+
+---
+
+## 8. Out of scope
+
+- Generating and publishing client SDKs. Stable operation ids and a valid 3.1
+  document make it possible; it is tracked separately.
+- A hosted developer portal. The reference stays same-origin at `/api/docs`.
+- Behavioral changes to any endpoint, auth flow, or permission. The only
+  additive runtime behavior is the docs page's token helper.
+- Converting the remaining class-based `@ApiProperty` DTOs to zod. Converge
+  opportunistically, not as a sweep.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
       ],
       "dependencies": {
         "ink": "^6.8.0"
+      },
+      "devDependencies": {
+        "@stoplight/spectral-cli": "^6.16.3"
       }
     },
     "apps/api": {
@@ -380,6 +383,16 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@asyncapi/specs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.11.1.tgz",
+      "integrity": "sha512-A3WBLqAKGoJ2+6FWFtpjBlCQ1oFCcs4GxF7zsIGvNqp/klGUHjlA3aAcZ9XMMpLGE8zPeYDz2x9FmO6DSuKraQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
     },
     "node_modules/@aws-sdk/checksums": {
       "version": "3.1000.22",
@@ -3969,6 +3982,45 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/ternary": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.4.tgz",
+      "integrity": "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -4953,6 +5005,44 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@open-draft/deferred-promise": {
@@ -7211,6 +7301,112 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+      "integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -7338,6 +7534,785 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@stoplight/better-ajv-errors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
+      "integrity": "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/@stoplight/json": {
+      "version": "3.21.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.7.tgz",
+      "integrity": "sha512-xcJXgKFqv/uCEgtGlPxy3tPA+4I+ZI4vAuMJ885+ThkTHFVkC+0Fm58lA9NlsyjnkpxFh4YiQWpH+KefHdbA0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.3",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+      "integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-resolver": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.6.tgz",
+      "integrity": "sha512-YNcWv3R3n3U6iQYBsFOiWSuRGE5su1tJSiX6pAPRVk7dP0L7lqCteXGzuVRQ0gMZqUl8v1P0+fAKxF6PLo9B5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "^3.21.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
+        "dependency-graph": "~0.11.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^9.0.6",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "urijs": "^1.19.11"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json/node_modules/jsonc-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+      "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stoplight/json/node_modules/safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stoplight/ordered-object-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.5.tgz",
+      "integrity": "sha512-COTiuCU5bgMUtbIFBuyyh2/yVVzlr5Om0v5utQDgBCuQUOPgU1DwoffkTfg4UBQOvByi5foF4w4T+H9CoRe5wg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/path": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+      "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli": {
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.3.tgz",
+      "integrity": "sha512-corAOQ/WhGoPJOQ3Tcipyn64TgKYDkEhsDplS6vNSGys3kzi9+zzxiVOlbzk9mWuafovzoW+TpGCoNwIZvFf5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": "^1.19.5",
+        "@stoplight/spectral-formatters": "^1.4.1",
+        "@stoplight/spectral-parsers": "^1.0.4",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-ruleset-bundler": "^1.6.0",
+        "@stoplight/spectral-ruleset-migrator": "^1.11.0",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "chalk": "4.1.2",
+        "fast-glob": "~3.2.12",
+        "hpagent": "~1.2.0",
+        "lodash": "^4.18.1",
+        "pony-cause": "^1.1.1",
+        "stacktracey": "^2.1.8",
+        "tslib": "^2.8.1",
+        "yargs": "~17.7.2"
+      },
+      "bin": {
+        "spectral": "dist/index.js"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stoplight/spectral-core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.1.tgz",
+      "integrity": "sha512-VLC8OhpO/pMJKb6IHhurxJjXO1qB56Ng1unIb8b+hNxdw0+SEcASvmR+RpjfHYX/jv/DfSaA1x8QhFBJBmqBOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.18.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.1",
+        "es-aggregate-error": "^1.0.7",
+        "expr-eval-fork": "^3.0.1",
+        "jsonpath-plus": "^10.3.0",
+        "lodash": "^4.18.1",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "^3.1.4",
+        "nimma": "0.2.3",
+        "pony-cause": "^1.1.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.6.0.tgz",
+      "integrity": "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/spectral-formats": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.5.tgz",
+      "integrity": "sha512-xaC0rCH0p7/bzNJsz+JgLSj+Cp6uwYGWpePQxdLkF2G6a8Zyp3OyS7umkGYNiimEwKrOjvCNNTFJpeuiENZSBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@types/json-schema": "^7.0.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formatters/-/spectral-formatters-1.5.1.tgz",
+      "integrity": "sha512-mGXaiIrPglPokSnbFqbkWN3DoozIbwrZAA6OgqSIl+djeD5+e6PMELg0g6r3ot3ZzntO+6/GXaDnxEQ/p9M/EQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.15.0",
+        "@types/markdown-escape": "^1.1.3",
+        "chalk": "4.1.2",
+        "cliui": "7.0.4",
+        "lodash": "^4.18.1",
+        "markdown-escape": "^2.0.0",
+        "node-sarif-builder": "^2.0.3",
+        "strip-ansi": "6.0",
+        "text-table": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-formatters/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.5.tgz",
+      "integrity": "sha512-vDCd0NJ93715bcUpZZ5vNHiyxd4cgHF6tuXsDiXOXKAByg+I1fR5/dMijEo6Ce1Lz95a+RZ22JKYhF1YuzVvuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.1",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "ajv": "^8.18.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.1",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/spectral-parsers": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-parsers/-/spectral-parsers-1.0.5.tgz",
+      "integrity": "sha512-ANDTp2IHWGvsQDAY85/jQi9ZrF4mRrA5bciNHX+PUxPr4DwS6iv4h+FVWJMVwcEYdpyoIdyL+SRmHdJfQEPmwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/types": "^14.1.1",
+        "@stoplight/yaml": "~4.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-parsers/node_modules/@stoplight/types": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-ref-resolver": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ref-resolver/-/spectral-ref-resolver-1.0.5.tgz",
+      "integrity": "sha512-gj3TieX5a9zMW29z3mBlAtDOCgN3GEc1VgZnCVlr5irmR4Qi5LuECuFItAq4pTn5Zu+sW5bqutsCH7D4PkpyAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json-ref-readers": "1.2.2",
+        "@stoplight/json-ref-resolver": "~3.1.6",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "dependency-graph": "0.11.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-bundler": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.7.0.tgz",
+      "integrity": "sha512-PpIdj5Wje0T7ktxY8EUzBWLU0+mGGQHznT8nlQxTMnRhWLNYsm6HvSZDXLtMi+86yqvTuf7loJy6JvLBDzHGAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rollup/plugin-commonjs": "~22.0.2",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": ">=1",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": ">=1",
+        "@stoplight/spectral-parsers": ">=1",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-ruleset-migrator": "^1.9.6",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/node": "*",
+        "pony-cause": "1.1.1",
+        "rollup": "~2.80.0",
+        "tslib": "^2.8.1",
+        "validate-npm-package-name": "3.0.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-migrator": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.2.tgz",
+      "integrity": "sha512-9hTcyXnBGppM1kMA8vVvY6aWzF3vXbU7+mZvvd9wdPE8QdHj9NO//1s+A/TfiWOKdH9GOERC5NITCnVvbEYEWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/ordered-object-literal": "~1.0.4",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@stoplight/yaml": "~4.2.3",
+        "@types/node": "*",
+        "ajv": "^8.18.0",
+        "ast-types": "0.14.2",
+        "astring": "^1.9.0",
+        "reserved": "0.1.2",
+        "tslib": "^2.8.1",
+        "validate-npm-package-name": "3.0.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/@stoplight/yaml": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.3.tgz",
+      "integrity": "sha512-Mx01wjRAR9C7yLMUyYFTfbUf5DimEpHMkRDQ1PKLe9dfNILbgdxyrncsOXM3vCpsQ1Hfj4bPiGl+u4u6e9Akqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.1",
+        "@stoplight/types": "^13.0.0",
+        "@stoplight/yaml-ast-parser": "0.0.48",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+      "integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stoplight/spectral-rulesets": {
+      "version": "1.22.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.7.tgz",
+      "integrity": "sha512-cT1B6Ly21923lvr235lu7iIgmcnoCTJaN3ANOyTqr4D5GA/4p2k0+yhjhdfj/1ks/Os3kUzSFnFkzpWH7WszFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asyncapi/specs": "6.11.1",
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.23.0",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "^13.6.0",
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^8.18.0",
+        "ajv-formats": "~2.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "leven": "3.1.0",
+        "lodash": "^4.18.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-rulesets/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/spectral-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.6.tgz",
+      "integrity": "sha512-Y8rEDyMN4bSMJCrDs2shdcVHYyCnH3FvXRP4dBhha4Z8iJv+JPp7KqOV/hwVB/hWFC209upiwj2oDmLfR0qCDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "^3.20.1",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "lodash": "^4.18.1",
+        "node-fetch": "^2.7.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-runtime/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/spectral-runtime/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stoplight/spectral-runtime/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@stoplight/spectral-runtime/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@stoplight/types": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.20.0.tgz",
+      "integrity": "sha512-2FNTv05If7ib79VPDA/r9eUet76jewXFH2y2K5vuge6SXbRHtWBhcaRmu+6QpF4/WRNoJj5XYRSwLGXDxysBGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.3.0.tgz",
+      "integrity": "sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.5",
+        "@stoplight/types": "^14.1.1",
+        "@stoplight/yaml-ast-parser": "0.0.50",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.50.tgz",
+      "integrity": "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stoplight/yaml/node_modules/@stoplight/types": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -7707,6 +8682,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/es-aggregate-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.6.tgz",
+      "integrity": "sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -7889,6 +8874,13 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-escape": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-escape/-/markdown-escape-1.1.3.tgz",
+      "integrity": "sha512-JIc1+s3y5ujKnt/+N+wq6s/QdL2qZ11fP79MijrVXsAAnzSxCbT2j/3prHRouJdZ2yFLN3vkP0HytfnoCczjOw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/memcached": {
@@ -8090,6 +9082,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -8167,6 +9166,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.26",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.26.tgz",
+      "integrity": "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.15.10",
@@ -9273,6 +10279,31 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
@@ -9565,12 +10596,61 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -9587,6 +10667,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
@@ -9608,11 +10701,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -9640,6 +10753,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/avvio": {
@@ -10158,6 +11287,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
@@ -10264,6 +11406,13 @@
         "node": ">=0.2.0"
       }
     },
+    "node_modules/builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/c12": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
@@ -10321,6 +11470,25 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -10931,6 +12099,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -11335,6 +12510,60 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -11523,6 +12752,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/dequal": {
@@ -11831,6 +13070,117 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-aggregate-error": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.14.tgz",
+      "integrity": "sha512-3YxX6rVb07B5TV11AV5wsL7nQCHXNwoHPsQC8S4AmBiqYhyNCJ5BRKXkXyDJvs8QzXN20NgRtxe3dEEQD9NLHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "globalthis": "^1.0.4",
+        "has-property-descriptors": "^1.0.2",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -11882,6 +13232,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-toolkit": {
@@ -12145,6 +13516,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
@@ -12230,6 +13611,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -12276,6 +13674,13 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
@@ -12496,6 +13901,19 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
@@ -12542,6 +13960,22 @@
       "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -12855,6 +14289,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gaxios": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
@@ -12892,6 +14360,16 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -12981,6 +14459,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/get-source/node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-source/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -12992,6 +14498,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/giget": {
@@ -13025,6 +14549,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -13184,6 +14721,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13200,6 +14750,22 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13313,6 +14879,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -13424,6 +15000,17 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -13649,6 +15236,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -13667,11 +15269,95 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -13680,6 +15366,83 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13713,6 +15476,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-in-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
@@ -13737,12 +15533,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -13758,6 +15607,64 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -13769,6 +15676,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -13788,6 +15746,52 @@
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -15540,6 +17544,16 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -15636,6 +17650,35 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -16328,6 +18371,13 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -16517,6 +18567,13 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-2.0.0.tgz",
+      "integrity": "sha512-Trz4v0+XWlwy68LJIyw3bLbsJiC8XAbRCKF9DbEtZjyndKOGVx6n+wNB0VfoRmY2LKboQLeniap3xrb6LGSJ8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/matcher": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
@@ -16590,6 +18647,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -16598,6 +18665,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -17032,6 +19126,26 @@
         }
       }
     },
+    "node_modules/nimma": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
+      "integrity": "sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsep-plugin/regex": "^1.0.1",
+        "@jsep-plugin/ternary": "^1.0.2",
+        "astring": "^1.8.1",
+        "jsep": "^1.2.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "optionalDependencies": {
+        "jsonpath-plus": "^6.0.1 || ^10.1.0",
+        "lodash.topath": "^4.5.2"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.94.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
@@ -17116,6 +19230,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-sarif-builder": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-2.0.3.tgz",
+      "integrity": "sha512-Pzr3rol8fvhG/oJjIq2NTVB0vmdNNlz22FENhhPojYRZ4/ee08CfK4YuKmuL54V9MLhI1kpzxfOJ/63LzmZzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.4",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
@@ -17188,6 +19316,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -17424,6 +19573,25 @@
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -17961,6 +20129,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/pony-cause": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
+      "integrity": "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==",
+      "dev": true,
+      "license": "0BSD",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
@@ -18114,6 +20302,13 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/prisma": {
       "version": "7.9.1",
@@ -18276,6 +20471,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -18567,11 +20783,55 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/remeda": {
       "version": "2.33.4",
@@ -18619,6 +20879,15 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
+    },
+    "node_modules/reserved": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved/-/reserved-0.1.2.tgz",
+      "integrity": "sha512-/qO54MWj5L8WCBP9/UNe2iefJc+L9yETbH32xO/ft/EYPOTCR5k+azvDUgdCOKwZH8hXwPd0b8XBL78Nn2U69g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -18854,6 +21123,46 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -18862,6 +21171,33 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -18882,6 +21218,48 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-regex2": {
       "version": "5.1.1",
@@ -19058,6 +21436,55 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -19365,6 +21792,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -19410,6 +21845,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -19435,6 +21881,20 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -19564,6 +22024,66 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -20158,6 +22678,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thread-stream": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
@@ -20255,6 +22782,19 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/to-rotated": {
       "version": "1.0.0",
@@ -20597,6 +23137,84 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -20653,6 +23271,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici": {
@@ -20840,6 +23477,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -20854,6 +23498,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -20916,6 +23570,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^1.0.3"
       }
     },
     "node_modules/validator": {
@@ -21370,6 +24034,102 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "api:test": "npm -w apps/api test",
     "web:test": "npm -w apps/web test",
     "audit:triage": "node scripts/audit-triage.mjs",
+    "openapi:dump": "npm run openapi:dump --workspace=api -- ../../openapi.json",
+    "openapi:lint": "spectral lint openapi.json --ruleset .spectral.yaml --fail-severity=error",
     "postinstall": "node scripts/patch-react-transition-group.js"
   },
   "overrides": {
@@ -30,5 +32,8 @@
   },
   "dependencies": {
     "ink": "^6.8.0"
+  },
+  "devDependencies": {
+    "@stoplight/spectral-cli": "^6.16.3"
   }
 }


### PR DESCRIPTION
## Summary

Turns `/api/docs` from the scaffold's unconfigured Swagger UI over an "Enterprise App API" document into a branded, interactive [Scalar](https://scalar.com) reference backed by a valid OpenAPI **3.1** spec — with one-click session authorization, a grouped and described tag taxonomy, permissions generated from the guards themselves, accurate response shapes, and CI gates that stop the spec rotting again.

Implements all seven phases of epic #414. No endpoint, auth flow, or permission behavior changes; the only additive runtime behavior is the docs page's token helper.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Fixes #414

## Changes Made

**Branding & metadata (phase 1)** — MemoriaHub title, version resolved from the deployed build (was a hardcoded `1.0`), same-origin server, contact/external-docs links, and a Markdown getting-started guide baked into `info.description` covering the four ways to obtain a token, the response envelope, both pagination styles, the error shape, and the two-layer permission model. `cleanupOpenApiDoc` now runs so zod-derived DTOs emit real JSON Schema.

**Tag taxonomy (phase 2)** — All 62 tags declared once in `openapi/tags.ts` with descriptions and a deliberate order, grouped into 13 `x-tagGroups` sidebar sections. The three coexisting admin-tag conventions (`Admin - X`, `Admin — X`, `Admin: X`) are normalized to `Admin: X`. Tags no operation uses are pruned, which is what lets one static taxonomy be correct in both environments — `Test Authentication` is registered only outside production.

**Scalar UI + session auth (phases 3–4)** — `/api/docs` serves a searchable sectioned sidebar, built-in request client, generated code samples, and dark mode. Landing on it while signed in leaves the client **already authorized**: the page exchanges the browser's refresh cookie for an access token and hands it to Scalar as pre-authorization before mounting. `/api/openapi.json` is unchanged as the canonical machine-readable spec. PAT (`pat_…`) and node-credential (`nod_…`) schemes are documented and attached to the operations that actually accept them, derived from the path and guard marker.

**Self-documenting RBAC (phase 5)** — `@Auth()` stamps an `x-rbac` extension; a document pass renders it into each operation's description ("**Requires:** authentication, plus permission `media:read`."). `ErrorDto` describes the real `HttpExceptionFilter` envelope and is attached as the `default` response everywhere.

**Response-shape audit (phase 6)** — See "the drift was structural" below.

**Spec quality gates (phase 7)** — `operationIdFactory` (`media_listMedia`, not `MediaController_listMedia`), a Spectral ruleset, `npm run openapi:dump` / `openapi:lint`, and a CI job that generates the spec, lints it, and posts a diff against the base branch on PRs.

### Three findings worth a reviewer's attention

**1. The response-shape drift was structural, not a handful of endpoints.** `TransformInterceptor` is a global `APP_INTERCEPTOR` that wraps every handler return value in `{ data, meta }`, while `@ApiResponse({ type: Dto })` describes what the handler returns — so almost every documented response was one level off from the wire. `applyDataEnvelope` performs on the document exactly the transformation the interceptor performs on the response, which fixes all of them and stays fixed. Editing ~70 controllers would have been a large sweep that the next new endpoint immediately reopens.

**2. Spectral found a real defect.** Fifteen controllers called `@ApiBearerAuth()` with no scheme name, emitting `security: [{ bearer: [] }]` against a scheme the document never defined. Not cosmetic: an undefined scheme gives the Authorize dialog nothing to attach, so a reader who *had* authorized still got `401` from every one of those operations. Also fixed several schemas that contradicted the wire — `GET /api/users?isActive=` documented as a boolean though it is a query string parsed into one, numeric examples on implicitly-string pagination params, and six `string | null` fields publishing `type: object` because that type reflects as `Object` without an explicit `type`.

**3. OpenAPI 3.1 was required, and it opens a `nullable` trap.** zod v4 emits JSON Schema 2020-12, which 3.0 rejects — the zod DTOs were publishing numeric `exclusiveMinimum` and `propertyNames` keywords that are invalid there. But `@ApiProperty({ nullable: true })` emits the 3.0 spelling, and 3.1 removed the keyword: a 3.1 consumer reads `type: "string"` and generates a **non-nullable** field, wrong about exactly the values most likely to break a client. `applyNullableFor31` rewrites all 28 occurrences into `type: ["string", "null"]` (and a nullable `$ref` into a `oneOf`). It walks the document rather than being fixed at each call site, because the next `@ApiProperty` written will use the 3.0 spelling too — that is what the decorator's own types document.

### Two implementation decisions worth confirming

- **`@scalar/nestjs-api-reference` was installed, then dropped** in favour of a ~60-line template we control. Its template's last statement *is* the `createApiReference` call, and the pre-auth fetch has to resolve before it (the token cannot be resolved server-side either — the refresh cookie is scoped to `path=/api/auth` and never reaches `/api/docs`). String-surgery on generated HTML was the alternative.
- **The Scalar bundle loads from a CDN**, matching Scalar's own default. For a self-hosted product that means `/api/docs` is blank without internet, so `API_DOCS_CDN` points the page at a self-hosted copy. Bundling `@scalar/api-reference` would add ~11 MB to the API image — happy to pay that instead if preferred.

## Testing

- [x] Unit tests pass (`npm test`) — API **7,909 passed**, web **4,988 passed**, 0 failures
- [x] Type checks pass (`npm run typecheck`) — api, web, and the new `scripts/tsconfig.json`
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — spec generated and linted end to end

Spectral reports **no errors** over the generated document (344 operations). The dump script runs on a bare checkout with no database: it boots the app in Nest's preview mode, so every module is loaded and every controller's metadata read while no provider is instantiated, no cron starts, and nothing needs tearing down.

New coverage: `test/openapi/openapi-document.spec.ts` boots the real `AppModule` and asserts the finished document (one admin-tag convention, no undeclared or orphaned tags, every tag described and grouped, unique operation ids, a requirements line on every guarded operation, correct auth schemes per route, the error envelope everywhere, no `nullable` left); `test/openapi/docs-routes.spec.ts` exercises both routes end to end; `src/openapi/*.spec.ts` cover the pure passes.

### Test Instructions

1. `npm run openapi:dump && npm run openapi:lint` — writes `./openapi.json` and lints it; expect "No results with a severity of 'error' found!"
2. Start the app and open http://localhost:3535/api/docs **while signed in to MemoriaHub in the same browser**. The header bar should read "Authorized with your session"; expand any authenticated operation and send a request from the built-in client without pasting a token. Reload — it should re-authorize.
3. Open it signed out: the bar should read "Not signed in — sign in to MemoriaHub, then reload" and the reference should still render.
4. Check the sidebar groups, and confirm any guarded operation's description ends with a generated **Requires:** line naming its real permission.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

New spec: [`docs/specs/api-documentation.md`](docs/specs/api-documentation.md). README, CLAUDE.md, `docs/API.md`, and the changelog are updated to describe the Scalar reference rather than stock Swagger UI.

One partial against the epic's success criteria, stated plainly: **per-circle roles are declared, not inferred.** There is no per-circle guard to derive them from — membership is checked inside the services — so `@Auth({ circleRole })` exists to state it where a route enforces one, but it is not applied across the circle-scoped controllers in this PR. System permissions *are* generated everywhere. Applying `circleRole` route-by-route is a good follow-up; a partial sweep would read as inconsistent, so I left it at zero rather than some.

The dependency added is `@stoplight/spectral-cli` (devDependency, CI only). The PR spec diff is best-effort by construction — it borrows the checkout's `node_modules` for the base worktree, which dependency drift can invalidate, and a base branch predating this job cannot produce a spec at all; both outcomes report "skipped" rather than failing a PR over information.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoggyB7kFqD8J3yfZaK3hF)_