### PR TITLE
feat(web): batch AI enhancement Phase 3 — batch progress panel and Enhancements hub integration

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -76,6 +76,9 @@ const WorkflowListPage = lazy(() => import('./pages/Workflows/WorkflowListPage')
 const WorkflowBuilderPage = lazy(() => import('./pages/Workflows/WorkflowBuilderPage'));
 const WorkflowRunPage = lazy(() => import('./pages/Workflows/WorkflowRunPage'));
 const EnhancementsPage = lazy(() => import('./pages/Enhancements/EnhancementsPage'));
+const EnhancementBatchPage = lazy(
+  () => import('./pages/Enhancements/EnhancementBatchPage'),
+);
 const NotificationsPage = lazy(() => import('./pages/Notifications/NotificationsPage'));
 const MemoriesPage = lazy(() => import('./pages/Memories/MemoriesPage'));
 const MemoryDetailPage = lazy(() => import('./pages/Memories/MemoryDetailPage'));
@@ -184,6 +187,13 @@ function AppRoutes() {
                 <Route path="/workflows/:id" element={<WorkflowBuilderPage />} />
                 <Route path="/workflows/:id/runs/:runId" element={<WorkflowRunPage />} />
                 <Route path="/enhancements" element={<EnhancementsPage />} />
+                {/* Bulk-enhance batch progress (epic #420). Sits beside the
+                    other run pages and, like them, renders its own not-found
+                    for an unknown id or another circle's batch. */}
+                <Route
+                  path="/enhancement-batches/:batchId"
+                  element={<EnhancementBatchPage />}
+                />
                 <Route path="/notifications" element={<NotificationsPage />} />
                 {/* Memories (epic #300). The routes always resolve — a bookmark
                     must not 404 — and each page renders its own disabled state

--- a/apps/web/src/__tests__/components/media/BatchEnhanceDialog.test.tsx
+++ b/apps/web/src/__tests__/components/media/BatchEnhanceDialog.test.tsx
@@ -404,6 +404,7 @@ describe('BatchEnhanceDialog', () => {
 
       expect(onSuccess).toHaveBeenCalledWith(
         expect.stringMatching(/Queued AI enhancement for 1 photo · 2 skipped/i),
+        'batch-1',
       );
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -420,7 +421,10 @@ describe('BatchEnhanceDialog', () => {
       await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
 
       await waitFor(() => {
-        expect(onSuccess).toHaveBeenCalledWith('Queued AI enhancement for 2 photos');
+        expect(onSuccess).toHaveBeenCalledWith(
+          'Queued AI enhancement for 2 photos',
+          'batch-1',
+        );
       });
       expect(onClose).toHaveBeenCalledTimes(1);
       // No result step ever rendered.
@@ -443,10 +447,11 @@ describe('BatchEnhanceDialog', () => {
       await user.click(screen.getByRole('button', { name: /^Enhance 2 photos$/i }));
 
       await waitFor(() => {
-        expect(onSuccess).toHaveBeenCalledWith('No photos were queued');
+        expect(onSuccess).toHaveBeenCalledWith('No photos were queued', 'batch-1');
       });
       expect(onSuccess).not.toHaveBeenCalledWith(
         expect.stringMatching(/Queued AI enhancement for 0/i),
+        expect.anything(),
       );
     });
 
@@ -472,9 +477,13 @@ describe('BatchEnhanceDialog', () => {
       ).not.toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: /^done$/i }));
-      expect(onSuccess).toHaveBeenCalledWith('No photos queued — 2 photos were skipped');
+      expect(onSuccess).toHaveBeenCalledWith(
+        'No photos queued — 2 photos were skipped',
+        'batch-1',
+      );
       expect(onSuccess).not.toHaveBeenCalledWith(
         expect.stringMatching(/Queued AI enhancement for 0/i),
+        expect.anything(),
       );
     });
   });

--- a/apps/web/src/__tests__/hooks/useEnhancementBatch.test.ts
+++ b/apps/web/src/__tests__/hooks/useEnhancementBatch.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for `useEnhancementBatch` (epic #420, issue #423).
+ *
+ * The hook is shaped exactly like `useTrashEmptyRun`/`useReviewRun` — a single
+ * `fetchBatch(batchId)` that populates `batch`/`isLoading`/`error` — so this
+ * suite mirrors `useMediaTags.test.ts`'s teardown-guard regression pattern
+ * (issue #196) rather than inventing a new harness.
+ *
+ * Covers:
+ *  - fetch / refetch behaviour (loading toggles, batch populated, refetch
+ *    replaces the previous batch)
+ *  - error surfacing (Error instance message, and the fallback message for a
+ *    non-Error throw), and that a failed fetch clears any previously-loaded
+ *    batch
+ *  - unmount safety: no state update fires once the component has unmounted,
+ *    even when the in-flight fetch resolves afterwards — the exact race
+ *    `useIsMounted` exists to guard against
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useEnhancementBatch } from '../../hooks/useEnhancementBatch';
+import type { EnhancementBatch } from '../../services/enhance';
+
+vi.mock('../../services/enhance', () => ({
+  getEnhancementBatch: vi.fn(),
+}));
+
+import { getEnhancementBatch } from '../../services/enhance';
+
+const mockGetEnhancementBatch = vi.mocked(getEnhancementBatch);
+
+function makeBatch(overrides: Partial<EnhancementBatch> = {}): EnhancementBatch {
+  return {
+    id: 'batch-1',
+    circleId: 'circle-1',
+    status: 'running',
+    matchedCount: 10,
+    processedCount: 3,
+    succeededCount: 2,
+    failedCount: 1,
+    skippedCount: 0,
+    startedById: 'user-1',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:10.000Z',
+    startedAt: '2026-08-01T00:00:01.000Z',
+    finishedAt: null,
+    lastError: null,
+    requestedCount: 10,
+    queuedCount: 10,
+    skipped: null,
+    params: {},
+    source: 'selection',
+    cancelledAt: null,
+    ...overrides,
+  };
+}
+
+describe('useEnhancementBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Fetch / refetch behaviour
+  // -------------------------------------------------------------------------
+  describe('fetch / refetch', () => {
+    it('starts with an empty, non-loading state', () => {
+      const { result } = renderHook(() => useEnhancementBatch());
+
+      expect(result.current.batch).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('fetches and populates the batch, toggling isLoading around it', async () => {
+      let resolveGet!: (value: EnhancementBatch) => void;
+      const pending = new Promise<EnhancementBatch>((resolve) => {
+        resolveGet = resolve;
+      });
+      mockGetEnhancementBatch.mockReturnValue(pending);
+
+      const { result } = renderHook(() => useEnhancementBatch());
+
+      let fetchPromise!: Promise<void>;
+      act(() => {
+        fetchPromise = result.current.fetchBatch('batch-1');
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+      await act(async () => {
+        resolveGet(makeBatch());
+        await fetchPromise;
+      });
+
+      expect(mockGetEnhancementBatch).toHaveBeenCalledWith('batch-1');
+      expect(result.current.batch).toEqual(makeBatch());
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('a later fetchBatch call replaces the previously-loaded batch (poll semantics)', async () => {
+      mockGetEnhancementBatch.mockResolvedValueOnce(
+        makeBatch({ status: 'running', processedCount: 3 }),
+      );
+      const { result } = renderHook(() => useEnhancementBatch());
+
+      await act(async () => {
+        await result.current.fetchBatch('batch-1');
+      });
+      expect(result.current.batch?.processedCount).toBe(3);
+
+      mockGetEnhancementBatch.mockResolvedValueOnce(
+        makeBatch({ status: 'completed', processedCount: 10, succeededCount: 9 }),
+      );
+      await act(async () => {
+        await result.current.fetchBatch('batch-1');
+      });
+
+      expect(mockGetEnhancementBatch).toHaveBeenCalledTimes(2);
+      expect(result.current.batch?.status).toBe('completed');
+      expect(result.current.batch?.processedCount).toBe(10);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error surfacing
+  // -------------------------------------------------------------------------
+  describe('error surfacing', () => {
+    it('surfaces an Error instance message and clears the batch', async () => {
+      mockGetEnhancementBatch.mockResolvedValueOnce(makeBatch());
+      const { result } = renderHook(() => useEnhancementBatch());
+
+      await act(async () => {
+        await result.current.fetchBatch('batch-1');
+      });
+      expect(result.current.batch).not.toBeNull();
+
+      mockGetEnhancementBatch.mockRejectedValueOnce(new Error('Enhancement batch not found'));
+      await act(async () => {
+        await result.current.fetchBatch('missing-batch');
+      });
+
+      expect(result.current.error).toBe('Enhancement batch not found');
+      // A failed re-fetch must not leave a stale batch on screen.
+      expect(result.current.batch).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('falls back to a generic message for a non-Error throw', async () => {
+      mockGetEnhancementBatch.mockRejectedValueOnce('nope');
+      const { result } = renderHook(() => useEnhancementBatch());
+
+      await act(async () => {
+        await result.current.fetchBatch('batch-1');
+      });
+
+      expect(result.current.error).toBe('Failed to fetch the enhancement batch');
+      expect(result.current.batch).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unmount safety (issue #196's useIsMounted guard)
+  // -------------------------------------------------------------------------
+  describe('unmount safety', () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+    let unhandledRejections: unknown[];
+    let onUnhandledRejection: (reason: unknown) => void;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      unhandledRejections = [];
+      onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandledRejection);
+    });
+
+    afterEach(() => {
+      process.off('unhandledRejection', onUnhandledRejection);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not update state, warn, or reject when an in-flight fetch resolves AFTER unmount', async () => {
+      let resolveGet!: (value: EnhancementBatch) => void;
+      const pending = new Promise<EnhancementBatch>((resolve) => {
+        resolveGet = resolve;
+      });
+      mockGetEnhancementBatch.mockReturnValue(pending);
+
+      const { result, unmount } = renderHook(() => useEnhancementBatch());
+
+      // Kick off the fetch — it is now in flight (mocked promise still pending).
+      let fetchPromise!: Promise<void>;
+      act(() => {
+        fetchPromise = result.current.fetchBatch('batch-1');
+      });
+
+      // Unmount BEFORE the fetch resolves — the exact race issue #196 guards.
+      unmount();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const savedWindow = (globalThis as any).window;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).window;
+
+      // Now let the fetch resolve, well after teardown.
+      resolveGet(makeBatch());
+
+      // Give the resolved promise's continuation (the guarded `then`/`finally`
+      // block inside useEnhancementBatch) every opportunity to run.
+      await fetchPromise;
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).window = savedWindow;
+
+      // No thrown/rejected error escaped the continuation.
+      expect(unhandledRejections).toEqual([]);
+      // No React "not wrapped in act" (or any other) warning fired — meaning
+      // no state update was attempted against the unmounted component.
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not update state when an in-flight fetch REJECTS after unmount', async () => {
+      let rejectGet!: (reason: unknown) => void;
+      const pending = new Promise<EnhancementBatch>((_resolve, reject) => {
+        rejectGet = reject;
+      });
+      mockGetEnhancementBatch.mockReturnValue(pending);
+      // A rejected promise this test intentionally never lets propagate as an
+      // unhandled rejection from the mock itself.
+      pending.catch(() => {});
+
+      const { result, unmount } = renderHook(() => useEnhancementBatch());
+
+      let fetchPromise!: Promise<void>;
+      act(() => {
+        fetchPromise = result.current.fetchBatch('batch-1');
+      });
+
+      unmount();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const savedWindow = (globalThis as any).window;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).window;
+
+      rejectGet(new Error('boom'));
+
+      await fetchPromise;
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).window = savedWindow;
+
+      expect(unhandledRejections).toEqual([]);
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/__tests__/pages/Enhancements/EnhancementBatchPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Enhancements/EnhancementBatchPage.test.tsx
@@ -1,0 +1,618 @@
+/**
+ * RTL tests for EnhancementBatchPage — the bulk AI-enhance batch progress page
+ * (epic #420, issue #423).
+ *
+ * Modelled directly on `TrashEmptyRunPage.test.tsx` / `ReviewRunPage.test.tsx`:
+ * all data hooks are mocked directly, so these tests exercise the page's own
+ * render/effect logic (and the shared `RunProgressPanel` + `useRunPolling`
+ * pieces it assembles) without a real network.
+ *
+ * Covers:
+ *  - Counters rendered via RunProgressPanel, with the two LOAD-BEARING relabels
+ *    — "Ready to review" (succeeded) and "Cancelled" (skipped) — asserted
+ *    explicitly, since everywhere else in the app "succeeded" means done and
+ *    here it means waiting for the user.
+ *  - "Cancel remaining" wording, and the body copy stating in-flight
+ *    enhancements are left to finish.
+ *  - Cancel visibility: gated by per-circle role (collaborator+), by the
+ *    active circle matching the batch's own circle, and hidden once terminal.
+ *  - Cancel calling the endpoint then refetching, and a 400 surfacing the
+ *    SERVER's message rather than a generic one.
+ *  - "Review N results" appearing exactly when succeededCount > 0, and its
+ *    link target.
+ *  - An empty batch (0 queued) rendering a sensible terminal state rather than
+ *    a stuck progress bar.
+ *  - Unknown id / cross-circle batch → a clean not-found, never an unhandled
+ *    error.
+ *  - The failed-items table when failedCount > 0.
+ *  - Progress polling: `fetchBatch` re-invoked every 2s (fake timers) while
+ *    non-terminal, and STOPS the instant a poll tick reports a terminal
+ *    status — the assertion most likely to regress silently, per issue #423.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+import {
+  installLayoutStubs,
+  resetContainerWidth,
+} from '../../../components/datatable/__tests__/testUtils/layoutStubs';
+import { api } from '../../../services/api';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../hooks/useCircle', () => ({
+  useCircle: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useEnhancementBatch', () => ({
+  useEnhancementBatch: vi.fn(),
+}));
+
+vi.mock('../../../services/enhance', () => ({
+  cancelEnhancementBatch: vi.fn(),
+  listEnhancements: vi.fn().mockResolvedValue({
+    items: [],
+    meta: { page: 1, pageSize: 25, totalItems: 0, totalPages: 0 },
+  }),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ batchId: 'batch-1' }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import EnhancementBatchPage from '../../../pages/Enhancements/EnhancementBatchPage';
+import { useCircle } from '../../../hooks/useCircle';
+import { useEnhancementBatch } from '../../../hooks/useEnhancementBatch';
+import { cancelEnhancementBatch, listEnhancements } from '../../../services/enhance';
+import type { EnhancementBatch, EnhancementListItem } from '../../../services/enhance';
+
+const mockUseCircle = vi.mocked(useCircle);
+const mockUseEnhancementBatch = vi.mocked(useEnhancementBatch);
+const mockCancelEnhancementBatch = vi.mocked(cancelEnhancementBatch);
+const mockListEnhancements = vi.mocked(listEnhancements);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCircleContext(overrides: Partial<ReturnType<typeof useCircle>> = {}) {
+  return {
+    activeCircle: {
+      id: 'circle-1',
+      name: 'Test Circle',
+      description: null,
+      ownerId: 'user-1',
+      isPersonal: false,
+      createdAt: '',
+      updatedAt: '',
+    },
+    activeCircleId: 'circle-1',
+    activeCircleRole: 'collaborator',
+    circles: [],
+    loading: false,
+    setActiveCircle: vi.fn().mockResolvedValue(undefined),
+    refreshCircles: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ReturnType<typeof useCircle>;
+}
+
+function makeBatch(overrides: Partial<EnhancementBatch> = {}): EnhancementBatch {
+  return {
+    id: 'batch-1',
+    circleId: 'circle-1',
+    status: 'running',
+    matchedCount: 10,
+    processedCount: 5,
+    succeededCount: 3,
+    // Deliberately 0 by default: a nonzero failedCount triggers the page's
+    // failed-items `listEnhancements` fetch, which most tests below never
+    // await — opt in explicitly (see the "failed items" describe block).
+    failedCount: 0,
+    skippedCount: 1,
+    startedById: 'user-1',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:10.000Z',
+    startedAt: '2026-08-01T00:00:01.000Z',
+    finishedAt: null,
+    lastError: null,
+    requestedCount: 10,
+    queuedCount: 10,
+    skipped: null,
+    params: { preset: 'restore_old_photo', strength: 'strong' },
+    source: 'selection',
+    cancelledAt: null,
+    ...overrides,
+  };
+}
+
+type BatchHookReturn = ReturnType<typeof useEnhancementBatch>;
+function makeBatchHook(overrides: Partial<BatchHookReturn> = {}): BatchHookReturn {
+  return {
+    batch: makeBatch(),
+    isLoading: false,
+    error: null,
+    fetchBatch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as BatchHookReturn;
+}
+
+function makeFailedItem(overrides: Partial<EnhancementListItem> = {}): EnhancementListItem {
+  return {
+    id: 'enh-1',
+    mediaItemId: 'm-1',
+    status: 'failed',
+    decision: null,
+    model: 'gpt-image-1',
+    params: {},
+    original: { thumbnailUrl: 'https://cdn/o.jpg', width: 100, height: 100, size: '1000' },
+    enhanced: { thumbnailUrl: null, width: null, height: null, size: null },
+    downscaled: false,
+    expiresAt: null,
+    lastError: 'The model returned a 400',
+    resultMediaItemId: null,
+    sourceFilename: 'broken.jpg',
+    capturedAt: null,
+    createdBy: { id: 'user-1', name: 'Test User' },
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeAll(() => {
+  // The failed-items table is a DataTable; jsdom performs no layout, so both
+  // the container-width hook and MUI X measure 0×0 without these.
+  installLayoutStubs();
+});
+
+describe('EnhancementBatchPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetContainerWidth(1400); // desktop layout unless a test says otherwise
+    mockUseCircle.mockReturnValue(makeCircleContext());
+    mockListEnhancements.mockResolvedValue({
+      items: [],
+      meta: { page: 1, pageSize: 25, totalItems: 0, totalPages: 0 },
+    });
+    // The failed-items table's layout-persistence hook reads/writes
+    // `/user-settings` (docs/specs/datatable.md §15).
+    vi.spyOn(api, 'get').mockResolvedValue({} as never);
+    vi.spyOn(api, 'patch').mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Counters
+  // -------------------------------------------------------------------------
+  describe('counters', () => {
+    it('renders the counters via RunProgressPanel, with the load-bearing succeeded/skipped relabels', async () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({
+          batch: makeBatch({
+            matchedCount: 10,
+            processedCount: 5,
+            succeededCount: 3,
+            failedCount: 1,
+            skippedCount: 2,
+          }),
+        }),
+      );
+
+      render(<EnhancementBatchPage />);
+      // failedCount > 0 triggers the failed-items fetch; let it settle so it
+      // never resolves after this test's own assertions have returned.
+      await screen.findByText('Failed photos (1)');
+
+      // "Succeeded" is relabelled "Ready to review" — everywhere else in the
+      // app that word means DONE; here it means waiting for the user.
+      const readyTile = screen.getByText('Ready to review').closest('.MuiCardContent-root');
+      expect(readyTile).not.toBeNull();
+      expect(readyTile).toHaveTextContent('3');
+      expect(screen.queryByText('Succeeded')).not.toBeInTheDocument();
+
+      // "Skipped" is relabelled "Cancelled" — these rows were withdrawn by a
+      // cancel, not skipped for some other reason.
+      const cancelledTile = screen.getByText('Cancelled').closest('.MuiCardContent-root');
+      expect(cancelledTile).not.toBeNull();
+      expect(cancelledTile).toHaveTextContent('2');
+      expect(screen.queryByText('Skipped')).not.toBeInTheDocument();
+
+      // The generic tiles keep their default labels.
+      const totalTile = screen.getByText('Total').closest('.MuiCardContent-root');
+      expect(totalTile).toHaveTextContent('10');
+      const processedTile = screen.getByText('Processed').closest('.MuiCardContent-root');
+      expect(processedTile).toHaveTextContent('5');
+      const failedTile = screen.getByText('Failed').closest('.MuiCardContent-root');
+      expect(failedTile).toHaveTextContent('1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cancel: wording, gating, behaviour
+  // -------------------------------------------------------------------------
+  describe('cancel', () => {
+    it('reads "Cancel remaining" and the body states in-flight photos will finish', () => {
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook());
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.getByRole('button', { name: 'Cancel remaining' })).toBeInTheDocument();
+      expect(
+        screen.getByText(/any photo already being enhanced finishes/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/its AI credits are already spent/i),
+      ).toBeInTheDocument();
+    });
+
+    it('is visible for a collaborator on a matching, non-terminal batch', () => {
+      mockUseCircle.mockReturnValue(makeCircleContext({ activeCircleRole: 'collaborator' }));
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook());
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.getByRole('button', { name: 'Cancel remaining' })).toBeInTheDocument();
+    });
+
+    it('is visible for circle_admin as well (collaborator OR circle_admin)', () => {
+      mockUseCircle.mockReturnValue(makeCircleContext({ activeCircleRole: 'circle_admin' }));
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook());
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.getByRole('button', { name: 'Cancel remaining' })).toBeInTheDocument();
+    });
+
+    it('is hidden for a plain viewer', () => {
+      mockUseCircle.mockReturnValue(makeCircleContext({ activeCircleRole: 'viewer' }));
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook());
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.queryByRole('button', { name: 'Cancel remaining' })).not.toBeInTheDocument();
+    });
+
+    it('is hidden when the batch belongs to a different circle than the active one', () => {
+      // A batch deep-linked from another circle carries no role we can trust,
+      // so the affordance is withheld rather than guessed at.
+      mockUseCircle.mockReturnValue(makeCircleContext({ activeCircleRole: 'collaborator' }));
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: makeBatch({ circleId: 'circle-other' }) }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.queryByRole('button', { name: 'Cancel remaining' })).not.toBeInTheDocument();
+    });
+
+    it('is hidden once the batch is terminal, even for a collaborator on a matching circle', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({
+          batch: makeBatch({ status: 'completed', succeededCount: 10, processedCount: 10 }),
+        }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.queryByRole('button', { name: 'Cancel remaining' })).not.toBeInTheDocument();
+      // The in-flight-work notice is gated the same way — nothing left to cancel.
+      expect(
+        screen.queryByText(/any photo already being enhanced finishes/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls the cancel endpoint then refetches the batch', async () => {
+      const user = userEvent.setup();
+      const fetchBatch = vi.fn().mockResolvedValue(undefined);
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook({ fetchBatch }));
+      mockCancelEnhancementBatch.mockResolvedValue({
+        batchId: 'batch-1',
+        status: 'cancelled',
+        cancelled: 3,
+      });
+
+      render(<EnhancementBatchPage />);
+
+      // Mount fetch already happened once.
+      expect(fetchBatch).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole('button', { name: 'Cancel remaining' }));
+
+      await screen.findByText('3 queued photos were cancelled');
+      expect(mockCancelEnhancementBatch).toHaveBeenCalledWith('batch-1');
+      expect(fetchBatch).toHaveBeenCalledTimes(2);
+      expect(fetchBatch).toHaveBeenLastCalledWith('batch-1');
+    });
+
+    it('pluralizes the cancelled-count message for exactly 1', async () => {
+      const user = userEvent.setup();
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook());
+      mockCancelEnhancementBatch.mockResolvedValue({
+        batchId: 'batch-1',
+        status: 'cancelled',
+        cancelled: 1,
+      });
+
+      render(<EnhancementBatchPage />);
+      await user.click(screen.getByRole('button', { name: 'Cancel remaining' }));
+
+      expect(await screen.findByText('1 queued photo was cancelled')).toBeInTheDocument();
+    });
+
+    it('a 400 (already terminal) surfaces the SERVER message, not a generic one', async () => {
+      const user = userEvent.setup();
+      const fetchBatch = vi.fn().mockResolvedValue(undefined);
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook({ fetchBatch }));
+      mockCancelEnhancementBatch.mockRejectedValue(
+        new Error('This batch has already finished'),
+      );
+
+      render(<EnhancementBatchPage />);
+      await user.click(screen.getByRole('button', { name: 'Cancel remaining' }));
+
+      expect(await screen.findByText('This batch has already finished')).toBeInTheDocument();
+      expect(screen.queryByText('Failed to cancel the batch')).not.toBeInTheDocument();
+      // Re-read after the failure too — a terminal batch is exactly the case
+      // that should make the button vanish.
+      expect(fetchBatch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Review handoff
+  // -------------------------------------------------------------------------
+  describe('review handoff', () => {
+    it('shows "No results yet" (disabled) while succeededCount is 0', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: makeBatch({ succeededCount: 0 }) }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      const button = screen.getByRole('button', { name: 'No results yet' });
+      expect(button).toBeDisabled();
+      expect(screen.queryByText(/Review \d+ results?/)).not.toBeInTheDocument();
+    });
+
+    it('shows "Review N results →" and links to the batch-filtered inbox as soon as succeededCount > 0', async () => {
+      const user = userEvent.setup();
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({
+          batch: makeBatch({ status: 'running', succeededCount: 5, matchedCount: 20 }),
+        }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      const button = screen.getByRole('button', { name: 'Review 5 results →' });
+      expect(button).toBeEnabled();
+
+      await user.click(button);
+      expect(mockNavigate).toHaveBeenCalledWith('/enhancements?batchId=batch-1');
+    });
+
+    it('singularizes "Review 1 result →"', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: makeBatch({ succeededCount: 1 }) }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.getByRole('button', { name: 'Review 1 result →' })).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty batch
+  // -------------------------------------------------------------------------
+  describe('empty batch', () => {
+    it('renders a sensible terminal state rather than a stuck progress bar', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({
+          batch: makeBatch({
+            status: 'completed',
+            requestedCount: 0,
+            queuedCount: 0,
+            matchedCount: 0,
+            processedCount: 0,
+            succeededCount: 0,
+            failedCount: 0,
+            skippedCount: 0,
+          }),
+        }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      // Neither the evaluating nor the running block (the only two places a
+      // LinearProgress can appear) is rendered for a terminal batch.
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      // A terminal summary alert IS shown.
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'No results yet' })).toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Not found
+  // -------------------------------------------------------------------------
+  describe('not found', () => {
+    it('shows a spinner while the initial load is in flight', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: null, isLoading: true }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows the SERVER error for an unknown id, with a way back, not an unhandled error', async () => {
+      const user = userEvent.setup();
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: null, isLoading: false, error: 'Enhancement batch not found' }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      const alert = screen.getByRole('alert');
+      expect(within(alert).getByText('Enhancement batch not found')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /back to ai enhancements/i }));
+      expect(mockNavigate).toHaveBeenCalledWith('/enhancements');
+    });
+
+    it('falls back to a generic not-found message when the hook reports no error text (e.g. cross-circle batch)', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: null, isLoading: false, error: null }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      expect(
+        within(screen.getByRole('alert')).getByText('Enhancement batch not found.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Failed items
+  // -------------------------------------------------------------------------
+  describe('failed items', () => {
+    it('renders the failed-items table when failedCount > 0', async () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({
+          batch: makeBatch({
+            status: 'completed_with_errors',
+            matchedCount: 10,
+            processedCount: 10,
+            succeededCount: 8,
+            failedCount: 2,
+          }),
+        }),
+      );
+      mockListEnhancements.mockResolvedValue({
+        items: [
+          makeFailedItem({ id: 'enh-1', sourceFilename: 'broken-one.jpg' }),
+          makeFailedItem({ id: 'enh-2', sourceFilename: 'broken-two.jpg', mediaItemId: 'm-2' }),
+        ],
+        meta: { page: 1, pageSize: 25, totalItems: 2, totalPages: 1 },
+      });
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.getByText('Failed photos (2)')).toBeInTheDocument();
+      expect(await screen.findByText('broken-one.jpg')).toBeInTheDocument();
+      expect(screen.getByText('broken-two.jpg')).toBeInTheDocument();
+
+      expect(mockListEnhancements).toHaveBeenCalledWith(
+        expect.objectContaining({
+          circleId: 'circle-1',
+          batchId: 'batch-1',
+          status: 'failed',
+          page: 1,
+          pageSize: 25,
+        }),
+      );
+    });
+
+    it('does not render the failed-items table when failedCount is 0', () => {
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: makeBatch({ failedCount: 0 }) }),
+      );
+
+      render(<EnhancementBatchPage />);
+
+      expect(screen.queryByText(/^Failed photos/)).not.toBeInTheDocument();
+      expect(mockListEnhancements).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Progress polling — the assertion most likely to regress silently.
+  // -------------------------------------------------------------------------
+  describe('progress polling', () => {
+    it('re-fetches the batch every 2s while non-terminal, and issues NO FURTHER requests once a poll tick reports a terminal status', () => {
+      vi.useFakeTimers();
+      const fetchBatch = vi.fn().mockResolvedValue(undefined);
+      const runningBatch = makeBatch({ status: 'running', matchedCount: 100, processedCount: 10 });
+      mockUseEnhancementBatch.mockReturnValue(makeBatchHook({ batch: runningBatch, fetchBatch }));
+
+      const { rerender } = render(<EnhancementBatchPage />);
+
+      // Initial mount fetch.
+      expect(fetchBatch).toHaveBeenCalledTimes(1);
+      expect(fetchBatch).toHaveBeenCalledWith('batch-1');
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(fetchBatch).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(fetchBatch).toHaveBeenCalledTimes(3);
+
+      // A poll tick reports the batch is now complete — the transition this
+      // test exists to cover.
+      const completedBatch = makeBatch({
+        status: 'completed',
+        matchedCount: 100,
+        processedCount: 100,
+        succeededCount: 100,
+      });
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: completedBatch, fetchBatch }),
+      );
+      rerender(<EnhancementBatchPage />);
+
+      const callsAtTerminal = fetchBatch.mock.calls.length;
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      // No further requests — the request count must not keep increasing.
+      expect(fetchBatch).toHaveBeenCalledTimes(callsAtTerminal);
+    });
+
+    it('does not poll at all when the batch starts already terminal', () => {
+      vi.useFakeTimers();
+      const fetchBatch = vi.fn().mockResolvedValue(undefined);
+      const completedBatch = makeBatch({
+        status: 'completed',
+        matchedCount: 10,
+        processedCount: 10,
+        succeededCount: 10,
+      });
+      mockUseEnhancementBatch.mockReturnValue(
+        makeBatchHook({ batch: completedBatch, fetchBatch }),
+      );
+
+      render(<EnhancementBatchPage />);
+      const callsAfterMount = fetchBatch.mock.calls.length;
+
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      expect(fetchBatch).toHaveBeenCalledTimes(callsAfterMount);
+    });
+  });
+});

--- a/apps/web/src/__tests__/pages/Enhancements/EnhancementsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Enhancements/EnhancementsPage.test.tsx
@@ -9,7 +9,7 @@
  *  - only the active tab's data is fetched
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSearchParams } from 'react-router-dom';
 import { render } from '../../utils/test-utils';
@@ -126,6 +126,46 @@ describe('EnhancementsPage', () => {
     expect(
       await screen.findByText(/History — the full audit trail of past enhancements/),
     ).toBeInTheDocument();
+  });
+
+  it('reads ?batchId= from the URL and passes it to the pending tab (epic #420, issue #423)', () => {
+    render(<EnhancementsPage />, {
+      wrapperOptions: { route: '/enhancements?batchId=batch-1' },
+    });
+
+    expect(pendingTabSpy).toHaveBeenCalledWith({
+      circleId: 'circle-1',
+      batchId: 'batch-1',
+      onClearBatchFilter: expect.any(Function),
+    });
+  });
+
+  it('clearing the batch filter drops ?batchId= from the URL and re-renders the tab unfiltered', async () => {
+    render(
+      <>
+        <EnhancementsPage />
+        <SearchParamsProbe />
+      </>,
+      { wrapperOptions: { route: '/enhancements?batchId=batch-1' } },
+    );
+
+    expect(screen.getByTestId('search-params')).toHaveTextContent('batchId=batch-1');
+    const { onClearBatchFilter } = pendingTabSpy.mock.calls.at(-1)![0] as {
+      onClearBatchFilter: () => void;
+    };
+
+    act(() => {
+      onClearBatchFilter();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-params')).not.toHaveTextContent('batchId');
+    });
+    await waitFor(() => {
+      expect(pendingTabSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({ batchId: undefined }),
+      );
+    });
   });
 
   it('mirrors a non-default tab into the URL and removes it again on return', async () => {

--- a/apps/web/src/__tests__/pages/Enhancements/EnhancementsPage.test.tsx
+++ b/apps/web/src/__tests__/pages/Enhancements/EnhancementsPage.test.tsx
@@ -62,7 +62,12 @@ describe('EnhancementsPage', () => {
 
   it('passes the active circle id down to the pending tab', () => {
     render(<EnhancementsPage />);
-    expect(pendingTabSpy).toHaveBeenCalledWith({ circleId: 'circle-1' });
+    // `batchId` is undefined unless the URL carries one (epic #420, issue #423).
+    expect(pendingTabSpy).toHaveBeenCalledWith({
+      circleId: 'circle-1',
+      batchId: undefined,
+      onClearBatchFilter: expect.any(Function),
+    });
   });
 
   it('opens the tab named by ?tab= on mount', () => {

--- a/apps/web/src/__tests__/pages/Enhancements/PendingEnhancementsTab.test.tsx
+++ b/apps/web/src/__tests__/pages/Enhancements/PendingEnhancementsTab.test.tsx
@@ -37,6 +37,10 @@ vi.mock('../../../hooks/useFeatureFlags', () => ({
 vi.mock('../../../services/enhance', () => ({
   applyEnhancement: vi.fn().mockResolvedValue({}),
   discardEnhancement: vi.fn().mockResolvedValue(undefined),
+  // Called by the tab's "Recent batches" section (epic #420, issue #423).
+  // Empty by default: that section renders nothing without batches, leaving
+  // every assertion below about the inbox itself.
+  listEnhancementBatches: vi.fn().mockResolvedValue({ items: [], meta: null }),
 }));
 
 vi.mock('../../../services/media', () => ({

--- a/apps/web/src/__tests__/pages/Enhancements/PendingEnhancementsTab.test.tsx
+++ b/apps/web/src/__tests__/pages/Enhancements/PendingEnhancementsTab.test.tsx
@@ -57,7 +57,11 @@ vi.mock('../../../components/media/MediaEnhancementDrawer', () => ({
 
 import { useEnhancements } from '../../../hooks/useEnhancements';
 import { useFeatureFlags } from '../../../hooks/useFeatureFlags';
-import { applyEnhancement, discardEnhancement } from '../../../services/enhance';
+import {
+  applyEnhancement,
+  discardEnhancement,
+  listEnhancementBatches,
+} from '../../../services/enhance';
 import { getMedia } from '../../../services/media';
 
 const mockUseEnhancements = vi.mocked(useEnhancements);
@@ -507,6 +511,98 @@ describe('PendingEnhancementsTab', () => {
 
       expect(screen.queryByRole('checkbox')).toBeNull();
       expect(screen.queryByRole('button', { name: /Select all/i })).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Batch narrowing (epic #420, issue #423)
+  // ---------------------------------------------------------------------
+  describe('batch narrowing', () => {
+    it('narrows the request passed to listEnhancements and renders the explanatory chip', () => {
+      mockList([makeItem()], {
+        meta: { page: 1, pageSize: 24, totalItems: 3, totalPages: 1 },
+      });
+      render(<PendingEnhancementsTab circleId="circle-1" batchId="batch-1" />);
+
+      expect(mockUseEnhancements).toHaveBeenCalledWith(
+        expect.objectContaining({ circleId: 'circle-1', batchId: 'batch-1' }),
+      );
+      expect(
+        screen.getByText('Showing 3 results from one batch'),
+      ).toBeInTheDocument();
+    });
+
+    it('singularizes the chip copy for exactly one result', () => {
+      mockList([makeItem()], {
+        meta: { page: 1, pageSize: 24, totalItems: 1, totalPages: 1 },
+      });
+      render(<PendingEnhancementsTab circleId="circle-1" batchId="batch-1" />);
+
+      expect(screen.getByText('Showing 1 result from one batch')).toBeInTheDocument();
+    });
+
+    it('suppresses the "Recent batches" section (and its request) while narrowed to one batch', async () => {
+      // `RecentBatches` isn't mounted at all while `batchId` is set — proven
+      // by the fact its data call never fires, not merely that it renders
+      // nothing because the mock happens to return no items.
+      mockList([makeItem()], {
+        meta: { page: 1, pageSize: 24, totalItems: 1, totalPages: 1 },
+      });
+      render(<PendingEnhancementsTab circleId="circle-1" batchId="batch-1" />);
+
+      // Give any stray effect a chance to have fired at all.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The chip already says where the user is; a second "recent batches"
+      // list beside it would be redundant navigation.
+      expect(screen.queryByText('Recent batches')).not.toBeInTheDocument();
+      expect(listEnhancementBatches).not.toHaveBeenCalled();
+    });
+
+    it('calls onClearBatchFilter when the chip is cleared, and the tab then requests the unfiltered list', async () => {
+      const user = userEvent.setup();
+      const onClearBatchFilter = vi.fn();
+      mockList([makeItem()], {
+        meta: { page: 1, pageSize: 24, totalItems: 1, totalPages: 1 },
+      });
+      const { rerender } = render(
+        <PendingEnhancementsTab
+          circleId="circle-1"
+          batchId="batch-1"
+          onClearBatchFilter={onClearBatchFilter}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Show all' }));
+      expect(onClearBatchFilter).toHaveBeenCalledTimes(1);
+
+      // The tab itself owns no URL state — clearing the param is the parent's
+      // job (EnhancementsPage). Once the parent re-renders with batchId gone,
+      // the tab must go back to requesting the unfiltered list.
+      mockUseEnhancements.mockClear();
+      rerender(<PendingEnhancementsTab circleId="circle-1" />);
+
+      const lastCallParams = mockUseEnhancements.mock.calls.at(-1)?.[0];
+      expect(lastCallParams).not.toHaveProperty('batchId');
+      expect(screen.queryByRole('button', { name: 'Show all' })).toBeNull();
+    });
+
+    it('behaves EXACTLY as before when batchId is absent — the regression pin', () => {
+      mockList([makeItem()]);
+      render(<PendingEnhancementsTab circleId="circle-1" />);
+
+      // No batch narrowing chip, no batchId on the wire, and the hub's own
+      // recovery list (Recent batches) is free to render.
+      expect(screen.queryByText(/from one batch/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Show all' })).toBeNull();
+      const lastCallParams = mockUseEnhancements.mock.calls.at(-1)?.[0];
+      expect(lastCallParams).not.toHaveProperty('batchId');
+      expect(lastCallParams).toEqual({
+        circleId: 'circle-1',
+        page: 1,
+        pageSize: 24,
+        sortOrder: 'desc',
+      });
     });
   });
 });

--- a/apps/web/src/__tests__/pages/Enhancements/RecentBatches.test.tsx
+++ b/apps/web/src/__tests__/pages/Enhancements/RecentBatches.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * RecentBatches — unit tests (epic #420, issue #423).
+ *
+ * The recovery path back to a batch's progress page: the submit toast's "View
+ * progress" action is how a user normally gets there, and this is what is
+ * left after dismissing it or reloading. Covers:
+ *  - renders nothing while the list is empty (including on a failed lookup)
+ *  - lists recent batches with their derived status/photo-count/relative time
+ *  - the params + ready-to-review + failed summary line
+ *  - clicking a batch card navigates to its own progress page
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../utils/test-utils';
+import { RecentBatches } from '../../../pages/Enhancements/RecentBatches';
+import type { EnhancementBatch } from '../../../services/enhance';
+
+vi.mock('../../../services/enhance', () => ({
+  listEnhancementBatches: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import { listEnhancementBatches } from '../../../services/enhance';
+
+const mockListEnhancementBatches = vi.mocked(listEnhancementBatches);
+
+function makeBatch(overrides: Partial<EnhancementBatch> = {}): EnhancementBatch {
+  return {
+    id: 'batch-1',
+    circleId: 'circle-1',
+    status: 'running',
+    matchedCount: 12,
+    processedCount: 4,
+    succeededCount: 3,
+    failedCount: 0,
+    skippedCount: 0,
+    startedById: 'user-1',
+    createdAt: '2026-08-01T11:58:00.000Z',
+    updatedAt: '2026-08-01T11:59:00.000Z',
+    startedAt: '2026-08-01T11:58:01.000Z',
+    finishedAt: null,
+    lastError: null,
+    requestedCount: 12,
+    queuedCount: 12,
+    skipped: null,
+    params: { preset: 'restore_old_photo', strength: 'strong' },
+    source: 'selection',
+    cancelledAt: null,
+    ...overrides,
+  };
+}
+
+describe('RecentBatches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing while there are no recent batches', async () => {
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [],
+      meta: { page: 1, pageSize: 5, totalItems: 0, totalPages: 0 },
+    });
+
+    const { container } = render(<RecentBatches circleId="circle-1" />);
+
+    await waitFor(() => expect(mockListEnhancementBatches).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the lookup fails — this is a convenience list, never the reason the user is on the page', async () => {
+    mockListEnhancementBatches.mockRejectedValue(new Error('network error'));
+
+    const { container } = render(<RecentBatches circleId="circle-1" />);
+
+    await waitFor(() => expect(mockListEnhancementBatches).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('requests the 5 most recent batches for the given circle', async () => {
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [makeBatch()],
+      meta: { page: 1, pageSize: 5, totalItems: 1, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    await waitFor(() => {
+      expect(mockListEnhancementBatches).toHaveBeenCalledWith({
+        circleId: 'circle-1',
+        pageSize: 5,
+      });
+    });
+  });
+
+  it('lists a batch with its derived status, photo count, and relative time', async () => {
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [makeBatch({ status: 'running', matchedCount: 12 })],
+      meta: { page: 1, pageSize: 5, totalItems: 1, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    expect(await screen.findByText('Recent batches')).toBeInTheDocument();
+    expect(screen.getByText('12 photos')).toBeInTheDocument();
+    // runStatusLabel('running') -> 'Running'.
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('singularizes the photo count for exactly one photo', async () => {
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [makeBatch({ matchedCount: 1 })],
+      meta: { page: 1, pageSize: 5, totalItems: 1, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    expect(await screen.findByText('1 photo')).toBeInTheDocument();
+  });
+
+  it('summarises params plus ready-to-review and failed counts on one line', async () => {
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [
+        makeBatch({
+          id: 'batch-1',
+          params: { preset: 'restore_old_photo', strength: 'strong' },
+          succeededCount: 4,
+          failedCount: 2,
+        }),
+      ],
+      meta: { page: 1, pageSize: 5, totalItems: 1, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    expect(
+      await screen.findByText('restore old photo · strong · 4 ready to review · 2 failed'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the ready-to-review/failed clauses when both are zero', async () => {
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [
+        makeBatch({
+          id: 'batch-1',
+          params: {},
+          succeededCount: 0,
+          failedCount: 0,
+        }),
+      ],
+      meta: { page: 1, pageSize: 5, totalItems: 1, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    expect(await screen.findByText('auto')).toBeInTheDocument();
+    expect(screen.queryByText(/ready to review/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/failed/)).not.toBeInTheDocument();
+  });
+
+  it('navigates to the batch\'s own progress page when its card is clicked', async () => {
+    const user = userEvent.setup();
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [makeBatch({ id: 'batch-42' })],
+      meta: { page: 1, pageSize: 5, totalItems: 1, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    const card = (await screen.findByText('12 photos')).closest(
+      '.MuiCardActionArea-root',
+    ) as HTMLElement;
+    await user.click(within(card).getByText('12 photos'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/enhancement-batches/batch-42');
+  });
+
+  it('lists multiple recent batches, each linking to its own page', async () => {
+    const user = userEvent.setup();
+    mockListEnhancementBatches.mockResolvedValue({
+      items: [
+        makeBatch({ id: 'batch-1', matchedCount: 5 }),
+        makeBatch({ id: 'batch-2', matchedCount: 8, status: 'completed' }),
+      ],
+      meta: { page: 1, pageSize: 5, totalItems: 2, totalPages: 1 },
+    });
+
+    render(<RecentBatches circleId="circle-1" />);
+
+    expect(await screen.findByText('5 photos')).toBeInTheDocument();
+    expect(screen.getByText('8 photos')).toBeInTheDocument();
+
+    const secondCard = screen
+      .getByText('8 photos')
+      .closest('.MuiCardActionArea-root') as HTMLElement;
+    await user.click(within(secondCard).getByText('8 photos'));
+    expect(mockNavigate).toHaveBeenCalledWith('/enhancement-batches/batch-2');
+  });
+});

--- a/apps/web/src/components/media/BatchEnhanceDialog.tsx
+++ b/apps/web/src/components/media/BatchEnhanceDialog.tsx
@@ -84,8 +84,12 @@ interface BatchEnhanceDialogProps {
   maxBatchSize: number;
   /** Optional model label, shown alongside the presets (ai.features.enhance). */
   modelLabel?: string | null;
-  /** Called with the one-line, SERVER-derived summary once the batch is queued. */
-  onSuccess: (message: string) => void;
+  /**
+   * Called with the one-line, SERVER-derived summary once the batch is queued,
+   * plus the batch id so the host can make its toast ACTIONABLE — a link to the
+   * batch's progress page is the main way a user ever reaches it (issue #423).
+   */
+  onSuccess: (message: string, batchId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +211,7 @@ export function BatchEnhanceDialog({
         // the toast only ever carries the one-line summary.
         setResult(res);
       } else {
-        onSuccess(message);
+        onSuccess(message, res.batchId);
         onClose();
       }
     } catch (err) {
@@ -221,7 +225,7 @@ export function BatchEnhanceDialog({
   };
 
   const finishAfterResult = () => {
-    if (result) onSuccess(buildResultMessage(result));
+    if (result) onSuccess(buildResultMessage(result), result.batchId);
     onClose();
   };
 

--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -532,6 +532,9 @@ export function MediaGallery({
   const feedLoadMore = feedResult.loadMore;
   const feedReset = feedResult.reset;
 
+  // Used only by the bulk-enhance toast's "View progress" action (issue #423).
+  const navigate = useNavigate();
+
   // Infinite scroll sentinel
   const sentinelRef = useRef<HTMLDivElement>(null);
   // `feedIsLoading` is deliberately NOT part of `disabled`: flipping it tears
@@ -708,6 +711,12 @@ export function MediaGallery({
   const [snackbar, setSnackbar] = useState<{
     message: string;
     severity: 'success' | 'error';
+    /**
+     * Set only by the bulk-enhance path (issue #423). A batch runs for minutes
+     * and costs real AI credits, so its toast is the ONE toast here that has to
+     * lead somewhere: it carries a "View progress" action to the batch page.
+     */
+    batchId?: string;
   } | null>(null);
 
   // -------------------------------------------------------------------------
@@ -1330,17 +1339,21 @@ export function MediaGallery({
         maxBatchSize={pictureEnhancement?.maxBatchSize ?? 25}
         modelLabel={pictureEnhancement?.model ?? undefined}
         // Queueing changes nothing about the items yet, so this is the ordinary
-        // metadata path: toast + clear the selection, never a feed reset.
-        onSuccess={(msg) => {
+        // metadata path: toast + clear the selection, never a feed reset. The
+        // toast is then re-set with the batch id so it carries a link to the
+        // progress page — without it a queued batch vanishes from view.
+        onSuccess={(msg, batchId) => {
           setBatchEnhanceOpen(false);
           handleBulkSuccess(msg);
+          setSnackbar({ message: msg, severity: 'success', batchId });
         }}
       />
 
       {/* Snackbar for bulk operation feedback */}
       <Snackbar
         open={snackbar !== null}
-        autoHideDuration={4000}
+        // An actionable toast needs long enough to actually be acted on.
+        autoHideDuration={snackbar?.batchId ? 10000 : 4000}
         onClose={() => setSnackbar(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
@@ -1348,6 +1361,21 @@ export function MediaGallery({
           onClose={() => setSnackbar(null)}
           severity={snackbar?.severity ?? 'success'}
           sx={{ width: '100%' }}
+          action={
+            snackbar?.batchId ? (
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  const id = snackbar.batchId;
+                  setSnackbar(null);
+                  navigate(`/enhancement-batches/${id}`);
+                }}
+              >
+                View progress
+              </Button>
+            ) : undefined
+          }
         >
           {snackbar?.message}
         </Alert>

--- a/apps/web/src/hooks/useEnhancementBatch.ts
+++ b/apps/web/src/hooks/useEnhancementBatch.ts
@@ -1,0 +1,47 @@
+import { useState, useCallback } from 'react';
+import type { EnhancementBatch } from '../services/enhance';
+import { getEnhancementBatch as getEnhancementBatchApi } from '../services/enhance';
+import { useIsMounted } from './useIsMounted';
+
+interface UseEnhancementBatchResult {
+  batch: EnhancementBatch | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchBatch: (batchId: string) => Promise<void>;
+}
+
+/**
+ * Fetch a single bulk-enhance batch's progress (epic #420, issue #423).
+ *
+ * Shaped exactly like `useTrashEmptyRun` — and deliberately so: the batch
+ * payload is BaseRun-shaped, so the caller pairs this with the shared
+ * `useRunPolling` for live progress and `RunProgressPanel` for the rendering.
+ * Because the API reports a real terminal `RunStatus`, polling stops itself;
+ * there is no bespoke termination logic here or in the page.
+ */
+export function useEnhancementBatch(): UseEnhancementBatchResult {
+  const [batch, setBatch] = useState<EnhancementBatch | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isMounted = useIsMounted();
+
+  const fetchBatch = useCallback(async (batchId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await getEnhancementBatchApi(batchId);
+      if (!isMounted()) return;
+      setBatch(response);
+    } catch (err) {
+      if (!isMounted()) return;
+      const message =
+        err instanceof Error ? err.message : 'Failed to fetch the enhancement batch';
+      setError(message);
+      setBatch(null);
+    } finally {
+      if (isMounted()) setIsLoading(false);
+    }
+  }, [isMounted]);
+
+  return { batch, isLoading, error, fetchBatch };
+}

--- a/apps/web/src/pages/Enhancements/EnhancementBatchPage.tsx
+++ b/apps/web/src/pages/Enhancements/EnhancementBatchPage.tsx
@@ -1,0 +1,422 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Snackbar,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCircle } from '../../hooks/useCircle';
+import { useEnhancementBatch } from '../../hooks/useEnhancementBatch';
+import { useRunPolling } from '../../hooks/useRunPolling';
+import { cancelEnhancementBatch, listEnhancements } from '../../services/enhance';
+import type { EnhancementBatch, EnhancementListItem } from '../../services/enhance';
+import RunProgressPanel from '../../components/runs/RunProgressPanel';
+import type { RunTerminalSummary } from '../../components/runs/RunProgressPanel';
+import {
+  RUN_ITEMS_EMPTY_STATE,
+  RUN_ITEMS_PAGE_SIZE,
+  buildRunItemColumns,
+} from '../../components/runs/runItemsTable';
+import { DataTable, type DataTableRowAction } from '../../components/datatable';
+import type { BaseRunItem } from '../../types/runs';
+import {
+  formatCount,
+  formatRelativeTime,
+  isTerminalRunStatus,
+  runStatusColor,
+  runStatusLabel,
+} from '../../utils/runFormat';
+import { describeParams } from './PendingEnhancementsTab';
+
+/**
+ * Persistence key for the failed-items table's column/density choices
+ * (`user_settings.dataTables['enhancement-batch-items']`,
+ * docs/specs/datatable.md §15).
+ */
+export const ENHANCEMENT_BATCH_ITEMS_TABLE_ID = 'enhancement-batch-items';
+
+// ---------------------------------------------------------------------------
+// Bulk AI enhancement — batch progress page (epic #420, issue #423).
+//
+// Assembly, not construction: issue #421 shaped the batch payload as a
+// `BaseRun`, so polling, the progress bar, the counter tiles and the cancel
+// affordance all come from the shared run pieces (`useRunPolling` +
+// `RunProgressPanel`). This page owns only three things:
+//
+//  1. The wording — two labels here are load-bearing rather than cosmetic:
+//     "Cancel remaining" (cancel stops QUEUED work; anything already rendering
+//     is already billed and is left to finish), and "Ready to review" for the
+//     succeeded tile (everywhere else in the app "succeeded" means done; here
+//     it means WAITING FOR YOU, and calling it "Succeeded" would tell users the
+//     work is finished when it has only started needing them).
+//  2. The review handoff, enabled the moment the first result lands rather than
+//     at completion — reviewing a 26-photo batch should not wait for photo 26.
+//  3. The failed-items list, sourced from the enhancements listing filtered by
+//     `batchId`: batches deliberately have no `review_run_items` analogue, so
+//     there is no per-item run endpoint to call.
+// ---------------------------------------------------------------------------
+
+/** The failed enhancements table's row — a list row mapped onto `BaseRunItem`. */
+interface FailedEnhancementRow extends BaseRunItem {
+  mediaItemId: string;
+}
+
+/**
+ * Project an enhancement list row onto the shared run-item shape so
+ * `buildRunItemColumns` renders it exactly like every other run's failures.
+ */
+function toFailedRow(item: EnhancementListItem): FailedEnhancementRow {
+  return {
+    id: item.id,
+    mediaItemId: item.mediaItemId,
+    status: 'failed',
+    error: item.lastError,
+    updatedAt: item.updatedAt,
+    media: {
+      type: 'photo',
+      capturedAt: item.capturedAt,
+      filename: item.sourceFilename,
+      width: item.original.width,
+      height: item.original.height,
+    },
+    thumbnailUrl: item.original.thumbnailUrl,
+  };
+}
+
+/** Severity + message for a terminal batch. */
+function terminalSummary(batch: EnhancementBatch): RunTerminalSummary {
+  switch (batch.status) {
+    case 'completed':
+      return {
+        severity: 'success',
+        message: `${formatCount(batch.succeededCount)} photo${
+          batch.succeededCount === 1 ? '' : 's'
+        } finished enhancing and ${
+          batch.succeededCount === 1 ? 'is' : 'are'
+        } waiting for your review.`,
+      };
+    case 'completed_with_errors':
+      return {
+        severity: 'warning',
+        message:
+          'The batch finished, but some photos could not be enhanced. Review the failures below.',
+      };
+    case 'failed':
+      return { severity: 'error', message: batch.lastError ?? 'The batch failed.' };
+    case 'cancelled':
+      return {
+        severity: 'info',
+        message:
+          'This batch was cancelled. Photos that were already being enhanced finished, and their results are still waiting for you.',
+      };
+    default:
+      return { severity: 'info', message: '' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function EnhancementBatchPage() {
+  const { batchId } = useParams<{ batchId: string }>();
+  const navigate = useNavigate();
+  const { activeCircle, activeCircleRole } = useCircle();
+
+  const { batch, isLoading, error, fetchBatch } = useEnhancementBatch();
+
+  const [failedItems, setFailedItems] = useState<FailedEnhancementRow[]>([]);
+  const [failedTotal, setFailedTotal] = useState(0);
+  const [failedLoading, setFailedLoading] = useState(false);
+  // ZERO-based (the DataTable convention); converted at the fetch boundary.
+  const [failedPage, setFailedPage] = useState(0);
+  const [failedPageSize, setFailedPageSize] = useState(RUN_ITEMS_PAGE_SIZE);
+
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Initial load.
+  useEffect(() => {
+    if (batchId) void fetchBatch(batchId);
+  }, [batchId, fetchBatch]);
+
+  // Live progress while the batch is non-terminal. The API reports a real
+  // terminal RunStatus, so this stops itself.
+  useRunPolling({ runId: batchId, status: batch?.status, onPoll: fetchBatch });
+
+  // Load the failed-item table whenever there are failures to show.
+  //
+  // Keyed on SCALARS, never on `batch` itself: the poll hands back a fresh
+  // object every tick, and depending on that identity would refetch the item
+  // page — and reset the table with it (docs/specs/datatable.md §18.4).
+  const circleId = batch?.circleId;
+  const failedCount = batch?.failedCount ?? 0;
+  useEffect(() => {
+    if (!batchId || !circleId || failedCount <= 0) return;
+    let cancelled = false;
+    setFailedLoading(true);
+    listEnhancements({
+      circleId,
+      batchId,
+      status: 'failed',
+      page: failedPage + 1, // the API is 1-based, the table 0-based
+      pageSize: failedPageSize,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        setFailedItems(res.items.map(toFailedRow));
+        setFailedTotal(res.meta?.totalItems ?? res.items.length);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setErrorMsg(
+          err instanceof Error ? err.message : 'Failed to load the failed photos',
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setFailedLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [batchId, circleId, failedCount, failedPage, failedPageSize]);
+
+  // --- Failed-items table ----------------------------------------------------
+  // Keyed on nothing a poll can churn, so these arrays keep their identity
+  // across ticks.
+
+  const failedItemColumns = useMemo(
+    () =>
+      buildRunItemColumns<FailedEnhancementRow>({
+        subjectLabel: 'Photo',
+        itemLabel: (item) => item.media?.filename ?? item.mediaItemId,
+      }),
+    [],
+  );
+
+  const failedItemActions = useMemo<DataTableRowAction<FailedEnhancementRow>[]>(
+    () => [
+      {
+        id: 'view',
+        label: 'View',
+        icon: <VisibilityIcon fontSize="small" />,
+        onClick: (item) => navigate(`/media?item=${item.mediaItemId}`),
+      },
+    ],
+    [navigate],
+  );
+
+  const handleCancel = useCallback(async () => {
+    if (!batchId) return;
+    setIsCancelling(true);
+    setErrorMsg(null);
+    try {
+      const res = await cancelEnhancementBatch(batchId);
+      setSuccessMsg(
+        res.cancelled === 1
+          ? '1 queued photo was cancelled'
+          : `${formatCount(res.cancelled)} queued photos were cancelled`,
+      );
+      void fetchBatch(batchId);
+    } catch (err) {
+      // Surface the SERVER's message — a 400 here means "already finished",
+      // which is a real answer, not a generic failure.
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to cancel the batch');
+      // Re-read: a terminal batch is exactly the case the button should vanish.
+      void fetchBatch(batchId);
+    } finally {
+      setIsCancelling(false);
+    }
+  }, [batchId, fetchBatch]);
+
+  // First-load spinner (only when we have no batch yet).
+  if (!batch && isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // Unknown id, or a batch in a circle the caller cannot see: a clean
+  // not-found, never an unhandled error.
+  if (!batch) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <Alert severity="error">{error ?? 'Enhancement batch not found.'}</Alert>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          sx={{ mt: 2, minHeight: 44 }}
+          onClick={() => navigate('/enhancements')}
+        >
+          Back to AI Enhancements
+        </Button>
+      </Box>
+    );
+  }
+
+  const terminal = isTerminalRunStatus(batch.status);
+
+  // Cancelling needs media:write + the per-circle collaborator role (the
+  // location-suggestion precedent, not trash-empty's circle_admin). Scoped to
+  // the ACTIVE circle: a batch deep-linked from another circle carries no role
+  // we can trust here, so the affordance is withheld rather than guessed at.
+  const canCancel =
+    batch.circleId === activeCircle?.id &&
+    (activeCircleRole === 'collaborator' || activeCircleRole === 'circle_admin');
+
+  const paramsSummary = describeParams(batch);
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 } }}>
+      {/* Header */}
+      <Box sx={{ mb: 2 }}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          size="small"
+          onClick={() => navigate('/enhancements')}
+          sx={{ mb: 1, minHeight: 44 }}
+        >
+          Back to AI Enhancements
+        </Button>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+          <AutoFixHighIcon color="primary" />
+          <Typography variant="h5" component="h1">
+            AI enhancement batch
+          </Typography>
+          <Chip
+            label={runStatusLabel(batch.status)}
+            color={runStatusColor(batch.status)}
+            size="small"
+          />
+          <Typography variant="body2" color="text.secondary">
+            {formatRelativeTime(batch.createdAt)}
+          </Typography>
+        </Stack>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {paramsSummary}
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <RunProgressPanel
+        run={batch}
+        subjectNoun="photo"
+        // "Ready to review", not "Succeeded" — see the header comment.
+        countLabels={{ succeeded: 'Ready to review', skipped: 'Cancelled' }}
+        runningTitle="Enhancing photos…"
+        terminalSummary={terminalSummary(batch)}
+        canCancel={canCancel}
+        onCancel={() => void handleCancel()}
+        isCancelling={isCancelling}
+        // The label must not promise more than the backend delivers.
+        cancelLabel="Cancel remaining"
+      >
+        {/* Review handoff — deliberately live before the batch finishes. */}
+        <Stack spacing={1} sx={{ mb: 2 }}>
+          <Box>
+            <Button
+              variant="contained"
+              startIcon={<CompareArrowsIcon />}
+              disabled={batch.succeededCount === 0}
+              onClick={() => navigate(`/enhancements?batchId=${batch.id}`)}
+              sx={{ minHeight: 44 }}
+            >
+              {batch.succeededCount === 0
+                ? 'No results yet'
+                : `Review ${formatCount(batch.succeededCount)} result${
+                    batch.succeededCount === 1 ? '' : 's'
+                  } →`}
+            </Button>
+          </Box>
+          <Typography variant="body2" color="text.secondary">
+            {terminal
+              ? 'Nothing has been changed yet — each result waits for you to compare and decide.'
+              : 'You can start reviewing finished photos while the rest are still enhancing. Nothing is changed until you decide on each one.'}
+          </Typography>
+          {canCancel && !terminal && (
+            <Typography variant="body2" color="text.secondary">
+              Cancelling stops the photos still waiting in the queue. Any photo
+              already being enhanced finishes — its AI credits are already spent,
+              so stopping it would throw the result away for nothing.
+            </Typography>
+          )}
+        </Stack>
+
+        {failedCount > 0 && (
+          <Card variant="outlined" sx={{ mt: 1, mb: 2 }}>
+            <CardContent>
+              <Typography variant="subtitle2" sx={{ mb: 1.5 }}>
+                Failed photos ({formatCount(failedCount)})
+              </Typography>
+              {/*
+                Rendered UNCONDITIONALLY — `loading` is a prop, never a gate.
+                docs/specs/datatable.md §18.4.
+              */}
+              <DataTable<FailedEnhancementRow>
+                columns={failedItemColumns}
+                rows={failedItems}
+                rowId={(item) => item.id}
+                tableId={ENHANCEMENT_BATCH_ITEMS_TABLE_ID}
+                ariaLabel="Failed photos"
+                density="compact"
+                loading={failedLoading}
+                emptyState={RUN_ITEMS_EMPTY_STATE}
+                pagination={{
+                  page: failedPage,
+                  pageSize: failedPageSize,
+                  total: failedTotal,
+                  onPaginationChange: ({ page: nextPage, pageSize: nextSize }) => {
+                    setFailedPage(nextPage);
+                    setFailedPageSize(nextSize);
+                  },
+                }}
+                rowActions={failedItemActions}
+                csvExport={{ filename: 'enhancement-batch-failed-photos' }}
+              />
+            </CardContent>
+          </Card>
+        )}
+      </RunProgressPanel>
+
+      {/* Feedback */}
+      <Snackbar
+        open={Boolean(successMsg)}
+        autoHideDuration={4000}
+        onClose={() => setSuccessMsg(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setSuccessMsg(null)} severity="success" sx={{ width: '100%' }}>
+          {successMsg}
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={Boolean(errorMsg)}
+        autoHideDuration={6000}
+        onClose={() => setErrorMsg(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setErrorMsg(null)} severity="error" sx={{ width: '100%' }}>
+          {errorMsg}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/Enhancements/EnhancementsPage.tsx
+++ b/apps/web/src/pages/Enhancements/EnhancementsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Box, Alert, Tabs, Tab, Typography, Stack } from '@mui/material';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
@@ -45,6 +45,21 @@ export default function EnhancementsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, setSearchParams]);
 
+  // Batch narrowing (epic #420, issue #423): a link from a batch's progress
+  // page lands here with `?batchId=`. The param IS the state — clearing the
+  // chip drops it from the URL, so the back button restores the narrowed view.
+  const batchId = searchParams.get('batchId') ?? undefined;
+  const clearBatchFilter = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('batchId');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
   if (!activeCircle) {
     return (
       <Box sx={{ p: { xs: 2, md: 3 } }}>
@@ -79,7 +94,13 @@ export default function EnhancementsPage() {
 
       {/* Only the active tab's data is fetched — each tab owns its own hook
           call, so mounting one never triggers the others' requests. */}
-      {tab === 'pending' && <PendingEnhancementsTab circleId={activeCircle.id} />}
+      {tab === 'pending' && (
+        <PendingEnhancementsTab
+          circleId={activeCircle.id}
+          batchId={batchId}
+          onClearBatchFilter={clearBatchFilter}
+        />
+      )}
 
       {tab === 'enhanced' && (
         <Alert severity="info">

--- a/apps/web/src/pages/Enhancements/PendingEnhancementsTab.tsx
+++ b/apps/web/src/pages/Enhancements/PendingEnhancementsTab.tsx
@@ -423,6 +423,14 @@ export function EnhancementCard({
 
 interface PendingEnhancementsTabProps {
   circleId: string;
+  /**
+   * Narrow the inbox to one bulk-enhance batch (epic #420, issue #423). Set
+   * from the page's `?batchId=` param when a user arrives from a batch's
+   * progress page. Absent — the normal case — leaves behaviour untouched.
+   */
+  batchId?: string;
+  /** Drop the batch narrowing (and the URL param behind it). */
+  onClearBatchFilter?: () => void;
 }
 
 /**
@@ -431,7 +439,11 @@ interface PendingEnhancementsTabProps {
  *
  * Multi-select and bulk actions are deliberately absent — they land in PR2.
  */
-export function PendingEnhancementsTab({ circleId }: PendingEnhancementsTabProps) {
+export function PendingEnhancementsTab({
+  circleId,
+  batchId,
+  onClearBatchFilter,
+}: PendingEnhancementsTabProps) {
   const { pictureEnhancement } = useFeatureFlags();
   const [status, setStatus] = useState<'all' | EnhancementStatusFilter>('all');
   const [sortOrder, setSortOrder] = useState<EnhancementSortOrder>('desc');
@@ -445,17 +457,18 @@ export function PendingEnhancementsTab({ circleId }: PendingEnhancementsTabProps
 
   useEffect(() => {
     setPage(1);
-  }, [circleId, status, sortOrder]);
+  }, [circleId, status, sortOrder, batchId]);
 
   const params = useMemo(
     () => ({
       circleId,
       ...(status !== 'all' ? { status } : {}),
+      ...(batchId ? { batchId } : {}),
       page,
       pageSize: PAGE_SIZE,
       sortOrder,
     }),
-    [circleId, status, page, sortOrder],
+    [circleId, status, batchId, page, sortOrder],
   );
 
   const { items, meta, isLoading, error, polling, refresh } = useEnhancements(params);
@@ -545,6 +558,38 @@ export function PendingEnhancementsTab({ circleId }: PendingEnhancementsTabProps
 
   return (
     <Box>
+      {/*
+        Batch narrowing (epic #420). A user landing here from a batch's progress
+        page must be told WHY the inbox looks short, and must have a one-tap way
+        back out — otherwise a filter set by a link reads as missing data.
+      */}
+      {batchId && (
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{ mb: 2, alignItems: 'center', flexWrap: 'wrap', gap: 1 }}
+        >
+          <Chip
+            color="primary"
+            variant="outlined"
+            icon={<AutoFixHighIcon />}
+            label={
+              meta
+                ? `Showing ${meta.totalItems} result${
+                    meta.totalItems === 1 ? '' : 's'
+                  } from one batch`
+                : 'Showing one batch'
+            }
+            onDelete={onClearBatchFilter}
+          />
+          {onClearBatchFilter && (
+            <Button size="small" onClick={onClearBatchFilter} sx={{ minHeight: 44 }}>
+              Show all
+            </Button>
+          )}
+        </Stack>
+      )}
+
       {/* ---------- Filters ---------- */}
       <Stack direction="row" spacing={1.5} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
         <FormControl size="small" sx={{ minWidth: 180 }}>
@@ -598,12 +643,23 @@ export function PendingEnhancementsTab({ circleId }: PendingEnhancementsTabProps
           <Typography variant="h6" gutterBottom>
             Nothing waiting for you
           </Typography>
+          {batchId ? (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ maxWidth: 480, mx: 'auto' }}
+            >
+              Nothing from this batch is waiting for a decision right now.
+              Results appear here as they finish enhancing.
+            </Typography>
+          ) : (
           <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 480, mx: 'auto' }}>
             AI Enhance improves a photo&apos;s exposure, color, clarity and noise.
             Start one from a photo&apos;s viewer or the gallery selection bar — the
             result waits here for you to compare and decide, and nothing is
             changed until you do.
           </Typography>
+          )}
         </Box>
       ) : (
         <Stack spacing={2}>

--- a/apps/web/src/pages/Enhancements/PendingEnhancementsTab.tsx
+++ b/apps/web/src/pages/Enhancements/PendingEnhancementsTab.tsx
@@ -34,6 +34,7 @@ import type {
 } from '../../services/enhance';
 import type { MediaItem } from '../../types/media';
 import { MediaEnhancementDrawer } from '../../components/media/MediaEnhancementDrawer';
+import { RecentBatches } from './RecentBatches';
 
 const PAGE_SIZE = 24;
 
@@ -590,6 +591,10 @@ export function PendingEnhancementsTab({
         </Stack>
       )}
 
+      {/* The way back to a batch after the submit toast is gone. Suppressed
+          while already looking at one — the chip above says where you are. */}
+      {!batchId && <RecentBatches circleId={circleId} />}
+
       {/* ---------- Filters ---------- */}
       <Stack direction="row" spacing={1.5} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
         <FormControl size="small" sx={{ minWidth: 180 }}>
@@ -653,12 +658,16 @@ export function PendingEnhancementsTab({
               Results appear here as they finish enhancing.
             </Typography>
           ) : (
-          <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 480, mx: 'auto' }}>
-            AI Enhance improves a photo&apos;s exposure, color, clarity and noise.
-            Start one from a photo&apos;s viewer or the gallery selection bar — the
-            result waits here for you to compare and decide, and nothing is
-            changed until you do.
-          </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ maxWidth: 480, mx: 'auto' }}
+            >
+              AI Enhance improves a photo&apos;s exposure, color, clarity and
+              noise. Start one from a photo&apos;s viewer or the gallery
+              selection bar — the result waits here for you to compare and
+              decide, and nothing is changed until you do.
+            </Typography>
           )}
         </Box>
       ) : (

--- a/apps/web/src/pages/Enhancements/PendingEnhancementsTab.tsx
+++ b/apps/web/src/pages/Enhancements/PendingEnhancementsTab.tsx
@@ -105,8 +105,14 @@ export function formatElapsedSince(from: string, now: number = Date.now()): stri
   return `${m}m ${String(s).padStart(2, '0')}s`;
 }
 
-/** Human summary of the params a run was launched with. */
-export function describeParams(item: EnhancementListItem): string {
+/**
+ * Human summary of the params a run was launched with.
+ *
+ * Typed on the `params` field alone rather than the whole list row, so a
+ * bulk-enhance BATCH — which carries the one params object its whole batch was
+ * launched with — reuses this instead of growing a second formatter.
+ */
+export function describeParams(item: Pick<EnhancementListItem, 'params'>): string {
   const p = item.params ?? {};
   const bits: string[] = [];
   if (p.preset) bits.push(p.preset.replace(/_/g, ' '));

--- a/apps/web/src/pages/Enhancements/RecentBatches.tsx
+++ b/apps/web/src/pages/Enhancements/RecentBatches.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from '@mui/material';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import { useNavigate } from 'react-router-dom';
+import { listEnhancementBatches } from '../../services/enhance';
+import type { EnhancementBatch } from '../../services/enhance';
+import { useIsMounted } from '../../hooks/useIsMounted';
+import {
+  formatCount,
+  formatRelativeTime,
+  isTerminalRunStatus,
+  runStatusColor,
+  runStatusLabel,
+} from '../../utils/runFormat';
+import { describeParams } from './PendingEnhancementsTab';
+
+/** How many batches the recovery list shows. Recent, not a history tab. */
+const RECENT_BATCH_COUNT = 5;
+
+// ---------------------------------------------------------------------------
+// Recent bulk-enhance batches (epic #420, issue #423).
+//
+// The RECOVERY path. The submit toast's "View progress" action is how a user
+// normally reaches a batch; this is what they have left after dismissing it or
+// reloading the page. Deliberately not a nav entry or a sidebar badge: a batch
+// lives for minutes, and the hub's own pending-review badge already counts the
+// photos it produces — a second badge would count the same photos twice.
+// ---------------------------------------------------------------------------
+
+interface RecentBatchesProps {
+  circleId: string;
+}
+
+export function RecentBatches({ circleId }: RecentBatchesProps) {
+  const navigate = useNavigate();
+  const isMounted = useIsMounted();
+  const [batches, setBatches] = useState<EnhancementBatch[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    listEnhancementBatches({ circleId, pageSize: RECENT_BATCH_COUNT })
+      .then((res) => {
+        if (cancelled || !isMounted()) return;
+        setBatches(res.items);
+      })
+      // A failed lookup silently hides the section: this is a convenience list
+      // beside the inbox, never the reason the user came to this page.
+      .catch(() => {
+        if (!cancelled && isMounted()) setBatches([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [circleId, isMounted]);
+
+  if (batches.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Recent batches
+      </Typography>
+      <Stack spacing={1}>
+        {batches.map((batch) => {
+          const live = !isTerminalRunStatus(batch.status);
+          return (
+            <Card key={batch.id} variant="outlined">
+              <CardActionArea
+                onClick={() => navigate(`/enhancement-batches/${batch.id}`)}
+                sx={{ minHeight: 44 }}
+              >
+                <CardContent sx={{ py: 1.5 }}>
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: 'center', flexWrap: 'wrap', gap: 1 }}
+                  >
+                    <AutoFixHighIcon fontSize="small" color={live ? 'primary' : 'disabled'} />
+                    <Typography variant="body2" sx={{ minWidth: 0 }}>
+                      {formatCount(batch.matchedCount)} photo
+                      {batch.matchedCount === 1 ? '' : 's'}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={runStatusLabel(batch.status)}
+                      color={runStatusColor(batch.status)}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      {formatRelativeTime(batch.createdAt)}
+                    </Typography>
+                  </Stack>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mt: 0.5 }}
+                  >
+                    {describeParams(batch)}
+                    {batch.succeededCount > 0
+                      ? ` · ${formatCount(batch.succeededCount)} ready to review`
+                      : ''}
+                    {batch.failedCount > 0
+                      ? ` · ${formatCount(batch.failedCount)} failed`
+                      : ''}
+                  </Typography>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/apps/web/src/services/enhance.ts
+++ b/apps/web/src/services/enhance.ts
@@ -1,4 +1,6 @@
 import { api, ApiError } from './api';
+import type { BaseRun } from '../types/runs';
+import type { BulkEnhanceSkipped } from './media';
 
 // ---------------------------------------------------------------------------
 // Types — AI Picture Enhancer (see docs/specs/picture-enhancer.md §4.1, §8)
@@ -166,11 +168,68 @@ export interface EnhancementListResponse {
 export interface ListEnhancementsParams {
   circleId: string;
   status?: EnhancementStatusFilter;
+  /**
+   * Narrow the listing to one bulk-enhance batch (epic #420, issue #421).
+   * Server-side, composes with `status` — e.g. a batch's failed rows.
+   */
+  batchId?: string;
   page?: number;
   /** Server caps this at 50 (default 24). */
   pageSize?: number;
   sortBy?: EnhancementSortBy;
   sortOrder?: EnhancementSortOrder;
+}
+
+// ---------------------------------------------------------------------------
+// Types — bulk-enhance batches (epic #420, issue #421)
+// GET /api/enhancement-batches[/:id] · POST /api/enhancement-batches/:id/cancel
+// ---------------------------------------------------------------------------
+
+/**
+ * A bulk-enhance batch, as the API serializes it.
+ *
+ * Deliberately a {@link BaseRun}: issue #421 shaped this payload with the same
+ * field set as trash-empty runs, workflow runs and review runs precisely so the
+ * shared `RunProgressPanel` + `useRunPolling` drive it with no new component.
+ * Everything below `lastError` is a batch-specific extra outside that contract.
+ *
+ * Note what the shared counters MEAN here, which is not what they mean
+ * elsewhere: `succeededCount` counts renders that COMPLETED (ready, applied,
+ * discarded, expired) — a `ready` row is waiting for a human, not finished —
+ * and `skippedCount` counts rows a cancel withdrew before any render ran. The
+ * page relabels both tiles accordingly.
+ */
+export interface EnhancementBatch extends BaseRun {
+  /** Distinct ids the server considered when the batch was created. */
+  requestedCount: number;
+  /** Enhancements actually enqueued at creation time. */
+  queuedCount: number;
+  /** Per-reason tally of items declined at creation; null for older batches. */
+  skipped: BulkEnhanceSkipped | null;
+  /** The one params object every photo in the batch was enhanced with. */
+  params: EnhanceParams | null;
+  /** How the batch was started (currently always `selection`). */
+  source: string;
+  cancelledAt: string | null;
+}
+
+export interface EnhancementBatchListResponse {
+  items: EnhancementBatch[];
+  meta: EnhancementListMeta;
+}
+
+export interface ListEnhancementBatchesParams {
+  circleId: string;
+  page?: number;
+  /** Server caps this at 50 (default 20). */
+  pageSize?: number;
+}
+
+export interface CancelEnhancementBatchResult {
+  batchId: string;
+  status: 'cancelled';
+  /** Number of still-pending enhancements withdrawn. */
+  cancelled: number;
 }
 
 /**
@@ -219,6 +278,7 @@ export async function listEnhancements(
 ): Promise<EnhancementListResponse> {
   const p = new URLSearchParams({ circleId: params.circleId });
   if (params.status) p.set('status', params.status);
+  if (params.batchId) p.set('batchId', params.batchId);
   if (params.page) p.set('page', String(params.page));
   if (params.pageSize) p.set('pageSize', String(params.pageSize));
   if (params.sortBy) p.set('sortBy', params.sortBy);
@@ -266,6 +326,43 @@ export async function applyEnhancement(
   return api.post<ApplyEnhancementResult>(
     `/media/${id}/enhance/${enhancementId}/apply`,
     { decision },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk-enhance batches (epic #420)
+// ---------------------------------------------------------------------------
+
+/** Paginated batch list for a circle, newest first. */
+export async function listEnhancementBatches(
+  params: ListEnhancementBatchesParams,
+): Promise<EnhancementBatchListResponse> {
+  const p = new URLSearchParams({ circleId: params.circleId });
+  if (params.page) p.set('page', String(params.page));
+  if (params.pageSize) p.set('pageSize', String(params.pageSize));
+  const result = await api.get<EnhancementBatchListResponse>(
+    `/enhancement-batches?${p.toString()}`,
+  );
+  return { items: result.items ?? [], meta: result.meta };
+}
+
+/** Poll one batch's progress. The payload is BaseRun-shaped — see EnhancementBatch. */
+export async function getEnhancementBatch(batchId: string): Promise<EnhancementBatch> {
+  return api.get<EnhancementBatch>(`/enhancement-batches/${batchId}`);
+}
+
+/**
+ * Withdraw every enhancement in the batch that is still QUEUED.
+ *
+ * An enhancement already rendering is deliberately left to finish server-side:
+ * its model call is already billed, so aborting spends the money and discards
+ * the result. `cancelled` is how many queued rows were actually withdrawn.
+ */
+export async function cancelEnhancementBatch(
+  batchId: string,
+): Promise<CancelEnhancementBatchResult> {
+  return api.post<CancelEnhancementBatchResult>(
+    `/enhancement-batches/${batchId}/cancel`,
   );
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of epic #420. After Phase 2, submitting a batch produced a toast and then nothing — no progress, no way to tell which failed, and **no way to stop it**. That is fine for a free idempotent rerun; it is not fine for 26 billable `gpt-image-1` calls that take minutes and can be misconfigured.

This phase answers the three questions the toast cannot: *how far along is it*, *can I stop it*, and *where do I review the results*.

**No new progress component was written.** `RunProgressPanel` already does this job and is purely presentational; Phase 1 deliberately shaped `GET /api/enhancement-batches/:id` as a `BaseRun` so this phase is assembly, not construction. Polling terminates on the API's own `RunStatus` via the shared `useRunPolling` — no bespoke termination logic.

Stacked on #429 (Phase 2) → #427 (Phase 1). **Review those first**; the diff here is Phase 3 only.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #423
Relates to #420, depends on #421, #422

## Changes Made

**`/enhancement-batches/:id`** — lazy-routed beside the existing run pages, modelled on `TrashEmptyRunPage`. Two label choices are load-bearing rather than cosmetic:

- **`cancelLabel="Cancel remaining"`, not "Cancel run"** — the label must not promise more than the backend does. Cancel stops *queued* items; in-flight ones finish because their OpenAI call is already being billed. The page states this in body copy too, not only on the button.
- **`succeeded` is relabelled "Ready to review"** — everywhere else in the app "succeeded" means *done*. Here it means *waiting for you*, and mislabelling it would tell users the work is finished when it has only started needing them. `skipped` reads "Cancelled".

**"Review N results →"** is enabled as soon as `succeededCount > 0`, not at completion — the whole point is that reviewing can begin while the batch is still running. Failed items render through `buildRunItemColumns` + `DataTable`, sourced from `GET /media/enhancements?batchId=&status=failed`; no new API was invented.

**Hub `batchId` filter** — `?batchId=` narrows the Pending tab with a dismissible chip explaining why the list is narrowed and how to escape it. With no `batchId`, behaviour is exactly as before (pinned by a regression test).

**Two ways back to a batch**: the submit toast gains a **View progress** action (the main path), and the hub gains a **Recent batches** section (the recovery path for a user who dismissed the toast or reloaded).

**No nav entry and no second badge** — a batch is transient, minutes not a standing queue, and the hub's existing `pendingEnhancements` badge already rises as a batch produces results. A second badge would double-count the same photos.

## Testing

- [x] Unit tests pass (`npm test`) — **254 files / 5064 tests**, +37 net, 0 regressions
- [x] Type checks pass (`npm run typecheck`)
- [ ] E2E tests pass (if applicable) — n/a
- [ ] Manual testing completed — **not performed**; no running app or OpenAI credential in this environment. Behaviour is covered by tests, but nobody has watched a real batch progress in a browser.

The assertion that matters most is the **polling-termination test**: a batch transitioning `running → completed` between ticks issues **no further requests**. A leaked 2s interval on a hub page is a real ongoing cost, and it is the kind of thing that regresses silently. There is also a test that a batch starting already-terminal never polls at all.

Also covered: both load-bearing labels, cancel gated by circle role and non-terminal status, a cancel 400 surfacing the server's own message, "Review N results" appearing at `succeededCount > 0` **and not at 0**, the empty-batch terminal state, unknown-id not-found, hook unmount safety, and the hub filter chip round-tripping through the real URL param.

### Test Instructions

1. Submit a batch → the toast carries **View progress**; follow it.
2. Watch counters advance; confirm the bar stops polling the moment it completes (network tab).
3. Cancel mid-flight → queued items stop, in-flight ones finish, panel shows `cancelled`, polling stops.
4. Click **Review N results** before the batch finishes → the hub lists only that batch, with the chip; clear it and confirm the full list returns.
5. Reload, then reach the batch again via **Recent batches** on the hub.
6. As a `viewer`, confirm cancel is absent. At 360px, confirm no horizontal scroll.

## Additional Notes

Five implementer deviations worth a reviewer's eye:

1. **`BatchEnhanceDialog.onSuccess` is now `(message, batchId)`** — the toast cannot link anywhere without the id. Four existing assertions were updated to the two-argument form, including two `.not.toHaveBeenCalledWith` guards that would otherwise have become vacuous.
2. **Cancel requires `collaborator`+ *and* `batch.circleId === activeCircle.id`.** `activeCircleRole` describes the active circle only, so for a batch deep-linked from another circle the affordance is withheld rather than guessed at. The read still succeeds, because the server checks membership of the batch's own circle.
3. **Snackbar auto-hide extends to 10s only when the toast carries the action** — MUI's `Alert` replaces the close button when `action` is set, and 4s is too tight to act in.
4. **`describeParams` was widened to `Pick<EnhancementListItem, 'params'>`** so the batch page and Recent Batches reuse it rather than growing a second formatter or casting.
5. The test agent found its own draft fixture (`failedCount: 1` by default) was triggering an un-awaited fetch across nearly every test and producing act-warning noise; it changed the default to `0` with explicit opt-in, so the new page's suite emits none.

**Retention is why the review path matters, not just convenience.** `pictureEnhancement.retentionHours` defaults to 168 h; unreviewed staged bytes are reaped by `picture_enhancement_purge`, and every one of those was a paid call. The hub's existing expiry countdown is the mitigation, and the batch → hub link is what makes a 26-photo batch reach it.

Multi-select and bulk review actions in the hub remain deliberately out of scope (epic #420, spec §15) — this phase adds only the "review what I just enhanced" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXs8GNhptV9NvqDTyX3E9A)_