### PR TITLE
fix(api): "Authorize with my session" never authorized — read the token out of the { data } envelope

### DIFF
--- a/apps/api/src/openapi/docs-auth-script.spec.ts
+++ b/apps/api/src/openapi/docs-auth-script.spec.ts
@@ -1,0 +1,164 @@
+import { buildDocsAuthScript, renderDocsPage } from './docs-page';
+
+/**
+ * Runs the docs page's bootstrap script for real.
+ *
+ * This suite exists because of a defect it would have caught: the page read the
+ * refresh response as `body.accessToken`, but the global `TransformInterceptor`
+ * wraps every JSON body in `{ data, meta }`, so the token was always
+ * `undefined`. Scalar mounted unauthenticated and every request from the docs
+ * page returned 401.
+ *
+ * Nothing failed, because the only tests over this code asserted that the HTML
+ * *contained* `fetch('/api/auth/refresh')` and `credentials: 'include'`. String
+ * matching on a script proves it was written, not that it works. So these tests
+ * evaluate the exact string the browser is served, against stubbed globals.
+ */
+
+interface Harness {
+  run: (fetchImpl: jest.Mock) => Promise<unknown>;
+  status: () => { text: string; kind: string };
+  mountedConfig: () => Record<string, unknown> | undefined;
+  clickAuthorize: () => void;
+  reloads: () => number;
+}
+
+const CONFIG = { url: '/api/openapi.json', layout: 'modern' };
+const SCHEME = 'JWT-auth';
+
+/**
+ * Evaluates the script with `document`, `fetch` and `window` supplied as
+ * parameters, which shadow the globals the browser would provide.
+ */
+function harness(): Harness {
+  const script = buildDocsAuthScript(CONFIG, SCHEME);
+
+  const statusEl = { textContent: '', className: '' };
+  let clickHandler: (() => void) | undefined;
+  const buttonEl = {
+    addEventListener: (_event: string, handler: () => void) => {
+      clickHandler = handler;
+    },
+  };
+
+  let mountedConfig: Record<string, unknown> | undefined;
+  let reloads = 0;
+
+  const documentStub = {
+    getElementById: (id: string) => (id === 'mh-status' ? statusEl : buttonEl),
+  };
+  const windowStub: Record<string, unknown> = {
+    Scalar: {
+      createApiReference: (_selector: string, config: Record<string, unknown>) => {
+        mountedConfig = config;
+      },
+    },
+    location: {
+      reload: () => {
+        reloads += 1;
+      },
+    },
+  };
+
+  return {
+    run: async (fetchImpl) => {
+      // eslint-disable-next-line no-new-func
+      const evaluate = new Function('window', 'document', 'fetch', script);
+      evaluate(windowStub, documentStub, fetchImpl);
+      return windowStub.__memoriaHubDocsAuth;
+    },
+    status: () => ({ text: statusEl.textContent, kind: statusEl.className }),
+    mountedConfig: () => mountedConfig,
+    clickAuthorize: () => clickHandler?.(),
+    reloads: () => reloads,
+  };
+}
+
+const jsonResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+describe('docs page bootstrap script', () => {
+  it('reads the token out of the { data } envelope the API actually returns', async () => {
+    const h = harness();
+    const fetchImpl = jest.fn().mockResolvedValue(
+      // The exact wire shape: TransformInterceptor wraps the handler's
+      // `{ accessToken, expiresIn }` return value.
+      jsonResponse({ data: { accessToken: 'tok-123', expiresIn: 900 }, meta: { timestamp: 'x' } }),
+    );
+
+    await h.run(fetchImpl);
+
+    expect(h.mountedConfig()?.authentication).toEqual({
+      preferredSecurityScheme: SCHEME,
+      securitySchemes: { [SCHEME]: { token: 'tok-123' } },
+    });
+    expect(h.status()).toEqual({ text: 'Authorized with your session', kind: 'mh-ok' });
+  });
+
+  it('also accepts an unwrapped body, so it survives the envelope changing', async () => {
+    const h = harness();
+    await h.run(jest.fn().mockResolvedValue(jsonResponse({ accessToken: 'tok-bare' })));
+
+    expect(h.mountedConfig()?.authentication).toEqual({
+      preferredSecurityScheme: SCHEME,
+      securitySchemes: { [SCHEME]: { token: 'tok-bare' } },
+    });
+  });
+
+  it('calls the refresh endpoint with the cookie attached', async () => {
+    const h = harness();
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ data: { accessToken: 't' } }));
+
+    await h.run(fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/auth/refresh',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    );
+  });
+
+  it('still mounts, unauthorized, when the caller is not signed in', async () => {
+    const h = harness();
+    await h.run(jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+
+    expect(h.mountedConfig()).toBeDefined();
+    expect(h.mountedConfig()?.authentication).toBeUndefined();
+    expect(h.status().text).toContain('Not signed in');
+    expect(h.status().kind).toBe('mh-warn');
+  });
+
+  it('still mounts when the refresh request itself fails', async () => {
+    const h = harness();
+    await h.run(jest.fn().mockRejectedValue(new Error('offline')));
+
+    expect(h.mountedConfig()).toBeDefined();
+    expect(h.status().kind).toBe('mh-warn');
+  });
+
+  it('preserves the rest of the configuration when authorizing', async () => {
+    const h = harness();
+    await h.run(jest.fn().mockResolvedValue(jsonResponse({ data: { accessToken: 't' } })));
+
+    expect(h.mountedConfig()).toMatchObject(CONFIG);
+  });
+
+  it('reloads on Authorize, which is what re-runs the exchange', async () => {
+    const h = harness();
+    await h.run(jest.fn().mockResolvedValue(jsonResponse({ data: { accessToken: 't' } })));
+
+    expect(h.reloads()).toBe(0);
+    h.clickAuthorize();
+    expect(h.reloads()).toBe(1);
+  });
+
+  it('is the same script the rendered page serves', () => {
+    // Otherwise these tests could pass against a script the page does not use.
+    const html = renderDocsPage({
+      title: 'T',
+      version: '1.0.0',
+      specUrl: '/api/openapi.json',
+      cdn: 'https://example.test/bundle.js',
+    });
+    expect(html).toContain('window.__memoriaHubDocsAuth');
+    expect(html).toContain('(body && body.data) || body');
+  });
+});

--- a/apps/api/src/openapi/docs-page.spec.ts
+++ b/apps/api/src/openapi/docs-page.spec.ts
@@ -47,25 +47,28 @@ describe('renderDocsPage', () => {
   });
 
   describe('one-click session auth', () => {
+    // Only the wiring is asserted here — that the page carries the bootstrap and
+    // loads the bundle before it. The bootstrap's BEHAVIOUR is covered in
+    // docs-auth-script.spec.ts, which evaluates it. Matching strings in this
+    // file is what let a broken token read ship: the page contained
+    // `fetch('/api/auth/refresh')` exactly as asserted, and did not work.
     const html = renderDocsPage(options);
 
-    it('exchanges the refresh cookie for an access token', () => {
-      expect(html).toContain("fetch('/api/auth/refresh'");
-      // The cookie is path-scoped to /api/auth, so it rides along only with
-      // credentials: 'include'. Without this the whole feature silently no-ops.
-      expect(html).toContain("credentials: 'include'");
+    it('embeds the bootstrap', () => {
+      expect(html).toContain('window.__memoriaHubDocsAuth');
     });
 
-    it('pre-authorizes the client before mounting it', () => {
+    it('loads the Scalar bundle before the script that calls into it', () => {
+      expect(html.indexOf('<script src=')).toBeLessThan(
+        html.indexOf('window.__memoriaHubDocsAuth'),
+      );
+    });
+
+    it('pre-authorizes before mounting, never after', () => {
       const fetchAt = html.indexOf('fetchSessionToken');
       const mountAt = html.indexOf('createApiReference');
       expect(fetchAt).toBeGreaterThan(-1);
       expect(fetchAt).toBeLessThan(mountAt);
-      expect(html).toContain('preferredSecurityScheme');
-    });
-
-    it('tells a signed-out reader what to do instead of failing silently', () => {
-      expect(html).toContain('Not signed in');
     });
   });
 

--- a/apps/api/src/openapi/docs-page.ts
+++ b/apps/api/src/openapi/docs-page.ts
@@ -115,9 +115,33 @@ export function renderDocsPage(options: DocsPageOptions): string {
     <div id="app"></div>
     <script src="${escapeHtml(cdn)}"></script>
     <script>
-      (function () {
-        var CONFIG = ${jsonForScript(scalarConfig)};
-        var SCHEME = ${jsonForScript(SESSION_SECURITY_SCHEME)};
+${buildDocsAuthScript(scalarConfig, SESSION_SECURITY_SCHEME)}
+    </script>
+  </body>
+</html>
+`;
+}
+
+/**
+ * The page's only runtime logic: exchange the session cookie for an access
+ * token, then mount Scalar pre-authorized with it.
+ *
+ * Exported, and returned as a standalone string, so `docs-page.spec.ts` can
+ * **execute** it against stubbed globals rather than pattern-match the markup.
+ * That distinction is not academic — this shipped broken precisely because the
+ * tests asserted the page *contained* `fetch('/api/auth/refresh')` and never ran
+ * it, so nothing noticed the response was being read one level too shallow.
+ *
+ * A plain string rather than a serialized TypeScript function on purpose: a
+ * function put through `Function.prototype.toString()` carries whatever the
+ * compiler emitted, including coverage instrumentation under `test:cov`, which
+ * would be broken JavaScript in a browser. A string is inert data, and the spec
+ * evaluates exactly the bytes the browser receives.
+ */
+export function buildDocsAuthScript(config: unknown, scheme: string): string {
+  return `      (function () {
+        var CONFIG = ${jsonForScript(config)};
+        var SCHEME = ${jsonForScript(scheme)};
         var statusEl = document.getElementById('mh-status');
         var buttonEl = document.getElementById('mh-auth');
 
@@ -137,7 +161,14 @@ export function renderDocsPage(options: DocsPageOptions): string {
             headers: { Accept: 'application/json' },
           })
             .then(function (res) { return res.ok ? res.json() : null; })
-            .then(function (body) { return (body && body.accessToken) || null; })
+            .then(function (body) {
+              // The global response interceptor wraps every JSON body in
+              // { data, meta }, so the token is at body.data.accessToken — NOT
+              // body.accessToken. Tolerating both mirrors the web client, and
+              // means this keeps working whichever shape the endpoint returns.
+              var payload = (body && body.data) || body;
+              return (payload && payload.accessToken) || null;
+            })
             .catch(function () { return null; });
         }
 
@@ -149,23 +180,23 @@ export function renderDocsPage(options: DocsPageOptions): string {
             config.authentication = { preferredSecurityScheme: SCHEME, securitySchemes: schemes };
             setStatus('Authorized with your session', 'ok');
           } else {
-            setStatus('Not signed in — sign in to MemoriaHub, then reload', 'warn');
+            setStatus('Not signed in \u2014 sign in to MemoriaHub, then reload', 'warn');
           }
           window.Scalar.createApiReference('#app', config);
+          return token;
         }
 
         // Re-authorizing means re-mounting, and re-mounting cleanly is what a
-        // reload already does. The auto-fetch on load is what makes the button
-        // rarely necessary: land on this page signed in and the client below is
-        // already authorized.
+        // reload already does — the fetch above runs again on load. The button
+        // is for a token that has expired (15 minutes); landing here signed in
+        // needs no click at all.
         buttonEl.addEventListener('click', function () { window.location.reload(); });
 
-        fetchSessionToken().then(mount);
-      })();
-    </script>
-  </body>
-</html>
-`;
+        // Exposed so the spec can await the bootstrap, and so a reader
+        // debugging an authorization problem in the console has something to
+        // inspect.
+        window.__memoriaHubDocsAuth = fetchSessionToken().then(mount);
+      })();`;
 }
 
 /**


### PR DESCRIPTION
## Summary

The docs page's one-click session auth was broken on arrival. It read the refresh response as `body.accessToken`, but the global `TransformInterceptor` wraps every JSON body in `{ data, meta }` — so the token was always `undefined`, Scalar mounted unauthenticated, and every request from `/api/docs` returned `401`. Reported from a screen recording; reproduced and fixed.

Not user error: nothing about the page indicated it had failed except the yellow "Not signed in" status, and clicking **Authorize with my session** reloads (which re-runs the same broken read).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #414 (regression in #415)

## Changes Made

**The fix** — one line. The token read is now `(body && body.data) || body`, tolerating both shapes, exactly as `apps/web/src/services/api.ts` already does with an explicit comment about this same interceptor.

This was doubly avoidable: #415 added a whole document pass (`applyDataEnvelope`) whose entire subject is that envelope, and the web client unwraps it two files away.

**Why it shipped, and what stops the next one** — the only coverage over this code asserted the rendered HTML *contained* `fetch('/api/auth/refresh')` and `credentials: 'include'`. Both were true of the broken page. String-matching a script proves it was written, not that it runs — and this feature's only runtime logic is browser JavaScript embedded in a template string, so nothing ever executed it.

The bootstrap is now produced by an exported `buildDocsAuthScript()`, and `docs-auth-script.spec.ts` **executes** it: `new Function('window', 'document', 'fetch', script)` so those parameters shadow the globals a browser would supply, then asserts against

- the real wire shape (`{ data: { accessToken, expiresIn }, meta }`),
- an unwrapped body (so the fix survives the envelope changing),
- a `401` (mounts unauthorized, warns, does not throw),
- a rejected fetch (same),
- that the config handed to `createApiReference` carries the token under the scheme Scalar expects,
- and that this is the same script the rendered page serves.

Reverting the one-line fix fails two of those tests — verified, not assumed.

It stays a plain **string** rather than a `Function.prototype.toString()`-serialized TypeScript function on purpose: a serialized function carries whatever the compiler emitted, including coverage instrumentation under `test:cov`, which would be broken JavaScript in a browser. A string is inert data, and the spec evaluates exactly the bytes the browser receives.

The weak assertions in `docs-page.spec.ts` are replaced with wiring-only checks (bundle loads before the bootstrap; pre-auth precedes mount) and a comment saying where the behavioural coverage lives, so they can't be mistaken for it again.

## Testing

- [x] Unit tests pass (`npm test`) — 79 passed across the 8 OpenAPI suites
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [x] Manual testing completed — spec regenerated, Spectral clean (344 operations)

Confirmed the new spec is a real guard: with `var payload = body` (the original code) the suite reports **2 failed**; with the fix, **8 passed**.

I also verified the Scalar config shape against `@scalar/types` rather than trusting the earlier assumption — `httpBearer: { token }` under `securitySchemes[name]` with `preferredSecurityScheme` is correct, so the token read was the only defect.

### Test Instructions

1. Open `/api/docs` while signed in to MemoriaHub in the same browser.
2. The header bar should read **"Authorized with your session"** in green (previously yellow "Not signed in").
3. Expand any authenticated endpoint — e.g. `GET /api/users` — and send it from the built-in client. Expect `200`, not `401`.
4. Reload the page; it should re-authorize automatically.
5. Signed out (or in a private window), the bar should read "Not signed in" and the reference should still render.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The branch was rebuilt from `main` after #415 squash-merged, so this contains only the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoggyB7kFqD8J3yfZaK3hF)_