### PR TITLE
feat(web): batch AI enhancement Phase 2 — multi-select AI Enhance trigger and the batch submit dialog

### DIFF
--- a/apps/web/src/__tests__/components/media/BatchEnhanceDialog.test.tsx
+++ b/apps/web/src/__tests__/components/media/BatchEnhanceDialog.test.tsx
@@ -1,0 +1,481 @@
+/**
+ * BatchEnhanceDialog — unit tests (issue #422, epic #420 phase 2).
+ *
+ * Multi-photo AI enhance: params step (preset picker + optional Customize) ->
+ * submit -> either an immediate close (nothing skipped) or a result step
+ * showing the per-reason skip breakdown before the user dismisses it.
+ *
+ * Mocks the media service so we don't need a real API. The preset ->
+ * EnhanceParams mapping is asserted by IMPORTING `buildEnhanceParams` /
+ * `resolvePreset` from the shared `enhancePresets` module (also consumed by
+ * MediaEnhancementDrawer) rather than hard-coding an expected literal, so the
+ * two enhance surfaces can never silently drift apart.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { render } from '../../utils/test-utils';
+import { BatchEnhanceDialog } from '../../../components/media/BatchEnhanceDialog';
+import type { BatchEnhanceSelectionTarget } from '../../../components/media/BatchEnhanceDialog';
+import {
+  buildEnhanceParams,
+  resolvePreset,
+  DEFAULT_ADJUSTMENTS,
+} from '../../../components/media/enhancePresets';
+import type { EnhanceFormState } from '../../../components/media/enhancePresets';
+import type { BulkEnhanceResult } from '../../../services/media';
+
+// ---------------------------------------------------------------------------
+// Mock media service
+// ---------------------------------------------------------------------------
+vi.mock('../../../services/media', () => ({
+  bulkEnhance: vi.fn(),
+}));
+
+import { bulkEnhance } from '../../../services/media';
+
+const mockBulkEnhance = vi.mocked(bulkEnhance);
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+function makeTarget(overrides: Partial<BatchEnhanceSelectionTarget> = {}): BatchEnhanceSelectionTarget {
+  return {
+    kind: 'selection',
+    circleId: 'circle-1',
+    photoIds: ['p1', 'p2'],
+    nonPhotoCount: 0,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<BulkEnhanceResult> = {}): BulkEnhanceResult {
+  return {
+    batchId: 'batch-1',
+    requested: 2,
+    queued: 2,
+    skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 },
+    ...overrides,
+  };
+}
+
+/** The default, nothing-touched form state for a given preset selection. */
+function defaultFormStateFor(presetKey: EnhanceFormState['presetKey']): EnhanceFormState {
+  const preset = resolvePreset(presetKey);
+  return {
+    presetKey,
+    adjustments: preset.prefill.adjustments,
+    strength: preset.prefill.strength,
+    preserveFaces: preset.prefill.preserveFaces,
+    instructions: '',
+    quality: '',
+  };
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  target: makeTarget(),
+  maxBatchSize: 25,
+  onSuccess: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('BatchEnhanceDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBulkEnhance.mockResolvedValue(makeResult());
+  });
+
+  // -------------------------------------------------------------------------
+  // Count rendering
+  // -------------------------------------------------------------------------
+  describe('count rendering', () => {
+    it('shows the photo count in the headline and the confirm button', () => {
+      const ids = Array.from({ length: 12 }, (_, i) => `p${i}`);
+      render(
+        <BatchEnhanceDialog {...defaultProps} target={makeTarget({ photoIds: ids })} />,
+      );
+
+      expect(screen.getByText(/Enhance 12 photos with AI/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^Enhance 12 photos$/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('uses singular phrasing for exactly one photo', () => {
+      render(
+        <BatchEnhanceDialog {...defaultProps} target={makeTarget({ photoIds: ['p1'] })} />,
+      );
+
+      expect(screen.getByText(/Enhance 1 photo with AI/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^Enhance 1 photo$/i })).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-photo (video) notice
+  // -------------------------------------------------------------------------
+  describe('non-photo items in the selection', () => {
+    it('shows a "N videos will be skipped" notice when nonPhotoCount > 0', () => {
+      render(
+        <BatchEnhanceDialog
+          {...defaultProps}
+          target={makeTarget({ photoIds: ['p1', 'p2'], nonPhotoCount: 2 })}
+        />,
+      );
+
+      expect(
+        screen.getByText(/2 videos in your selection will be skipped/i),
+      ).toBeInTheDocument();
+    });
+
+    it('uses singular phrasing for exactly one non-photo item', () => {
+      render(
+        <BatchEnhanceDialog
+          {...defaultProps}
+          target={makeTarget({ photoIds: ['p1'], nonPhotoCount: 1 })}
+        />,
+      );
+
+      expect(
+        screen.getByText(/1 video in your selection will be skipped/i),
+      ).toBeInTheDocument();
+    });
+
+    it('shows no video notice when nonPhotoCount is 0', () => {
+      render(
+        <BatchEnhanceDialog {...defaultProps} target={makeTarget({ nonPhotoCount: 0 })} />,
+      );
+
+      expect(screen.queryByText(/will be skipped/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Preset -> params equivalence with the single-item drawer (shared module)
+  // -------------------------------------------------------------------------
+  describe('preset params equivalence (shared enhancePresets module)', () => {
+    it('sends the same params as the drawer would for an untouched real preset', async () => {
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /^restore old photo —/i }));
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      const expected = buildEnhanceParams(defaultFormStateFor('restore_old_photo'));
+
+      await waitFor(() => {
+        expect(mockBulkEnhance).toHaveBeenCalledWith({
+          circleId: 'circle-1',
+          ids: ['p1', 'p2'],
+          params: expected,
+        });
+      });
+      // Sanity: a real preset must carry `preset`, never `intent` when untouched.
+      expect(expected.preset).toBe('restore_old_photo');
+      expect(expected.intent).toBeUndefined();
+    });
+
+    it('sends {} (full server defaults) for "Auto" with nothing customized', async () => {
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} />);
+
+      // "Auto" is selected by default — submit without touching anything.
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      const expected = buildEnhanceParams(defaultFormStateFor('auto'));
+      expect(expected).toEqual({});
+
+      await waitFor(() => {
+        expect(mockBulkEnhance).toHaveBeenCalledWith({
+          circleId: 'circle-1',
+          ids: ['p1', 'p2'],
+          params: expected,
+        });
+      });
+    });
+
+    it('sends intent: "custom" and the changed adjustments once the user actually customizes', async () => {
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} />);
+
+      // Open the Customize panel and flip "Reduce noise" off (default: true).
+      await user.click(screen.getByRole('button', { name: /customize/i }));
+      await user.click(screen.getByText(/reduce noise/i));
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      const customizedFormState: EnhanceFormState = {
+        ...defaultFormStateFor('auto'),
+        adjustments: { ...DEFAULT_ADJUSTMENTS, denoise: false },
+      };
+      const expected = buildEnhanceParams(customizedFormState);
+
+      // The isCustomized rule: a real deviation from the preset's prefill
+      // must send intent: 'custom' — this is the assertion the shared-module
+      // equivalence check protects against drifting silently.
+      expect(expected.intent).toBe('custom');
+
+      await waitFor(() => {
+        expect(mockBulkEnhance).toHaveBeenCalledWith({
+          circleId: 'circle-1',
+          ids: ['p1', 'p2'],
+          params: expected,
+        });
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Over the batch cap
+  // -------------------------------------------------------------------------
+  describe('over maxBatchSize', () => {
+    it('disables submit and names both the selection size and the cap', () => {
+      const ids = Array.from({ length: 30 }, (_, i) => `p${i}`);
+      render(
+        <BatchEnhanceDialog
+          {...defaultProps}
+          target={makeTarget({ photoIds: ids })}
+          maxBatchSize={25}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          /You selected 30 photos; the limit is 25 per batch\. Deselect 5/i,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^Enhance 30 photos$/i })).toBeDisabled();
+    });
+
+    it('does not disable submit when the selection is within the cap', () => {
+      render(
+        <BatchEnhanceDialog
+          {...defaultProps}
+          target={makeTarget({ photoIds: ['p1', 'p2'] })}
+          maxBatchSize={25}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /^Enhance 2 photos$/i })).not.toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Submit payload
+  // -------------------------------------------------------------------------
+  describe('submit payload', () => {
+    it('calls bulkEnhance with the target photo ids only, the circleId, and the built params', async () => {
+      const user = userEvent.setup();
+      render(
+        <BatchEnhanceDialog
+          {...defaultProps}
+          target={makeTarget({ circleId: 'circle-42', photoIds: ['pa', 'pb', 'pc'] })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 3 photos$/i }));
+
+      await waitFor(() => {
+        expect(mockBulkEnhance).toHaveBeenCalledTimes(1);
+      });
+      expect(mockBulkEnhance).toHaveBeenCalledWith({
+        circleId: 'circle-42',
+        ids: ['pa', 'pb', 'pc'],
+        params: {},
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Double-submit guard
+  // -------------------------------------------------------------------------
+  describe('double-submit guard', () => {
+    it('disables the submit button while a request is in flight, so a fast double click cannot fire twice', async () => {
+      let resolveBulkEnhance: (result: BulkEnhanceResult) => void = () => {};
+      mockBulkEnhance.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveBulkEnhance = resolve;
+          }),
+      );
+
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} />);
+
+      const submitBtn = screen.getByRole('button', { name: /^Enhance 2 photos$/i });
+      await user.click(submitBtn);
+
+      // Now disabled — a real `<button disabled>` does not dispatch click at
+      // all, so even a raw fireEvent (bypassing userEvent's own pointer-events
+      // guard) cannot re-trigger the handler.
+      expect(submitBtn).toBeDisabled();
+      fireEvent.click(submitBtn);
+
+      expect(mockBulkEnhance).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveBulkEnhance(makeResult());
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Server error
+  // -------------------------------------------------------------------------
+  describe('server error', () => {
+    it('renders the server message inline in an error Alert and keeps the dialog open', async () => {
+      mockBulkEnhance.mockRejectedValueOnce(
+        new Error('Picture enhancement is disabled'),
+      );
+      const onClose = vi.fn();
+      const onSuccess = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BatchEnhanceDialog {...defaultProps} onClose={onClose} onSuccess={onSuccess} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      const message = await screen.findByText('Picture enhancement is disabled');
+      const alertRoot = message.closest('.MuiAlert-root');
+      expect(alertRoot).not.toBeNull();
+      expect(alertRoot).toHaveClass('MuiAlert-colorError');
+
+      // Still on the params step, not closed.
+      expect(screen.getByRole('button', { name: /^Enhance 2 photos$/i })).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a generic message for a non-Error rejection', async () => {
+      mockBulkEnhance.mockRejectedValueOnce('boom');
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      expect(
+        await screen.findByText('Failed to queue AI enhancements'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Result step — skipped breakdown vs. immediate close
+  // -------------------------------------------------------------------------
+  describe('result step', () => {
+    it('keeps the dialog open with the per-reason skip breakdown when something was skipped', async () => {
+      const onSuccess = vi.fn();
+      const onClose = vi.fn();
+      mockBulkEnhance.mockResolvedValueOnce(
+        makeResult({
+          requested: 3,
+          queued: 1,
+          skipped: { notPhoto: 0, tooLarge: 1, alreadyLive: 1 },
+        }),
+      );
+      const user = userEvent.setup();
+      render(
+        <BatchEnhanceDialog {...defaultProps} onSuccess={onSuccess} onClose={onClose} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      await screen.findByText(/AI enhancements queued/i);
+      // Neither callback fires until the user acknowledges the breakdown.
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+
+      expect(screen.getByText(/2 photos were skipped/i)).toBeInTheDocument();
+      expect(screen.getByText(/too large to enhance/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/already has an enhancement waiting for review/i),
+      ).toBeInTheDocument();
+      // notPhoto is 0 — its reason line must not render.
+      expect(screen.queryByText(/not a photo/i)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /^done$/i }));
+
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.stringMatching(/Queued AI enhancement for 1 photo · 2 skipped/i),
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes immediately with the toast message when nothing was skipped', async () => {
+      const onSuccess = vi.fn();
+      const onClose = vi.fn();
+      mockBulkEnhance.mockResolvedValueOnce(makeResult({ requested: 2, queued: 2 }));
+      const user = userEvent.setup();
+      render(
+        <BatchEnhanceDialog {...defaultProps} onSuccess={onSuccess} onClose={onClose} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith('Queued AI enhancement for 2 photos');
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+      // No result step ever rendered.
+      expect(screen.queryByText(/AI enhancements queued/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // queued === 0
+  // -------------------------------------------------------------------------
+  describe('queued === 0', () => {
+    it('renders "No photos were queued" rather than "Queued AI enhancement for 0 photos" when nothing was skipped either', async () => {
+      const onSuccess = vi.fn();
+      mockBulkEnhance.mockResolvedValueOnce(
+        makeResult({ requested: 0, queued: 0, skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 } }),
+      );
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} onSuccess={onSuccess} />);
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith('No photos were queued');
+      });
+      expect(onSuccess).not.toHaveBeenCalledWith(
+        expect.stringMatching(/Queued AI enhancement for 0/i),
+      );
+    });
+
+    it('renders "No photos queued — N skipped" (not the 0-photos phrasing) when everything was skipped', async () => {
+      mockBulkEnhance.mockResolvedValueOnce(
+        makeResult({
+          requested: 2,
+          queued: 0,
+          skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 2 },
+        }),
+      );
+      const onSuccess = vi.fn();
+      const user = userEvent.setup();
+      render(<BatchEnhanceDialog {...defaultProps} onSuccess={onSuccess} />);
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      const heading = await screen.findByText(/nothing was queued/i);
+      expect(heading).toBeInTheDocument();
+      expect(screen.getByText(/2 photos were skipped/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/queued ai enhancement for 0 photos/i),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /^done$/i }));
+      expect(onSuccess).toHaveBeenCalledWith('No photos queued — 2 photos were skipped');
+      expect(onSuccess).not.toHaveBeenCalledWith(
+        expect.stringMatching(/Queued AI enhancement for 0/i),
+      );
+    });
+  });
+});

--- a/apps/web/src/__tests__/components/media/BulkActionToolbar.test.tsx
+++ b/apps/web/src/__tests__/components/media/BulkActionToolbar.test.tsx
@@ -572,4 +572,185 @@ describe('BulkActionToolbar', () => {
       expect(onOpenEnhance).toHaveBeenCalledTimes(1);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // AI Enhance gate — multi-photo selection via `selectedItems` (issue #422,
+  // epic #420 phase 2).
+  //
+  // `selectedItems` is the source of truth once a caller migrates to it (the
+  // block above still pins down the `singleSelectedItem`-only fallback). The
+  // gate counts PHOTOS ONLY:
+  //   - exactly 1 photo  -> the single-item drawer (onOpenEnhance)
+  //   - 2+ photos        -> the batch dialog (onOpenBatchEnhance)
+  //   - a mix of 1 photo + N videos is still exactly 1 photo -> single drawer
+  //   - videos alone contribute nothing -> button absent
+  // -------------------------------------------------------------------------
+  describe('AI Enhance gate — multi-photo selection (selectedItems)', () => {
+    const photo = (id: string) => makeMediaItem({ id, type: 'photo' });
+    const video = (id: string) => makeMediaItem({ id, type: 'video' });
+
+    it('exactly 1 photo selected calls onOpenEnhance, not onOpenBatchEnhance', async () => {
+      const onOpenEnhance = vi.fn();
+      const onOpenBatchEnhance = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1'])}
+          selectedItems={[photo('p1')]}
+          enhanceEnabled
+          onOpenEnhance={onOpenEnhance}
+          onOpenBatchEnhance={onOpenBatchEnhance}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /ai enhance/i }));
+      expect(onOpenEnhance).toHaveBeenCalledTimes(1);
+      expect(onOpenBatchEnhance).not.toHaveBeenCalled();
+    });
+
+    it('2+ photos selected calls onOpenBatchEnhance, not onOpenEnhance', async () => {
+      const onOpenEnhance = vi.fn();
+      const onOpenBatchEnhance = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'p2'])}
+          selectedItems={[photo('p1'), photo('p2')]}
+          enhanceEnabled
+          onOpenEnhance={onOpenEnhance}
+          onOpenBatchEnhance={onOpenBatchEnhance}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /ai enhance/i }));
+      expect(onOpenBatchEnhance).toHaveBeenCalledTimes(1);
+      expect(onOpenEnhance).not.toHaveBeenCalled();
+    });
+
+    it('videos only: the AI Enhance button is absent', () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['v1', 'v2'])}
+          selectedItems={[video('v1'), video('v2')]}
+          enhanceEnabled
+          onOpenEnhance={vi.fn()}
+          onOpenBatchEnhance={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /ai enhance/i })).not.toBeInTheDocument();
+    });
+
+    it('mixed selection: the count reflects PHOTOS ONLY (3 photos + 2 videos -> "AI Enhance 3 photos")', () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'p2', 'p3', 'v1', 'v2'])}
+          selectedItems={[
+            photo('p1'),
+            photo('p2'),
+            photo('p3'),
+            video('v1'),
+            video('v2'),
+          ]}
+          enhanceEnabled
+          onOpenEnhance={vi.fn()}
+          onOpenBatchEnhance={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'AI Enhance 3 photos' }),
+      ).toBeInTheDocument();
+    });
+
+    it('1 photo + 1 video: still routes to the SINGLE drawer, not the batch dialog', async () => {
+      const onOpenEnhance = vi.fn();
+      const onOpenBatchEnhance = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'v1'])}
+          selectedItems={[photo('p1'), video('v1')]}
+          enhanceEnabled
+          onOpenEnhance={onOpenEnhance}
+          onOpenBatchEnhance={onOpenBatchEnhance}
+        />,
+      );
+
+      // The count reflects the single photo, not the size-2 raw selection.
+      const button = screen.getByRole('button', { name: 'AI Enhance 1 photo' });
+      await user.click(button);
+
+      expect(onOpenEnhance).toHaveBeenCalledTimes(1);
+      expect(onOpenBatchEnhance).not.toHaveBeenCalled();
+    });
+
+    it('is absent for viewer role even with a multi-photo selection', () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'p2'])}
+          selectedItems={[photo('p1'), photo('p2')]}
+          activeCircleRole="viewer"
+          enhanceEnabled
+          onOpenEnhance={vi.fn()}
+          onOpenBatchEnhance={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /ai enhance/i })).not.toBeInTheDocument();
+    });
+
+    it('is absent when the feature flag is off, even with photos selected', () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'p2'])}
+          selectedItems={[photo('p1'), photo('p2')]}
+          enhanceEnabled={false}
+          onOpenEnhance={vi.fn()}
+          onOpenBatchEnhance={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /ai enhance/i })).not.toBeInTheDocument();
+    });
+
+    it('is absent while flags are still loading (enhanceEnabled undefined) — must not flash in', () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'p2'])}
+          selectedItems={[photo('p1'), photo('p2')]}
+          // enhanceEnabled deliberately omitted, mirroring useFeatureFlags()
+          // before its first response resolves (pictureEnhancement === null).
+          onOpenEnhance={vi.fn()}
+          onOpenBatchEnhance={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /ai enhance/i })).not.toBeInTheDocument();
+    });
+
+    it('the aria-label names the photo count', () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['p1', 'p2', 'p3'])}
+          selectedItems={[photo('p1'), photo('p2'), photo('p3')]}
+          enhanceEnabled
+          onOpenEnhance={vi.fn()}
+          onOpenBatchEnhance={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByRole('button', { name: 'AI Enhance 3 photos' });
+      expect(button).toHaveAttribute('aria-label', 'AI Enhance 3 photos');
+    });
+  });
 });

--- a/apps/web/src/components/media/BatchEnhanceDialog.tsx
+++ b/apps/web/src/components/media/BatchEnhanceDialog.tsx
@@ -1,0 +1,460 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  CircularProgress,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import {
+  ADJUSTMENT_FIELDS,
+  DEFAULT_ADJUSTMENTS,
+  PRESETS,
+  PresetCard,
+  buildEnhanceParams,
+  resolvePreset,
+} from './enhancePresets';
+import type { AdjustmentsState, PresetKey } from './enhancePresets';
+import { bulkEnhance } from '../../services/media';
+import type { BulkEnhanceResult } from '../../services/media';
+import type { EnhanceQuality, EnhanceStrength } from '../../services/enhance';
+
+// ---------------------------------------------------------------------------
+// Target
+//
+// What a batch acts on. Today there is exactly one kind — an explicit client
+// selection — but the dialog reads `photoCount` and delegates submission to
+// `submitTarget`, so issue #424's "enhance everything matching this filter"
+// mode can be added as a second member whose count comes from the server
+// (a resolved `matchedCount`) without reworking any of the UI below.
+// ---------------------------------------------------------------------------
+
+export interface BatchEnhanceSelectionTarget {
+  kind: 'selection';
+  circleId: string;
+  /** Ids of the selected PHOTOS. Non-photos are excluded before we get here. */
+  photoIds: string[];
+  /**
+   * Non-photo items sharing the selection. Reported to the user so a batch of
+   * "12 of your 15 selected items" is never a silent surprise; never sent.
+   */
+  nonPhotoCount: number;
+}
+
+export type BatchEnhanceTarget = BatchEnhanceSelectionTarget;
+
+/** How many photos this target will enhance, as far as the client can tell. */
+function targetPhotoCount(target: BatchEnhanceTarget): number {
+  return target.photoIds.length;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface BatchEnhanceDialogProps {
+  open: boolean;
+  onClose: () => void;
+  target: BatchEnhanceTarget;
+  /**
+   * Server-enforced ceiling (`pictureEnhancement.maxBatchSize`, from
+   * GET /api/features). Submission is disabled above it — the server rejects an
+   * over-cap request with a 400 either way; this is the courteous half.
+   */
+  maxBatchSize: number;
+  /** Optional model label, shown alongside the presets (ai.features.enhance). */
+  modelLabel?: string | null;
+  /** Called with the one-line, SERVER-derived summary once the batch is queued. */
+  onSuccess: (message: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Copy helpers
+// ---------------------------------------------------------------------------
+
+function plural(n: number, one: string, many: string): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+function totalSkipped(result: BulkEnhanceResult): number {
+  const { notPhoto, tooLarge, alreadyLive } = result.skipped;
+  return notPhoto + tooLarge + alreadyLive;
+}
+
+/**
+ * The toast line. Built from the SERVER's counts — never the client's
+ * optimistic selection size, since eligibility is decided server-side and a
+ * selection of 30 can legitimately queue 26.
+ */
+function buildResultMessage(result: BulkEnhanceResult): string {
+  const skipped = totalSkipped(result);
+  if (result.queued === 0) {
+    return skipped > 0
+      ? `No photos queued — ${plural(skipped, 'photo was', 'photos were')} skipped`
+      : 'No photos were queued';
+  }
+  const base = `Queued AI enhancement for ${plural(result.queued, 'photo', 'photos')}`;
+  return skipped > 0 ? `${base} · ${skipped} skipped` : base;
+}
+
+const SKIP_REASON_LABELS: { key: keyof BulkEnhanceResult['skipped']; label: string }[] = [
+  { key: 'notPhoto', label: 'not a photo' },
+  { key: 'tooLarge', label: 'too large to enhance' },
+  { key: 'alreadyLive', label: 'already has an enhancement waiting for review' },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Multi-photo AI enhance.
+ *
+ * Deliberately a Dialog rather than the single-item drawer: a batch produces no
+ * result to compare, so the drawer's params → progress → compare → decide
+ * machine does not apply. One preset applies to every photo in the batch —
+ * per-photo tuning would be guesswork before seeing any result — and each
+ * result is still reviewed individually in the Enhancements hub afterwards.
+ */
+export function BatchEnhanceDialog({
+  open,
+  onClose,
+  target,
+  maxBatchSize,
+  modelLabel,
+  onSuccess,
+}: BatchEnhanceDialogProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const photoCount = targetPhotoCount(target);
+  const overCap = photoCount > maxBatchSize;
+
+  // Params state — same vocabulary as the single-item drawer (./enhancePresets)
+  const [presetKey, setPresetKey] = useState<PresetKey>('auto');
+  const [customize, setCustomize] = useState(false);
+  const [adjustments, setAdjustments] = useState<AdjustmentsState>(DEFAULT_ADJUSTMENTS);
+  const [strength, setStrength] = useState<EnhanceStrength>('balanced');
+  const [preserveFaces, setPreserveFaces] = useState(true);
+  const [instructions, setInstructions] = useState('');
+  /** Empty string = "let the server's pictureEnhancement.defaultQuality apply". */
+  const [quality, setQuality] = useState<EnhanceQuality | ''>('');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  /** Set once the batch is queued; the dialog then shows the skip breakdown. */
+  const [result, setResult] = useState<BulkEnhanceResult | null>(null);
+
+  // A reopened dialog is a fresh decision — never a stale result or error.
+  useEffect(() => {
+    if (open) {
+      setError(null);
+      setResult(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const formState = useMemo(
+    () => ({ presetKey, adjustments, strength, preserveFaces, instructions, quality }),
+    [presetKey, adjustments, strength, preserveFaces, instructions, quality],
+  );
+
+  const selectPreset = (key: PresetKey) => {
+    const def = resolvePreset(key);
+    setPresetKey(key);
+    // Prefill, but leave everything editable — subsequent tweaks are sent.
+    setAdjustments(def.prefill.adjustments);
+    setStrength(def.prefill.strength);
+    setPreserveFaces(def.prefill.preserveFaces);
+    if (key === 'custom') setCustomize(true);
+  };
+
+  const submitTarget = async (): Promise<BulkEnhanceResult> =>
+    bulkEnhance({
+      circleId: target.circleId,
+      ids: target.photoIds,
+      params: buildEnhanceParams(formState),
+    });
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await submitTarget();
+      const message = buildResultMessage(res);
+      if (totalSkipped(res) > 0) {
+        // Keep the dialog open so the per-reason breakdown is actually read;
+        // the toast only ever carries the one-line summary.
+        setResult(res);
+      } else {
+        onSuccess(message);
+        onClose();
+      }
+    } catch (err) {
+      // Render the SERVER's message (cap exceeded, feature disabled, no model
+      // configured) inline and leave the dialog open — the selection is still
+      // intact, so the user can act on what they were told.
+      setError(err instanceof Error ? err.message : 'Failed to queue AI enhancements');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const finishAfterResult = () => {
+    if (result) onSuccess(buildResultMessage(result));
+    onClose();
+  };
+
+  const showResult = result !== null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => !submitting && onClose()}
+      fullWidth
+      maxWidth="sm"
+      fullScreen={fullScreen}
+      aria-labelledby="batch-enhance-title"
+    >
+      <DialogTitle id="batch-enhance-title" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <AutoFixHighIcon color="primary" fontSize="small" />
+        <Box component="span" sx={{ minWidth: 0 }}>
+          {showResult
+            ? 'AI enhancements queued'
+            : `Enhance ${plural(photoCount, 'photo', 'photos')} with AI`}
+        </Box>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {showResult ? (
+          // ---------- Result step: the per-reason skip breakdown ----------
+          <Stack spacing={2}>
+            <Alert severity={result.queued > 0 ? 'success' : 'warning'}>
+              {result.queued > 0
+                ? `${plural(result.queued, 'photo is', 'photos are')} now in the enhancement queue.`
+                : 'Nothing was queued.'}
+            </Alert>
+
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                {plural(totalSkipped(result), 'photo was', 'photos were')} skipped
+              </Typography>
+              <Stack component="ul" spacing={0.5} sx={{ pl: 3, m: 0 }}>
+                {SKIP_REASON_LABELS.filter(({ key }) => result.skipped[key] > 0).map(
+                  ({ key, label }) => (
+                    <Typography key={key} component="li" variant="body2" color="text.secondary">
+                      {result.skipped[key]} {label}
+                    </Typography>
+                  ),
+                )}
+              </Stack>
+            </Box>
+
+            <Typography variant="body2" color="text.secondary">
+              Results appear in AI Enhancements as they finish. Nothing changes
+              until you review and approve each one.
+            </Typography>
+          </Stack>
+        ) : (
+          // ---------- Params step ----------
+          <Stack spacing={2}>
+            {error && <Alert severity="error">{error}</Alert>}
+
+            {target.nonPhotoCount > 0 && (
+              <Alert severity="info">
+                {plural(target.nonPhotoCount, 'video', 'videos')} in your selection
+                will be skipped. AI Enhance works on photos only.
+              </Alert>
+            )}
+
+            {overCap && (
+              <Alert severity="warning">
+                <AlertTitle>Too many photos for one batch</AlertTitle>
+                You selected {plural(photoCount, 'photo', 'photos')}; the limit is{' '}
+                {maxBatchSize} per batch. Deselect {photoCount - maxBatchSize}, or ask
+                an admin to raise the limit.
+              </Alert>
+            )}
+
+            <Typography variant="body2" color="text.secondary">
+              One setting applies to every photo in this batch. Each result is a
+              preview you review before anything is saved.
+            </Typography>
+
+            {/* Preset picker */}
+            <Box>
+              <Typography variant="subtitle2" sx={{ mb: 1 }} id="batch-enhance-preset-label">
+                What are we fixing?
+              </Typography>
+              <Box
+                role="group"
+                aria-labelledby="batch-enhance-preset-label"
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gap: 1,
+                }}
+              >
+                {PRESETS.map((def) => (
+                  <PresetCard
+                    key={def.key}
+                    def={def}
+                    selected={presetKey === def.key}
+                    onSelect={() => selectPreset(def.key)}
+                  />
+                ))}
+              </Box>
+            </Box>
+
+            {presetKey === 'colorize_bw' && (
+              <Alert severity="warning" variant="outlined">
+                Colorizing is interpretive: the colors are the AI&apos;s best guess,
+                not the real colors of the scene. Applied across a batch, every
+                photo gets an invented palette.
+              </Alert>
+            )}
+
+            {modelLabel && (
+              <Typography variant="caption" color="text.secondary">
+                Model: <strong>{modelLabel}</strong>
+              </Typography>
+            )}
+
+            <Button
+              size="small"
+              onClick={() => setCustomize((v) => !v)}
+              endIcon={customize ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              sx={{ alignSelf: 'flex-start', minHeight: 44 }}
+            >
+              Customize
+            </Button>
+
+            <Collapse in={customize} unmountOnExit>
+              <Stack spacing={1.5}>
+                {ADJUSTMENT_FIELDS.map(({ key, label }) => (
+                  <FormControlLabel
+                    key={key}
+                    control={
+                      <Switch
+                        size="small"
+                        checked={adjustments[key]}
+                        onChange={(e) =>
+                          setAdjustments((prev) => ({ ...prev, [key]: e.target.checked }))
+                        }
+                      />
+                    }
+                    label={label}
+                  />
+                ))}
+
+                <FormControl size="small" fullWidth>
+                  <InputLabel>Strength</InputLabel>
+                  <Select
+                    label="Strength"
+                    value={strength}
+                    onChange={(e) => setStrength(e.target.value as EnhanceStrength)}
+                  >
+                    <MenuItem value="subtle">Subtle</MenuItem>
+                    <MenuItem value="balanced">Balanced</MenuItem>
+                    <MenuItem value="strong">Strong</MenuItem>
+                  </Select>
+                </FormControl>
+
+                <FormControl size="small" fullWidth>
+                  <InputLabel>Output quality</InputLabel>
+                  <Select
+                    label="Output quality"
+                    value={quality}
+                    onChange={(e) => setQuality(e.target.value as EnhanceQuality | '')}
+                  >
+                    <MenuItem value="">Default (set by administrator)</MenuItem>
+                    <MenuItem value="low">Low — fastest, cheapest</MenuItem>
+                    <MenuItem value="medium">Medium</MenuItem>
+                    <MenuItem value="high">High — slowest, best detail</MenuItem>
+                  </Select>
+                </FormControl>
+
+                <FormControlLabel
+                  control={
+                    <Switch
+                      size="small"
+                      checked={preserveFaces}
+                      onChange={(e) => setPreserveFaces(e.target.checked)}
+                    />
+                  }
+                  label="Preserve faces & identities"
+                />
+
+                <TextField
+                  label="Additional instructions"
+                  size="small"
+                  fullWidth
+                  multiline
+                  minRows={2}
+                  value={instructions}
+                  onChange={(e) => setInstructions(e.target.value.slice(0, 500))}
+                  placeholder="Optional guidance (max 500 chars)"
+                  helperText={`${instructions.length}/500`}
+                />
+              </Stack>
+            </Collapse>
+
+            <Divider />
+
+            {/* Cost confirmation — the count is named, not implied. */}
+            <Alert severity="info" icon={<AutoFixHighIcon fontSize="inherit" />}>
+              This will start {plural(photoCount, 'AI enhancement', 'AI enhancements')}.
+              Each one uses AI credits and cannot be undone once started. You&apos;ll
+              review and approve each result before anything changes.
+            </Alert>
+          </Stack>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        {showResult ? (
+          <Button variant="contained" onClick={finishAfterResult} sx={{ minHeight: 44 }}>
+            Done
+          </Button>
+        ) : (
+          <>
+            <Button onClick={onClose} disabled={submitting} sx={{ minHeight: 44 }}>
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              onClick={() => void handleSubmit()}
+              disabled={submitting || overCap || photoCount === 0}
+              startIcon={
+                submitting ? <CircularProgress size={16} /> : <AutoFixHighIcon />
+              }
+              sx={{ minHeight: 44 }}
+            >
+              Enhance {plural(photoCount, 'photo', 'photos')}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/media/BulkActionToolbar.tsx
+++ b/apps/web/src/components/media/BulkActionToolbar.tsx
@@ -103,14 +103,28 @@ interface BulkActionToolbarProps {
   /** Controls archive-related actions shown. Default: 'home'. */
   mode?: BulkActionMode;
   /**
-   * The single selected item (present only when exactly one is selected). Used
-   * to decide whether the photo-only "AI Enhance" action can appear.
+   * The single selected item (present only when exactly one is selected). Kept
+   * as the fallback source for the AI Enhance gate for callers that do not yet
+   * pass `selectedItems`.
    */
   singleSelectedItem?: MediaItem | null;
+  /**
+   * The full set of selected items. Drives the AI Enhance gate: one selected
+   * photo opens the single-item drawer, several open the batch dialog. Videos
+   * never count toward either.
+   */
+  selectedItems?: MediaItem[];
   /** Feature flag: features.pictureEnhancement. Gates the AI Enhance trigger. */
   enhanceEnabled?: boolean;
+  /**
+   * Server-enforced batch ceiling (`pictureEnhancement.maxBatchSize`). Used
+   * only to warn in the tooltip; the batch dialog owns the actual gate.
+   */
+  maxBatchSize?: number;
   /** Open the AI enhancement drawer for the single selected photo. */
   onOpenEnhance?: () => void;
+  /** Open the batch enhance dialog for a multi-photo selection. */
+  onOpenBatchEnhance?: () => void;
 }
 
 export function BulkActionToolbar({
@@ -129,8 +143,11 @@ export function BulkActionToolbar({
   onRemoveFromAlbum,
   mode = 'home',
   singleSelectedItem,
+  selectedItems,
   enhanceEnabled,
+  maxBatchSize,
   onOpenEnhance,
+  onOpenBatchEnhance,
 }: BulkActionToolbarProps) {
   const [moreAnchor, setMoreAnchor] = useState<null | HTMLElement>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -141,11 +158,26 @@ export function BulkActionToolbar({
   const ids = Array.from(selected);
   const count = ids.length;
 
+  // --- AI Enhance gate ------------------------------------------------------
+  //
+  // Counted over PHOTOS only, so a mixed selection of one photo and one video
+  // is still a single-photo enhance rather than a batch of one. `selectedItems`
+  // is the source of truth; `singleSelectedItem` is the fallback for callers
+  // that have not been migrated.
+  const enhancePhotos =
+    selectedItems?.filter((item) => item.type === 'photo') ??
+    (singleSelectedItem?.type === 'photo' ? [singleSelectedItem] : []);
+  const enhancePhotoCount = enhancePhotos.length;
+  const isBatchEnhance = enhancePhotoCount > 1;
+  const openEnhance = isBatchEnhance ? onOpenBatchEnhance : onOpenEnhance;
   const canEnhance =
-    Boolean(enhanceEnabled) &&
-    Boolean(onOpenEnhance) &&
-    count === 1 &&
-    singleSelectedItem?.type === 'photo';
+    Boolean(enhanceEnabled) && enhancePhotoCount > 0 && !isViewer && Boolean(openEnhance);
+
+  const enhanceLabel = `AI Enhance ${enhancePhotoCount} photo${enhancePhotoCount !== 1 ? 's' : ''}`;
+  const enhanceTooltip =
+    maxBatchSize != null && enhancePhotoCount > maxBatchSize
+      ? `${enhanceLabel} (limit ${maxBatchSize} per batch)`
+      : enhanceLabel;
 
   if (count === 0) return null;
 
@@ -296,10 +328,10 @@ export function BulkActionToolbar({
         {!isViewer && (
           <>
             {canEnhance && (
-              <Tooltip title="AI Enhance">
+              <Tooltip title={enhanceTooltip}>
                 <IconButton
-                  aria-label="AI Enhance"
-                  onClick={onOpenEnhance}
+                  aria-label={enhanceLabel}
+                  onClick={openEnhance}
                   disabled={loading}
                   color="primary"
                 >

--- a/apps/web/src/components/media/MediaEnhancementDrawer.tsx
+++ b/apps/web/src/components/media/MediaEnhancementDrawer.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ComponentType } from 'react';
 import {
   Drawer,
   Box,
@@ -7,8 +6,6 @@ import {
   IconButton,
   Stack,
   Button,
-  ButtonBase,
-  Chip,
   CircularProgress,
   LinearProgress,
   Alert,
@@ -30,26 +27,26 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
-import HealingIcon from '@mui/icons-material/Healing';
-import NightlightIcon from '@mui/icons-material/Nightlight';
-import PaletteIcon from '@mui/icons-material/Palette';
-import FaceRetouchingNaturalIcon from '@mui/icons-material/FaceRetouchingNatural';
-import TuneIcon from '@mui/icons-material/Tune';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import { useTheme } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
-import type { SvgIconProps } from '@mui/material';
 import type { MediaItem } from '../../types/media';
 import { useMediaEnhance } from '../../hooks/useMediaEnhance';
 import type { EnhanceUiStatus } from '../../hooks/useMediaEnhance';
 import { BeforeAfterSlider } from './BeforeAfterSlider';
+import {
+  ADJUSTMENT_FIELDS,
+  DEFAULT_ADJUSTMENTS,
+  PRESETS,
+  PresetCard,
+  buildEnhanceParams,
+  resolvePreset,
+} from './enhancePresets';
+import type { AdjustmentsState, PresetKey } from './enhancePresets';
 import type {
-  EnhanceParams,
-  EnhancePreset,
   EnhanceQuality,
   EnhanceStrength,
   EnhanceImageInfo,
@@ -93,141 +90,6 @@ interface MediaEnhancementDrawerProps {
    * current call sites do); reopening restores the review via `resumeLatest`.
    */
   onFinishedInBackground?: (status: 'ready' | 'failed') => void;
-}
-
-// ---------------------------------------------------------------------------
-// Adjustments
-// ---------------------------------------------------------------------------
-
-interface AdjustmentsState {
-  color: boolean;
-  tone: boolean;
-  sharpness: boolean;
-  denoise: boolean;
-  dehaze: boolean;
-  straighten: boolean;
-}
-
-const ADJUSTMENT_FIELDS: { key: keyof AdjustmentsState; label: string }[] = [
-  { key: 'color', label: 'Correct color & white balance' },
-  { key: 'tone', label: 'Balance exposure & tone' },
-  { key: 'sharpness', label: 'Increase clarity & sharpness' },
-  { key: 'denoise', label: 'Reduce noise' },
-  { key: 'dehaze', label: 'Remove haze' },
-  { key: 'straighten', label: 'Straighten horizon' },
-];
-
-/** Mirrors the server-side defaults in `enhance-prompt.builder.ts`. */
-const DEFAULT_ADJUSTMENTS: AdjustmentsState = {
-  color: true,
-  tone: true,
-  sharpness: true,
-  denoise: true,
-  dehaze: false,
-  straighten: false,
-};
-
-// ---------------------------------------------------------------------------
-// Presets
-// ---------------------------------------------------------------------------
-
-/**
- * `auto` and `custom` are UI-only choices — neither sends a `preset` to the
- * API. The four real values map 1:1 onto the server's preset enum.
- */
-type PresetKey = 'auto' | EnhancePreset | 'custom';
-
-interface PresetDef {
-  key: PresetKey;
-  label: string;
-  description: string;
-  Icon: ComponentType<SvgIconProps>;
-  /** Shown as a warning chip for presets whose output is an AI invention. */
-  interpretive?: boolean;
-  /** Prefill applied when the preset is picked; every field stays editable. */
-  prefill: {
-    adjustments: AdjustmentsState;
-    strength: EnhanceStrength;
-    preserveFaces: boolean;
-  };
-}
-
-const PRESETS: PresetDef[] = [
-  {
-    key: 'auto',
-    label: 'Auto',
-    description: 'Balanced all-round improvement',
-    Icon: AutoAwesomeIcon,
-    prefill: {
-      adjustments: DEFAULT_ADJUSTMENTS,
-      strength: 'balanced',
-      preserveFaces: true,
-    },
-  },
-  {
-    key: 'restore_old_photo',
-    label: 'Restore old photo',
-    description: 'Repair scratches, fading and creases in scans of old prints',
-    Icon: HealingIcon,
-    prefill: {
-      adjustments: { ...DEFAULT_ADJUSTMENTS, tone: true, sharpness: true, denoise: true, dehaze: true },
-      strength: 'strong',
-      preserveFaces: true,
-    },
-  },
-  {
-    key: 'low_light',
-    label: 'Low-light rescue',
-    description: 'Brighten dim indoor and night photos without washing them out',
-    Icon: NightlightIcon,
-    prefill: {
-      adjustments: { ...DEFAULT_ADJUSTMENTS, tone: true, denoise: true },
-      strength: 'strong',
-      preserveFaces: true,
-    },
-  },
-  {
-    key: 'colorize_bw',
-    label: 'Colorize B&W',
-    description: 'Add natural color to a black-and-white photo',
-    Icon: PaletteIcon,
-    interpretive: true,
-    prefill: {
-      adjustments: DEFAULT_ADJUSTMENTS,
-      strength: 'balanced',
-      preserveFaces: true,
-    },
-  },
-  {
-    key: 'portrait_polish',
-    label: 'Portrait polish',
-    description: 'Even out skin tone and lighting on faces, gently',
-    Icon: FaceRetouchingNaturalIcon,
-    prefill: {
-      adjustments: { ...DEFAULT_ADJUSTMENTS, sharpness: true, denoise: true },
-      strength: 'subtle',
-      preserveFaces: true,
-    },
-  },
-  {
-    key: 'custom',
-    label: 'Custom',
-    description: 'Choose the corrections yourself',
-    Icon: TuneIcon,
-    prefill: {
-      adjustments: DEFAULT_ADJUSTMENTS,
-      strength: 'balanced',
-      preserveFaces: true,
-    },
-  },
-];
-
-const PRESET_BY_KEY = new Map(PRESETS.map((p) => [p.key, p]));
-
-function adjustmentsEqual(a: AdjustmentsState, b: AdjustmentsState): boolean {
-  return (ADJUSTMENT_FIELDS as { key: keyof AdjustmentsState }[]).every(
-    ({ key }) => a[key] === b[key],
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -275,69 +137,6 @@ function formatElapsed(ms: number): string {
   const m = Math.floor(total / 60);
   const s = total % 60;
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-}
-
-// ---------------------------------------------------------------------------
-// Preset card
-// ---------------------------------------------------------------------------
-
-function PresetCard({
-  def,
-  selected,
-  onSelect,
-}: {
-  def: PresetDef;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  const { Icon } = def;
-  return (
-    <ButtonBase
-      onClick={onSelect}
-      aria-pressed={selected}
-      aria-label={`${def.label} — ${def.description}`}
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        textAlign: 'left',
-        gap: 0.5,
-        p: 1.25,
-        minHeight: 96,
-        width: '100%',
-        borderRadius: 1.5,
-        border: '2px solid',
-        borderColor: selected ? 'primary.main' : 'divider',
-        bgcolor: selected ? 'action.selected' : 'transparent',
-        transition: 'border-color 120ms, background-color 120ms',
-        '&:hover': { borderColor: selected ? 'primary.main' : 'text.disabled' },
-        '&:focus-visible': {
-          outline: '3px solid',
-          outlineColor: 'primary.main',
-          outlineOffset: 2,
-        },
-      }}
-    >
-      <Stack direction="row" spacing={0.75} sx={{ width: '100%', alignItems: 'center' }}>
-        <Icon fontSize="small" color={selected ? 'primary' : 'action'} />
-        <Typography variant="body2" sx={{ flex: 1, minWidth: 0, fontWeight: 600 }}>
-          {def.label}
-        </Typography>
-      </Stack>
-      <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.3 }}>
-        {def.description}
-      </Typography>
-      {def.interpretive && (
-        <Chip
-          size="small"
-          color="warning"
-          variant="outlined"
-          label="Interpretive"
-          sx={{ height: 20, '& .MuiChip-label': { px: 0.75, fontSize: 11 } }}
-        />
-      )}
-    </ButtonBase>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -408,9 +207,8 @@ export function MediaEnhancementDrawer({
 
   // ---- Preset selection ----------------------------------------------------
   const selectPreset = useCallback((key: PresetKey) => {
-    const def = PRESET_BY_KEY.get(key);
+    const def = resolvePreset(key);
     setPresetKey(key);
-    if (!def) return;
     // Prefill, but leave everything editable — subsequent tweaks are sent.
     setAdjustments(def.prefill.adjustments);
     setStrength(def.prefill.strength);
@@ -418,62 +216,21 @@ export function MediaEnhancementDrawer({
     if (key === 'custom') setCustomize(true);
   }, []);
 
-  const activePreset = PRESET_BY_KEY.get(presetKey) ?? PRESETS[0];
-
   /**
-   * True when the user has actually deviated from the selected preset's
-   * prefill (or typed free-text guidance) — NOT merely because the Customize
-   * panel is expanded. This drives `intent`, which changes the prompt's opening
-   * sentence server-side and is the only thing that makes `instructions` count.
+   * The shared form state both enhance surfaces collect. `buildEnhanceParams`
+   * lives in `./enhancePresets` (together with its `isEnhanceCustomized` rule,
+   * which decides when `intent: 'custom'` is sent) so the single-item drawer
+   * and the multi-photo batch dialog can never drift apart on what a preset
+   * means or which params it produces.
    */
-  const isCustomized = useMemo(
-    () =>
-      !adjustmentsEqual(adjustments, activePreset.prefill.adjustments) ||
-      strength !== activePreset.prefill.strength ||
-      preserveFaces !== activePreset.prefill.preserveFaces ||
-      instructions.trim().length > 0,
-    [adjustments, strength, preserveFaces, instructions, activePreset],
+  const formState = useMemo(
+    () => ({ presetKey, adjustments, strength, preserveFaces, instructions, quality }),
+    [presetKey, adjustments, strength, preserveFaces, instructions, quality],
   );
-
-  /**
-   * Param mapping (deliberate, see issue #98 commit set E):
-   *  - `preset` is sent for the four real presets only; `auto`/`custom` are UI
-   *    affordances and send none.
-   *  - `intent: 'custom'` is sent ONLY when the user genuinely customized. It
-   *    swaps the prompt's base sentence and is the gate for `instructions`.
-   *  - A preset's prefilled adjustments/strength/preserveFaces are still sent
-   *    even when untouched, because they differ from the SERVER's defaults
-   *    (e.g. portrait_polish = subtle). They are honored regardless of intent.
-   *  - Full-auto with nothing touched sends `{}` so every server default wins.
-   */
-  const buildParams = (): EnhanceParams => {
-    const params: EnhanceParams = {};
-
-    if (presetKey !== 'auto' && presetKey !== 'custom') {
-      params.preset = presetKey;
-    }
-
-    if (isCustomized) {
-      params.intent = 'custom';
-      params.adjustments = { ...adjustments };
-      params.strength = strength;
-      params.preserveFaces = preserveFaces;
-      const trimmed = instructions.trim();
-      if (trimmed) params.instructions = trimmed;
-    } else if (presetKey !== 'auto') {
-      params.adjustments = { ...adjustments };
-      params.strength = strength;
-      params.preserveFaces = preserveFaces;
-    }
-
-    if (quality) params.quality = quality;
-
-    return params;
-  };
 
   const handleStart = () => {
     setCommitError(null);
-    void start(buildParams());
+    void start(buildEnhanceParams(formState));
   };
 
   const confirmDecision = async () => {

--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -81,6 +81,7 @@ import { MediaDetailDrawer } from './MediaDetailDrawer';
 import { MediaSelectionCheckbox } from './MediaSelectionCheckbox';
 import { MediaLightbox } from './MediaLightbox';
 import { MediaEnhancementDrawer } from './MediaEnhancementDrawer';
+import { BatchEnhanceDialog } from './BatchEnhanceDialog';
 import { BulkActionToolbar } from './BulkActionToolbar';
 import type { BulkEffect, BulkSuccessOptions } from './BulkActionToolbar';
 import { useFeatureFlags } from '../../hooks/useFeatureFlags';
@@ -726,11 +727,33 @@ export function MediaGallery({
   const enhanceEnabled = Boolean(pictureEnhancement?.enabled);
   const [enhanceOpen, setEnhanceOpen] = useState(false);
 
+  const [batchEnhanceOpen, setBatchEnhanceOpen] = useState(false);
+
   const singleSelectedItem = useMemo<MediaItem | null>(() => {
     if (selected.size !== 1) return null;
     const [onlyId] = Array.from(selected);
     return mergedItems.find((it) => it.id === onlyId) ?? null;
   }, [selected, mergedItems]);
+
+  /** The selected items, resolved against the current feed. */
+  const selectedItems = useMemo(
+    () => mergedItems.filter((it) => selected.has(it.id)),
+    [selected, mergedItems],
+  );
+
+  /**
+   * Photos in the selection. AI Enhance is photo-only, so a mixed selection of
+   * one photo and one video is still a single-photo enhance — the per-item
+   * drawer, with its live compare and immediate decision, is a better
+   * experience than a batch of one.
+   */
+  const selectedPhotos = useMemo(
+    () => selectedItems.filter((it) => it.type === 'photo'),
+    [selectedItems],
+  );
+
+  /** The item the single-photo enhance drawer acts on, if exactly one. */
+  const enhanceTargetItem = selectedPhotos.length === 1 ? selectedPhotos[0] : null;
 
   // -------------------------------------------------------------------------
   // Bulk success handler
@@ -1027,8 +1050,11 @@ export function MediaGallery({
           onSuccess={handleBulkSuccess}
           onError={(msg) => setSnackbar({ message: msg, severity: 'error' })}
           singleSelectedItem={singleSelectedItem}
+          selectedItems={selectedItems}
           enhanceEnabled={enhanceEnabled}
+          maxBatchSize={pictureEnhancement?.maxBatchSize}
           onOpenEnhance={() => setEnhanceOpen(true)}
+          onOpenBatchEnhance={() => setBatchEnhanceOpen(true)}
         />
       )}
 
@@ -1247,9 +1273,9 @@ export function MediaGallery({
       />
 
       {/* AI enhancement drawer (single photo) */}
-      {singleSelectedItem && singleSelectedItem.type === 'photo' && (
+      {enhanceTargetItem && (
         <MediaEnhancementDrawer
-          item={singleSelectedItem}
+          item={enhanceTargetItem}
           open={enhanceOpen}
           onClose={() => setEnhanceOpen(false)}
           modelLabel={pictureEnhancement?.model ?? undefined}
@@ -1290,6 +1316,26 @@ export function MediaGallery({
           }
         />
       )}
+
+      {/* AI enhancement dialog (multi-photo batch) */}
+      <BatchEnhanceDialog
+        open={batchEnhanceOpen}
+        onClose={() => setBatchEnhanceOpen(false)}
+        target={{
+          kind: 'selection',
+          circleId,
+          photoIds: selectedPhotos.map((it) => it.id),
+          nonPhotoCount: selectedItems.length - selectedPhotos.length,
+        }}
+        maxBatchSize={pictureEnhancement?.maxBatchSize ?? 25}
+        modelLabel={pictureEnhancement?.model ?? undefined}
+        // Queueing changes nothing about the items yet, so this is the ordinary
+        // metadata path: toast + clear the selection, never a feed reset.
+        onSuccess={(msg) => {
+          setBatchEnhanceOpen(false);
+          handleBulkSuccess(msg);
+        }}
+      />
 
       {/* Snackbar for bulk operation feedback */}
       <Snackbar

--- a/apps/web/src/components/media/__tests__/MediaGalleryBatchEnhance.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGalleryBatchEnhance.test.tsx
@@ -1,0 +1,394 @@
+/**
+ * Component tests — MediaGallery multi-photo AI Enhance wiring
+ * (issue #422, epic #420 phase 2).
+ *
+ * Covers:
+ *   - `selectedItems`/`selectedPhotos` derivation, INCLUDING a selection that
+ *     spans a paginated append (ids selected on page 1 still resolve after
+ *     page 2 is merged into `mergedItems`).
+ *   - The post-submit snackbar uses the SERVER's `result.queued`, never the
+ *     client's selection size, and surfaces the skipped summary when
+ *     `queued < requested`.
+ *   - The selection is cleared after a successful batch submit.
+ *
+ * `BulkActionToolbar` is replaced with a harness that surfaces the exact
+ * `selectedItems` prop MediaGallery computed (so raw derivation can be
+ * asserted without depending on the real toolbar's rendering) plus a trigger
+ * for `onOpenBatchEnhance`. `BatchEnhanceDialog` itself is left UNMOCKED —
+ * the preset -> submit -> bulkEnhance -> snackbar/selection-clear flow is
+ * exercised through the real component, mirroring MediaGalleryFeedState's
+ * "drive the real completion wiring" approach.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../__tests__/utils/test-utils';
+import { MediaGallery } from '../MediaGallery';
+import type { MediaItem } from '../../../types/media';
+import type { BulkEnhanceResult } from '../../../services/media';
+import type { PictureEnhancementPolicy } from '../../../services/features';
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared before any imports of the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('../MediaLightbox', () => ({ MediaLightbox: vi.fn(() => null) }));
+vi.mock('../MediaDetailDrawer', () => ({ MediaDetailDrawer: vi.fn(() => null) }));
+vi.mock('../MediaEnhancementDrawer', () => ({ MediaEnhancementDrawer: vi.fn(() => null) }));
+vi.mock('../BulkLocationDialog', () => ({ BulkLocationDialog: vi.fn(() => null) }));
+vi.mock('../BulkDateDialog', () => ({ BulkDateDialog: vi.fn(() => null) }));
+vi.mock('../BulkTagsDialog', () => ({ BulkTagsDialog: vi.fn(() => null) }));
+vi.mock('../../album/AddToAlbumDialog', () => ({ AddToAlbumDialog: vi.fn(() => null) }));
+
+// Captures every prop set BulkActionToolbar was rendered with, so a test can
+// inspect the exact `selectedItems` array MediaGallery derived — the harness
+// also exposes a plain button for `onOpenBatchEnhance` so the real
+// BatchEnhanceDialog (left unmocked below) can be driven end-to-end.
+interface CapturedToolbarProps {
+  selected: Set<string>;
+  selectedItems?: MediaItem[];
+  onOpenBatchEnhance?: () => void;
+}
+const toolbarCalls: CapturedToolbarProps[] = [];
+vi.mock('../BulkActionToolbar', () => ({
+  BulkActionToolbar: vi.fn((props: CapturedToolbarProps) => {
+    toolbarCalls.push(props);
+    if (props.selected.size === 0) return null;
+    return (
+      <div>
+        <div data-testid="bulk-toolbar">Bulk toolbar ({props.selected.size})</div>
+        {props.onOpenBatchEnhance && (
+          <button onClick={props.onOpenBatchEnhance}>harness-open-batch-enhance</button>
+        )}
+      </div>
+    );
+  }),
+}));
+
+vi.mock('../../../services/media', () => ({
+  listMedia: vi.fn(),
+  getMedia: vi.fn(),
+  getThumbnails: vi.fn().mockResolvedValue([]),
+  patchMedia: vi.fn().mockResolvedValue({}),
+  removeAlbumItem: vi.fn().mockResolvedValue(undefined),
+  bulkEnhance: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useIntersectionObserver', () => ({
+  useIntersectionObserver: vi.fn(),
+}));
+
+vi.mock('../../../contexts/MediaPreviewContext', () => ({
+  useMediaPreview: vi.fn(),
+}));
+
+const mockPictureEnhancement: PictureEnhancementPolicy = {
+  enabled: true,
+  allowReplace: true,
+  blockReplaceOnDownscale: false,
+  model: null,
+  maxBatchSize: 25,
+};
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(() => ({
+    features: null,
+    pictureEnhancement: mockPictureEnhancement,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { listMedia, getMedia, bulkEnhance } from '../../../services/media';
+import { useIntersectionObserver } from '../../../hooks/useIntersectionObserver';
+import { useMediaPreview } from '../../../contexts/MediaPreviewContext';
+
+const mockListMedia = vi.mocked(listMedia);
+const mockGetMedia = vi.mocked(getMedia);
+const mockBulkEnhance = vi.mocked(bulkEnhance);
+const mockUseIntersectionObserver = vi.mocked(useIntersectionObserver);
+const mockUseMediaPreview = vi.mocked(useMediaPreview);
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeItem(id: string, overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    id,
+    storageObjectId: `storage-${id}`,
+    addedById: 'user-001',
+    circleId: 'circle-1',
+    type: 'photo',
+    capturedAt: '2024-06-15T10:00:00.000Z',
+    capturedAtOffset: null,
+    importedAt: null,
+    source: 'web',
+    contentHash: null,
+    width: 1920,
+    height: 1080,
+    durationMs: null,
+    orientation: null,
+    takenLat: null,
+    takenLng: null,
+    takenAltitude: null,
+    cameraMake: null,
+    cameraModel: null,
+    originalFilename: `file-${id}.jpg`,
+    description: null,
+    favorite: false,
+    geoCountry: null,
+    geoCountryCode: null,
+    geoAdmin1: null,
+    geoAdmin2: null,
+    geoLocality: null,
+    geoPlaceName: null,
+    geoSource: null,
+    geocodedAt: null,
+    createdAt: '2024-06-15T10:00:00.000Z',
+    updatedAt: '2024-06-15T10:00:00.000Z',
+    deletedAt: null,
+    metadata: null,
+    thumbnailUrl: `https://cdn.example.com/${id}.jpg`,
+    downloadUrl: null,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<BulkEnhanceResult> = {}): BulkEnhanceResult {
+  return {
+    batchId: 'batch-1',
+    requested: 2,
+    queued: 2,
+    skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 },
+    ...overrides,
+  };
+}
+
+/** Latest props BulkActionToolbar was rendered with. */
+function latestToolbarProps(): CapturedToolbarProps {
+  return toolbarCalls[toolbarCalls.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MediaGallery — multi-photo AI Enhance wiring (epic #420)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toolbarCalls.length = 0;
+    mockGetMedia.mockImplementation((id: string) => Promise.resolve(makeItem(id)));
+    mockBulkEnhance.mockResolvedValue(makeResult());
+    mockUseMediaPreview.mockReturnValue({
+      addPreview: vi.fn(),
+      getPreview: vi.fn(() => undefined),
+      removePreview: vi.fn(),
+      version: 0,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // selectedItems / selectedPhotos derivation across a paginated append
+  // -------------------------------------------------------------------------
+  describe('selection derivation', () => {
+    it('keeps a page-1 selection resolved in selectedItems once page 2 is merged in', async () => {
+      const user = userEvent.setup();
+      mockListMedia.mockResolvedValueOnce({
+        items: [makeItem('p1', { type: 'photo' }), makeItem('v1', { type: 'video' })],
+        meta: { pageSize: 50, nextCursor: 'cursor-2', hasMore: true },
+      });
+
+      render(
+        <MediaGallery
+          circleId="circle-1"
+          activeCircleRole="circle_admin"
+          queryParams={{ circleId: 'circle-1' }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByAltText('file-p1.jpg')).toBeInTheDocument();
+      });
+
+      // Select the photo on page 1.
+      const checkboxes = screen.getAllByRole('button', { name: /select item/i });
+      await user.click(checkboxes[0]);
+
+      await waitFor(() => {
+        expect(latestToolbarProps().selectedItems?.map((it) => it.id)).toEqual(['p1']);
+      });
+
+      // Load page 2 — simulate the sentinel intersecting by invoking the
+      // callback useIntersectionObserver was wired with directly.
+      mockListMedia.mockResolvedValueOnce({
+        items: [makeItem('p3', { type: 'photo' })],
+        meta: { pageSize: 50, nextCursor: null, hasMore: false },
+      });
+      const feedLoadMore = mockUseIntersectionObserver.mock.calls[
+        mockUseIntersectionObserver.mock.calls.length - 1
+      ][1];
+      await act(async () => {
+        feedLoadMore();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByAltText('file-p3.jpg')).toBeInTheDocument();
+      });
+
+      // The page-1 selection survives the merge, resolved against the fresh
+      // merged item object (not lost, not stale).
+      const propsAfterMerge = latestToolbarProps();
+      expect(propsAfterMerge.selected.has('p1')).toBe(true);
+      expect(propsAfterMerge.selectedItems?.map((it) => it.id)).toEqual(['p1']);
+      expect(propsAfterMerge.selectedItems?.[0].type).toBe('photo');
+
+      // Selecting the newly-loaded page-2 item extends the derivation rather
+      // than replacing it.
+      const checkboxesAfterMerge = screen.getAllByRole('button', { name: /select item/i });
+      await user.click(checkboxesAfterMerge[checkboxesAfterMerge.length - 1]);
+
+      await waitFor(() => {
+        expect(latestToolbarProps().selectedItems?.map((it) => it.id).sort()).toEqual([
+          'p1',
+          'p3',
+        ]);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Full submit flow through the real BatchEnhanceDialog
+  // -------------------------------------------------------------------------
+  describe('batch submit flow', () => {
+    async function selectAllAndOpenBatchDialog(user: ReturnType<typeof userEvent.setup>) {
+      const checkboxes = screen.getAllByRole('button', { name: /select item/i });
+      for (const checkbox of checkboxes) {
+        await user.click(checkbox);
+      }
+      await user.click(screen.getByText('harness-open-batch-enhance'));
+      await screen.findByRole('dialog');
+    }
+
+    it('sends only photo ids to bulkEnhance (videos excluded) for a mixed selection', async () => {
+      const user = userEvent.setup();
+      mockListMedia.mockResolvedValueOnce({
+        items: [
+          makeItem('mp1', { type: 'photo' }),
+          makeItem('mp2', { type: 'photo' }),
+          makeItem('mv1', { type: 'video' }),
+        ],
+        meta: { pageSize: 50, nextCursor: null, hasMore: false },
+      });
+
+      render(
+        <MediaGallery
+          circleId="circle-1"
+          activeCircleRole="circle_admin"
+          queryParams={{ circleId: 'circle-1' }}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByAltText('file-mp1.jpg')).toBeInTheDocument();
+      });
+
+      await selectAllAndOpenBatchDialog(user);
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      await waitFor(() => {
+        expect(mockBulkEnhance).toHaveBeenCalledTimes(1);
+      });
+      expect(mockBulkEnhance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          circleId: 'circle-1',
+          ids: expect.arrayContaining(['mp1', 'mp2']),
+        }),
+      );
+      const [call] = mockBulkEnhance.mock.calls;
+      expect(call[0].ids).toHaveLength(2);
+      expect(call[0].ids).not.toContain('mv1');
+    });
+
+    it('shows the SERVER queued count (not the client selection size) and the skipped summary when queued < requested', async () => {
+      const user = userEvent.setup();
+      mockListMedia.mockResolvedValueOnce({
+        items: [makeItem('sp1', { type: 'photo' }), makeItem('sp2', { type: 'photo' })],
+        meta: { pageSize: 50, nextCursor: null, hasMore: false },
+      });
+      mockBulkEnhance.mockResolvedValueOnce(
+        makeResult({
+          requested: 2,
+          queued: 1,
+          skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 1 },
+        }),
+      );
+
+      render(
+        <MediaGallery
+          circleId="circle-1"
+          activeCircleRole="circle_admin"
+          queryParams={{ circleId: 'circle-1' }}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByAltText('file-sp1.jpg')).toBeInTheDocument();
+      });
+
+      await selectAllAndOpenBatchDialog(user);
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      // Result step shows the breakdown first (queued < requested).
+      await screen.findByText(/AI enhancements queued/i);
+      await user.click(screen.getByRole('button', { name: /^done$/i }));
+
+      // The snackbar reflects the server's queued=1, never the client's
+      // selection size of 2, and names the 1 skipped item.
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Queued AI enhancement for 1 photo · 1 skipped/i),
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText(/Queued AI enhancement for 2 photos/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('clears the selection after a successful batch submit', async () => {
+      const user = userEvent.setup();
+      mockListMedia.mockResolvedValueOnce({
+        items: [makeItem('cp1', { type: 'photo' }), makeItem('cp2', { type: 'photo' })],
+        meta: { pageSize: 50, nextCursor: null, hasMore: false },
+      });
+      mockBulkEnhance.mockResolvedValueOnce(makeResult({ requested: 2, queued: 2 }));
+
+      render(
+        <MediaGallery
+          circleId="circle-1"
+          activeCircleRole="circle_admin"
+          queryParams={{ circleId: 'circle-1' }}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByAltText('file-cp1.jpg')).toBeInTheDocument();
+      });
+
+      await selectAllAndOpenBatchDialog(user);
+      expect(latestToolbarProps().selected.size).toBe(2);
+
+      await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
+
+      // Nothing skipped -> the dialog closes immediately and the selection
+      // is cleared as part of the ordinary metadata-success path.
+      await waitFor(() => {
+        expect(screen.queryByTestId('bulk-toolbar')).not.toBeInTheDocument();
+      });
+      expect(latestToolbarProps().selected.size).toBe(0);
+    });
+  });
+});

--- a/apps/web/src/components/media/enhancePresets.tsx
+++ b/apps/web/src/components/media/enhancePresets.tsx
@@ -1,0 +1,297 @@
+import type { ComponentType } from 'react';
+import { ButtonBase, Chip, Stack, Typography } from '@mui/material';
+import type { SvgIconProps } from '@mui/material';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import HealingIcon from '@mui/icons-material/Healing';
+import NightlightIcon from '@mui/icons-material/Nightlight';
+import PaletteIcon from '@mui/icons-material/Palette';
+import FaceRetouchingNaturalIcon from '@mui/icons-material/FaceRetouchingNatural';
+import TuneIcon from '@mui/icons-material/Tune';
+import type {
+  EnhanceParams,
+  EnhancePreset,
+  EnhanceQuality,
+  EnhanceStrength,
+} from '../../services/enhance';
+
+// ---------------------------------------------------------------------------
+// Shared AI-enhance preset vocabulary (epic #420).
+//
+// Single source of truth for the preset catalog, the adjustment switches, the
+// preset card, and the params builder. Consumed by BOTH the single-item
+// MediaEnhancementDrawer and the multi-photo BatchEnhanceDialog — two copies of
+// this catalog would let the same "Restore old photo" button mean two different
+// things depending on how many photos happened to be selected.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Adjustments
+// ---------------------------------------------------------------------------
+
+export interface AdjustmentsState {
+  color: boolean;
+  tone: boolean;
+  sharpness: boolean;
+  denoise: boolean;
+  dehaze: boolean;
+  straighten: boolean;
+}
+
+export const ADJUSTMENT_FIELDS: { key: keyof AdjustmentsState; label: string }[] = [
+  { key: 'color', label: 'Correct color & white balance' },
+  { key: 'tone', label: 'Balance exposure & tone' },
+  { key: 'sharpness', label: 'Increase clarity & sharpness' },
+  { key: 'denoise', label: 'Reduce noise' },
+  { key: 'dehaze', label: 'Remove haze' },
+  { key: 'straighten', label: 'Straighten horizon' },
+];
+
+/** Mirrors the server-side defaults in `enhance-prompt.builder.ts`. */
+export const DEFAULT_ADJUSTMENTS: AdjustmentsState = {
+  color: true,
+  tone: true,
+  sharpness: true,
+  denoise: true,
+  dehaze: false,
+  straighten: false,
+};
+
+export function adjustmentsEqual(a: AdjustmentsState, b: AdjustmentsState): boolean {
+  return (ADJUSTMENT_FIELDS as { key: keyof AdjustmentsState }[]).every(
+    ({ key }) => a[key] === b[key],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Presets
+// ---------------------------------------------------------------------------
+
+/**
+ * `auto` and `custom` are UI-only choices — neither sends a `preset` to the
+ * API. The four real values map 1:1 onto the server's preset enum.
+ */
+export type PresetKey = 'auto' | EnhancePreset | 'custom';
+
+export interface PresetDef {
+  key: PresetKey;
+  label: string;
+  description: string;
+  Icon: ComponentType<SvgIconProps>;
+  /** Shown as a warning chip for presets whose output is an AI invention. */
+  interpretive?: boolean;
+  /** Prefill applied when the preset is picked; every field stays editable. */
+  prefill: {
+    adjustments: AdjustmentsState;
+    strength: EnhanceStrength;
+    preserveFaces: boolean;
+  };
+}
+
+export const PRESETS: PresetDef[] = [
+  {
+    key: 'auto',
+    label: 'Auto',
+    description: 'Balanced all-round improvement',
+    Icon: AutoAwesomeIcon,
+    prefill: {
+      adjustments: DEFAULT_ADJUSTMENTS,
+      strength: 'balanced',
+      preserveFaces: true,
+    },
+  },
+  {
+    key: 'restore_old_photo',
+    label: 'Restore old photo',
+    description: 'Repair scratches, fading and creases in scans of old prints',
+    Icon: HealingIcon,
+    prefill: {
+      adjustments: { ...DEFAULT_ADJUSTMENTS, tone: true, sharpness: true, denoise: true, dehaze: true },
+      strength: 'strong',
+      preserveFaces: true,
+    },
+  },
+  {
+    key: 'low_light',
+    label: 'Low-light rescue',
+    description: 'Brighten dim indoor and night photos without washing them out',
+    Icon: NightlightIcon,
+    prefill: {
+      adjustments: { ...DEFAULT_ADJUSTMENTS, tone: true, denoise: true },
+      strength: 'strong',
+      preserveFaces: true,
+    },
+  },
+  {
+    key: 'colorize_bw',
+    label: 'Colorize B&W',
+    description: 'Add natural color to a black-and-white photo',
+    Icon: PaletteIcon,
+    interpretive: true,
+    prefill: {
+      adjustments: DEFAULT_ADJUSTMENTS,
+      strength: 'balanced',
+      preserveFaces: true,
+    },
+  },
+  {
+    key: 'portrait_polish',
+    label: 'Portrait polish',
+    description: 'Even out skin tone and lighting on faces, gently',
+    Icon: FaceRetouchingNaturalIcon,
+    prefill: {
+      adjustments: { ...DEFAULT_ADJUSTMENTS, sharpness: true, denoise: true },
+      strength: 'subtle',
+      preserveFaces: true,
+    },
+  },
+  {
+    key: 'custom',
+    label: 'Custom',
+    description: 'Choose the corrections yourself',
+    Icon: TuneIcon,
+    prefill: {
+      adjustments: DEFAULT_ADJUSTMENTS,
+      strength: 'balanced',
+      preserveFaces: true,
+    },
+  },
+];
+
+export const PRESET_BY_KEY = new Map(PRESETS.map((p) => [p.key, p]));
+
+/** The preset a key resolves to, falling back to `auto` for an unknown key. */
+export function resolvePreset(key: PresetKey): PresetDef {
+  return PRESET_BY_KEY.get(key) ?? PRESETS[0];
+}
+
+// ---------------------------------------------------------------------------
+// Params builder
+// ---------------------------------------------------------------------------
+
+/**
+ * The editable form state both enhance surfaces collect. `quality: ''` means
+ * "let the server's `pictureEnhancement.defaultQuality` apply".
+ */
+export interface EnhanceFormState {
+  presetKey: PresetKey;
+  adjustments: AdjustmentsState;
+  strength: EnhanceStrength;
+  preserveFaces: boolean;
+  instructions: string;
+  quality: EnhanceQuality | '';
+}
+
+/**
+ * True when the user has actually deviated from the selected preset's prefill
+ * (or typed free-text guidance) — NOT merely because the Customize panel is
+ * expanded. This drives `intent`, which changes the prompt's opening sentence
+ * server-side and is the only thing that makes `instructions` count.
+ */
+export function isEnhanceCustomized(state: EnhanceFormState): boolean {
+  const preset = resolvePreset(state.presetKey);
+  return (
+    !adjustmentsEqual(state.adjustments, preset.prefill.adjustments) ||
+    state.strength !== preset.prefill.strength ||
+    state.preserveFaces !== preset.prefill.preserveFaces ||
+    state.instructions.trim().length > 0
+  );
+}
+
+/**
+ * Param mapping (deliberate, see issue #98 commit set E):
+ *  - `preset` is sent for the four real presets only; `auto`/`custom` are UI
+ *    affordances and send none.
+ *  - `intent: 'custom'` is sent ONLY when the user genuinely customized. It
+ *    swaps the prompt's base sentence and is the gate for `instructions`.
+ *  - A preset's prefilled adjustments/strength/preserveFaces are still sent
+ *    even when untouched, because they differ from the SERVER's defaults
+ *    (e.g. portrait_polish = subtle). They are honored regardless of intent.
+ *  - Full-auto with nothing touched sends `{}` so every server default wins.
+ */
+export function buildEnhanceParams(state: EnhanceFormState): EnhanceParams {
+  const params: EnhanceParams = {};
+
+  if (state.presetKey !== 'auto' && state.presetKey !== 'custom') {
+    params.preset = state.presetKey;
+  }
+
+  if (isEnhanceCustomized(state)) {
+    params.intent = 'custom';
+    params.adjustments = { ...state.adjustments };
+    params.strength = state.strength;
+    params.preserveFaces = state.preserveFaces;
+    const trimmed = state.instructions.trim();
+    if (trimmed) params.instructions = trimmed;
+  } else if (state.presetKey !== 'auto') {
+    params.adjustments = { ...state.adjustments };
+    params.strength = state.strength;
+    params.preserveFaces = state.preserveFaces;
+  }
+
+  if (state.quality) params.quality = state.quality;
+
+  return params;
+}
+
+// ---------------------------------------------------------------------------
+// Preset card
+// ---------------------------------------------------------------------------
+
+export function PresetCard({
+  def,
+  selected,
+  onSelect,
+}: {
+  def: PresetDef;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const { Icon } = def;
+  return (
+    <ButtonBase
+      onClick={onSelect}
+      aria-pressed={selected}
+      aria-label={`${def.label} — ${def.description}`}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        textAlign: 'left',
+        gap: 0.5,
+        p: 1.25,
+        minHeight: 96,
+        width: '100%',
+        borderRadius: 1.5,
+        border: '2px solid',
+        borderColor: selected ? 'primary.main' : 'divider',
+        bgcolor: selected ? 'action.selected' : 'transparent',
+        transition: 'border-color 120ms, background-color 120ms',
+        '&:hover': { borderColor: selected ? 'primary.main' : 'text.disabled' },
+        '&:focus-visible': {
+          outline: '3px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: 2,
+        },
+      }}
+    >
+      <Stack direction="row" spacing={0.75} sx={{ width: '100%', alignItems: 'center' }}>
+        <Icon fontSize="small" color={selected ? 'primary' : 'action'} />
+        <Typography variant="body2" sx={{ flex: 1, minWidth: 0, fontWeight: 600 }}>
+          {def.label}
+        </Typography>
+      </Stack>
+      <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.3 }}>
+        {def.description}
+      </Typography>
+      {def.interpretive && (
+        <Chip
+          size="small"
+          color="warning"
+          variant="outlined"
+          label="Interpretive"
+          sx={{ height: 20, '& .MuiChip-label': { px: 0.75, fontSize: 11 } }}
+        />
+      )}
+    </ButtonBase>
+  );
+}

--- a/apps/web/src/services/features.ts
+++ b/apps/web/src/services/features.ts
@@ -22,6 +22,13 @@ export interface PictureEnhancementPolicy {
   blockReplaceOnDownscale: boolean;
   /** Configured enhancement model NAME (never a credential); null when unset. */
   model: string | null;
+  /**
+   * Server-enforced ceiling on how many distinct items one bulk-enhance request
+   * may carry (`pictureEnhancement.maxBatchSize`, default 25). The UI disables
+   * submission above it so an over-cap selection is explained before it costs a
+   * round trip — POST /api/media/bulk/enhance rejects it with a 400 regardless.
+   */
+  maxBatchSize: number;
 }
 
 export interface FeatureFlags {

--- a/apps/web/src/services/media.ts
+++ b/apps/web/src/services/media.ts
@@ -1,5 +1,6 @@
 import { api } from './api';
 import { createTrashEmptyRun } from './trashEmptyRuns';
+import type { EnhanceParams } from './enhance';
 import type { CreateTrashEmptyRunResponse } from '../types/trashEmptyRuns';
 import type {
   MediaItem,
@@ -407,6 +408,54 @@ export async function bulkRerunFaces(dto: BulkRerunDto): Promise<{ queued: numbe
 
 export async function bulkRerunThumbnails(dto: BulkRerunDto): Promise<{ queued: number }> {
   return api.post<{ queued: number }>('/media/bulk/thumbnail/rerun', dto);
+}
+
+// ---------------------------------------------------------------------------
+// Bulk AI enhancement (epic #420)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-reason tally of selected items the server declined to queue. An
+ * ineligible item never fails the request — it is reported here instead.
+ */
+export interface BulkEnhanceSkipped {
+  /** Videos and other non-photo media. */
+  notPhoto: number;
+  /** Photos over `pictureEnhancement.maxInputMegapixels`. */
+  tooLarge: number;
+  /**
+   * Items that already have a pending/processing/ready enhancement. A `ready`
+   * result is deliberately never superseded — it is an already-billed render
+   * awaiting a human decision.
+   */
+  alreadyLive: number;
+}
+
+export interface BulkEnhanceResult {
+  /** Poll target for the batch (GET /api/enhancement-batches/:id). */
+  batchId: string;
+  /** Distinct ids the server considered. */
+  requested: number;
+  /** Enhancements actually enqueued. */
+  queued: number;
+  skipped: BulkEnhanceSkipped;
+}
+
+export interface BulkEnhanceDto {
+  circleId: string;
+  ids: string[];
+  /** One params object applies to EVERY item — a batch is a single intent. */
+  params?: EnhanceParams;
+}
+
+/**
+ * Queue one AI enhancement per eligible photo in a selection.
+ *
+ * Returns 202 with the SERVER's counts; never report the client-side selection
+ * size back to the user, since eligibility is decided server-side.
+ */
+export async function bulkEnhance(dto: BulkEnhanceDto): Promise<BulkEnhanceResult> {
+  return api.post<BulkEnhanceResult>('/media/bulk/enhance', dto);
 }
 
 export async function bulkUnarchive(dto: BulkArchiveDto): Promise<{ unarchived: number }> {


### PR DESCRIPTION
## Summary

Phase 2 of epic #420, and the phase that delivers the actual user-facing ask: **select many photos, click AI Enhance, they all go to the queue.**

AI Enhance was the one action in the selection bar that refused more than one photo — select two and the button silently vanished. It now counts photos in the selection and routes to one of two experiences:

- **exactly 1 photo → the existing `MediaEnhancementDrawer`, byte-for-byte unchanged.** That is a *better* experience for one photo (live before/after compare, immediate keep/replace/discard) and is deliberately preserved rather than folded into the batch path.
- **2+ photos → the new `BatchEnhanceDialog`.**

Stacked on #427 (Phase 1). **Review that first** — this PR targets it, so the diff here is web-only.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #422
Relates to #420, depends on #421

## Changes Made

**One wiring point, not four.** `BulkActionToolbar` is rendered from exactly one place (`MediaGallery.tsx`), so Home, Media Library, person-filtered views, Album detail and Search all inherit this transitively.

**The gate** — videos never count:

| Selection | Result |
|---|---|
| 1 photo | existing single-item drawer |
| 2+ photos | `BatchEnhanceDialog` |
| 1 photo + 1 video | still the single drawer (1 photo) |
| videos only | button absent |
| `viewer` role | button absent |
| flag off / still loading | button absent (no flash-in) |

The flag is read from `useFeatureFlags()` (`GET /api/features`, authentication only), **never `useSystemSettings()`**, which is Admin-gated and would 403 for exactly the non-admin collaborators this feature is for. The spec records that as a bug already fixed once; there is now a test pinning it.

**Shared preset module** — `PRESETS`, `PresetCard`, the adjustment fields and `buildEnhanceParams()` are lifted into `components/media/enhancePresets.tsx` and imported by both the drawer and the dialog. There is now exactly one `PRESETS` array in the codebase, and the tests assert the two paths produce identical params rather than hard-coding a literal, so they cannot drift.

**The dialog** is a `Dialog`, not a `Drawer` — there is no result to compare, so the drawer's three-step machine does not apply. One preset applies to every photo; per-photo parameters are not offered and would be guesswork before seeing any output. It carries the cost confirmation with the count **in the button** ("Enhance 12 photos"), not only in the prose, and disables submit above `maxBatchSize` with copy naming both the selection size and the cap. The server enforces the cap too — this is the courteous half.

**Result feedback uses the server's numbers, never the client's optimistic count**: `"Queued AI enhancement for 26 photos · 4 skipped"`. The per-reason `skipped` breakdown appears in the dialog before it closes; the toast gets the one-line summary. Selection clears on success.

## Testing

- [x] Unit tests pass (`npm test`) — **251 files / 5019 tests**, +31 net, 0 regressions
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [ ] Manual testing completed — **not performed**; no running app or OpenAI credential in this environment. The gate matrix, dialog behaviour and submit wiring are covered by tests, but nobody has clicked this in a browser.

Coverage: the full gate matrix (including the subtle 1-photo-plus-1-video case below), preset→params equivalence with the drawer, over-cap disabling, submit payload carrying photo ids only, the double-submit guard, a server 400 rendering the server's own message, the skipped-breakdown step, and `selectedItems` derivation surviving a paginated append (page-1 selection still resolves after page 2 merges).

### Test Instructions

1. Select 2+ photos in the gallery → AI Enhance appears labelled with the photo count; confirm the dialog names the count in both the warning and the button.
2. Select exactly 1 photo → the existing drawer opens, unchanged.
3. Select 1 photo + 1 video → still the drawer.
4. Select more than `maxBatchSize` photos → submit disabled with both numbers named.
5. Submit a mixed selection → toast reports the server's `queued`, the dialog lists what was skipped, selection clears.
6. As a `viewer`, confirm the button never appears. At 360px, confirm no horizontal scroll.

## Additional Notes

Three implementer deviations worth a reviewer's eye:

1. **A 400 renders inline in the dialog rather than via a toast.** Every 400 this endpoint returns is actionable (cap exceeded, feature disabled, no model configured), and a toast that closed the dialog would discard the selection the user needs in order to act. `MediaEnhancementDrawer` already renders its errors inline, so this follows the feature's own precedent.

2. **`enhanceTargetItem` was added alongside `singleSelectedItem`.** This one is a genuine gap in the issue's own spec: the issue asked for "1 photo + 1 video → single drawer", but `singleSelectedItem` is null whenever `selected.size !== 1`, so that case would have shown the button and opened nothing. The drawer now renders off the single selected *photo*; `singleSelectedItem` is kept and still passed to the toolbar. There is an explicit test for it.

3. **The skipped breakdown gates the close.** Skipping nothing closes immediately; skipping something switches to a result step with a **Done** button. `queued === 0` gets explicit copy rather than "Queued AI enhancement for 0 photos".

**Forward-compat for #424:** the dialog takes a `target: BatchEnhanceTarget` discriminated union (`kind: 'selection'` is the only member today) and every count string derives from `targetPhotoCount(target)`, so Phase 4's filter mode — carrying a server-resolved `matchedCount` — slots in without a second dialog component.

No selection store was introduced: selection remains plain `useState<Set<string>>` local to `MediaGallery`. `BulkActionToolbar`'s unreachable `mode === 'archive'` branch is pre-existing and deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXs8GNhptV9NvqDTyX3E9A)_