### PR TITLE
feat(api): batch AI enhancement Phase 1 — data model, batch API, and the maxBatchSize guard

### DIFF
--- a/apps/api/prisma/migrations/20260812000000_add_media_enhancement_batches/migration.sql
+++ b/apps/api/prisma/migrations/20260812000000_add_media_enhancement_batches/migration.sql
@@ -1,0 +1,55 @@
+-- AI Picture Enhancer — Bulk Enhance batching (epic #420, issue #421, Phase 1).
+--
+-- Data model only — no service/controller logic lands in this migration.
+--
+-- media_enhancement_batches holds one row per bulk "AI Enhance" request
+-- against multiple MediaItems in a circle. requestedCount is how many items
+-- the caller asked to enhance; queuedCount is how many media_enhancements
+-- rows were actually created (requestedCount minus anything skipped up
+-- front, recorded in `skipped`). `source` distinguishes how the batch was
+-- formed (e.g. "selection" for a gallery multi-select) for future entry
+-- points.
+--
+-- media_enhancements gains a nullable batch_id grouping column, set only for
+-- enhancements created as part of a batch request. ON DELETE SET NULL is
+-- deliberate: deleting a batch record must never delete the enhancements it
+-- produced, which may already be 'applied' — mirrors the existing
+-- media_enhancements_result_media_item_id_fkey SetNull precedent.
+
+-- -----------------------------------------------------------------------------
+-- Table: media_enhancement_batches
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE "media_enhancement_batches" (
+    "id"              UUID        NOT NULL DEFAULT gen_random_uuid(),
+    "circle_id"       UUID        NOT NULL,
+    "requested_count" INTEGER     NOT NULL,
+    "queued_count"    INTEGER     NOT NULL DEFAULT 0,
+    "skipped"         JSONB,
+    "params"          JSONB,
+    "source"          TEXT        NOT NULL DEFAULT 'selection',
+    "cancelled_at"    TIMESTAMPTZ,
+    "last_error"      TEXT,
+    "created_by_id"   UUID,
+    "created_at"      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updated_at"      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT "media_enhancement_batches_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "media_enhancement_batches_circle_id_fkey"
+        FOREIGN KEY ("circle_id") REFERENCES "circles"("id") ON DELETE CASCADE,
+    CONSTRAINT "media_enhancement_batches_created_by_id_fkey"
+        FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX "media_enhancement_batches_circle_id_created_at_idx" ON "media_enhancement_batches" ("circle_id", "created_at");
+
+-- -----------------------------------------------------------------------------
+-- Table: media_enhancements — add batch_id grouping column
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "media_enhancements" ADD COLUMN "batch_id" UUID;
+
+CREATE INDEX "media_enhancements_batch_id_idx" ON "media_enhancements" ("batch_id");
+
+ALTER TABLE "media_enhancements" ADD CONSTRAINT "media_enhancements_batch_id_fkey"
+    FOREIGN KEY ("batch_id") REFERENCES "media_enhancement_batches"("id") ON DELETE SET NULL;

--- a/apps/api/prisma/migrations/20260812010000_add_media_enhancement_cancelled_status/migration.sql
+++ b/apps/api/prisma/migrations/20260812010000_add_media_enhancement_cancelled_status/migration.sql
@@ -1,0 +1,18 @@
+-- AlterEnum
+--
+-- Bulk Enhance batching (epic #420, issue #421, Phase 1).
+--
+-- `ALTER TYPE ... ADD VALUE` cannot run in the same transaction as statements
+-- that REFERENCE the new value, so this gets its own migration containing
+-- nothing else — the same precedent as
+-- 20260705000000_add_media_tag_source_system and
+-- 20260810000000_add_memories_ready_notification_type.
+--
+-- `cancelled` means the row was superseded or withdrawn before a render ever
+-- ran — "never rendered at all". It is deliberately DISTINCT from
+-- `discarded`, which means a human looked at a completed `ready` result and
+-- said no.
+--
+-- IF NOT EXISTS makes the statement idempotent, so a re-applied migration on
+-- a database that already carries the value is a no-op rather than an error.
+ALTER TYPE "MediaEnhancementStatus" ADD VALUE IF NOT EXISTS 'cancelled';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -37,66 +37,68 @@ model User {
   linkedPersonId          String?          @map("linked_person_id") @db.Uuid
 
   // Relations
-  identities                  UserIdentity[]
-  userRoles                   UserRole[]
-  userSettings                UserSettings?
-  auditEvents                 AuditEvent[]                @relation("ActorEvents")
-  settingsUpdates             SystemSettings[]            @relation("SettingsUpdater")
-  refreshTokens               RefreshToken[]              @relation("UserRefreshTokens")
-  allowlistEntriesAdded       AllowedEmail[]              @relation("AllowlistAddedBy")
-  allowlistEntry              AllowedEmail?               @relation("AllowlistClaimedBy")
-  deviceCodes                 DeviceCode[]                @relation("UserDeviceCodes")
-  storageObjects              StorageObject[]             @relation("UserStorageObjects")
-  personalAccessTokens        PersonalAccessToken[]       @relation("UserPersonalAccessTokens")
-  mediaItems                  MediaItem[]                 @relation("MediaAddedBy")
-  albums                      Album[]                     @relation("AlbumAddedBy")
-  tags                        Tag[]                       @relation("TagAddedBy")
+  identities                     UserIdentity[]
+  userRoles                      UserRole[]
+  userSettings                   UserSettings?
+  auditEvents                    AuditEvent[]                @relation("ActorEvents")
+  settingsUpdates                SystemSettings[]            @relation("SettingsUpdater")
+  refreshTokens                  RefreshToken[]              @relation("UserRefreshTokens")
+  allowlistEntriesAdded          AllowedEmail[]              @relation("AllowlistAddedBy")
+  allowlistEntry                 AllowedEmail?               @relation("AllowlistClaimedBy")
+  deviceCodes                    DeviceCode[]                @relation("UserDeviceCodes")
+  storageObjects                 StorageObject[]             @relation("UserStorageObjects")
+  personalAccessTokens           PersonalAccessToken[]       @relation("UserPersonalAccessTokens")
+  mediaItems                     MediaItem[]                 @relation("MediaAddedBy")
+  albums                         Album[]                     @relation("AlbumAddedBy")
+  tags                           Tag[]                       @relation("TagAddedBy")
   // Circle relations
-  ownedCircles                Circle[]                    @relation("CircleOwner")
-  circleMemberships           CircleMember[]
-  circleInvitesAdded          CircleInvite[]              @relation("CircleInviteAddedBy")
-  circleInvitesClaimed        CircleInvite[]              @relation("CircleInviteClaimedBy")
+  ownedCircles                   Circle[]                    @relation("CircleOwner")
+  circleMemberships              CircleMember[]
+  circleInvitesAdded             CircleInvite[]              @relation("CircleInviteAddedBy")
+  circleInvitesClaimed           CircleInvite[]              @relation("CircleInviteClaimedBy")
   // AI Search relations
-  aiCredentialsUpdated        AiProviderCredential[]      @relation("AiCredentialUpdater")
+  aiCredentialsUpdated           AiProviderCredential[]      @relation("AiCredentialUpdater")
   // Face Recognition relations
-  faceCredentialsUpdated      FaceProviderCredential[]    @relation("FaceCredentialUpdater")
+  faceCredentialsUpdated         FaceProviderCredential[]    @relation("FaceCredentialUpdater")
   // Storage Provider relations
-  storageCredentialsUpdated   StorageProviderCredential[] @relation("StorageCredentialUpdater")
-  peopleAdded                 Person[]                    @relation("PersonAddedBy")
-  resolvedBursts              BurstGroup[]                @relation("BurstGroupResolvedBy")
+  storageCredentialsUpdated      StorageProviderCredential[] @relation("StorageCredentialUpdater")
+  peopleAdded                    Person[]                    @relation("PersonAddedBy")
+  resolvedBursts                 BurstGroup[]                @relation("BurstGroupResolvedBy")
   // Duplicate Detection relations
-  resolvedDuplicates          DuplicateGroup[]            @relation("DuplicateGroupResolvedBy")
+  resolvedDuplicates             DuplicateGroup[]            @relation("DuplicateGroupResolvedBy")
   // Geo Provider relations
-  geoCredentialsUpdated       GeoProviderCredential[]     @relation("GeoCredentialUpdater")
+  geoCredentialsUpdated          GeoProviderCredential[]     @relation("GeoCredentialUpdater")
   // Media Sharing relations
-  mediaShares                 MediaShare[]                @relation("MediaShareCreatedBy")
+  mediaShares                    MediaShare[]                @relation("MediaShareCreatedBy")
   // Location Inference relations
-  resolvedLocationSuggestions LocationSuggestion[]        @relation("LocationSuggestionResolvedBy")
+  resolvedLocationSuggestions    LocationSuggestion[]        @relation("LocationSuggestionResolvedBy")
   // Distributed Worker Node relations
-  workerNodes                 WorkerNode[]
-  nodeCredentials             NodeCredential[]            @relation("UserNodeCredentials")
+  workerNodes                    WorkerNode[]
+  nodeCredentials                NodeCredential[]            @relation("UserNodeCredentials")
   // AI Picture Enhancer relations
-  mediaEnhancementsCreated    MediaEnhancement[]          @relation("MediaEnhancementCreatedBy")
+  mediaEnhancementsCreated       MediaEnhancement[]          @relation("MediaEnhancementCreatedBy")
+  // AI Picture Enhancer — bulk batches (epic #420, issue #421)
+  mediaEnhancementBatchesCreated MediaEnhancementBatch[]     @relation("MediaEnhancementBatchCreatedBy")
   // Workflow Automation relations
-  workflowsCreated            Workflow[]                  @relation("WorkflowCreatedBy")
-  workflowRunsStarted         WorkflowRun[]               @relation("WorkflowRunStartedBy")
-  workflowRunsApproved        WorkflowRun[]               @relation("WorkflowRunApprovedBy")
+  workflowsCreated               Workflow[]                  @relation("WorkflowCreatedBy")
+  workflowRunsStarted            WorkflowRun[]               @relation("WorkflowRunStartedBy")
+  workflowRunsApproved           WorkflowRun[]               @relation("WorkflowRunApprovedBy")
   // Empty Trash at Scale relations
-  trashEmptyRunsStarted       TrashEmptyRun[]             @relation("TrashEmptyRunStartedBy")
+  trashEmptyRunsStarted          TrashEmptyRun[]             @relation("TrashEmptyRunStartedBy")
   // Review Runs relations (bursts / duplicates / location suggestions —
   // supersedes the former LocationSuggestionRun-only relation, issue #190)
-  reviewRunsStarted           ReviewRun[]                 @relation("ReviewRunStartedBy")
+  reviewRunsStarted              ReviewRun[]                 @relation("ReviewRunStartedBy")
   // Notification Center relations (epic #240, issue #244; schema-only)
-  notifications               Notification[]              @relation("UserNotifications")
+  notifications                  Notification[]              @relation("UserNotifications")
   // Memories relations (epic #300, issue #301)
-  memoryUserStates            MemoryUserState[]
+  memoryUserStates               MemoryUserState[]
   // PostgreSQL Database Backup & Restore relations (epic #339, issue #340)
-  databaseBackupsCreated      DatabaseBackupRun[]         @relation("DatabaseBackupCreatedBy")
-  databaseBackupsRestored     DatabaseBackupRun[]         @relation("DatabaseBackupRestoredBy")
+  databaseBackupsCreated         DatabaseBackupRun[]         @relation("DatabaseBackupCreatedBy")
+  databaseBackupsRestored        DatabaseBackupRun[]         @relation("DatabaseBackupRestoredBy")
   // Profile picture management relations (issue #354)
-  linkedPerson                Person?                     @relation("UserLinkedPerson", fields: [linkedPersonId], references: [id], onDelete: SetNull)
+  linkedPerson                   Person?                     @relation("UserLinkedPerson", fields: [linkedPersonId], references: [id], onDelete: SetNull)
   // Location Grouping relations (issue #373)
-  locationGroups              LocationGroup[]
+  locationGroups                 LocationGroup[]
 
   @@index([linkedPersonId])
   @@map("users")
@@ -400,44 +402,46 @@ model Circle {
   updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   // Relations
-  owner                 User                  @relation("CircleOwner", fields: [ownerId], references: [id], onDelete: Restrict)
-  members               CircleMember[]
-  invites               CircleInvite[]
-  mediaItems            MediaItem[]
-  albums                Album[]
-  tags                  Tag[]
+  owner                   User                    @relation("CircleOwner", fields: [ownerId], references: [id], onDelete: Restrict)
+  members                 CircleMember[]
+  invites                 CircleInvite[]
+  mediaItems              MediaItem[]
+  albums                  Album[]
+  tags                    Tag[]
   // Face Recognition relations
-  people                Person[]
-  faces                 Face[]
-  enrichmentJobs        EnrichmentJob[]
+  people                  Person[]
+  faces                   Face[]
+  enrichmentJobs          EnrichmentJob[]
   // Auto-Tagging relations
-  mediaTagStatuses      MediaTagStatus[]
+  mediaTagStatuses        MediaTagStatus[]
   // Metadata Re-run relations
-  mediaMetadataStatuses MediaMetadataStatus[]
+  mediaMetadataStatuses   MediaMetadataStatus[]
   // Geocode Status relations
-  mediaGeocodeStatuses  MediaGeocodeStatus[]
+  mediaGeocodeStatuses    MediaGeocodeStatus[]
   // Burst Detection relations
-  bursts                BurstGroup[]
+  bursts                  BurstGroup[]
   // Duplicate Detection relations
-  duplicateGroups       DuplicateGroup[]
+  duplicateGroups         DuplicateGroup[]
   // Media Sharing relations
-  mediaShares           MediaShare[]
+  mediaShares             MediaShare[]
   // Location Inference relations
-  locationSuggestions   LocationSuggestion[]
+  locationSuggestions     LocationSuggestion[]
   // AI Picture Enhancer relations
-  mediaEnhancements     MediaEnhancement[]
+  mediaEnhancements       MediaEnhancement[]
+  // AI Picture Enhancer — bulk batches (epic #420, issue #421)
+  mediaEnhancementBatches MediaEnhancementBatch[]
   // Workflow Automation relations
-  workflows             Workflow[]
-  workflowRuns          WorkflowRun[]
+  workflows               Workflow[]
+  workflowRuns            WorkflowRun[]
   // Empty Trash at Scale relations
-  trashEmptyRuns        TrashEmptyRun[]
+  trashEmptyRuns          TrashEmptyRun[]
   // Review Runs relations (bursts / duplicates / location suggestions —
   // supersedes the former LocationSuggestionRun-only relation, issue #190)
-  reviewRuns            ReviewRun[]
+  reviewRuns              ReviewRun[]
   // Notification Center relations (epic #240, issue #244; schema-only)
-  notifications         Notification[]        @relation("CircleNotifications")
+  notifications           Notification[]          @relation("CircleNotifications")
   // Memories relations (epic #300, issue #301)
-  memories              Memory[]
+  memories                Memory[]
 
   @@index([ownerId])
   @@map("circles")
@@ -1751,19 +1755,59 @@ model MediaEnhancement {
   lastError         String? @map("last_error")
   createdById       String? @map("created_by_id") @db.Uuid
 
+  // Bulk-enhance batching (epic #420, issue #421): the batch this enhancement
+  // was created under, or null for a single-item (non-batched) request.
+  // onDelete: SetNull is deliberate — deleting a batch record must never
+  // delete enhancements it produced, which may already be `applied`; mirrors
+  // resultMediaItemId above.
+  batchId String? @map("batch_id") @db.Uuid
+
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   // Relations
-  mediaItem       MediaItem  @relation("MediaEnhancementSource", fields: [mediaItemId], references: [id], onDelete: Cascade)
-  circle          Circle     @relation(fields: [circleId], references: [id], onDelete: Cascade)
-  resultMediaItem MediaItem? @relation("MediaEnhancementResult", fields: [resultMediaItemId], references: [id], onDelete: SetNull)
-  createdBy       User?      @relation("MediaEnhancementCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  mediaItem       MediaItem              @relation("MediaEnhancementSource", fields: [mediaItemId], references: [id], onDelete: Cascade)
+  circle          Circle                 @relation(fields: [circleId], references: [id], onDelete: Cascade)
+  resultMediaItem MediaItem?             @relation("MediaEnhancementResult", fields: [resultMediaItemId], references: [id], onDelete: SetNull)
+  createdBy       User?                  @relation("MediaEnhancementCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  batch           MediaEnhancementBatch? @relation(fields: [batchId], references: [id], onDelete: SetNull)
 
   @@index([mediaItemId, status])
   @@index([circleId, status])
   @@index([status, updatedAt])
+  @@index([batchId])
   @@map("media_enhancements")
+}
+
+// One row per bulk "AI Enhance" request against multiple MediaItems in a
+// circle (epic #420, issue #421 — Phase 1 data model only; the batching
+// service/controller land in a later phase). requestedCount is how many
+// items the caller asked to enhance; queuedCount is how many
+// MediaEnhancement rows were actually created (requestedCount minus any
+// items skipped up front — e.g. non-photo items, items already mid-flight —
+// recorded in `skipped`). `source` distinguishes how the batch was formed
+// (e.g. "selection" for a gallery multi-select) for future entry points.
+model MediaEnhancementBatch {
+  id             String    @id @default(uuid()) @db.Uuid
+  circleId       String    @map("circle_id") @db.Uuid
+  requestedCount Int       @map("requested_count")
+  queuedCount    Int       @default(0) @map("queued_count")
+  skipped        Json?     @db.JsonB
+  params         Json?     @db.JsonB
+  source         String    @default("selection")
+  cancelledAt    DateTime? @map("cancelled_at") @db.Timestamptz
+  lastError      String?   @map("last_error")
+  createdById    String?   @map("created_by_id") @db.Uuid
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+
+  // Relations
+  circle       Circle             @relation(fields: [circleId], references: [id], onDelete: Cascade)
+  createdBy    User?              @relation("MediaEnhancementBatchCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  enhancements MediaEnhancement[]
+
+  @@index([circleId, createdAt])
+  @@map("media_enhancement_batches")
 }
 
 // =============================================================================

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1712,6 +1712,14 @@ enum MediaEnhancementStatus {
   applied
   discarded
   expired
+  // Bulk-enhance batching (epic #420, issue #421): the row was superseded or
+  // withdrawn before a render ever ran — "never rendered at all". Deliberately
+  // distinct from `discarded`, which means a human reviewed a completed
+  // `ready` result and chose not to keep it. Placed LAST, matching the
+  // append-only `ALTER TYPE ... ADD VALUE` in the migration (no BEFORE/AFTER
+  // clause) — same precedent as MediaTagSource.system and
+  // NotificationType.memories_ready.
+  cancelled
 }
 
 enum MediaEnhancementDecision {

--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -628,6 +628,11 @@ export const systemSettingsSchema = z.object({
     // 168h (7 days). The enhancements hub is an inbox users work through over
     // time; a 3-day window destroyed staged previews before they were reviewed.
     retentionHours: z.number().int().min(1).max(720).default(168),
+    // Bulk enhance (epic #420, issue #421): the AUTHORITATIVE cap on how many
+    // items one POST /api/media/bulk/enhance may queue. Each queued item is a
+    // separately-billed gpt-image-1 call, so the cap is the admin's spend
+    // guardrail — the DTO's own max(200) is only a schema backstop.
+    maxBatchSize: z.number().int().min(1).max(200).default(25),
   }).optional().default({
     defaultQuality: 'high',
     defaultStrength: 'balanced',
@@ -636,6 +641,7 @@ export const systemSettingsSchema = z.object({
     blockReplaceOnDownscale: false,
     maxInputMegapixels: 50,
     retentionHours: 168,
+    maxBatchSize: 25,
   }),
   // Node backup change feed (issue #310, epic #308). Read by
   // NodeBackupQueryService via the cached getSettings() call.
@@ -938,6 +944,7 @@ export const systemSettingsPatchSchema = z.object({
     blockReplaceOnDownscale: z.boolean().optional(),
     maxInputMegapixels: z.number().min(1).max(100).optional(),
     retentionHours: z.number().int().min(1).max(720).optional(),
+    maxBatchSize: z.number().int().min(1).max(200).optional(),
   }).optional(),
   backup: z.object({
     maxPageSize: z.number().int().min(50).max(500).optional(),

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -350,6 +350,13 @@ export interface SystemSettingsValue {
      * through over time, so a shorter window silently destroys unreviewed work.
      */
     retentionHours: number;
+    /**
+     * Bulk enhance (epic #420, issue #421): the AUTHORITATIVE cap on items one
+     * POST /api/media/bulk/enhance may queue. Every queued item is a separately
+     * billed model call, so this is the admin's spend guardrail; the request
+     * DTO's own array max is only a schema backstop.
+     */
+    maxBatchSize: number;
   };
   /**
    * Node backup change feed (issue #310, epic #308). Read by
@@ -751,6 +758,7 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
     blockReplaceOnDownscale: false,
     maxInputMegapixels: 50,
     retentionHours: 168,
+    maxBatchSize: 25,
   },
   backup: {
     maxPageSize: 200,

--- a/apps/api/src/enhancement/dto/bulk-enhance.dto.ts
+++ b/apps/api/src/enhancement/dto/bulk-enhance.dto.ts
@@ -1,0 +1,27 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { enhanceParamsSchema } from './enhance-params.dto';
+
+/**
+ * Request body for POST /api/media/bulk/enhance (epic #420, issue #421).
+ *
+ * One `params` object applies to EVERY item in the batch — a bulk enhance is a
+ * single intent applied across a selection, not per-item tuning — and is
+ * snapshotted on the batch row as the audit of what was asked for.
+ *
+ * NOTE on the two caps: `.max(200)` here is a SCHEMA BACKSTOP only, bounding the
+ * request body so a pathological payload is rejected before it reaches the
+ * service. The AUTHORITATIVE limit is the `pictureEnhancement.maxBatchSize`
+ * system setting, enforced in MediaEnhancementService.startBatch — an admin
+ * lowering that setting to 10 must actually cap batches at 10, which a static
+ * schema max cannot express.
+ */
+export const bulkEnhanceSchema = z.object({
+  circleId: z.string().uuid(),
+  ids: z.array(z.string().uuid()).min(1).max(200),
+  params: enhanceParamsSchema.optional().default({}),
+});
+
+export type BulkEnhance = z.infer<typeof bulkEnhanceSchema>;
+
+export class BulkEnhanceDto extends createZodDto(bulkEnhanceSchema) {}

--- a/apps/api/src/enhancement/dto/list-enhancement-batches-query.dto.ts
+++ b/apps/api/src/enhancement/dto/list-enhancement-batches-query.dto.ts
@@ -1,0 +1,17 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+/** GET /api/enhancement-batches query params (epic #420, issue #421). */
+export const listEnhancementBatchesQuerySchema = z.object({
+  circleId: z.string().uuid(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+export type ListEnhancementBatchesQuery = z.infer<
+  typeof listEnhancementBatchesQuerySchema
+>;
+
+export class ListEnhancementBatchesQueryDto extends createZodDto(
+  listEnhancementBatchesQuerySchema,
+) {}

--- a/apps/api/src/enhancement/dto/list-enhancements-query.dto.ts
+++ b/apps/api/src/enhancement/dto/list-enhancements-query.dto.ts
@@ -32,6 +32,11 @@ export const listEnhancementsQuerySchema = z.object({
       ...(Object.keys(ENHANCEMENT_STATUS_ALIASES) as [string, ...string[]]),
     ])
     .optional(),
+  /**
+   * Narrow the hub listing to one bulk-enhance batch (epic #420, issue #421).
+   * Composes with `status` — e.g. a batch's `awaiting_decision` rows.
+   */
+  batchId: z.string().uuid().optional(),
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(50).default(24),
   sortBy: z.enum(['createdAt', 'updatedAt']).default('createdAt'),

--- a/apps/api/src/enhancement/enhancement-batches.controller.spec.ts
+++ b/apps/api/src/enhancement/enhancement-batches.controller.spec.ts
@@ -1,0 +1,624 @@
+/**
+ * Unit tests for EnhancementBatchesController (epic #420, issue #421).
+ *
+ * EnhancementBatchesController is a thin pass-through — list()/get()/cancel()
+ * each delegate straight to MediaEnhancementService.{listBatches,getBatch,
+ * cancelBatch}() — so the behavior worth testing (status derivation, counter
+ * math, cancel semantics) lives in the SERVICE's tallyBatches/serializeBatch/
+ * cancelBatch/loadBatch. This file wires the REAL MediaEnhancementService
+ * behind the controller (only its I/O boundaries — PrismaService and
+ * CircleMembershipService — are mocked), mirroring the mocking strategy in
+ * media-enhancement.service.spec.ts, so what's under test is the actual
+ * controller -> service call path with real derivation logic.
+ *
+ * The controller is instantiated directly (`new EnhancementBatchesController(
+ * service)`, mirroring features.controller.spec.ts / db-backup.controller.spec.ts)
+ * rather than through a compiled Nest TestingModule with `controllers: [...]`
+ * — the latter eagerly resolves the `@Auth()` guard chain's constructor deps
+ * (JwtAuthGuard -> PatService -> ...) even without an app instance, which this
+ * module doesn't provide and doesn't need: guard/RBAC enforcement is exercised
+ * separately by the real-HTTP-stack pattern in media-enhancement.controller.spec.ts.
+ *
+
+ * Covers:
+ *   - Status derivation, table-driven over prisma.mediaEnhancement.groupBy
+ *     fixtures: running / completed / completed_with_errors / cancelled
+ *     (cancelledAt wins over everything, including still-pending rows).
+ *   - The empty-batch case (zero rows -> completed, never a stuck running).
+ *   - The cascade case: a batch whose row count has SHRUNK below
+ *     requestedCount/queuedCount (a hard-deleted MediaItem cascades its
+ *     MediaEnhancement row away) still reaches a terminal status, because
+ *     serializeBatch keys off "no rows remain pending/processing", never off
+ *     counter equality (schema.prisma:2036-2043 documents the same failure
+ *     mode for review_runs).
+ *   - The exact response field set (BaseRun contract + batch-specific extras)
+ *     and the counter-derivation formulas.
+ *   - Cancel semantics (pending rows + their pending jobs withdrawn;
+ *     processing rows and running jobs left untouched), cancel-on-terminal
+ *     400, cancel-by-non-collaborator 403, unknown id 404, viewer-can-GET-
+ *     but-cannot-cancel.
+ *   - List: paginated, newest-first, circle-scoped, one groupBy per page.
+ */
+
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CircleRole, JobStatus, MediaEnhancementStatus } from '@prisma/client';
+import { EnhancementBatchesController } from './enhancement-batches.controller';
+import { MediaEnhancementService } from './media-enhancement.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { CircleMembershipService } from '../circles/circle-membership.service';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+import { StorageProcessingRecoveryService } from '../storage/tasks/storage-processing-recovery.service';
+import { MediaMetadataSyncService } from '../media/sync/media-metadata-sync.service';
+import { MediaEnrichmentService } from '../media/enrichment/media-enrichment.service';
+import { MediaThumbnailService } from '../media/media-thumbnail.service';
+import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
+import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
+import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+
+const USER: RequestUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  roles: ['Contributor'],
+  permissions: ['media:read', 'media:write'],
+  isActive: true,
+};
+
+const CIRCLE_ID = 'circle-1';
+const BATCH_ID = 'batch-1';
+
+function makeBatch(overrides: Record<string, any> = {}) {
+  return {
+    id: BATCH_ID,
+    circleId: CIRCLE_ID,
+    requestedCount: 3,
+    queuedCount: 3,
+    skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 },
+    params: {},
+    source: 'selection',
+    cancelledAt: null,
+    lastError: null,
+    createdById: USER.id,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:05:00Z'),
+    ...overrides,
+  };
+}
+
+/**
+ * Builds the raw groupBy rows tallyBatches() consumes: one row per
+ * (batchId, status) pair actually present, matching the shape of
+ * `prisma.mediaEnhancement.groupBy({ by: ['batchId', 'status'], ... })`.
+ */
+function groupByRows(
+  batchId: string,
+  counts: Partial<Record<MediaEnhancementStatus, number>>,
+  maxUpdatedAt: Date = new Date('2026-01-01T00:10:00Z'),
+) {
+  return Object.entries(counts)
+    .filter(([, count]) => (count ?? 0) > 0)
+    .map(([status, count]) => ({
+      batchId,
+      status: status as MediaEnhancementStatus,
+      _count: { _all: count as number },
+      _max: { updatedAt: maxUpdatedAt },
+    }));
+}
+
+describe('EnhancementBatchesController', () => {
+  let controller: EnhancementBatchesController;
+  let mockPrisma: MockPrismaService;
+  let mockMembership: { assertCircleAccess: jest.Mock };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockPrisma = createMockPrismaService();
+    mockMembership = {
+      assertCircleAccess: jest
+        .fn()
+        .mockResolvedValue({ role: CircleRole.collaborator, isSuperAdmin: false }),
+    };
+
+    // listBatches runs findMany + count inside a `$transaction([...])` array
+    // form — resolve it as Promise.all, mirroring media-enhancement.service.spec.ts.
+    (mockPrisma.$transaction as jest.Mock).mockImplementation(async (arg: any) => {
+      if (typeof arg === 'function') return arg(mockPrisma);
+      if (Array.isArray(arg)) return Promise.all(arg);
+      return arg;
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaEnhancementService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: CircleMembershipService, useValue: mockMembership },
+        { provide: StorageProviderResolver, useValue: {} },
+        { provide: StorageProcessingRecoveryService, useValue: {} },
+        { provide: MediaMetadataSyncService, useValue: {} },
+        { provide: MediaEnrichmentService, useValue: {} },
+        { provide: MediaThumbnailService, useValue: {} },
+        { provide: EnrichmentJobService, useValue: {} },
+        { provide: SystemSettingsService, useValue: {} },
+      ],
+    }).compile();
+
+    const service = module.get<MediaEnhancementService>(MediaEnhancementService);
+    controller = new EnhancementBatchesController(service);
+  });
+
+  // ===========================================================================
+  // GET /enhancement-batches/:id — status derivation (table-driven)
+  // ===========================================================================
+
+  describe('get() — status derivation', () => {
+    it.each<[string, Partial<Record<MediaEnhancementStatus, number>>, Date | null, string]>([
+      ['running: only pending rows', { pending: 2 }, null, 'running'],
+      ['running: only processing rows', { processing: 1 }, null, 'running'],
+      [
+        'running: a pending row present alongside already-succeeded ones',
+        { pending: 1, ready: 2 },
+        null,
+        'running',
+      ],
+      ['completed: all ready, none pending/processing/failed', { ready: 3 }, null, 'completed'],
+      [
+        'completed: every succeeded-alias status (ready/applied/discarded/expired), no failed',
+        { ready: 1, applied: 1, discarded: 1, expired: 1 },
+        null,
+        'completed',
+      ],
+      [
+        'completed_with_errors: a failed row present, none pending/processing',
+        { ready: 1, failed: 2 },
+        null,
+        'completed_with_errors',
+      ],
+      ['completed_with_errors: every row failed', { failed: 3 }, null, 'completed_with_errors'],
+      [
+        'cancelled: cancelledAt set WINS even though a pending row is still present',
+        { pending: 1, ready: 2 },
+        new Date('2026-01-01T00:02:00Z'),
+        'cancelled',
+      ],
+      [
+        'cancelled: cancelledAt set with every row already terminal (cancelled)',
+        { cancelled: 3 },
+        new Date('2026-01-01T00:02:00Z'),
+        'cancelled',
+      ],
+    ])('%s -> %s', async (_label, counts, cancelledAt, expectedStatus) => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(
+        makeBatch({ cancelledAt }),
+      );
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, counts),
+      );
+
+      const result = await controller.get(BATCH_ID, USER);
+
+      expect(result.status).toBe(expectedStatus);
+    });
+
+    it('the empty-batch case: zero rows renders a terminal completed, never a stuck running', async () => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(
+        makeBatch({ requestedCount: 0, queuedCount: 0 }),
+      );
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue([]);
+
+      const result = await controller.get(BATCH_ID, USER);
+
+      expect(result.status).toBe('completed');
+      expect(result.matchedCount).toBe(0);
+      expect(result.processedCount).toBe(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // THE CASCADE TEST — a hard-deleted MediaItem cascades its MediaEnhancement
+    // row away (schema.prisma: `mediaItemId ... onDelete: Cascade`), so a
+    // batch's row count can legitimately SHRINK below what was queued.
+    // serializeBatch must key off "no rows remain pending/processing", never
+    // off `processedCount === matchedCount` (or, transitively, off
+    // queuedCount) — the exact failure documented for review_runs at
+    // schema.prisma:2036-2043. Simulated here by a groupBy fixture whose
+    // total row count (2) is below the batch's own requestedCount/queuedCount
+    // (5): the "missing" 3 rows are gone, not merely unprocessed.
+    // -------------------------------------------------------------------------
+
+    it('CASCADE: a batch whose row count shrank below requestedCount/queuedCount (deleted media items) still reaches completed', async () => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(
+        makeBatch({ requestedCount: 5, queuedCount: 5 }),
+      );
+      // Only 2 of the original 5 enhancement rows still exist; both succeeded.
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { ready: 1, applied: 1 }),
+      );
+
+      const result = await controller.get(BATCH_ID, USER);
+
+      expect(result.matchedCount).toBe(2); // NOT 5 — the shrink is real
+      expect(result.matchedCount).toBeLessThan(result.queuedCount);
+      expect(result.status).toBe('completed'); // NOT stuck at 'running'
+    });
+
+    it('CASCADE: the shrunk set can also surface completed_with_errors when a failure is among the survivors', async () => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(
+        makeBatch({ requestedCount: 10, queuedCount: 10 }),
+      );
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { ready: 2, failed: 1 }), // 7 rows vanished via cascade
+      );
+
+      const result = await controller.get(BATCH_ID, USER);
+
+      expect(result.matchedCount).toBe(3);
+      expect(result.status).toBe('completed_with_errors');
+    });
+  });
+
+  // ===========================================================================
+  // GET /enhancement-batches/:id — exact response shape
+  // ===========================================================================
+
+  describe('get() — response shape', () => {
+    beforeEach(() => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(
+        makeBatch({ requestedCount: 6, queuedCount: 5 }),
+      );
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, {
+          pending: 1,
+          processing: 1,
+          ready: 1,
+          applied: 1,
+          failed: 1,
+          cancelled: 1,
+        }),
+      );
+    });
+
+    it('emits every field of the shared BaseRun contract, correctly derived', async () => {
+      const result = await controller.get(BATCH_ID, USER);
+
+      expect(result).toMatchObject({
+        id: BATCH_ID,
+        circleId: CIRCLE_ID,
+        status: 'running', // pending+processing still present
+        matchedCount: 6, // 1+1+1+1+1+1
+        processedCount: 4, // succeeded(2) + failed(1) + skipped(1)
+        succeededCount: 2, // ready + applied
+        failedCount: 1,
+        skippedCount: 1, // cancelled
+        startedById: USER.id, // == batch.createdById
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        startedAt: expect.any(Date), // == batch.createdAt (no evaluating phase)
+        finishedAt: null, // still running
+        lastError: null,
+      });
+    });
+
+    it('the complete key set is EXACTLY the 14 BaseRun fields plus the 6 documented batch-specific extras (no more, no fewer)', async () => {
+      const result = await controller.get(BATCH_ID, USER);
+
+      // Deliberately more complete than "assert only the BaseRun subset" —
+      // this catches a rename/removal of ANY field, base or extra, per the
+      // code's own comment: "Batch-specific extras, outside the BaseRun
+      // contract" (requestedCount, queuedCount, skipped, params, source,
+      // cancelledAt).
+      expect(Object.keys(result as Record<string, unknown>).sort()).toEqual(
+        [
+          // BaseRun contract (the RunProgressPanel / useRunPolling shape)
+          'id',
+          'circleId',
+          'status',
+          'matchedCount',
+          'processedCount',
+          'succeededCount',
+          'failedCount',
+          'skippedCount',
+          'startedById',
+          'createdAt',
+          'updatedAt',
+          'startedAt',
+          'finishedAt',
+          'lastError',
+          // Batch-specific extras
+          'requestedCount',
+          'queuedCount',
+          'skipped',
+          'params',
+          'source',
+          'cancelledAt',
+        ].sort(),
+      );
+    });
+
+    it('finishedAt is null while running and set to the tally max updatedAt once terminal', async () => {
+      const runningResult = await controller.get(BATCH_ID, USER);
+      expect(runningResult.finishedAt).toBeNull();
+
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { ready: 1 }, new Date('2026-01-01T00:09:00Z')),
+      );
+      const terminalResult = await controller.get(BATCH_ID, USER);
+      expect(terminalResult.finishedAt).toEqual(new Date('2026-01-01T00:09:00Z'));
+    });
+
+    it('asserts circle access at the viewer level', async () => {
+      await controller.get(BATCH_ID, USER);
+
+      expect(mockMembership.assertCircleAccess).toHaveBeenCalledWith(
+        USER.id,
+        CIRCLE_ID,
+        USER.permissions,
+        CircleRole.viewer,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // GET /enhancement-batches/:id — 404
+  // ===========================================================================
+
+  describe('get() — unknown id', () => {
+    it('throws 404 when the batch does not exist', async () => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(controller.get('missing-batch', USER)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ===========================================================================
+  // POST /enhancement-batches/:id/cancel
+  // ===========================================================================
+
+  describe('cancel()', () => {
+    beforeEach(() => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(makeBatch());
+      (mockPrisma.mediaEnhancementBatch.update as jest.Mock).mockResolvedValue({});
+      (mockPrisma.enrichmentJob.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+      (mockPrisma.mediaEnhancement.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+    });
+
+    it('asserts circle access at the collaborator level', async () => {
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { pending: 1 }),
+      );
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([]);
+
+      await controller.cancel(BATCH_ID, USER);
+
+      expect(mockMembership.assertCircleAccess).toHaveBeenCalledWith(
+        USER.id,
+        CIRCLE_ID,
+        USER.permissions,
+        CircleRole.collaborator,
+      );
+    });
+
+    it('withdraws pending rows: deletes their PENDING job rows and marks them cancelled, leaving PROCESSING rows and jobs untouched', async () => {
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { pending: 2, processing: 1 }),
+      );
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([
+        { id: 'enh-p1' },
+        { id: 'enh-p2' },
+      ]);
+      (mockPrisma.mediaEnhancement.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+      const result = await controller.cancel(BATCH_ID, USER);
+
+      // The batch itself is stamped cancelled.
+      expect(mockPrisma.mediaEnhancementBatch.update).toHaveBeenCalledWith({
+        where: { id: BATCH_ID },
+        data: { cancelledAt: expect.any(Date) },
+      });
+
+      // Only the still-PENDING rows were looked up for withdrawal.
+      expect(mockPrisma.mediaEnhancement.findMany).toHaveBeenCalledWith({
+        where: { batchId: BATCH_ID, status: MediaEnhancementStatus.pending },
+        select: { id: true },
+      });
+
+      // Their job rows are deleted, scoped to status=pending — a running job
+      // for the still-processing row can never match this filter.
+      expect(mockPrisma.enrichmentJob.deleteMany).toHaveBeenCalledWith({
+        where: {
+          type: 'picture_enhancement',
+          status: JobStatus.pending,
+          OR: [
+            { payload: { path: ['enhancementId'], equals: 'enh-p1' } },
+            { payload: { path: ['enhancementId'], equals: 'enh-p2' } },
+          ],
+        },
+      });
+
+      // Only pending rows are flipped to cancelled — re-filtered on pending,
+      // so a row that started processing between the read and the write is
+      // never clobbered mid-render.
+      expect(mockPrisma.mediaEnhancement.updateMany).toHaveBeenCalledWith({
+        where: { batchId: BATCH_ID, status: MediaEnhancementStatus.pending },
+        data: { status: MediaEnhancementStatus.cancelled },
+      });
+
+      expect(result).toEqual({ batchId: BATCH_ID, status: 'cancelled', cancelled: 2 });
+    });
+
+    it('does nothing to jobs/rows when there are no pending rows to withdraw (only processing remains)', async () => {
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { processing: 1 }),
+      );
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await controller.cancel(BATCH_ID, USER);
+
+      expect(mockPrisma.enrichmentJob.deleteMany).not.toHaveBeenCalled();
+      expect(mockPrisma.mediaEnhancement.updateMany).not.toHaveBeenCalled();
+      expect(result).toEqual({ batchId: BATCH_ID, status: 'cancelled', cancelled: 0 });
+    });
+
+    it('throws 400 ("Batch already finished") when the batch is already terminal, and never stamps cancelledAt', async () => {
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { ready: 3 }), // completed — no pending/processing
+      );
+
+      await expect(controller.cancel(BATCH_ID, USER)).rejects.toThrow(BadRequestException);
+      await expect(controller.cancel(BATCH_ID, USER)).rejects.toThrow('Batch already finished');
+      expect(mockPrisma.mediaEnhancementBatch.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when the batch was already cancelled', async () => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(
+        makeBatch({ cancelledAt: new Date() }),
+      );
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { cancelled: 3 }),
+      );
+
+      await expect(controller.cancel(BATCH_ID, USER)).rejects.toThrow('Batch already finished');
+      expect(mockPrisma.mediaEnhancementBatch.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 403 for a caller lacking the collaborator role', async () => {
+      mockMembership.assertCircleAccess.mockRejectedValue(
+        new ForbiddenException('viewer cannot write'),
+      );
+
+      await expect(controller.cancel(BATCH_ID, USER)).rejects.toThrow(ForbiddenException);
+      expect(mockPrisma.mediaEnhancementBatch.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 for an unknown batch id', async () => {
+      (mockPrisma.mediaEnhancementBatch.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(controller.cancel('missing-batch', USER)).rejects.toThrow(NotFoundException);
+    });
+
+    // -------------------------------------------------------------------------
+    // Viewer CAN GET but cannot cancel — the two endpoints require different
+    // per-circle roles (viewer for GET, collaborator for cancel).
+    // -------------------------------------------------------------------------
+
+    it('a viewer (below collaborator) can GET the batch but gets a 403 on cancel', async () => {
+      mockMembership.assertCircleAccess.mockImplementation(
+        async (_userId: string, _circleId: string, _perms: string[], role: CircleRole) => {
+          if (role === CircleRole.collaborator) {
+            throw new ForbiddenException('requires collaborator role');
+          }
+          return { role: CircleRole.viewer, isSuperAdmin: false };
+        },
+      );
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue(
+        groupByRows(BATCH_ID, { pending: 1 }),
+      );
+
+      // GET succeeds (viewer-level check).
+      await expect(controller.get(BATCH_ID, USER)).resolves.toMatchObject({ status: 'running' });
+
+      // Cancel is rejected (collaborator-level check).
+      await expect(controller.cancel(BATCH_ID, USER)).rejects.toThrow(ForbiddenException);
+      expect(mockPrisma.mediaEnhancementBatch.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // GET /enhancement-batches — list
+  // ===========================================================================
+
+  describe('list()', () => {
+    function makeQuery(overrides: Record<string, any> = {}) {
+      return { circleId: CIRCLE_ID, page: 1, pageSize: 20, ...overrides };
+    }
+
+    beforeEach(() => {
+      (mockPrisma.mediaEnhancementBatch.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.mediaEnhancementBatch.count as jest.Mock).mockResolvedValue(0);
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('asserts circle access at the viewer level', async () => {
+      await controller.list(makeQuery() as any, USER);
+
+      expect(mockMembership.assertCircleAccess).toHaveBeenCalledWith(
+        USER.id,
+        CIRCLE_ID,
+        USER.permissions,
+        CircleRole.viewer,
+      );
+    });
+
+    it('is circle-scoped: where:{circleId} on both findMany and count', async () => {
+      await controller.list(makeQuery() as any, USER);
+
+      expect(mockPrisma.mediaEnhancementBatch.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { circleId: CIRCLE_ID } }),
+      );
+      expect(mockPrisma.mediaEnhancementBatch.count).toHaveBeenCalledWith({
+        where: { circleId: CIRCLE_ID },
+      });
+    });
+
+    it('orders newest first with an id tiebreaker: [{createdAt:desc},{id:desc}]', async () => {
+      await controller.list(makeQuery() as any, USER);
+
+      expect(mockPrisma.mediaEnhancementBatch.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ orderBy: [{ createdAt: 'desc' }, { id: 'desc' }] }),
+      );
+    });
+
+    it('derives skip/take from page/pageSize', async () => {
+      await controller.list(makeQuery({ page: 3, pageSize: 10 }) as any, USER);
+
+      expect(mockPrisma.mediaEnhancementBatch.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 20, take: 10 }),
+      );
+    });
+
+    it('computes meta.totalPages by ceiling division', async () => {
+      (mockPrisma.mediaEnhancementBatch.count as jest.Mock).mockResolvedValue(25);
+
+      const result = await controller.list(makeQuery({ page: 1, pageSize: 10 }) as any, USER);
+
+      expect(result.meta).toEqual({ page: 1, pageSize: 10, totalItems: 25, totalPages: 3 });
+    });
+
+    it('tallies every batch on the page with exactly ONE groupBy call, not one per batch', async () => {
+      const batchA = makeBatch({ id: 'batch-a' });
+      const batchB = makeBatch({ id: 'batch-b' });
+      (mockPrisma.mediaEnhancementBatch.findMany as jest.Mock).mockResolvedValue([batchA, batchB]);
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue([
+        ...groupByRows('batch-a', { ready: 2 }),
+        ...groupByRows('batch-b', { pending: 1 }),
+      ]);
+
+      const result = await controller.list(makeQuery() as any, USER);
+
+      expect(mockPrisma.mediaEnhancement.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.mediaEnhancement.groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { batchId: { in: ['batch-a', 'batch-b'] } } }),
+      );
+      const byId = new Map(result.items.map((i: any) => [i.id, i]));
+      expect(byId.get('batch-a').status).toBe('completed');
+      expect(byId.get('batch-b').status).toBe('running');
+    });
+
+    it('a batch with no rows at all in the tally still serializes (EMPTY_TALLY fallback)', async () => {
+      (mockPrisma.mediaEnhancementBatch.findMany as jest.Mock).mockResolvedValue([makeBatch()]);
+      (mockPrisma.mediaEnhancement.groupBy as jest.Mock).mockResolvedValue([]); // nothing tallied
+
+      const result = await controller.list(makeQuery() as any, USER);
+
+      expect(result.items[0]).toMatchObject({ status: 'completed', matchedCount: 0 });
+    });
+
+    it('never calls groupBy for an empty page', async () => {
+      (mockPrisma.mediaEnhancementBatch.findMany as jest.Mock).mockResolvedValue([]);
+
+      await controller.list(makeQuery() as any, USER);
+
+      expect(mockPrisma.mediaEnhancement.groupBy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/enhancement/enhancement-batches.controller.ts
+++ b/apps/api/src/enhancement/enhancement-batches.controller.ts
@@ -1,0 +1,118 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PERMISSIONS } from '../common/constants/roles.constants';
+import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+import { MediaEnhancementService } from './media-enhancement.service';
+import { ListEnhancementBatchesQueryDto } from './dto/list-enhancement-batches-query.dto';
+
+/**
+ * Bulk AI enhancement — batch inspection + cancel API (epic #420, issue #421).
+ *
+ * Circle-scoped in the service. Reads require media:read + per-circle viewer;
+ * cancel requires media:write + per-circle collaborator. No new RBAC permission:
+ * a batch is just a grouping over enhancements the caller can already act on.
+ *
+ * The detail payload is deliberately BaseRun-shaped (the same field set as
+ * trash-empty runs, workflow runs and review runs) so the web RunProgressPanel
+ * and useRunPolling drive it with no new component.
+ */
+@ApiTags('Picture Enhancement')
+@ApiBearerAuth('JWT-auth')
+@Controller('enhancement-batches')
+export class EnhancementBatchesController {
+  constructor(private readonly service: MediaEnhancementService) {}
+
+  @Get()
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({
+    summary: "List a circle's bulk-enhancement batches (paginated, newest first)",
+    description:
+      'Each item carries the same derived counters as the detail endpoint. Every counter is ' +
+      'computed live from the batch\'s enhancement rows — batches store no counter columns — ' +
+      'so a count can never drift from the rows it describes.',
+  })
+  @ApiQuery({
+    name: 'circleId',
+    required: true,
+    type: String,
+    format: 'uuid',
+    description: 'Circle to list batches for',
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Default 1' })
+  @ApiQuery({
+    name: 'pageSize',
+    required: false,
+    type: Number,
+    description: 'Default 20, max 50',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated batch list with { items, meta }' })
+  @ApiResponse({ status: 400, description: 'Invalid query params' })
+  @ApiResponse({ status: 403, description: 'Caller is not a viewer of the circle' })
+  async list(
+    @Query() query: ListEnhancementBatchesQueryDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.service.listBatches(query, user);
+  }
+
+  @Get(':id')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_READ] })
+  @ApiOperation({
+    summary: 'Get a bulk-enhancement batch (progress counters)',
+    description:
+      'Returns the shared async-run shape: { id, circleId, status, matchedCount, ' +
+      'processedCount, succeededCount, failedCount, skippedCount, startedById, createdAt, ' +
+      'updatedAt, startedAt, finishedAt, lastError }, plus the batch-specific ' +
+      'requestedCount / queuedCount / skipped / params / source / cancelledAt. ' +
+      '`succeededCount` counts every row whose render completed (ready, applied, discarded, ' +
+      'expired); `skippedCount` counts rows withdrawn by a cancel before any render ran. ' +
+      '`status` is terminal as soon as no rows remain pending or processing — a batch that ' +
+      'queued nothing reads `completed`, never a stuck `running`.',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Batch returned' })
+  @ApiResponse({ status: 403, description: 'Caller is not a viewer of the circle' })
+  @ApiResponse({ status: 404, description: 'Batch not found' })
+  async get(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: RequestUser) {
+    return this.service.getBatch(id, user);
+  }
+
+  @Post(':id/cancel')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Cancel a non-terminal bulk-enhancement batch (collaborator)',
+    description:
+      'Withdraws every enhancement still queued: its pending job row is deleted and the row ' +
+      'is marked `cancelled`. An enhancement already PROCESSING is deliberately left to ' +
+      'finish — its model call is already billed, so aborting spends the money and discards ' +
+      'the result. Returns { batchId, status, cancelled } where `cancelled` is the number of ' +
+      'pending enhancements withdrawn.',
+  })
+  @ApiParam({ name: 'id', type: String, format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Batch cancelled' })
+  @ApiResponse({ status: 400, description: 'Batch already finished' })
+  @ApiResponse({ status: 403, description: 'Caller is not a collaborator of the circle' })
+  @ApiResponse({ status: 404, description: 'Batch not found' })
+  async cancel(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: RequestUser) {
+    return this.service.cancelBatch(id, user);
+  }
+}

--- a/apps/api/src/enhancement/enhancement.module.ts
+++ b/apps/api/src/enhancement/enhancement.module.ts
@@ -8,6 +8,7 @@ import { SettingsModule } from '../settings/settings.module';
 import { AiModule } from '../ai/ai.module';
 import { MediaModule } from '../media/media.module';
 import { MediaEnhancementController } from './media-enhancement.controller';
+import { EnhancementBatchesController } from './enhancement-batches.controller';
 import { AdminEnhancementController } from './admin-enhancement.controller';
 import { MediaEnhancementService } from './media-enhancement.service';
 import { ExifCarryoverService } from './exif-carryover.service';
@@ -40,7 +41,11 @@ import { PictureEnhancementPurgeTask } from './picture-enhancement-purge.task';
     AiModule,
     MediaModule,
   ],
-  controllers: [MediaEnhancementController, AdminEnhancementController],
+  controllers: [
+    MediaEnhancementController,
+    EnhancementBatchesController,
+    AdminEnhancementController,
+  ],
   providers: [
     MediaEnhancementService,
     ExifCarryoverService,

--- a/apps/api/src/enhancement/media-enhancement.controller.spec.ts
+++ b/apps/api/src/enhancement/media-enhancement.controller.spec.ts
@@ -18,7 +18,8 @@ import {
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
 import { APP_PIPE } from '@nestjs/core';
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, RequestMethod } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
 import { ZodValidationPipe } from 'nestjs-zod';
 import request from 'supertest';
 import { randomUUID } from 'crypto';
@@ -68,6 +69,9 @@ function makeMockService() {
   return {
     startEnhance: jest.fn().mockResolvedValue({
       data: { enhancementId: ENH_ID, jobId: 'job-1', status: 'pending' },
+    }),
+    startBatch: jest.fn().mockResolvedValue({
+      data: { batchId: 'batch-1', requested: 1, queued: 1, skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 } },
     }),
     getLatestEnhancement: jest.fn().mockResolvedValue({ data: null }),
     getEnhancement: jest.fn().mockResolvedValue({
@@ -313,6 +317,84 @@ describe('MediaEnhancementController — route dispatch + RBAC + validation (sup
       await request(app.getHttpServer()).post('/media/not-a-uuid/enhance').send({}).expect(400);
 
       expect(mockService.startEnhance).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // POST /media/bulk/enhance — route-collision regression (issue #421)
+  //
+  // MediaEnhancementController declares `bulk/enhance` in its static-routes
+  // block, BEFORE the parameterised `:id/enhance` route below it — the same
+  // convention (and the same reason) as `GET /media/enhancements` above it.
+  // Without that ordering, a POST to /media/bulk/enhance is the exact same
+  // shape (<segment>/enhance) as POST /media/:id/enhance, so 'bulk' would be
+  // silently parsed as the :id param and routed to startEnhance() instead of
+  // startBatch().
+  // ===========================================================================
+
+  describe('POST /media/bulk/enhance — route-collision regression', () => {
+    it('202s and dispatches to startBatch() — "bulk" is never parsed as the :id param of POST :id/enhance', async () => {
+      app = await buildApp(WRITER);
+
+      const res = await request(app.getHttpServer())
+        .post('/media/bulk/enhance')
+        .send({ circleId: CIRCLE_ID, ids: [MEDIA_ID] })
+        .expect(202);
+
+      expect(mockService.startBatch).toHaveBeenCalledTimes(1);
+      expect(mockService.startBatch.mock.calls[0][0]).toMatchObject({
+        circleId: CIRCLE_ID,
+        ids: [MEDIA_ID],
+      });
+      // The strongest proof of no collision: the :id/enhance handler
+      // (startEnhance, which would have been called with id:'bulk' had the
+      // param route won) was never invoked at all.
+      expect(mockService.startEnhance).not.toHaveBeenCalled();
+      expect(res.body).toMatchObject({ data: { batchId: 'batch-1' } });
+    });
+
+    it('403s for a caller missing media:write, and never reaches startEnhance either', async () => {
+      app = await buildApp(READER);
+
+      await request(app.getHttpServer())
+        .post('/media/bulk/enhance')
+        .send({ circleId: CIRCLE_ID, ids: [MEDIA_ID] })
+        .expect(403);
+
+      expect(mockService.startBatch).not.toHaveBeenCalled();
+      expect(mockService.startEnhance).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Decorator-metadata-level check (mirrors media.controller.spec.ts's
+    // "route ordering — review-counts precedes @Get(:id)" pattern): reads the
+    // REAL compiled declaration order off the controller prototype, which is
+    // what NestJS's RouterExplorer walks to register routes. A future edit
+    // that moves `bulk/enhance` below `:id/enhance` in the source would flip
+    // this ordering and fail here even before a live-dispatch test could catch it.
+    // -------------------------------------------------------------------------
+
+    it('declares POST bulk/enhance at a lower prototype index than POST :id/enhance', () => {
+      const prototype = MediaEnhancementController.prototype;
+      const routes = Object.getOwnPropertyNames(prototype)
+        .filter((name) => name !== 'constructor')
+        .map((name) => ({
+          name,
+          path: Reflect.getMetadata(PATH_METADATA, (prototype as any)[name]),
+          method: Reflect.getMetadata(METHOD_METADATA, (prototype as any)[name]),
+        }))
+        .filter((entry) => entry.path !== undefined);
+
+      const bulkIdx = routes.findIndex(
+        (r) => r.path === 'bulk/enhance' && r.method === RequestMethod.POST,
+      );
+      const paramIdx = routes.findIndex(
+        (r) => r.path === ':id/enhance' && r.method === RequestMethod.POST,
+      );
+
+      expect(bulkIdx).toBeGreaterThanOrEqual(0);
+      expect(paramIdx).toBeGreaterThanOrEqual(0);
+      expect(bulkIdx).toBeLessThan(paramIdx);
     });
   });
 

--- a/apps/api/src/enhancement/media-enhancement.controller.ts
+++ b/apps/api/src/enhancement/media-enhancement.controller.ts
@@ -26,6 +26,7 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PERMISSIONS } from '../common/constants/roles.constants';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParamsDto } from './dto/enhance-params.dto';
+import { BulkEnhanceDto } from './dto/bulk-enhance.dto';
 import { ApplyEnhancementDto } from './dto/apply-enhancement.dto';
 import {
   ENHANCEMENT_STATUS_ALIASES,
@@ -46,6 +47,10 @@ export class MediaEnhancementController {
   // 'media' prefix as MediaController, whose @Get(':id') would otherwise
   // shadow /media/enhancements — same convention (and same reason) as the
   // static-route block in media.controller.ts.
+  //
+  // This applies to EVERY literal-prefixed route here, not just GET routes:
+  // POST 'bulk/enhance' must also live in this block, or 'bulk' is captured as
+  // the :id param of a later-registered parameterised route.
   // ===========================================================================
 
   /**
@@ -91,6 +96,41 @@ export class MediaEnhancementController {
     @CurrentUser() user: RequestUser,
   ) {
     return this.service.listEnhancements(query, user);
+  }
+
+  /**
+   * POST /api/media/bulk/enhance — queue an enhancement per eligible item in a
+   * selection. Declared in the static-routes block so `bulk` is never captured
+   * as an :id param.
+   */
+  @Post('bulk/enhance')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({
+    summary: 'Queue AI enhancements for a selection of photos (bulk)',
+    description:
+      'Creates a batch and queues one enhancement per ELIGIBLE item. Unlike the single-item ' +
+      'endpoint, an ineligible item never fails the request: non-photos, oversized images, ' +
+      'and items that already have a live (pending/processing/ready) enhancement are skipped ' +
+      'and reported per-reason in `skipped`. In particular an existing `ready` result is NEVER ' +
+      'superseded — it is a completed, already-billed render awaiting a human decision. ' +
+      'The batch row is created even when nothing is eligible (`queued: 0`), so the caller ' +
+      'always gets a pollable batch id explaining the outcome. Distinct ids are counted ' +
+      'against the `pictureEnhancement.maxBatchSize` limit (also surfaced on GET /api/features).',
+  })
+  @ApiResponse({
+    status: 202,
+    description:
+      'Batch created: { batchId, requested, queued, skipped: { notPhoto, tooLarge, alreadyLive } }',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Feature disabled / no model configured / selection exceeds maxBatchSize',
+  })
+  @ApiResponse({ status: 403, description: 'Caller is not a collaborator of the circle' })
+  @ApiResponse({ status: 404, description: 'One or more ids are not live items of the circle' })
+  async startBatch(@Body() dto: BulkEnhanceDto, @CurrentUser() user: RequestUser) {
+    return this.service.startBatch(dto, user);
   }
 
   // ===========================================================================

--- a/apps/api/src/enhancement/media-enhancement.controller.ts
+++ b/apps/api/src/enhancement/media-enhancement.controller.ts
@@ -84,6 +84,14 @@ export class MediaEnhancementController {
       '`in_progress` (pending, processing), `awaiting_decision` (ready), ' +
       '`terminal` (applied, discarded, expired).',
   })
+  @ApiQuery({
+    name: 'batchId',
+    required: false,
+    type: String,
+    format: 'uuid',
+    description:
+      'Narrow to one bulk-enhance batch (see GET /api/enhancement-batches). Composes with `status`.',
+  })
   @ApiQuery({ name: 'page', required: false, type: Number, description: 'Default 1' })
   @ApiQuery({ name: 'pageSize', required: false, type: Number, description: 'Default 24, max 50' })
   @ApiQuery({ name: 'sortBy', required: false, enum: ['createdAt', 'updatedAt'], description: 'Default createdAt' })

--- a/apps/api/src/enhancement/media-enhancement.service.spec.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.spec.ts
@@ -43,6 +43,7 @@ import { SystemSettingsService } from '../settings/system-settings/system-settin
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParams } from './dto/enhance-params.dto';
+import { BulkEnhance } from './dto/bulk-enhance.dto';
 import { ListEnhancementsQuery } from './dto/list-enhancements-query.dto';
 
 const USER: RequestUser = {
@@ -401,6 +402,382 @@ describe('MediaEnhancementService', () => {
         payload: { enhancementId: ENH_ID },
       });
       expect(result).toEqual({ data: { enhancementId: ENH_ID, jobId: 'job-1', status: 'pending' } });
+    });
+
+    it('regression: startEnhance enqueues with skipDedup:true (a plain requeue would silently hand back the superseded job)', async () => {
+      await service.startEnhance(MEDIA_ID, {}, USER);
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ skipDedup: true }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // startBatch (POST /api/media/bulk/enhance — issue #421)
+  // ===========================================================================
+
+  describe('startBatch', () => {
+    const CIRCLE_ID_2 = 'circle-2';
+
+    /** Bulk-enhance-flavored media item fixture: only the fields createBatchFrom selects. */
+    function makeBatchItem(overrides: Record<string, any> = {}) {
+      return {
+        id: 'media-x',
+        circleId: CIRCLE_ID,
+        type: MediaType.photo,
+        width: 1200,
+        height: 900,
+        storageObject: { id: 'obj-x', mimeType: 'image/jpeg' },
+        ...overrides,
+      };
+    }
+
+    function makeBulkDto(overrides: Partial<BulkEnhance> = {}): BulkEnhance {
+      return {
+        circleId: CIRCLE_ID,
+        ids: ['media-a', 'media-b'],
+        params: {},
+        ...overrides,
+      } as BulkEnhance;
+    }
+
+    /**
+     * Wires mediaItem.findMany for BOTH call shapes startBatch's flow uses on the
+     * same mock function: assertAllInCircle's existence check (`select: { id: true }`
+     * only) and createBatchFrom's full item fetch (everything else). Routing on the
+     * select shape — rather than on call order — keeps every test independent of how
+     * many times each is invoked.
+     */
+    function wireMediaItems(items: Array<Record<string, any>>) {
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockImplementation(async (args: any) => {
+        const ids: string[] = args.where.id.in;
+        const selectKeys = args.select ? Object.keys(args.select) : [];
+        const isExistenceCheck = selectKeys.length === 1 && selectKeys[0] === 'id';
+        const matched = items.filter((i) => ids.includes(i.id));
+        return isExistenceCheck ? matched.map((i) => ({ id: i.id })) : matched;
+      });
+    }
+
+    let createdEnhancementIds: string[];
+
+    beforeEach(() => {
+      createdEnhancementIds = [];
+      (mockPrisma.mediaEnhancementBatch.create as jest.Mock).mockImplementation(
+        async (args: any) => ({ id: 'batch-1', queuedCount: 0, ...args.data }),
+      );
+      (mockPrisma.mediaEnhancementBatch.update as jest.Mock).mockResolvedValue({});
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([]); // no live rows by default
+      (mockPrisma.mediaEnhancement.create as jest.Mock).mockImplementation(async (args: any) => {
+        const id = `enh-${args.data.mediaItemId}`;
+        createdEnhancementIds.push(id);
+        return { id, ...args.data };
+      });
+      wireMediaItems([makeBatchItem({ id: 'media-a' }), makeBatchItem({ id: 'media-b' })]);
+    });
+
+    // -------------------------------------------------------------------------
+    // Feature gate / config guards (mirror startEnhance's)
+    // -------------------------------------------------------------------------
+
+    it('throws 400 when features.pictureEnhancement is off', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings({ features: { pictureEnhancement: false } }));
+
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow(BadRequestException);
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow('Picture enhancement is disabled');
+      expect(mockMembership.assertCircleAccess).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when PICTURE_ENHANCEMENT_ENABLED=false, even with the feature flag on', async () => {
+      process.env['PICTURE_ENHANCEMENT_ENABLED'] = 'false';
+
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 when no enhancement model is configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ ai: { features: { enhance: null } } }),
+      );
+
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow(
+        'No enhancement model configured',
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Batch-size cap
+    // -------------------------------------------------------------------------
+
+    it('throws 400 naming BOTH the requested count and the configured cap when the (deduped) selection exceeds maxBatchSize', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ pictureEnhancement: { ...makeSettings().pictureEnhancement, maxBatchSize: 3 } }),
+      );
+      const dto = makeBulkDto({ ids: ['m1', 'm2', 'm3', 'm4', 'm5'] });
+
+      await expect(service.startBatch(dto, USER)).rejects.toThrow(BadRequestException);
+      await expect(service.startBatch(dto, USER)).rejects.toThrow(
+        'Cannot enhance 5 items in one batch; the limit is 3',
+      );
+      expect(mockMembership.assertCircleAccess).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a cap of 25 when pictureEnhancement.maxBatchSize is unset', async () => {
+      const dto = makeBulkDto({ ids: Array.from({ length: 26 }, (_, i) => `m${i}`) });
+
+      await expect(service.startBatch(dto, USER)).rejects.toThrow('the limit is 25');
+    });
+
+    // -------------------------------------------------------------------------
+    // RBAC / existence
+    // -------------------------------------------------------------------------
+
+    it('asserts circle access at the collaborator level before touching media items', async () => {
+      await service.startBatch(makeBulkDto(), USER);
+
+      expect(mockMembership.assertCircleAccess).toHaveBeenCalledWith(
+        USER.id,
+        CIRCLE_ID,
+        USER.permissions,
+        CircleRole.collaborator,
+      );
+    });
+
+    it('propagates a ForbiddenException from RBAC (non-collaborator)', async () => {
+      mockMembership.assertCircleAccess.mockRejectedValue(new ForbiddenException('nope'));
+
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow(ForbiddenException);
+      expect(mockPrisma.mediaEnhancementBatch.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException naming ids that are missing or belong to another circle', async () => {
+      // Only media-a exists in the circle; media-b does not resolve.
+      wireMediaItems([makeBatchItem({ id: 'media-a' })]);
+
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow(NotFoundException);
+      await expect(service.startBatch(makeBulkDto(), USER)).rejects.toThrow(/media-b/);
+      expect(mockPrisma.mediaEnhancementBatch.create).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Partition logic — each skip reason independently, and every id lands in
+    // EXACTLY ONE bucket.
+    // -------------------------------------------------------------------------
+
+    describe('partitioning', () => {
+      it('counts a non-photo MediaType as notPhoto', async () => {
+        wireMediaItems([makeBatchItem({ id: 'media-a', type: MediaType.video })]);
+
+        const result = await service.startBatch(makeBulkDto({ ids: ['media-a'] }), USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 1, tooLarge: 0, alreadyLive: 0 });
+        expect(result.data.queued).toBe(0);
+      });
+
+      it('counts an image/* mimeType mismatch as notPhoto (photo type, non-image storage object)', async () => {
+        wireMediaItems([
+          makeBatchItem({ id: 'media-a', storageObject: { id: 'obj-x', mimeType: 'application/pdf' } }),
+        ]);
+
+        const result = await service.startBatch(makeBulkDto({ ids: ['media-a'] }), USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 1, tooLarge: 0, alreadyLive: 0 });
+      });
+
+      it('counts an oversized item as tooLarge (maxInputMegapixels exceeded)', async () => {
+        // 12000x9000 = 108 MP > default 50 MP cap.
+        wireMediaItems([makeBatchItem({ id: 'media-a', width: 12000, height: 9000 })]);
+
+        const result = await service.startBatch(makeBulkDto({ ids: ['media-a'] }), USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 0, tooLarge: 1, alreadyLive: 0 });
+      });
+
+      it.each([
+        ['pending', MediaEnhancementStatus.pending],
+        ['processing', MediaEnhancementStatus.processing],
+        ['ready', MediaEnhancementStatus.ready],
+      ])('counts an item with an existing %s enhancement as alreadyLive', async (_label, status) => {
+        wireMediaItems([makeBatchItem({ id: 'media-a' })]);
+        (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([
+          { mediaItemId: 'media-a' },
+        ]);
+        void status; // the live-row query only returns mediaItemId — status is asserted via the it.each label
+
+        const result = await service.startBatch(makeBulkDto({ ids: ['media-a'] }), USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 0, tooLarge: 0, alreadyLive: 1 });
+        expect(result.data.queued).toBe(0);
+      });
+
+      it('places every id in exactly one bucket, and the counts sum to `requested`', async () => {
+        const items = [
+          makeBatchItem({ id: 'notphoto-1', type: MediaType.video }),
+          makeBatchItem({ id: 'notphoto-2', storageObject: { id: 'o', mimeType: 'application/pdf' } }),
+          makeBatchItem({ id: 'toolarge-1', width: 12000, height: 9000 }),
+          makeBatchItem({ id: 'live-1' }),
+          makeBatchItem({ id: 'live-2' }),
+          makeBatchItem({ id: 'live-3' }),
+          makeBatchItem({ id: 'eligible-1' }),
+        ];
+        wireMediaItems(items);
+        (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([
+          { mediaItemId: 'live-1' },
+          { mediaItemId: 'live-2' },
+          { mediaItemId: 'live-3' },
+        ]);
+        const dto = makeBulkDto({ ids: items.map((i) => i.id) });
+
+        const result = await service.startBatch(dto, USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 2, tooLarge: 1, alreadyLive: 3 });
+        expect(result.data.queued).toBe(1);
+        expect(result.data.requested).toBe(7);
+        const sumSkipped = Object.values(result.data.skipped).reduce((a: number, b: any) => a + b, 0);
+        expect(sumSkipped + result.data.queued).toBe(result.data.requested);
+      });
+
+      it('counts an id that vanishes between the RBAC existence check and the item fetch (a concurrent hard delete) as notPhoto', async () => {
+        // assertAllInCircle sees both ids; the createBatchFrom item fetch only
+        // resolves media-a — media-b raced away in between.
+        (mockPrisma.mediaItem.findMany as jest.Mock).mockImplementation(async (args: any) => {
+          const ids: string[] = args.where.id.in;
+          const selectKeys = args.select ? Object.keys(args.select) : [];
+          const isExistenceCheck = selectKeys.length === 1 && selectKeys[0] === 'id';
+          if (isExistenceCheck) return ids.map((id) => ({ id }));
+          return [makeBatchItem({ id: 'media-a' })]; // media-b vanished
+        });
+
+        const result = await service.startBatch(makeBulkDto({ ids: ['media-a', 'media-b'] }), USER);
+
+        expect(result.data.skipped.notPhoto).toBe(1);
+        expect(result.data.queued).toBe(1);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // THE ANTI-SUPERSEDE TEST — the criterion most likely to regress silently.
+    //
+    // A bulk enhance must NEVER call supersedeLive()/deleteStaging() on an
+    // item's existing `ready` enhancement: that row is a completed,
+    // already-billed gpt-image-1 result awaiting a human keep/replace/discard
+    // decision. Losing it silently (and the money that produced it) because
+    // the item happened to be re-selected in a later batch is exactly the
+    // defect DIVERGENCE 1 in media-enhancement.service.ts exists to prevent.
+    // -------------------------------------------------------------------------
+
+    it('NEVER supersedes a live `ready` enhancement: no discard, no staging-key mutation, no provider delete', async () => {
+      const liveReadyRow = makeEnhancementRow({
+        id: 'enh-live',
+        mediaItemId: 'media-a',
+        status: MediaEnhancementStatus.ready,
+        stagingStorageKey: 'enhancements/enh-live/result.jpg',
+        stagingThumbnailKey: 'enhancements/enh-live/thumb.jpg',
+      });
+      wireMediaItems([makeBatchItem({ id: 'media-a' })]);
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([
+        { mediaItemId: 'media-a' },
+      ]);
+      // Sanity: the row is real and would be discarded by supersedeLive() if it ran.
+      void liveReadyRow;
+
+      const result = await service.startBatch(makeBulkDto({ ids: ['media-a'] }), USER);
+
+      expect(result.data.skipped.alreadyLive).toBe(1);
+      expect(result.data.queued).toBe(0);
+      // The staged bytes were never touched.
+      expect(mockActiveProvider.delete).not.toHaveBeenCalled();
+      expect(mockObjectProvider.delete).not.toHaveBeenCalled();
+      // No enhancement row anywhere was updated (discarded or otherwise) —
+      // startBatch only ever CREATEs new rows for eligible items.
+      expect(mockPrisma.mediaEnhancement.update).not.toHaveBeenCalled();
+      // No new (superseding) enhancement row was created for this item either.
+      expect(mockPrisma.mediaEnhancement.create).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Enqueue shape
+    // -------------------------------------------------------------------------
+
+    describe('enqueue options', () => {
+      it('every enqueued job carries priority:50, skipDedup:true, reason:rerun, type:picture_enhancement, and payload.enhancementId for the row just created', async () => {
+        await service.startBatch(makeBulkDto({ ids: ['media-a', 'media-b'] }), USER);
+
+        expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledTimes(2);
+        for (const call of (mockEnrichmentJobService.enqueue as jest.Mock).mock.calls) {
+          const [opts] = call;
+          expect(opts).toMatchObject({
+            type: 'picture_enhancement',
+            reason: 'rerun',
+            priority: 50,
+            skipDedup: true,
+            providerKey: 'openai',
+            modelVersion: 'gpt-image-1',
+          });
+          expect(opts.payload).toEqual({ enhancementId: `enh-${opts.mediaItemId}` });
+        }
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Dedup of duplicate ids
+    // -------------------------------------------------------------------------
+
+    it('dedupes duplicate ids in the request before the cap check, producing one enhancement per unique id', async () => {
+      const dto = makeBulkDto({ ids: ['media-a', 'media-a', 'media-b'] });
+
+      const result = await service.startBatch(dto, USER);
+
+      expect(result.data.requested).toBe(2);
+      expect(result.data.queued).toBe(2);
+      expect(mockPrisma.mediaEnhancement.create).toHaveBeenCalledTimes(2);
+      // assertAllInCircle's existence check also only ever sees the 2 unique ids.
+      const existenceCall = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls.find(
+        (c: any[]) => c[0].select && Object.keys(c[0].select).length === 1 && c[0].select.id === true,
+      );
+      expect(existenceCall![0].where.id.in).toEqual(['media-a', 'media-b']);
+    });
+
+    // -------------------------------------------------------------------------
+    // Zero-eligible edge case
+    // -------------------------------------------------------------------------
+
+    it('creates the batch row and returns queued:0 when nothing is eligible', async () => {
+      wireMediaItems([makeBatchItem({ id: 'media-a', type: MediaType.video })]);
+
+      const result = await service.startBatch(makeBulkDto({ ids: ['media-a'] }), USER);
+
+      expect(mockPrisma.mediaEnhancementBatch.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          circleId: CIRCLE_ID,
+          requestedCount: 1,
+          queuedCount: 0,
+          source: 'selection',
+          createdById: USER.id,
+        }),
+      });
+      expect(result).toEqual({
+        data: {
+          batchId: 'batch-1',
+          requested: 1,
+          queued: 0,
+          skipped: { notPhoto: 1, tooLarge: 0, alreadyLive: 0 },
+        },
+      });
+      expect(mockEnrichmentJobService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('uses CIRCLE_ID_2 to prove the batch row is scoped to dto.circleId, not a hard-coded default', async () => {
+      mockMembership.assertCircleAccess.mockResolvedValue({
+        role: CircleRole.collaborator,
+        isSuperAdmin: false,
+      });
+      wireMediaItems([makeBatchItem({ id: 'media-a', circleId: CIRCLE_ID_2 })]);
+
+      await service.startBatch(makeBulkDto({ circleId: CIRCLE_ID_2, ids: ['media-a'] }), USER);
+
+      expect(mockPrisma.mediaEnhancementBatch.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ circleId: CIRCLE_ID_2 }),
+      });
     });
   });
 

--- a/apps/api/src/enhancement/media-enhancement.service.spec.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.spec.ts
@@ -394,6 +394,8 @@ describe('MediaEnhancementService', () => {
         circleId: CIRCLE_ID,
         reason: 'rerun',
         priority: 0,
+        // Required: dedup would otherwise return the superseded row's job.
+        skipDedup: true,
         providerKey: 'openai',
         modelVersion: 'gpt-image-1',
         payload: { enhancementId: ENH_ID },

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -828,6 +828,8 @@ export class MediaEnhancementService {
     const where: Prisma.MediaEnhancementWhereInput = {
       circleId,
       ...(statuses ? { status: { in: statuses } } : {}),
+      // Optional batch narrowing (issue #421), served by @@index([batchId]).
+      ...(query.batchId ? { batchId: query.batchId } : {}),
     };
 
     const [rows, totalItems] = await this.prisma.$transaction([

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -6,7 +6,9 @@ import {
 } from '@nestjs/common';
 import {
   CircleRole,
+  JobStatus,
   MediaType,
+  MediaEnhancementBatch,
   MediaEnhancementStatus,
   MediaEnhancementDecision,
   MediaTagSource,
@@ -29,6 +31,7 @@ import { streamToBuffer } from '../storage/processing/processors/stream-utils';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParams } from './dto/enhance-params.dto';
 import { BulkEnhance } from './dto/bulk-enhance.dto';
+import { ListEnhancementBatchesQuery } from './dto/list-enhancement-batches-query.dto';
 import {
   ListEnhancementsQuery,
   resolveStatusFilter,
@@ -42,6 +45,22 @@ import { randomUUID } from 'crypto';
 import { extname } from 'path';
 
 const SYSTEM_TAG = 'AI Enhanced';
+
+/** Derived batch statuses past which no further transition is possible. */
+const TERMINAL_BATCH_STATUSES: string[] = [
+  'completed',
+  'completed_with_errors',
+  'cancelled',
+];
+
+/** Per-batch status tally derived from its media_enhancements rows. */
+interface BatchTally {
+  counts: Record<string, number>;
+  maxUpdatedAt: Date | null;
+}
+
+/** Tally for a batch with no rows at all (nothing was eligible). */
+const EMPTY_TALLY: BatchTally = { counts: {}, maxUpdatedAt: null };
 
 interface CompareSection {
   url: string | null;
@@ -478,6 +497,249 @@ export class MediaEnhancementService {
         queued,
         skipped,
       },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /api/enhancement-batches  ·  GET|POST /api/enhancement-batches/:id[/cancel]
+  // ---------------------------------------------------------------------------
+
+  /** Paginated batch list for a circle, newest first (circle viewer). */
+  async listBatches(query: ListEnhancementBatchesQuery, user: RequestUser) {
+    const { circleId, page, pageSize } = query;
+
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      circleId,
+      user.permissions,
+      CircleRole.viewer,
+    );
+
+    // Served by the existing @@index([circleId, createdAt]); `id` tiebreak keeps
+    // paging deterministic when two batches share a createdAt.
+    const where: Prisma.MediaEnhancementBatchWhereInput = { circleId };
+    const [batches, totalItems] = await this.prisma.$transaction([
+      this.prisma.mediaEnhancementBatch.findMany({
+        where,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      this.prisma.mediaEnhancementBatch.count({ where }),
+    ]);
+
+    // ONE groupBy for the whole page — never one per batch.
+    const tallies = await this.tallyBatches(batches.map((b) => b.id));
+
+    return {
+      items: batches.map((b) =>
+        this.serializeBatch(b, tallies.get(b.id) ?? EMPTY_TALLY),
+      ),
+      meta: {
+        page,
+        pageSize,
+        totalItems,
+        totalPages: Math.ceil(totalItems / pageSize),
+      },
+    };
+  }
+
+  /** Single batch detail — the BaseRun-shaped progress payload (circle viewer). */
+  async getBatch(batchId: string, user: RequestUser) {
+    const batch = await this.loadBatch(batchId, user, CircleRole.viewer);
+    const tallies = await this.tallyBatches([batch.id]);
+    return this.serializeBatch(batch, tallies.get(batch.id) ?? EMPTY_TALLY);
+  }
+
+  /**
+   * Cancel a non-terminal batch (circle collaborator).
+   *
+   * Only rows still at `pending` are affected: their queued job row is deleted
+   * and the row is marked `cancelled`. A row already at `processing` is left
+   * running ON PURPOSE — its gpt-image-1 call is already billed, so aborting it
+   * spends the money and throws away the result. A `running` job row is likewise
+   * left alone; deleting it out from under the worker buys nothing.
+   *
+   * The handler's own batch-cancellation check (see PictureEnhancementHandler)
+   * covers the row whose job was already claimed when this landed.
+   */
+  async cancelBatch(batchId: string, user: RequestUser) {
+    const batch = await this.loadBatch(batchId, user, CircleRole.collaborator);
+
+    const tallies = await this.tallyBatches([batch.id]);
+    const view = this.serializeBatch(batch, tallies.get(batch.id) ?? EMPTY_TALLY);
+    if (batch.cancelledAt || TERMINAL_BATCH_STATUSES.includes(view.status)) {
+      throw new BadRequestException('Batch already finished');
+    }
+
+    await this.prisma.mediaEnhancementBatch.update({
+      where: { id: batch.id },
+      data: { cancelledAt: new Date() },
+    });
+
+    const pendingRows = await this.prisma.mediaEnhancement.findMany({
+      where: { batchId: batch.id, status: MediaEnhancementStatus.pending },
+      select: { id: true },
+    });
+
+    let cancelled = 0;
+    if (pendingRows.length > 0) {
+      // Delete only the still-PENDING job rows, matched precisely on the
+      // enhancement id in their payload (never by mediaItemId, which could
+      // catch an unrelated job for the same item).
+      await this.prisma.enrichmentJob.deleteMany({
+        where: {
+          type: 'picture_enhancement',
+          status: JobStatus.pending,
+          OR: pendingRows.map((r) => ({
+            payload: { path: ['enhancementId'], equals: r.id },
+          })),
+        },
+      });
+
+      // Re-filtered on `pending` so a row that started processing between the
+      // read above and this write is not clobbered mid-render.
+      const res = await this.prisma.mediaEnhancement.updateMany({
+        where: {
+          batchId: batch.id,
+          status: MediaEnhancementStatus.pending,
+        },
+        data: { status: MediaEnhancementStatus.cancelled },
+      });
+      cancelled = res.count;
+    }
+
+    this.logger.log(
+      `Enhancement batch ${batch.id} cancelled by user ${user.id} — ${cancelled} pending enhancement(s) withdrawn`,
+    );
+
+    return { batchId: batch.id, status: 'cancelled' as const, cancelled };
+  }
+
+  private async loadBatch(
+    batchId: string,
+    user: RequestUser,
+    role: CircleRole,
+  ): Promise<MediaEnhancementBatch> {
+    const batch = await this.prisma.mediaEnhancementBatch.findUnique({
+      where: { id: batchId },
+    });
+    if (!batch) {
+      throw new NotFoundException(`Enhancement batch ${batchId} not found`);
+    }
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      batch.circleId,
+      user.permissions,
+      role,
+    );
+    return batch;
+  }
+
+  /**
+   * Per-batch status tally + newest row timestamp, from ONE groupBy over
+   * media_enhancements. Nothing about a batch's progress is stored on the batch
+   * row itself: there are no counter columns and no finalize job, so a count can
+   * never drift from the rows it describes.
+   */
+  private async tallyBatches(batchIds: string[]): Promise<Map<string, BatchTally>> {
+    const out = new Map<string, BatchTally>();
+    if (batchIds.length === 0) return out;
+
+    const groups = await this.prisma.mediaEnhancement.groupBy({
+      by: ['batchId', 'status'],
+      where: { batchId: { in: batchIds } },
+      _count: { _all: true },
+      _max: { updatedAt: true },
+    });
+
+    for (const g of groups) {
+      if (!g.batchId) continue;
+      const tally =
+        out.get(g.batchId) ?? { counts: {} as Record<string, number>, maxUpdatedAt: null };
+      tally.counts[g.status] = g._count._all;
+      const max = g._max.updatedAt;
+      if (max && (!tally.maxUpdatedAt || max > tally.maxUpdatedAt)) {
+        tally.maxUpdatedAt = max;
+      }
+      out.set(g.batchId, tally);
+    }
+    return out;
+  }
+
+  /**
+   * Project a batch into the BaseRun shape every other async-run backend emits
+   * (workflow runs, trash-empty runs, review runs), so the web RunProgressPanel
+   * and useRunPolling work against it with no new component.
+   *
+   * Every number is DERIVED from the row tally — see tallyBatches.
+   *
+   *  - succeeded = ready | applied | discarded | expired. All four mean the
+   *    render completed successfully; what the human did with it afterwards is
+   *    a separate axis from whether the batch's work succeeded.
+   *  - skipped   = cancelled (withdrawn before any render ran).
+   *
+   * STATUS KEYS OFF "no rows remain pending/processing", NEVER off
+   * processedCount === matchedCount. MediaEnhancement.mediaItemId is
+   * onDelete: Cascade, so hard-deleting a photo mid-batch removes its
+   * enhancement row and SHRINKS the work set — under a counter-equality check
+   * the batch would sit at `running` forever. This is the exact failure mode
+   * documented for review_runs at schema.prisma:2036-2043.
+   *
+   * A batch with zero rows (nothing was eligible) therefore renders as a
+   * terminal `completed`, not a stuck `running`.
+   */
+  private serializeBatch(batch: MediaEnhancementBatch, tally: BatchTally) {
+    const c = tally.counts;
+    const n = (s: MediaEnhancementStatus) => c[s] ?? 0;
+
+    const pending = n(MediaEnhancementStatus.pending);
+    const processing = n(MediaEnhancementStatus.processing);
+    const succeededCount =
+      n(MediaEnhancementStatus.ready) +
+      n(MediaEnhancementStatus.applied) +
+      n(MediaEnhancementStatus.discarded) +
+      n(MediaEnhancementStatus.expired);
+    const failedCount = n(MediaEnhancementStatus.failed);
+    const skippedCount = n(MediaEnhancementStatus.cancelled);
+
+    const matchedCount = pending + processing + succeededCount + failedCount + skippedCount;
+    const processedCount = succeededCount + failedCount + skippedCount;
+
+    const inFlight = pending + processing > 0;
+    let status: 'running' | 'completed' | 'completed_with_errors' | 'cancelled';
+    if (batch.cancelledAt) {
+      status = 'cancelled';
+    } else if (!inFlight) {
+      status = failedCount > 0 ? 'completed_with_errors' : 'completed';
+    } else {
+      status = 'running';
+    }
+
+    return {
+      id: batch.id,
+      circleId: batch.circleId,
+      status,
+      matchedCount,
+      processedCount,
+      succeededCount,
+      failedCount,
+      skippedCount,
+      // Batch creation is synchronous (there is no evaluating phase), so the
+      // batch's own createdAt IS its start time.
+      startedById: batch.createdById,
+      createdAt: batch.createdAt,
+      updatedAt: batch.updatedAt,
+      startedAt: batch.createdAt,
+      finishedAt: status === 'running' ? null : tally.maxUpdatedAt ?? batch.updatedAt,
+      lastError: batch.lastError,
+      // Batch-specific extras, outside the BaseRun contract.
+      requestedCount: batch.requestedCount,
+      queuedCount: batch.queuedCount,
+      skipped: batch.skipped ?? null,
+      params: batch.params ?? {},
+      source: batch.source,
+      cancelledAt: batch.cancelledAt,
     };
   }
 

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -28,6 +28,7 @@ import { isPictureEnhancementEnabled } from '../common/types/settings.types';
 import { streamToBuffer } from '../storage/processing/processors/stream-utils';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParams } from './dto/enhance-params.dto';
+import { BulkEnhance } from './dto/bulk-enhance.dto';
 import {
   ListEnhancementsQuery,
   resolveStatusFilter,
@@ -238,6 +239,280 @@ export class MediaEnhancementService {
         },
       });
       this.logger.log(`Superseded live enhancement ${row.id} for MediaItem ${mediaItemId}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /api/media/bulk/enhance — batch enhance a selection (issue #421)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Queue an AI enhancement for every eligible item in a selection.
+   *
+   * FOUR deliberate divergences from the single-item startEnhance path. Each is
+   * commented at its site; collected here because "simplifying" any of them back
+   * toward startEnhance reintroduces a real defect:
+   *
+   *   1. A live enhancement is SKIPPED AND COUNTED, never superseded.
+   *   2. A non-photo / oversized item is SKIPPED AND COUNTED, never a 400.
+   *   3. Jobs are enqueued at priority 50, not 0.
+   *   4. Jobs are enqueued with skipDedup: true.
+   *
+   * Authorization and the batch-size cap happen here; the actual batch creation
+   * lives in createBatchFrom() so a future by-filter entry point (#424) can
+   * resolve its own id list server-side and reuse the rest verbatim.
+   */
+  async startBatch(dto: BulkEnhance, user: RequestUser) {
+    const settings = await this.systemSettings.getSettings();
+
+    // Feature gate: the SHARED helper (system setting + env kill-switch), never
+    // a second hand-rolled gate that could drift from startEnhance's.
+    if (!isPictureEnhancementEnabled(settings)) {
+      throw new BadRequestException('Picture enhancement is disabled');
+    }
+
+    const enhanceCfg = settings.ai?.features?.enhance;
+    if (!enhanceCfg?.provider || !enhanceCfg?.model) {
+      throw new BadRequestException(
+        'No enhancement model configured (ai.features.enhance is unset)',
+      );
+    }
+
+    const uniqueIds = [...new Set(dto.ids)];
+
+    // The AUTHORITATIVE cap (the DTO's array max is only a schema backstop).
+    // Deduplicated ids are counted, so pasting the same id twice never costs a
+    // caller part of their budget.
+    const maxBatchSize = settings.pictureEnhancement?.maxBatchSize ?? 25;
+    if (uniqueIds.length > maxBatchSize) {
+      throw new BadRequestException(
+        `Cannot enhance ${uniqueIds.length} items in one batch; the limit is ${maxBatchSize}`,
+      );
+    }
+
+    // ONE authorization pass for the whole batch (never per item).
+    await this.assertAllInCircle(uniqueIds, dto.circleId, user, 'collaborator');
+
+    return this.createBatchFrom(
+      uniqueIds,
+      dto.circleId,
+      dto.params ?? {},
+      'selection',
+      user,
+    );
+  }
+
+  /**
+   * Post-authorization half of a batch enhance: partition the ids, create the
+   * batch row, then create + enqueue one enhancement per eligible item.
+   *
+   * Deliberately takes an already-authorized id list so #424's by-filter entry
+   * point can resolve ids server-side and call straight into here — the caller
+   * owns "which items", this owns "what happens to them".
+   */
+  private async createBatchFrom(
+    ids: string[],
+    circleId: string,
+    params: EnhanceParams,
+    source: 'selection' | 'filter',
+    user: RequestUser,
+  ) {
+    // Cached (5 s TTL) — no extra DB read path.
+    const settings = await this.systemSettings.getSettings();
+    const enhanceCfg = settings.ai?.features?.enhance;
+    const provider = enhanceCfg!.provider;
+    const model = params.model ?? enhanceCfg!.model;
+
+    const items = await this.prisma.mediaItem.findMany({
+      where: { id: { in: ids } },
+      select: {
+        id: true,
+        circleId: true,
+        type: true,
+        width: true,
+        height: true,
+        storageObject: { select: { id: true, mimeType: true } },
+      },
+    });
+
+    // ONE query for every id's live-enhancement state, not one per item.
+    const liveRows = await this.prisma.mediaEnhancement.findMany({
+      where: {
+        mediaItemId: { in: ids },
+        status: {
+          in: [
+            MediaEnhancementStatus.pending,
+            MediaEnhancementStatus.processing,
+            MediaEnhancementStatus.ready,
+          ],
+        },
+      },
+      select: { mediaItemId: true },
+    });
+    const liveItemIds = new Set(liveRows.map((r) => r.mediaItemId));
+
+    const maxMp = settings.pictureEnhancement?.maxInputMegapixels ?? 50;
+
+    // Partition. Precedence is notPhoto → tooLarge → alreadyLive, so every id
+    // lands in EXACTLY ONE bucket and the four counts always sum to `requested`.
+    const skipped = { notPhoto: 0, tooLarge: 0, alreadyLive: 0 };
+    const eligible: typeof items = [];
+
+    for (const item of items) {
+      // DIVERGENCE 2a: startEnhance throws 400 for a non-photo. A batch must
+      // not fail wholesale because one video slipped into a mixed selection —
+      // the ineligible item is reported in `skipped` and the rest proceed.
+      if (
+        item.type !== MediaType.photo ||
+        !item.storageObject ||
+        !item.storageObject.mimeType.startsWith('image/')
+      ) {
+        skipped.notPhoto++;
+        continue;
+      }
+
+      // DIVERGENCE 2b: same reasoning for the megapixel guard.
+      if (item.width && item.height && (item.width * item.height) / 1_000_000 > maxMp) {
+        skipped.tooLarge++;
+        continue;
+      }
+
+      // DIVERGENCE 1 — THE most important rule in this method. startEnhance
+      // calls supersedeLive(), which DISCARDS a live enhancement and deletes its
+      // staged bytes. A batch must NEVER do that: a `ready` row is a completed,
+      // already-billed gpt-image-1 result awaiting a human keep/replace/discard
+      // decision, and silently destroying it because the item happened to be in
+      // a later selection loses both the work and the money. Skip and report.
+      //
+      // This rule is also what makes DIVERGENCE 4 (skipDedup) safe: at most one
+      // live enhancement — and therefore at most one in-flight job — can exist
+      // per item, enforced here rather than by the queue's dedup.
+      if (liveItemIds.has(item.id)) {
+        skipped.alreadyLive++;
+        continue;
+      }
+
+      eligible.push(item);
+    }
+
+    // An id that vanished between the authorization read and this one (a
+    // concurrent hard delete) is counted as notPhoto — it is ineligible, and
+    // failing the whole batch over a race would be worse than reporting it.
+    skipped.notPhoto += ids.length - items.length;
+
+    // The batch row is created even when nothing is eligible: the caller asked
+    // for something and deserves a record (and a pollable id) explaining why
+    // zero items were queued, rather than a bare 202 with no trace.
+    const batch = await this.prisma.mediaEnhancementBatch.create({
+      data: {
+        circleId,
+        requestedCount: ids.length,
+        queuedCount: 0,
+        skipped: skipped as unknown as Prisma.InputJsonValue,
+        params: (params ?? {}) as Prisma.InputJsonValue,
+        source,
+        createdById: user.id,
+      },
+    });
+
+    const effectiveStrength =
+      params.strength ?? settings.pictureEnhancement?.defaultStrength ?? 'balanced';
+    const prompt = buildEnhancePrompt(params, effectiveStrength);
+
+    let queued = 0;
+    for (const item of eligible) {
+      const row = await this.prisma.mediaEnhancement.create({
+        data: {
+          mediaItemId: item.id,
+          circleId: item.circleId,
+          batchId: batch.id,
+          status: MediaEnhancementStatus.pending,
+          params: (params ?? {}) as Prisma.InputJsonValue,
+          provider,
+          model,
+          prompt,
+          originalWidth: item.width,
+          originalHeight: item.height,
+          createdById: user.id,
+        },
+      });
+
+      await this.enrichmentJobService.enqueue({
+        type: 'picture_enhancement',
+        mediaItemId: item.id,
+        circleId: item.circleId,
+        reason: JobReason.rerun,
+        // DIVERGENCE 3: a single-item enhance is an interactive request the user
+        // is watching, so it jumps the queue at priority 0. A batch is bulk work
+        // — it sits BELOW upload enrichment (5/10) and workflow evaluate (20) so
+        // a large selection never starves a live import, and ABOVE the purges
+        // (100) so it still drains promptly.
+        priority: 50,
+        // DIVERGENCE 4: queue dedup on (type, mediaItemId, pending|running)
+        // would collapse a legitimate re-queue into a stale job pointing at an
+        // older enhancement row. The enhancement row is the idempotency unit,
+        // and the alreadyLive skip above guarantees at most one live row (hence
+        // at most one in-flight job) per item.
+        skipDedup: true,
+        providerKey: provider,
+        modelVersion: model,
+        payload: { enhancementId: row.id },
+      });
+      queued++;
+    }
+
+    await this.prisma.mediaEnhancementBatch.update({
+      where: { id: batch.id },
+      data: { queuedCount: queued },
+    });
+
+    this.logger.log(
+      `Enhancement batch ${batch.id} (${source}) in circle ${circleId}: requested=${ids.length} queued=${queued} ` +
+        `skipped=${JSON.stringify(skipped)}`,
+    );
+
+    return {
+      data: {
+        batchId: batch.id,
+        requested: ids.length,
+        queued,
+        skipped,
+      },
+    };
+  }
+
+  /**
+   * Verify circle access, then confirm every id is a live member of circleId.
+   *
+   * Deliberately a private re-implementation of MediaService.assertAllInCircle
+   * (which is private and in another module); the shape and the error message
+   * are kept identical so the two stay recognisably the same guard.
+   */
+  private async assertAllInCircle(
+    ids: string[],
+    circleId: string,
+    user: RequestUser,
+    role: 'viewer' | 'collaborator',
+  ): Promise<void> {
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      circleId,
+      user.permissions,
+      role as CircleRole,
+    );
+
+    const uniqueIds = [...new Set(ids)];
+    const found = await this.prisma.mediaItem.findMany({
+      where: { id: { in: uniqueIds }, circleId, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (found.length !== uniqueIds.length) {
+      const foundSet = new Set(found.map((f) => f.id));
+      const missing = uniqueIds.filter((id) => !foundSet.has(id));
+      throw new NotFoundException(
+        `MediaItems not found or not accessible: ${missing.join(', ')}`,
+      );
     }
   }
 

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -187,6 +187,16 @@ export class MediaEnhancementService {
       circleId: mediaItem.circleId,
       reason: JobReason.rerun,
       priority: 0,
+      // skipDedup is REQUIRED here, not an optimization. EnrichmentJobService
+      // dedups on (type, mediaItemId, status in pending|running) and returns the
+      // EXISTING job — whose payload points at the enhancement id superseded by
+      // the supersedeLive() call two statements up. Without this flag,
+      // re-enhancing an item whose previous job is still `pending` silently
+      // hands back that stale job, the handler resolves the now-`discarded` row
+      // and early-returns, and the row just created sits at `pending` forever.
+      // The media_enhancements row (one live per item, enforced by
+      // supersedeLive) is the real idempotency unit here — not the job row.
+      skipDedup: true,
       providerKey: provider,
       modelVersion: model,
       payload: { enhancementId: row.id },

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -338,9 +338,18 @@ export class MediaEnhancementService {
   ) {
     // Cached (5 s TTL) — no extra DB read path.
     const settings = await this.systemSettings.getSettings();
+
+    // Re-checked rather than assumed from the caller: this helper is the reuse
+    // seam for #424's by-filter entry point, and a future caller that forgot the
+    // gate would otherwise write rows with an undefined provider/model.
     const enhanceCfg = settings.ai?.features?.enhance;
-    const provider = enhanceCfg!.provider;
-    const model = params.model ?? enhanceCfg!.model;
+    if (!enhanceCfg?.provider || !enhanceCfg?.model) {
+      throw new BadRequestException(
+        'No enhancement model configured (ai.features.enhance is unset)',
+      );
+    }
+    const provider = enhanceCfg.provider;
+    const model = params.model ?? enhanceCfg.model;
 
     const items = await this.prisma.mediaItem.findMany({
       where: { id: { in: ids } },

--- a/apps/api/src/enhancement/picture-enhancement.handler.spec.ts
+++ b/apps/api/src/enhancement/picture-enhancement.handler.spec.ts
@@ -124,6 +124,7 @@ describe('PictureEnhancementHandler', () => {
   let mockRegistry: { register: jest.Mock };
   let mockPrisma: {
     mediaEnhancement: { findUnique: jest.Mock; update: jest.Mock };
+    mediaEnhancementBatch: { findUnique: jest.Mock };
     mediaItem: { findUnique: jest.Mock };
   };
   let mockDownload: jest.Mock;
@@ -152,6 +153,11 @@ describe('PictureEnhancementHandler', () => {
       mediaEnhancement: {
         findUnique: jest.fn().mockResolvedValue(makeEnhancementRow()),
         update: jest.fn().mockResolvedValue({}),
+      },
+      // Batch-cancellation gate (issue #421). Only consulted when the row
+      // carries a batchId; the default row is a single-item enhancement.
+      mediaEnhancementBatch: {
+        findUnique: jest.fn().mockResolvedValue(null),
       },
       mediaItem: {
         findUnique: jest.fn().mockResolvedValue(makeMediaItem()),

--- a/apps/api/src/enhancement/picture-enhancement.handler.spec.ts
+++ b/apps/api/src/enhancement/picture-enhancement.handler.spec.ts
@@ -286,6 +286,74 @@ describe('PictureEnhancementHandler', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Batch-cancellation gate (epic #420, issue #421). MediaEnhancementService
+  // .cancelBatch deletes still-PENDING job rows, but a job already claimed by
+  // a worker when the cancel landed is past that point — this second gate is
+  // what stops it from going on to make a billed gpt-image-1 call for a batch
+  // the user just stopped.
+  // -------------------------------------------------------------------------
+
+  describe('cancelled-batch no-op path', () => {
+    it('marks the row cancelled and returns WITHOUT calling the OpenAI provider when the owning batch is cancelled', async () => {
+      mockPrisma.mediaEnhancement.findUnique.mockResolvedValue(
+        makeEnhancementRow({ batchId: 'batch-1' }),
+      );
+      mockPrisma.mediaEnhancementBatch.findUnique.mockResolvedValue({
+        cancelledAt: new Date('2026-01-01T00:00:00Z'),
+      });
+
+      await handler.process(makeJob());
+
+      expect(mockPrisma.mediaEnhancementBatch.findUnique).toHaveBeenCalledWith({
+        where: { id: 'batch-1' },
+        select: { cancelledAt: true },
+      });
+      expect(mockPrisma.mediaEnhancement.update).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.mediaEnhancement.update).toHaveBeenCalledWith({
+        where: { id: 'enh-1' },
+        data: { status: MediaEnhancementStatus.cancelled },
+      });
+      // Never transitioned to `processing`, and the provider was never invoked.
+      expect(mockPrisma.mediaEnhancement.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: MediaEnhancementStatus.processing }),
+        }),
+      );
+      expect(mockAiProviderRegistry.get).not.toHaveBeenCalled();
+      expect(mockEnhanceImage).not.toHaveBeenCalled();
+      expect(mockResolver.getProviderFor).not.toHaveBeenCalled();
+      expect(mockDownload).not.toHaveBeenCalled();
+      expect(mockUpload).not.toHaveBeenCalled();
+    });
+
+    it('proceeds normally (no batch query at all) for a row with no batchId — a single-item enhance', async () => {
+      mockPrisma.mediaEnhancement.findUnique.mockResolvedValue(
+        makeEnhancementRow({ batchId: null }),
+      );
+
+      await handler.process(makeJob());
+
+      expect(mockPrisma.mediaEnhancementBatch.findUnique).not.toHaveBeenCalled();
+      expect(mockEnhanceImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('proceeds normally when the owning batch exists but is NOT cancelled', async () => {
+      mockPrisma.mediaEnhancement.findUnique.mockResolvedValue(
+        makeEnhancementRow({ batchId: 'batch-1' }),
+      );
+      mockPrisma.mediaEnhancementBatch.findUnique.mockResolvedValue({ cancelledAt: null });
+
+      await handler.process(makeJob());
+
+      expect(mockEnhanceImage).toHaveBeenCalledTimes(1);
+      const readyCall = mockPrisma.mediaEnhancement.update.mock.calls.find(
+        (c: any[]) => c[0].data.status === MediaEnhancementStatus.ready,
+      );
+      expect(readyCall).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Happy path
   // -------------------------------------------------------------------------
 

--- a/apps/api/src/enhancement/picture-enhancement.handler.ts
+++ b/apps/api/src/enhancement/picture-enhancement.handler.ts
@@ -92,6 +92,28 @@ export class PictureEnhancementHandler implements EnrichmentHandler, OnModuleIni
       return;
     }
 
+    // Second cancellation gate (epic #420, issue #421). MediaEnhancementService
+    // .cancelBatch deletes the still-PENDING job rows, but a job already claimed
+    // by a worker when the cancel landed is past that point — it would otherwise
+    // go on to make a billed gpt-image-1 call for a batch the user just stopped.
+    // One cheap read closes that window.
+    if (row.batchId) {
+      const batch = await this.prisma.mediaEnhancementBatch.findUnique({
+        where: { id: row.batchId },
+        select: { cancelledAt: true },
+      });
+      if (batch?.cancelledAt) {
+        await this.prisma.mediaEnhancement.update({
+          where: { id: row.id },
+          data: { status: MediaEnhancementStatus.cancelled },
+        });
+        this.logger.log(
+          `picture_enhancement job ${job.id}: batch ${row.batchId} was cancelled; skipping enhancement ${row.id}`,
+        );
+        return;
+      }
+    }
+
     await this.prisma.mediaEnhancement.update({
       where: { id: row.id },
       data: { status: MediaEnhancementStatus.processing, lastError: null },

--- a/apps/api/src/settings/dto/features-response.dto.ts
+++ b/apps/api/src/settings/dto/features-response.dto.ts
@@ -21,6 +21,13 @@ export const featuresResponseSchema = z.object({
     blockReplaceOnDownscale: z.boolean(),
     /** Configured enhancement model NAME (never a credential); null when unset. */
     model: z.string().nullable(),
+    /**
+     * Max items one bulk-enhance request may queue (epic #420, issue #421).
+     * Surfaced here — rather than only on the Admin-only system settings read —
+     * so a non-admin collaborator's client can cap/label its selection before
+     * submitting instead of discovering the limit as a 400.
+     */
+    maxBatchSize: z.number(),
   }),
 });
 

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -209,6 +209,7 @@ export const patchSystemSettingsSchema = z.object({
       blockReplaceOnDownscale: z.boolean().optional(),
       maxInputMegapixels: z.number().min(1).max(100).optional(),
       retentionHours: z.number().int().min(1).max(720).optional(),
+      maxBatchSize: z.number().int().min(1).max(200).optional(),
     })
     .optional(),
   // Memories (epic #300, issue #302). NOTE: this is the THIRD hand-maintained

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -64,6 +64,8 @@ export interface PublicFeatures {
     blockReplaceOnDownscale: boolean;
     /** Configured enhancement model NAME (never a credential); null when unset. */
     model: string | null;
+    /** Max items one POST /api/media/bulk/enhance may queue (issue #421). */
+    maxBatchSize: number;
   };
 }
 
@@ -193,6 +195,9 @@ export class SystemSettingsService {
         blockReplaceOnDownscale:
           settings.pictureEnhancement?.blockReplaceOnDownscale ?? false,
         model: settings.ai?.features?.enhance?.model ?? null,
+        // The client needs the bulk cap without an Admin-only settings read, so
+        // a selection can be capped/labelled up front rather than 400'd.
+        maxBatchSize: settings.pictureEnhancement?.maxBatchSize ?? 25,
       },
     };
   }
@@ -580,6 +585,10 @@ export class SystemSettingsService {
           (dto as any).pictureEnhancement?.retentionHours ??
           (current as any).pictureEnhancement?.retentionHours ??
           168,
+        maxBatchSize:
+          (dto as any).pictureEnhancement?.maxBatchSize ??
+          (current as any).pictureEnhancement?.maxBatchSize ??
+          25,
       },
       workflows: {
         maxItemsPerRun:

--- a/apps/api/test/enhancement/picture-enhancer-batch-settings.integration.spec.ts
+++ b/apps/api/test/enhancement/picture-enhancer-batch-settings.integration.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * Integration test for `pictureEnhancement.maxBatchSize` (epic #420, issue #421).
+ *
+ * The repo has a documented, real failure mode here: system settings are
+ * hand-duplicated across THREE files — `systemSettingsSchema` +
+ * `systemSettingsPatchSchema` (validation/merge) and, separately, the wire DTO
+ * `patchSystemSettingsSchema` in `settings/dto/update-system-settings.dto.ts`
+ * that `nestjs-zod` actually validates the HTTP request body against and which
+ * STRIPS UNKNOWN KEYS. A namespace/field present only in the first two passes
+ * every unit test asserting against the Zod schema directly while every real
+ * `PATCH /api/system-settings` silently no-ops. Asserting only against
+ * `patchSystemSettingsSchema.parse(...)` (as update-system-settings.dto.spec.ts
+ * does for other namespaces) would NOT catch that class of bug for this field,
+ * because it only exercises schema #1/#2's twin, not the wire boundary.
+ *
+ * This file therefore drives the assertion through a REAL HTTP request
+ * (supertest, mocked Prisma only — the same pattern as
+ * test/memories/memories-settings.integration.spec.ts), so a regression that
+ * reintroduces the trap (e.g. a future edit to `maxBatchSize` that forgets one
+ * of the three copies) fails here even though it would pass a schema-only test.
+ */
+
+import request from 'supertest';
+import {
+  TestContext,
+  createTestApp,
+  closeTestApp,
+} from '../helpers/test-app.helper';
+import { resetPrismaMock } from '../mocks/prisma.mock';
+import { setupBaseMocks } from '../fixtures/mock-setup.helper';
+import {
+  createMockAdminUser,
+  createMockViewerUser,
+  authHeader,
+} from '../helpers/auth-mock.helper';
+import { DEFAULT_SYSTEM_SETTINGS } from '../../src/common/types/settings.types';
+import { SystemSettingsService } from '../../src/settings/system-settings/system-settings.service';
+
+describe('pictureEnhancement.maxBatchSize settings integration (issue #421)', () => {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    context = await createTestApp({ useMockDatabase: true });
+  });
+
+  afterAll(async () => {
+    await closeTestApp(context);
+  });
+
+  beforeEach(async () => {
+    resetPrismaMock();
+    setupBaseMocks();
+    // SystemSettingsService caches for 5 s in process, and the app instance is
+    // shared across the whole file — without this, one test's settings row is
+    // still being served to the next.
+    (context.module.get(SystemSettingsService) as any).settingsCache = null;
+  });
+
+  /** Seed the mocked settings row and capture whatever the service writes. */
+  function stubSettingsRow(value: unknown = DEFAULT_SYSTEM_SETTINGS) {
+    context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+      id: 'settings-1',
+      key: 'global',
+      value: value as any,
+      version: 1,
+      updatedAt: new Date(),
+      updatedByUserId: null,
+      updatedByUser: null,
+    });
+    context.prismaMock.systemSettings.update.mockImplementation((args: any) =>
+      Promise.resolve({
+        id: 'settings-1',
+        key: 'global',
+        value: args.data.value,
+        version: 2,
+        updatedAt: new Date(),
+        updatedByUserId: null,
+        updatedByUser: null,
+      }),
+    );
+    context.prismaMock.auditEvent.create.mockResolvedValue({} as any);
+  }
+
+  /** The `pictureEnhancement` block the service actually persisted. */
+  function persistedPictureEnhancement(): any {
+    const call = context.prismaMock.systemSettings.update.mock.calls.at(-1);
+    return (call?.[0] as any).data.value.pictureEnhancement;
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. PATCH /api/system-settings — the wire-level round-trip
+  // -------------------------------------------------------------------------
+
+  describe('PATCH /api/system-settings — pictureEnhancement.maxBatchSize', () => {
+    beforeEach(() => stubSettingsRow());
+
+    it('ships the documented default of 25', async () => {
+      const admin = await createMockAdminUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .expect(200);
+
+      expect(response.body.data.pictureEnhancement.maxBatchSize).toBe(25);
+    });
+
+    it('round-trips a new maxBatchSize through the REAL HTTP PATCH request (not just the Zod schema)', async () => {
+      const admin = await createMockAdminUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: 10 } })
+        .expect(200);
+
+      // The HTTP response reflects the new value...
+      expect(response.body.data.pictureEnhancement.maxBatchSize).toBe(10);
+      // ...and it is what the service actually persisted, proving the wire DTO
+      // did not strip the field before it ever reached SystemSettingsService.
+      expect(persistedPictureEnhancement().maxBatchSize).toBe(10);
+    });
+
+    it('merges maxBatchSize without disturbing its pictureEnhancement siblings', async () => {
+      const admin = await createMockAdminUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: 5 } })
+        .expect(200);
+
+      const persisted = persistedPictureEnhancement();
+      expect(persisted.maxBatchSize).toBe(5);
+      expect(persisted.defaultQuality).toBe(DEFAULT_SYSTEM_SETTINGS.pictureEnhancement!.defaultQuality);
+      expect(persisted.allowReplace).toBe(DEFAULT_SYSTEM_SETTINGS.pictureEnhancement!.allowReplace);
+    });
+
+    it('accepts the inclusive bounds (1 and 200)', async () => {
+      const admin = await createMockAdminUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: 1 } })
+        .expect(200);
+      expect(persistedPictureEnhancement().maxBatchSize).toBe(1);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: 200 } })
+        .expect(200);
+      expect(persistedPictureEnhancement().maxBatchSize).toBe(200);
+    });
+
+    it.each([
+      ['below the min (0)', 0],
+      ['above the max (201)', 201],
+      ['a non-integer', 5.5],
+    ])('rejects maxBatchSize %s with 400', async (_label, value) => {
+      const admin = await createMockAdminUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: value } })
+        .expect(400);
+
+      expect(context.prismaMock.systemSettings.update).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 for a caller without system_settings:write', async () => {
+      const viewer = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(viewer.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: 10 } })
+        .expect(403);
+
+      expect(context.prismaMock.systemSettings.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. GET /api/features — the least-privilege carrier a non-admin client
+  //    actually reads the cap from before submitting a bulk-enhance batch.
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/features — pictureEnhancement.maxBatchSize', () => {
+    it('surfaces the default maxBatchSize of 25 to a non-admin caller', async () => {
+      stubSettingsRow();
+      const viewer = await createMockViewerUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/features')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.pictureEnhancement.maxBatchSize).toBe(25);
+    });
+
+    it('reflects a persisted non-default maxBatchSize', async () => {
+      stubSettingsRow({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        pictureEnhancement: { ...DEFAULT_SYSTEM_SETTINGS.pictureEnhancement, maxBatchSize: 7 },
+      });
+      const viewer = await createMockViewerUser(context);
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/features')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.pictureEnhancement.maxBatchSize).toBe(7);
+    });
+
+    it('reflects a value just written via PATCH /api/system-settings — end-to-end round trip', async () => {
+      stubSettingsRow();
+      const admin = await createMockAdminUser(context);
+      const viewer = await createMockViewerUser(context);
+
+      await request(context.app.getHttpServer())
+        .patch('/api/system-settings')
+        .set(authHeader(admin.accessToken))
+        .send({ pictureEnhancement: { maxBatchSize: 42 } })
+        .expect(200);
+
+      // GET /api/features reads through the same cached SystemSettingsService,
+      // so invalidate the in-process cache the same way stubSettingsRow's
+      // beforeEach does before every OTHER test in this file.
+      (context.module.get(SystemSettingsService) as any).settingsCache = null;
+      // The mocked findUnique must now serve the row the PATCH just wrote.
+      context.prismaMock.systemSettings.findUnique.mockResolvedValue({
+        id: 'settings-1',
+        key: 'global',
+        value: persistedPictureEnhancementAsFullSettings(),
+        version: 2,
+        updatedAt: new Date(),
+        updatedByUserId: null,
+        updatedByUser: null,
+      });
+
+      const response = await request(context.app.getHttpServer())
+        .get('/api/features')
+        .set(authHeader(viewer.accessToken))
+        .expect(200);
+
+      expect(response.body.data.pictureEnhancement.maxBatchSize).toBe(42);
+    });
+
+    /** Reconstructs the full settings document last written by systemSettings.update. */
+    function persistedPictureEnhancementAsFullSettings(): any {
+      const call = context.prismaMock.systemSettings.update.mock.calls.at(-1);
+      return (call?.[0] as any).data.value;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of epic #420: the data model, API and spend guard that let a selection of photos be sent to the AI Picture Enhancer as **one tracked, cancellable batch**. This phase is backend-only — no UI yet; #422 adds the trigger.

The batch is a **grouping key plus a cancel flag**, not a new engine. The per-item unit of work already exists as the `picture_enhancement` enrichment job, which supplies retry, 429/529 rate-limit deferral, execution timeouts and `/admin/jobs` visibility — so the review-run / trash-empty `evaluate` + `execute_batch` pair was deliberately not reused; it would only re-implement OpenAI orchestration in a second handler.

**Progress is derived, never stored.** One `groupBy(status)` over `media_enhancements WHERE batch_id = ?`. No counter columns, no increment race, no finalize job.

**Status is computed from "no rows remain `pending`/`processing`", never `processedCount === matchedCount`.** `MediaEnhancement.mediaItemId` is `onDelete: Cascade`, so hard-deleting a photo mid-batch removes its enhancement row and *shrinks* the work set — a counter-equality check would leave the batch `running` forever. This is the exact failure `review_runs` documents at `schema.prisma:2036-2043`, and it has a dedicated regression test.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — the latent `skipDedup` bug below

## Related Issues

Fixes #421
Relates to #420

## Changes Made

**Data model** (two migrations — the enum needs its own, since Postgres cannot add an enum value in the same transaction as statements referencing it)

- `media_enhancement_batches` table; `media_enhancements.batch_id` nullable FK with `onDelete: SetNull` and `@@index([batchId])`. SetNull is deliberate: deleting a batch record must never delete enhancements it produced, which may already be `applied`.
- `MediaEnhancementStatus.cancelled`, appended last to match the append-only `ALTER TYPE ... ADD VALUE` (same precedent as `MediaTagSource.system`). `cancelled` means *never rendered at all* and is deliberately distinct from `discarded` (*a human reviewed a result and said no*) — conflating them would corrupt the hub's status filters and the derived counters.

**Settings** — `pictureEnhancement.maxBatchSize` (int, 1–200, default 25), added to all four hand-maintained copies plus `GET /api/features`, so the client can cap its selection UI without an Admin-only settings read.

**`startBatch()`** — five deliberate divergences from `startEnhance`, each commented in place:

| | Single-item | Batch | Why |
|---|---|---|---|
| Live enhancement | `supersedeLive()` | **skip + count** | never destroy an unreviewed, already-billed `ready` result |
| Non-photo / oversized | `400` | **skip + count** | a mixed selection must not fail wholesale |
| Priority | `0` | **`50`** | below upload enrichment (5/10) and evaluate (20); above purges (100) |
| Dedup | default | **`skipDedup: true`** | the enhancement row is the idempotency unit, guaranteed by the skip rule |
| Authorization | per-item | **hoisted, once** | the `bulkRerunTags` contract |

**Endpoints**

- `POST /api/media/bulk/enhance` → `202 { batchId, requested, queued, skipped: { notPhoto, tooLarge, alreadyLive } }`. Declared in the controller's **static-routes block**, or `bulk` would be captured as an `:id` param by `MediaController`'s `@Get(':id')` — with a regression test.
- `GET /api/enhancement-batches?circleId=` — paginated, newest first
- `GET /api/enhancement-batches/:id` — the `BaseRun`-shaped detail
- `POST /api/enhancement-batches/:id/cancel` — cooperative
- `GET /api/media/enhancements?batchId=` — hub filter for "review what I just enhanced"

The detail response emits exactly `TrashEmptyRunService.serializeRun`'s field set, so #423 reuses `RunProgressPanel` + `useRunPolling` and writes **no new progress component**.

**Cancel is cooperative**: stamp `cancelledAt`, delete still-`pending` enrichment jobs, mark those rows `cancelled`. In-flight `processing` rows are left to finish — their `gpt-image-1` call is already being billed, so aborting wastes the money without saving any. A second gate in `PictureEnhancementHandler` catches a job already claimed when cancel landed.

**Latent bug fixed** — `startEnhance` called `supersedeLive()` then enqueued *without* `skipDedup`. Enrichment dedup matches `(type, mediaItemId, status IN (pending, running))`, so re-enhancing an item whose previous job had not yet been claimed returned the **old** job, whose payload still pointed at the now-`discarded` enhancement id. The new row was created and never processed — a silent dead row stuck at `pending`. Reproducible today by clicking AI Enhance twice within one `ENRICHMENT_JOB_POLL_MS` window (default 5 s).

No new RBAC permission — reuses `media:read`/`media:write` + per-circle viewer/collaborator.

## Testing

- [x] Unit tests pass (`npm test`) — **336 suites / 7989 tests**, no new failures and no pre-existing ones
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [ ] Manual testing completed — no live database or OpenAI credential available in this environment; migrations are hand-authored against existing house style and `prisma generate` is clean, but they have **not** been applied to a running database

Coverage added for the two criteria most likely to regress silently:

- **The anti-supersede test** — an item with a live `ready` enhancement is skipped, and its staged bytes still exist afterwards: no discard, no staging-key mutation, no provider delete.
- **The cascade test** — a batch whose row count has shrunk below `queuedCount` (hard-deleted media items) still reaches `completed`, in both the clean and the `completed_with_errors` variants.

Plus: the partition logic per skip reason, the cap 400 naming both numbers, feature/model gates, `priority: 50` + `skipDedup: true` asserted on the enqueue mock, full status-derivation table, cancel semantics, RBAC, the empty-batch terminal case, a settings round-trip **through the wire DTO** (a schema-only assertion passes while every real PATCH silently no-ops), and the route-collision guard.

### Test Instructions

1. Apply both migrations against a real database and confirm they succeed on a fresh **and** a populated one.
2. `PATCH /api/system-settings` with `pictureEnhancement.maxBatchSize`, then `GET` it back and confirm it appears in `GET /api/features`.
3. `POST /api/media/bulk/enhance` with a mixed selection (photos, a video, an item already mid-enhancement) — expect `202` with a partial `queued` and a populated `skipped` breakdown, and confirm the already-live item's staged bytes are still present.
4. Poll `GET /api/enhancement-batches/:id` through `running → completed`; cancel mid-flight and confirm queued items stop while in-flight ones finish.

## Additional Notes

Three implementer deviations worth a reviewer's eye:

1. **Batch read/cancel live on `MediaEnhancementService`** rather than a new service — the issue specified only a new *controller*, and keeping one owner of the batch lifecycle avoids splitting the tally/serialize logic across two providers.
2. **A 7th commit re-validates the enhance config inside `createBatchFrom`.** It originally relied on its single caller having gated first — exactly the assumption #424's new entry point would break.
3. **`skipped.notPhoto` absorbs ids that vanished between the authorization read and the partition read** (a concurrent hard delete), so the four buckets always sum to `requested` rather than failing a whole batch over a race. Slightly imprecise labelling in a rare case; the alternative was a fifth bucket for something a user cannot act on.

`serializeBatch` returns the 14 `BaseRun` fields **plus** six batch-specific extras (`requestedCount`, `queuedCount`, `skipped`, `params`, `source`, `cancelledAt`). All four emitted statuses are members of the web `RunStatus` union, so `RunProgressPanel` binds without change.

Spec and `CLAUDE.md` are deliberately **not** updated here — #425 syncs the documentation last, against what actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXs8GNhptV9NvqDTyX3E9A)_