### PR TITLE
feat(api): batch AI enhancement Phase 4 — "Enhance everything matching this filter"

### DIFF
--- a/apps/api/src/enhancement/dto/bulk-enhance-by-filter.dto.ts
+++ b/apps/api/src/enhancement/dto/bulk-enhance-by-filter.dto.ts
@@ -1,0 +1,40 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { mediaFilterFields } from '../../media/dto/media-query.dto';
+import { enhanceParamsSchema } from './enhance-params.dto';
+
+/**
+ * Request body for POST /api/media/bulk/enhance/by-filter (epic #420, issue #424).
+ *
+ * Composed exactly the way `AddAlbumItemsByFilterDto` is — spread the shared
+ * `mediaFilterFields` shape and force `circleId` required — so a client can hand
+ * the SAME filter object to either endpoint. That includes inheriting the shape's
+ * query-string-oriented quirks: the boolean-ish fields (`favorite`, `missingGeo`,
+ * `noFaces`, …) are `z.string().transform(...)`, i.e. they expect the literal
+ * strings `"true"` / `"false"` even in a JSON body. Diverging here (accepting real
+ * JSON booleans) would make the two endpoints subtly incompatible for a caller
+ * that reuses one filter object across both, so the quirk is matched on purpose.
+ *
+ * `personId` / `personIds` / `peopleMatch` ride along in `mediaFilterFields` but
+ * are NOT part of `buildMediaWhere` — they are applied separately via the
+ * `wherePeople(ids, mode)` export, same as `MediaService.addAlbumItemsByFilter`.
+ *
+ * There is deliberately NO id array and NO client-supplied cap here: the whole
+ * point of this endpoint is that the server resolves the match set. The
+ * `pictureEnhancement.maxBatchSize` system setting is the only limit, enforced in
+ * `MediaEnhancementService.startBatchByFilter` — which REFUSES an over-cap match
+ * rather than truncating it.
+ */
+export const bulkEnhanceByFilterSchema = z.object({
+  ...mediaFilterFields,
+  // circleId is required here (not optional as in mediaFilterFields).
+  circleId: z.string().uuid(),
+  // One `params` object applies to every matched item, exactly as in
+  // POST /api/media/bulk/enhance — a bulk enhance is a single intent applied
+  // across a set, not per-item tuning.
+  params: enhanceParamsSchema.optional().default({}),
+});
+
+export type BulkEnhanceByFilter = z.infer<typeof bulkEnhanceByFilterSchema>;
+
+export class BulkEnhanceByFilterDto extends createZodDto(bulkEnhanceByFilterSchema) {}

--- a/apps/api/src/enhancement/media-enhancement.controller.spec.ts
+++ b/apps/api/src/enhancement/media-enhancement.controller.spec.ts
@@ -73,6 +73,9 @@ function makeMockService() {
     startBatch: jest.fn().mockResolvedValue({
       data: { batchId: 'batch-1', requested: 1, queued: 1, skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 } },
     }),
+    startBatchByFilter: jest.fn().mockResolvedValue({
+      data: { batchId: 'batch-2', requested: 3, queued: 3, skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 } },
+    }),
     getLatestEnhancement: jest.fn().mockResolvedValue({ data: null }),
     getEnhancement: jest.fn().mockResolvedValue({
       data: { id: ENH_ID, status: 'ready' },
@@ -395,6 +398,133 @@ describe('MediaEnhancementController — route dispatch + RBAC + validation (sup
       expect(bulkIdx).toBeGreaterThanOrEqual(0);
       expect(paramIdx).toBeGreaterThanOrEqual(0);
       expect(bulkIdx).toBeLessThan(paramIdx);
+    });
+  });
+
+  // ===========================================================================
+  // POST /media/bulk/enhance/by-filter — route-collision regression (issue #424)
+  //
+  // Same static-routes-before-:id-routes convention as `bulk/enhance` above.
+  // `bulk/enhance/by-filter` has three path segments; the only route in this
+  // controller sharing that segment count is the PARAMETERISED
+  // GET `:id/enhance/:enhancementId` — a different HTTP method, so there is no
+  // literal ambiguity, but the live-dispatch assertion below is still the
+  // strongest proof: if `bulk` were ever parsed as `:id` (e.g. by a future
+  // route declared as `POST :id/enhance/:enhancementId`), the request would
+  // land on startEnhance or applyEnhancement instead of startBatchByFilter.
+  // ===========================================================================
+
+  describe('POST /media/bulk/enhance/by-filter — route-collision regression', () => {
+    it('202s and dispatches to startBatchByFilter() — never captured by any :id-based route', async () => {
+      app = await buildApp(WRITER);
+
+      const res = await request(app.getHttpServer())
+        .post('/media/bulk/enhance/by-filter')
+        .send({ circleId: CIRCLE_ID, tag: 'Beach' })
+        .expect(202);
+
+      expect(mockService.startBatchByFilter).toHaveBeenCalledTimes(1);
+      expect(mockService.startBatchByFilter.mock.calls[0][0]).toMatchObject({
+        circleId: CIRCLE_ID,
+        tag: 'Beach',
+      });
+      // Neither the single-item nor the id-list bulk handler was ever reached —
+      // the strongest proof that 'bulk'/'by-filter' were never parsed as :id
+      // params of a differently-shaped route.
+      expect(mockService.startEnhance).not.toHaveBeenCalled();
+      expect(mockService.startBatch).not.toHaveBeenCalled();
+      expect(mockService.applyEnhancement).not.toHaveBeenCalled();
+      expect(res.body).toMatchObject({ data: { batchId: 'batch-2' } });
+    });
+
+    it('403s for a caller missing media:write, and never reaches any other handler', async () => {
+      app = await buildApp(READER);
+
+      await request(app.getHttpServer())
+        .post('/media/bulk/enhance/by-filter')
+        .send({ circleId: CIRCLE_ID })
+        .expect(403);
+
+      expect(mockService.startBatchByFilter).not.toHaveBeenCalled();
+      expect(mockService.startEnhance).not.toHaveBeenCalled();
+      expect(mockService.startBatch).not.toHaveBeenCalled();
+    });
+
+    it('400s when circleId is missing from the body', async () => {
+      app = await buildApp(WRITER);
+
+      await request(app.getHttpServer())
+        .post('/media/bulk/enhance/by-filter')
+        .send({ tag: 'Beach' })
+        .expect(400);
+
+      expect(mockService.startBatchByFilter).not.toHaveBeenCalled();
+    });
+
+    it('400s when circleId is not a valid UUID', async () => {
+      app = await buildApp(WRITER);
+
+      await request(app.getHttpServer())
+        .post('/media/bulk/enhance/by-filter')
+        .send({ circleId: 'not-a-uuid' })
+        .expect(400);
+
+      expect(mockService.startBatchByFilter).not.toHaveBeenCalled();
+    });
+
+    it('accepts an empty filter (circleId only) — matching every photo in the circle is a valid request', async () => {
+      app = await buildApp(WRITER);
+
+      await request(app.getHttpServer())
+        .post('/media/bulk/enhance/by-filter')
+        .send({ circleId: CIRCLE_ID })
+        .expect(202);
+
+      expect(mockService.startBatchByFilter).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes an optional `params` object through to the service untouched', async () => {
+      app = await buildApp(WRITER);
+
+      await request(app.getHttpServer())
+        .post('/media/bulk/enhance/by-filter')
+        .send({ circleId: CIRCLE_ID, params: { strength: 'strong' } })
+        .expect(202);
+
+      expect(mockService.startBatchByFilter.mock.calls[0][0]).toMatchObject({
+        params: { strength: 'strong' },
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Decorator-metadata-level check, mirroring the `bulk/enhance` one above:
+    // reads the REAL compiled declaration order off the controller prototype.
+    // -------------------------------------------------------------------------
+
+    it('declares POST bulk/enhance/by-filter at a lower prototype index than every POST :id-based route', () => {
+      const prototype = MediaEnhancementController.prototype;
+      const routes = Object.getOwnPropertyNames(prototype)
+        .filter((name) => name !== 'constructor')
+        .map((name) => ({
+          name,
+          path: Reflect.getMetadata(PATH_METADATA, (prototype as any)[name]),
+          method: Reflect.getMetadata(METHOD_METADATA, (prototype as any)[name]),
+        }))
+        .filter((entry) => entry.path !== undefined);
+
+      const byFilterIdx = routes.findIndex(
+        (r) => r.path === 'bulk/enhance/by-filter' && r.method === RequestMethod.POST,
+      );
+      const paramPostRoutes = routes.filter(
+        (r) => r.method === RequestMethod.POST && typeof r.path === 'string' && r.path.startsWith(':id'),
+      );
+
+      expect(byFilterIdx).toBeGreaterThanOrEqual(0);
+      expect(paramPostRoutes.length).toBeGreaterThan(0);
+      for (const paramRoute of paramPostRoutes) {
+        const paramIdx = routes.indexOf(paramRoute);
+        expect(byFilterIdx).toBeLessThan(paramIdx);
+      }
     });
   });
 

--- a/apps/api/src/enhancement/media-enhancement.controller.ts
+++ b/apps/api/src/enhancement/media-enhancement.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -27,6 +28,7 @@ import { PERMISSIONS } from '../common/constants/roles.constants';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParamsDto } from './dto/enhance-params.dto';
 import { BulkEnhanceDto } from './dto/bulk-enhance.dto';
+import { BulkEnhanceByFilterDto } from './dto/bulk-enhance-by-filter.dto';
 import { ApplyEnhancementDto } from './dto/apply-enhancement.dto';
 import {
   ENHANCEMENT_STATUS_ALIASES,
@@ -139,6 +141,53 @@ export class MediaEnhancementController {
   @ApiResponse({ status: 404, description: 'One or more ids are not live items of the circle' })
   async startBatch(@Body() dto: BulkEnhanceDto, @CurrentUser() user: RequestUser) {
     return this.service.startBatch(dto, user);
+  }
+
+  /**
+   * POST /api/media/bulk/enhance/by-filter — queue an enhancement per photo
+   * matching a gallery filter, resolved server-side. Declared in the
+   * static-routes block for the same reason as `bulk/enhance` above.
+   */
+  @Post('bulk/enhance/by-filter')
+  @Auth({ permissions: [PERMISSIONS.MEDIA_WRITE] })
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({
+    summary: 'Queue AI enhancements for every photo matching a filter (bulk)',
+    description:
+      'Same outcome as POST /api/media/bulk/enhance, but the server resolves the match set ' +
+      'from a gallery filter instead of an explicit id list. The body takes the SAME filter ' +
+      'shape as GET /api/media and POST /api/media/albums/:id/items/by-filter (so one filter ' +
+      'object works against any of them), plus an optional `params`.\n\n' +
+      'Three things are pinned server-side regardless of the filter: trashed items, archived ' +
+      'items, and non-photos are always excluded — the last in SQL, so the match count is the ' +
+      'count that would actually run.\n\n' +
+      'If the filter matches MORE than `pictureEnhancement.maxBatchSize` photos the request is ' +
+      'REFUSED with 400 — it is never truncated to the first N, since silently enhancing an ' +
+      'unseen subset spends money on a result the caller did not ask for. The refusal carries ' +
+      '`details.matchedCount` and `details.maxBatchSize` so the caller can narrow the filter. ' +
+      'A filter matching zero photos is likewise a 400, not an empty batch.\n\n' +
+      'Everything after the match set is resolved is identical to the id-list endpoint: an ' +
+      'ineligible item is skipped and counted rather than failing the request, and an existing ' +
+      'live (pending/processing/ready) enhancement is NEVER superseded.',
+  })
+  @ApiBody({ type: BulkEnhanceByFilterDto })
+  @ApiResponse({
+    status: 202,
+    description:
+      'Batch created: { batchId, requested, queued, skipped: { notPhoto, tooLarge, alreadyLive } }',
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Feature disabled / no model configured / no photos match the filter / the match ' +
+      'exceeds maxBatchSize (with details.matchedCount and details.maxBatchSize)',
+  })
+  @ApiResponse({ status: 403, description: 'Caller is not a collaborator of the circle' })
+  async startBatchByFilter(
+    @Body() dto: BulkEnhanceByFilterDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.service.startBatchByFilter(dto, user);
   }
 
   // ===========================================================================

--- a/apps/api/src/enhancement/media-enhancement.service.spec.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.spec.ts
@@ -25,9 +25,15 @@
  *       reprocesses, re-enqueues face_detection, staging deleted, row ->
  *       applied/replace; allowReplace=false 400; downscale-block 400
  *   - discardEnhancement: RBAC (collaborator), deletes staging, row -> discarded
+ *   - startBatchByFilter (issue #424): auth-before-count (information-leak
+ *     guard), the three server-pinned predicates (deletedAt/archivedAt/type),
+ *     people-filter composition via wherePeople, never-truncate cap refusal
+ *     (+ the error envelope through the REAL HttpExceptionFilter), zero-match
+ *     400, and delegation to the shared createBatchFrom (source:'filter',
+ *     alreadyLive still skipped, priority:50/skipDedup:true)
  */
 
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ArgumentsHost, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CircleRole, MediaEnhancementStatus, MediaEnhancementDecision, MediaType, MediaTagSource } from '@prisma/client';
 import { MediaEnhancementService } from './media-enhancement.service';
@@ -44,7 +50,10 @@ import { createMockPrismaService, MockPrismaService } from '../../test/mocks/pri
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParams } from './dto/enhance-params.dto';
 import { BulkEnhance } from './dto/bulk-enhance.dto';
+import { BulkEnhanceByFilter } from './dto/bulk-enhance-by-filter.dto';
 import { ListEnhancementsQuery } from './dto/list-enhancements-query.dto';
+import { HttpExceptionFilter } from '../common/filters/http-exception.filter';
+import { buildMediaWhere } from '../search/media-where.builder';
 
 const USER: RequestUser = {
   id: 'user-1',
@@ -777,6 +786,503 @@ describe('MediaEnhancementService', () => {
 
       expect(mockPrisma.mediaEnhancementBatch.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ circleId: CIRCLE_ID_2 }),
+      });
+    });
+  });
+
+  // ===========================================================================
+  // startBatchByFilter (POST /api/media/bulk/enhance/by-filter — issue #424)
+  // ===========================================================================
+
+  describe('startBatchByFilter', () => {
+    /** Bulk-enhance-flavored media item fixture, same shape as startBatch's. */
+    function makeFilterBatchItem(overrides: Record<string, any> = {}) {
+      return {
+        id: 'media-x',
+        circleId: CIRCLE_ID,
+        type: MediaType.photo,
+        width: 1200,
+        height: 900,
+        storageObject: { id: 'obj-x', mimeType: 'image/jpeg' },
+        ...overrides,
+      };
+    }
+
+    function makeFilterDto(overrides: Partial<BulkEnhanceByFilter> = {}): BulkEnhanceByFilter {
+      return {
+        circleId: CIRCLE_ID,
+        params: {},
+        ...overrides,
+      } as BulkEnhanceByFilter;
+    }
+
+    /**
+     * Wires `mediaItem.count` / `mediaItem.findMany` for the by-filter flow's
+     * TWO distinct findMany call shapes on the same mock function:
+     *   1. `resolveFilterWhere`'s own match-id fetch — `select: { id: true }`,
+     *      `where` is the RESOLVED FILTER (no `where.id.in`).
+     *   2. `createBatchFrom`'s full item fetch — `where: { id: { in: ids } }`.
+     * Routed on `where.id.in` presence rather than call order, so every test
+     * stays independent of how many times each is invoked. Also captures the
+     * LAST `where` passed to `count`/the id-only `findMany`, so a test can
+     * assert on the actual resolved Prisma filter.
+     */
+    let lastFilterWhere: any;
+    function wireFilterItems(matchedItems: Array<Record<string, any>>) {
+      (mockPrisma.mediaItem.count as jest.Mock).mockImplementation(async (args: any) => {
+        lastFilterWhere = args.where;
+        return matchedItems.length;
+      });
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockImplementation(async (args: any) => {
+        if (args.where?.id?.in) {
+          const ids: string[] = args.where.id.in;
+          return matchedItems.filter((i) => ids.includes(i.id));
+        }
+        lastFilterWhere = args.where;
+        return matchedItems.map((i) => ({ id: i.id }));
+      });
+    }
+
+    beforeEach(() => {
+      lastFilterWhere = undefined;
+      (mockPrisma.mediaEnhancementBatch.create as jest.Mock).mockImplementation(
+        async (args: any) => ({ id: 'batch-1', queuedCount: 0, ...args.data }),
+      );
+      (mockPrisma.mediaEnhancementBatch.update as jest.Mock).mockResolvedValue({});
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([]); // no live rows by default
+      (mockPrisma.mediaEnhancement.create as jest.Mock).mockImplementation(async (args: any) => ({
+        id: `enh-${args.data.mediaItemId}`,
+        ...args.data,
+      }));
+      wireFilterItems([makeFilterBatchItem({ id: 'media-a' }), makeFilterBatchItem({ id: 'media-b' })]);
+    });
+
+    // -------------------------------------------------------------------------
+    // Feature gate / config guards (mirror startBatch's / startEnhance's)
+    // -------------------------------------------------------------------------
+
+    it('throws 400 when features.pictureEnhancement is off', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings({ features: { pictureEnhancement: false } }));
+
+      await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(BadRequestException);
+      await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow('Picture enhancement is disabled');
+      expect(mockMembership.assertCircleAccess).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when PICTURE_ENHANCEMENT_ENABLED=false, even with the feature flag on', async () => {
+      process.env['PICTURE_ENHANCEMENT_ENABLED'] = 'false';
+
+      await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 when no enhancement model is configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ ai: { features: { enhance: null } } }),
+      );
+
+      await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(
+        'No enhancement model configured',
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Authorization runs BEFORE the count — an information-leak guard.
+    //
+    // Unlike startBatch's cap check (a pure count of client-supplied ids),
+    // startBatchByFilter's cap check requires COUNTING ROWS IN THE CIRCLE.
+    // Reporting `matchedCount` to a caller who turns out not to be a member
+    // would leak how many photos the circle holds under a given filter. If a
+    // future edit reorders this, a non-member could learn the circle's size
+    // through the over-cap 400's `matchedCount` before ever being told they
+    // lack access.
+    // -------------------------------------------------------------------------
+
+    describe('authorization precedes the count (information-leak guard)', () => {
+      it('propagates ForbiddenException from RBAC and NEVER calls mediaItem.count', async () => {
+        mockMembership.assertCircleAccess.mockRejectedValue(new ForbiddenException('nope'));
+
+        await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(ForbiddenException);
+
+        expect(mockPrisma.mediaItem.count).not.toHaveBeenCalled();
+        expect(mockPrisma.mediaEnhancementBatch.create).not.toHaveBeenCalled();
+      });
+
+      it('asserts circle access at the collaborator level, scoped to dto.circleId', async () => {
+        await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(mockMembership.assertCircleAccess).toHaveBeenCalledWith(
+          USER.id,
+          CIRCLE_ID,
+          USER.permissions,
+          CircleRole.collaborator,
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // The three server-pinned predicates — each independently, per the task's
+    // explicit call-out. None may be implied by another: an over-eager reader
+    // could conflate `archivedAt: null` with `excludeArchived`, or assume
+    // `deletedAt: null` is redundant with buildMediaWhere's own base shape.
+    // -------------------------------------------------------------------------
+
+    describe('server-pinned predicates', () => {
+      it('THE HIGH-CONSEQUENCE GUARD: pins deletedAt: null so a by-filter enhance never re-renders trashed photos', async () => {
+        await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(lastFilterWhere).toMatchObject({ deletedAt: null });
+      });
+
+      it('pins archivedAt: null independently of any `excludeArchived` flag (which is never forwarded to buildMediaWhere here)', async () => {
+        await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(lastFilterWhere).toMatchObject({ archivedAt: null });
+      });
+
+      it('pins type: photo IN THE SQL — never a post-filter — so the reported count equals what would actually run', async () => {
+        await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(lastFilterWhere).toMatchObject({ type: MediaType.photo });
+        // The SAME where object (with the photo pin already applied) is reused
+        // for the subsequent findMany that resolves the match ids — there is
+        // no separate, unpinned query anywhere in the flow.
+        expect(mockPrisma.mediaItem.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({ where: expect.objectContaining({ type: MediaType.photo }) }),
+        );
+      });
+
+      it('a caller who explicitly filters type: video still gets the type:photo pin — the where ANDs an impossible video=photo condition rather than silently dropping the pin', async () => {
+        await service.startBatchByFilter(makeFilterDto({ type: 'video' as any }), USER);
+
+        // The server pin always wins as a top-level key; buildMediaWhere's own
+        // AND array separately carries the caller's `type: 'video'` fragment —
+        // together an unsatisfiable AND, which is the HONEST outcome (a real
+        // DB would return zero rows for it), never a silently-ignored filter.
+        expect(lastFilterWhere.type).toBe(MediaType.photo);
+        expect(lastFilterWhere.AND).toEqual(
+          expect.arrayContaining([{ type: 'video' }]),
+        );
+      });
+
+      it('a filter matching zero rows (e.g. type: video against real data) is the honest "no photos match" 400, never silently ignored', async () => {
+        wireFilterItems([]); // simulates the DB engine returning zero rows for the contradiction above
+        const dto = makeFilterDto({ type: 'video' as any });
+
+        await expect(service.startBatchByFilter(dto, USER)).rejects.toThrow('No photos match this filter');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Filter parity: EVERY mediaFilterFields key resolveFilterWhere destructures
+    // must reach buildMediaWhere unchanged. A field added to the DTO/registry but
+    // forgotten in the passthrough is the realistic failure this guards against —
+    // it would silently widen the match set (the field is accepted but never
+    // filters anything), the exact failure class this endpoint's whole "never
+    // surprise the user with an unseen match" design exists to prevent.
+    //
+    // Rather than hand-modeling what each field does to the where clause (fragile
+    // and duplicative of media-where.builder's own tests), this computes the
+    // REAL buildMediaWhere(...) output for the identical filter subset and
+    // diffs it against what startBatchByFilter actually sent — proving true 1:1
+    // passthrough rather than merely "some filtering happened".
+    // -------------------------------------------------------------------------
+
+    it('forwards EVERY mediaFilterFields key (type/dates/album/favorite/tag/geo/hash/camera/device/missing-*/noFaces) to buildMediaWhere unchanged', async () => {
+      const filterSubset = {
+        type: 'photo' as const,
+        capturedAtFrom: new Date('2024-01-01T00:00:00Z'),
+        capturedAtTo: new Date('2024-12-31T00:00:00Z'),
+        albumId: 'album-1',
+        favorite: true,
+        tag: 'Beach',
+        country: 'Costa Rica',
+        region: 'San José',
+        locality: 'Escazú',
+        place: 'Central Park',
+        location: 'somewhere',
+        contentHash: 'hash123',
+        cameraMake: 'Apple',
+        cameraModel: 'iPhone 15',
+        sourceDeviceId: 'device-1',
+        sourceDeviceName: 'My Phone',
+        missingGeo: true,
+        missingCapturedAt: true,
+        missingCamera: true,
+        noFaces: true,
+      };
+
+      await service.startBatchByFilter(makeFilterDto({ circleId: CIRCLE_ID, ...filterSubset }), USER);
+
+      const expectedFromBuildMediaWhere = buildMediaWhere(CIRCLE_ID, filterSubset);
+
+      // resolveFilterWhere's ONLY divergence from a bare buildMediaWhere(...) call
+      // is the addition of `archivedAt: null` and the top-level `type` override
+      // (deletedAt is already `null` in buildMediaWhere's own base shape, so
+      // pinning it again is a same-value no-op) — every filter fragment must be
+      // otherwise byte-identical.
+      expect(lastFilterWhere).toEqual({
+        ...expectedFromBuildMediaWhere,
+        archivedAt: null,
+        type: MediaType.photo,
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // People-filter composition via wherePeople (peopleMatch: 'all' | 'any')
+    // -------------------------------------------------------------------------
+
+    describe('people filter composition', () => {
+      it('mode "any" composes a `faces.some.personId.in` clause alongside the server-pinned predicates', async () => {
+        const dto = makeFilterDto({ personIds: ['person-1', 'person-2'], peopleMatch: 'any' });
+
+        await service.startBatchByFilter(dto, USER);
+
+        expect(lastFilterWhere).toMatchObject({
+          faces: { some: { personId: { in: ['person-1', 'person-2'] } } },
+          deletedAt: null,
+          archivedAt: null,
+          type: MediaType.photo,
+        });
+      });
+
+      it('mode "all" AND-composes one faces.some clause per person id', async () => {
+        const dto = makeFilterDto({ personIds: ['person-1', 'person-2'], peopleMatch: 'all' });
+
+        await service.startBatchByFilter(dto, USER);
+
+        expect(lastFilterWhere.AND).toEqual([
+          { faces: { some: { personId: 'person-1' } } },
+          { faces: { some: { personId: 'person-2' } } },
+        ]);
+      });
+
+      it('a single `personId` (no `personIds` array) is folded into a one-element people filter', async () => {
+        const dto = makeFilterDto({ personId: 'person-solo', peopleMatch: 'any' });
+
+        await service.startBatchByFilter(dto, USER);
+
+        expect(lastFilterWhere).toMatchObject({
+          faces: { some: { personId: { in: ['person-solo'] } } },
+        });
+      });
+
+      it('defaults to mode "any" when peopleMatch is omitted', async () => {
+        const dto = makeFilterDto({ personIds: ['person-1'] });
+        delete (dto as any).peopleMatch;
+
+        await service.startBatchByFilter(dto, USER);
+
+        expect(lastFilterWhere).toMatchObject({
+          faces: { some: { personId: { in: ['person-1'] } } },
+        });
+      });
+
+      it('no people filter is added when neither personId nor personIds is supplied', async () => {
+        await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(lastFilterWhere).not.toHaveProperty('faces');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Cap refusal — NEVER truncated
+    // -------------------------------------------------------------------------
+
+    describe('cap refusal (never truncates)', () => {
+      it('refuses with 400 naming BOTH matchedCount and maxBatchSize when the filter matches more than the cap', async () => {
+        mockSystemSettings.getSettings.mockResolvedValue(
+          makeSettings({ pictureEnhancement: { ...makeSettings().pictureEnhancement, maxBatchSize: 3 } }),
+        );
+        wireFilterItems(
+          Array.from({ length: 5 }, (_, i) => makeFilterBatchItem({ id: `m${i}` })),
+        );
+
+        await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(BadRequestException);
+        await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(
+          '5 photos match this filter; the limit is 3 per batch.',
+        );
+      });
+
+      it('NEVER creates a batch row and NEVER enqueues a job when the match exceeds the cap', async () => {
+        mockSystemSettings.getSettings.mockResolvedValue(
+          makeSettings({ pictureEnhancement: { ...makeSettings().pictureEnhancement, maxBatchSize: 3 } }),
+        );
+        wireFilterItems(
+          Array.from({ length: 5 }, (_, i) => makeFilterBatchItem({ id: `m${i}` })),
+        );
+
+        await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(BadRequestException);
+
+        expect(mockPrisma.mediaEnhancementBatch.create).not.toHaveBeenCalled();
+        expect(mockEnrichmentJobService.enqueue).not.toHaveBeenCalled();
+        // Nor does it ever fetch the full match set — the over-cap check
+        // happens strictly before the (potentially large) findMany.
+        expect(mockPrisma.mediaItem.findMany).not.toHaveBeenCalled();
+      });
+
+      it('does NOT truncate to the first maxBatchSize matches — there is no silent partial batch', async () => {
+        mockSystemSettings.getSettings.mockResolvedValue(
+          makeSettings({ pictureEnhancement: { ...makeSettings().pictureEnhancement, maxBatchSize: 2 } }),
+        );
+        wireFilterItems([
+          makeFilterBatchItem({ id: 'm0' }),
+          makeFilterBatchItem({ id: 'm1' }),
+          makeFilterBatchItem({ id: 'm2' }),
+        ]);
+
+        let caught: unknown;
+        try {
+          await service.startBatchByFilter(makeFilterDto(), USER);
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(BadRequestException);
+        expect(mockPrisma.mediaEnhancement.create).not.toHaveBeenCalled();
+      });
+
+      it('falls back to a cap of 25 when pictureEnhancement.maxBatchSize is unset', async () => {
+        wireFilterItems(Array.from({ length: 26 }, (_, i) => makeFilterBatchItem({ id: `m${i}` })));
+
+        await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow('the limit is 25');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Zero-match — a 400, never an empty batch
+    // -------------------------------------------------------------------------
+
+    it('throws 400 "No photos match this filter" when nothing matches, and creates no batch', async () => {
+      wireFilterItems([]);
+
+      await expect(service.startBatchByFilter(makeFilterDto(), USER)).rejects.toThrow(
+        'No photos match this filter',
+      );
+      expect(mockPrisma.mediaEnhancementBatch.create).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Delegation to the shared createBatchFrom internals — source: 'filter',
+    // and the alreadyLive skip still applies (never superseded).
+    // -------------------------------------------------------------------------
+
+    describe('delegation to createBatchFrom (shared with startBatch)', () => {
+      it('creates the batch with source: "filter" and a provenance snapshot of the resolved filter under params._filter', async () => {
+        const dto = makeFilterDto({ tag: 'Beach', favorite: true });
+
+        await service.startBatchByFilter(dto, USER);
+
+        expect(mockPrisma.mediaEnhancementBatch.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            circleId: CIRCLE_ID,
+            source: 'filter',
+            requestedCount: 2,
+            params: expect.objectContaining({
+              _filter: expect.objectContaining({ tag: 'Beach', favorite: true }),
+            }),
+          }),
+        });
+      });
+
+      it('an item with an existing live enhancement is skipped and counted as alreadyLive, never superseded (filter source too)', async () => {
+        wireFilterItems([makeFilterBatchItem({ id: 'media-a' })]);
+        (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([
+          { mediaItemId: 'media-a' },
+        ]);
+
+        const result = await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 0, tooLarge: 0, alreadyLive: 1 });
+        expect(result.data.queued).toBe(0);
+        expect(mockActiveProvider.delete).not.toHaveBeenCalled();
+        expect(mockObjectProvider.delete).not.toHaveBeenCalled();
+        expect(mockPrisma.mediaEnhancement.update).not.toHaveBeenCalled();
+      });
+
+      it('an oversized match is skipped as tooLarge, same partition rule as startBatch', async () => {
+        wireFilterItems([makeFilterBatchItem({ id: 'media-a', width: 12000, height: 9000 })]);
+
+        const result = await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(result.data.skipped).toEqual({ notPhoto: 0, tooLarge: 1, alreadyLive: 0 });
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Enqueue shape — priority: 50, skipDedup: true (bulk, not interactive)
+    // -------------------------------------------------------------------------
+
+    describe('enqueue options', () => {
+      it('every enqueued job carries priority:50 and skipDedup:true, matching startBatch', async () => {
+        await service.startBatchByFilter(makeFilterDto(), USER);
+
+        expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledTimes(2);
+        for (const call of (mockEnrichmentJobService.enqueue as jest.Mock).mock.calls) {
+          const [opts] = call;
+          expect(opts).toMatchObject({
+            type: 'picture_enhancement',
+            reason: 'rerun',
+            priority: 50,
+            skipDedup: true,
+          });
+        }
+      });
+    });
+  });
+
+  // ===========================================================================
+  // startBatchByFilter — error envelope through the REAL HttpExceptionFilter
+  //
+  // The over-cap 400 carries `details.matchedCount`/`details.maxBatchSize`.
+  // `HttpExceptionFilter` rebuilds every response body from a FIXED KEY
+  // ALLOWLIST (message, code, details, error, error_description, startedAt),
+  // so a payload field proven present only via `err.getResponse()` can still be
+  // silently dropped on the wire. This is a documented repo gotcha (CLAUDE.md
+  // "Gotchas / Lessons Learned") that has bitten this exact shape before
+  // (issue #343's `activeRunId`). Harness mirrors
+  // db-backup-admin.service.spec.ts's `sendThroughFilter`.
+  // ===========================================================================
+
+  describe('startBatchByFilter — over-cap error envelope (HttpExceptionFilter)', () => {
+    function sendThroughFilter(exception: unknown): any {
+      const response = {
+        code: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+      };
+      const host = {
+        switchToHttp: () => ({
+          getResponse: () => response,
+          getRequest: () => ({ url: '/api/media/bulk/enhance/by-filter', method: 'POST' }),
+        }),
+      } as unknown as ArgumentsHost;
+
+      new HttpExceptionFilter().catch(exception, host);
+      return response.send.mock.calls[0][0];
+    }
+
+    it('the SERIALIZED response body (post-filter) carries details.matchedCount and details.maxBatchSize', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ pictureEnhancement: { ...makeSettings().pictureEnhancement, maxBatchSize: 3 } }),
+      );
+      (mockPrisma.mediaItem.count as jest.Mock).mockResolvedValue(7);
+      (mockPrisma.mediaEnhancement.findMany as jest.Mock).mockResolvedValue([]);
+
+      let caught: unknown;
+      try {
+        await service.startBatchByFilter(
+          { circleId: CIRCLE_ID, params: {} } as BulkEnhanceByFilter,
+          USER,
+        );
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(BadRequestException);
+
+      const wireBody = sendThroughFilter(caught);
+      expect(wireBody.details).toEqual({ matchedCount: 7, maxBatchSize: 3 });
+      // Sanity that getResponse() alone would have looked fine too — the point
+      // is that BOTH must be checked, not that getResponse() lies.
+      expect((caught as BadRequestException).getResponse()).toMatchObject({
+        details: { matchedCount: 7, maxBatchSize: 3 },
       });
     });
   });

--- a/apps/api/src/enhancement/media-enhancement.service.spec.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.spec.ts
@@ -1056,6 +1056,45 @@ describe('MediaEnhancementService', () => {
         ]);
       });
 
+      it('mode "all" combined with another filter keeps BOTH — wherePeople\'s AND must never clobber buildMediaWhere\'s AND (which would silently drop the other filters and widen the paid match set)', async () => {
+        // Both fragments emit a top-level `AND` array; an object spread would let
+        // the people one overwrite the tag one, resolving MORE photos than the
+        // filter describes and paying gpt-image-1 for them.
+        const dto = makeFilterDto({
+          tag: 'Beach',
+          personIds: ['person-1', 'person-2'],
+          peopleMatch: 'all',
+        });
+
+        await service.startBatchByFilter(dto, USER);
+
+        const tagFragment = buildMediaWhere(CIRCLE_ID, { tag: 'Beach' }).AND as any[];
+        expect(tagFragment).toHaveLength(1);
+
+        // The tag fragment survives ALONGSIDE the per-person faces.some clauses.
+        expect(lastFilterWhere.AND).toEqual([
+          tagFragment[0],
+          { faces: { some: { personId: 'person-1' } } },
+          { faces: { some: { personId: 'person-2' } } },
+        ]);
+      });
+
+      it('mode "any" combined with another filter keeps both the AND array and the faces key', async () => {
+        const dto = makeFilterDto({
+          tag: 'Beach',
+          personIds: ['person-1', 'person-2'],
+          peopleMatch: 'any',
+        });
+
+        await service.startBatchByFilter(dto, USER);
+
+        const tagFragment = buildMediaWhere(CIRCLE_ID, { tag: 'Beach' }).AND as any[];
+        expect(lastFilterWhere.AND).toEqual([tagFragment[0]]);
+        expect(lastFilterWhere).toMatchObject({
+          faces: { some: { personId: { in: ['person-1', 'person-2'] } } },
+        });
+      });
+
       it('a single `personId` (no `personIds` array) is folded into a one-element people filter', async () => {
         const dto = makeFilterDto({ personId: 'person-solo', peopleMatch: 'any' });
 

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -29,8 +29,10 @@ import { SystemSettingsService } from '../settings/system-settings/system-settin
 import { isPictureEnhancementEnabled } from '../common/types/settings.types';
 import { streamToBuffer } from '../storage/processing/processors/stream-utils';
 import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
+import { buildMediaWhere, wherePeople } from '../search/media-where.builder';
 import { EnhanceParams } from './dto/enhance-params.dto';
 import { BulkEnhance } from './dto/bulk-enhance.dto';
+import { BulkEnhanceByFilter } from './dto/bulk-enhance-by-filter.dto';
 import { ListEnhancementBatchesQuery } from './dto/list-enhancement-batches-query.dto';
 import {
   ListEnhancementsQuery,
@@ -321,6 +323,209 @@ export class MediaEnhancementService {
     );
   }
 
+  // ---------------------------------------------------------------------------
+  // POST /api/media/bulk/enhance/by-filter — batch enhance a filter (issue #424)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Queue an AI enhancement for every photo matching a gallery filter.
+   *
+   * This is the ONLY path where a single click enqueues a set the user never
+   * enumerated, so it is also the only one that can spend real money on items
+   * nobody named. Three guards exist purely for that reason, all below:
+   *
+   *   1. `deletedAt` and `archivedAt` are pinned EXPLICITLY, because
+   *      buildMediaWhere pins neither for us (see resolveFilterWhere).
+   *   2. Photo-only is expressed in SQL, not as a post-filter, so the count the
+   *      user is refused with is the count that would actually have run.
+   *   3. An over-cap match is REFUSED with both numbers. It is never truncated.
+   *
+   * Gate ORDER matches startBatch (feature → model → …) so the disabled and
+   * unconfigured paths are byte-identical between the two endpoints. The one
+   * deliberate difference: authorization runs BEFORE the cap check here, not
+   * after. startBatch's cap is a pure count of client-supplied ids, but this
+   * one's requires counting rows in the circle — reporting `matchedCount` to a
+   * caller who turned out not to be a member would leak the circle's contents.
+   */
+  async startBatchByFilter(dto: BulkEnhanceByFilter, user: RequestUser) {
+    const settings = await this.systemSettings.getSettings();
+
+    // Feature gate: the SHARED helper (system setting + env kill-switch),
+    // identical to startBatch's — never a second hand-rolled gate.
+    if (!isPictureEnhancementEnabled(settings)) {
+      throw new BadRequestException('Picture enhancement is disabled');
+    }
+
+    const enhanceCfg = settings.ai?.features?.enhance;
+    if (!enhanceCfg?.provider || !enhanceCfg?.model) {
+      throw new BadRequestException(
+        'No enhancement model configured (ai.features.enhance is unset)',
+      );
+    }
+
+    // ONE authorization pass for the whole batch — and before any count, per
+    // the ordering note above.
+    await this.circleMembership.assertCircleAccess(
+      user.id,
+      dto.circleId,
+      user.permissions,
+      CircleRole.collaborator,
+    );
+
+    const where = this.resolveFilterWhere(dto);
+
+    const maxBatchSize = settings.pictureEnhancement?.maxBatchSize ?? 25;
+    const matchedCount = await this.prisma.mediaItem.count({ where });
+
+    if (matchedCount === 0) {
+      throw new BadRequestException('No photos match this filter');
+    }
+
+    if (matchedCount > maxBatchSize) {
+      // NEVER truncate to the first `maxBatchSize` matches. A user who filters
+      // to 400 photos and silently gets 25 enhanced — chosen by an ordering
+      // they cannot see — has been charged for a result they did not ask for
+      // and cannot reason about. Refusing with BOTH numbers lets them narrow
+      // the filter or ask an admin to raise the cap.
+      //
+      // `matchedCount`/`maxBatchSize` MUST live under `details`: the app-wide
+      // HttpExceptionFilter rebuilds every error body from a fixed key
+      // allowlist (message, code, details, error, error_description,
+      // startedAt), so a top-level custom field is silently dropped and never
+      // reaches the client — while err.getResponse() in a unit test still
+      // shows it present. Documented repo gotcha; it has bitten before.
+      throw new BadRequestException({
+        message: `${matchedCount} photos match this filter; the limit is ${maxBatchSize} per batch.`,
+        details: { matchedCount, maxBatchSize },
+      });
+    }
+
+    // A plain findMany with no pagination is safe ONLY because the cap check
+    // above already bounded the result to maxBatchSize rows. This deliberately
+    // does NOT copy addAlbumItemsByFilter's unbounded id fetch, which is fine
+    // for cheap album joins and not for a set that costs money to process.
+    const matches = await this.prisma.mediaItem.findMany({
+      where,
+      select: { id: true },
+    });
+
+    return this.createBatchFrom(
+      matches.map((m) => m.id),
+      dto.circleId,
+      dto.params ?? {},
+      'filter',
+      user,
+      // Provenance: the resolved filter is snapshotted onto the BATCH row so a
+      // reviewer can later see what the user actually asked for, not just how
+      // many items it happened to match.
+      this.snapshotFilter(dto),
+    );
+  }
+
+  /**
+   * Compile a by-filter request into the Prisma `where` the batch is resolved
+   * from. Three predicates are pinned here that buildMediaWhere will NOT add:
+   *
+   *  - `deletedAt: null` — buildMediaWhere never filters trash for us. Its
+   *    `excludeArchived` flag touches ONLY `archivedAt`. Without this pin a
+   *    by-filter enhance would spend real money re-rendering photos sitting in
+   *    the Trash.
+   *  - `archivedAt: null` — pinned directly rather than via `excludeArchived`,
+   *    so the guarantee does not depend on a flag another caller could stop
+   *    passing.
+   *  - `type: photo` — enhancement is photo-only, and this belongs in the SQL
+   *    rather than a post-filter: counting videos and then skipping them would
+   *    make the cap check (and the number the user is refused with) lie.
+   *
+   * A caller that explicitly filters `type=video` therefore matches nothing and
+   * gets the "no photos match" 400 — which is the honest answer.
+   */
+  private resolveFilterWhere(dto: BulkEnhanceByFilter): Prisma.MediaItemWhereInput {
+    const {
+      circleId,
+      type,
+      capturedAtFrom,
+      capturedAtTo,
+      albumId,
+      favorite,
+      tag,
+      country,
+      region,
+      locality,
+      place,
+      location,
+      contentHash,
+      cameraMake,
+      cameraModel,
+      sourceDeviceId,
+      sourceDeviceName,
+      missingGeo,
+      missingCapturedAt,
+      missingCamera,
+      noFaces,
+      personId,
+      personIds,
+      peopleMatch,
+    } = dto;
+
+    // People filtering is NOT part of buildMediaWhere — it is the separate
+    // wherePeople() export (same split as MediaService.addAlbumItemsByFilter).
+    const effectivePersonIds =
+      personIds && personIds.length > 0 ? personIds : personId ? [personId] : [];
+
+    return {
+      ...buildMediaWhere(circleId, {
+        type,
+        capturedAtFrom,
+        capturedAtTo,
+        albumId,
+        favorite,
+        tag,
+        country,
+        region,
+        locality,
+        place,
+        location,
+        contentHash,
+        cameraMake,
+        cameraModel,
+        sourceDeviceId,
+        sourceDeviceName,
+        missingGeo,
+        missingCapturedAt,
+        missingCamera,
+        noFaces,
+      }),
+      ...(effectivePersonIds.length > 0
+        ? wherePeople(effectivePersonIds, peopleMatch ?? 'any')
+        : {}),
+      // The three pins — see the doc comment above. Kept last so they can never
+      // be shadowed by a spread.
+      deletedAt: null,
+      archivedAt: null,
+      type: MediaType.photo,
+    };
+  }
+
+  /**
+   * Project a by-filter request down to the filter fields that were actually
+   * supplied, for storage on the batch row. `params` is excluded (it is stored
+   * on its own), and `undefined` values are dropped so the snapshot reads as
+   * "what the user set", not "every field the DTO knows about".
+   *
+   * The two date fields arrive as JS `Date`s (the DTO pipes them through
+   * `z.coerce.date()`), which is not a JSON value — so they are stringified
+   * here explicitly rather than leaning on Prisma's Date-in-JSONB coercion.
+   */
+  private snapshotFilter(dto: BulkEnhanceByFilter): Record<string, unknown> {
+    const { params: _params, ...filter } = dto;
+    return Object.fromEntries(
+      Object.entries(filter)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => [k, v instanceof Date ? v.toISOString() : v]),
+    );
+  }
+
   /**
    * Post-authorization half of a batch enhance: partition the ids, create the
    * batch row, then create + enqueue one enhancement per eligible item.
@@ -335,6 +540,14 @@ export class MediaEnhancementService {
     params: EnhanceParams,
     source: 'selection' | 'filter',
     user: RequestUser,
+    /**
+     * Optional provenance for a `source: 'filter'` batch — the resolved filter,
+     * recorded on the BATCH row's params under `_filter` (the repo-wide
+     * underscore convention for internal/derived keys). Deliberately NOT copied
+     * onto the per-item enhancement rows: those carry the enhance params the
+     * prompt was compiled from, and a filter is not one of them.
+     */
+    filterSnapshot?: Record<string, unknown>,
   ) {
     // Cached (5 s TTL) — no extra DB read path.
     const settings = await this.systemSettings.getSettings();
@@ -437,7 +650,9 @@ export class MediaEnhancementService {
         requestedCount: ids.length,
         queuedCount: 0,
         skipped: skipped as unknown as Prisma.InputJsonValue,
-        params: (params ?? {}) as Prisma.InputJsonValue,
+        params: (filterSnapshot
+          ? { ...(params ?? {}), _filter: filterSnapshot }
+          : (params ?? {})) as Prisma.InputJsonValue,
         source,
         createdById: user.id,
       },

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -473,32 +473,62 @@ export class MediaEnhancementService {
     const effectivePersonIds =
       personIds && personIds.length > 0 ? personIds : personId ? [personId] : [];
 
-    return {
-      ...buildMediaWhere(circleId, {
-        type,
-        capturedAtFrom,
-        capturedAtTo,
-        albumId,
-        favorite,
-        tag,
-        country,
-        region,
-        locality,
-        place,
-        location,
-        contentHash,
-        cameraMake,
-        cameraModel,
-        sourceDeviceId,
-        sourceDeviceName,
-        missingGeo,
-        missingCapturedAt,
-        missingCamera,
-        noFaces,
-      }),
-      ...(effectivePersonIds.length > 0
+    const base = buildMediaWhere(circleId, {
+      type,
+      capturedAtFrom,
+      capturedAtTo,
+      albumId,
+      favorite,
+      tag,
+      country,
+      region,
+      locality,
+      place,
+      location,
+      contentHash,
+      cameraMake,
+      cameraModel,
+      sourceDeviceId,
+      sourceDeviceName,
+      missingGeo,
+      missingCapturedAt,
+      missingCamera,
+      noFaces,
+    });
+    const people =
+      effectivePersonIds.length > 0
         ? wherePeople(effectivePersonIds, peopleMatch ?? 'any')
-        : {}),
+        : {};
+
+    // ---- AND-key collision: MERGE, never spread. Do not "simplify" this back. --
+    // buildMediaWhere collects EVERY filter fragment into a single top-level
+    // `AND` array (deliberately, so two fragments that each emit an `OR` cannot
+    // clobber each other). wherePeople(ids, 'all') ALSO returns a top-level
+    // `AND` array. Object-spreading the two therefore lets the people `AND`
+    // silently OVERWRITE the filter `AND`, dropping every other condition the
+    // user asked for and WIDENING the match set — which on this endpoint means
+    // paying gpt-image-1 to enhance photos the filter never described.
+    // ('any' mode is unaffected: it returns a `faces` key, not `AND`.)
+    //
+    // The same collision exists at the two pre-existing buildMediaWhere +
+    // wherePeople call sites (MediaService.listMedia and
+    // addAlbumItemsByFilter), which still spread. Fixing it in the shared
+    // builder would change gallery/album behaviour app-wide and is tracked
+    // separately; it is fixed HERE only. The resulting asymmetry is safe in
+    // this direction: this endpoint resolves the NARROWER, correct set and
+    // refuses rather than truncates, so it can never overcharge.
+    const { AND: baseAnd, ...baseRest } = base;
+    const { AND: peopleAnd, ...peopleRest } = people;
+    const asArray = (
+      and: Prisma.MediaItemWhereInput['AND'],
+    ): Prisma.MediaItemWhereInput[] =>
+      and === undefined ? [] : Array.isArray(and) ? and : [and];
+    const mergedAnd = [...asArray(baseAnd), ...asArray(peopleAnd)];
+
+    return {
+      ...baseRest,
+      ...peopleRest,
+      ...(mergedAnd.length > 0 ? { AND: mergedAnd } : {}),
       // The three pins — see the doc comment above. Kept last so they can never
       // be shadowed by a spread.
       deletedAt: null,

--- a/apps/web/src/__tests__/components/media/BatchEnhanceDialog.test.tsx
+++ b/apps/web/src/__tests__/components/media/BatchEnhanceDialog.test.tsx
@@ -1,5 +1,6 @@
 /**
- * BatchEnhanceDialog — unit tests (issue #422, epic #420 phase 2).
+ * BatchEnhanceDialog — unit tests (issue #422, epic #420 phase 2; filter mode
+ * added in issue #424, epic #420 phase 4).
  *
  * Multi-photo AI enhance: params step (preset picker + optional Customize) ->
  * submit -> either an immediate close (nothing skipped) or a result step
@@ -10,6 +11,12 @@
  * `resolvePreset` from the shared `enhancePresets` module (also consumed by
  * MediaEnhancementDrawer) rather than hard-coding an expected literal, so the
  * two enhance surfaces can never silently drift apart.
+ *
+ * Filter mode (`BatchEnhanceFilterTarget`, issue #424) submits through the
+ * SEPARATE `bulkEnhanceByFilter` service call, resolves a match set the client
+ * never enumerated, and surfaces the server's two "normal" 400s (over-cap
+ * refusal, empty match) as distinct, non-failure UI states rather than a
+ * generic error.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,7 +25,10 @@ import userEvent from '@testing-library/user-event';
 import { act } from 'react';
 import { render } from '../../utils/test-utils';
 import { BatchEnhanceDialog } from '../../../components/media/BatchEnhanceDialog';
-import type { BatchEnhanceSelectionTarget } from '../../../components/media/BatchEnhanceDialog';
+import type {
+  BatchEnhanceSelectionTarget,
+  BatchEnhanceFilterTarget,
+} from '../../../components/media/BatchEnhanceDialog';
 import {
   buildEnhanceParams,
   resolvePreset,
@@ -26,17 +36,20 @@ import {
 } from '../../../components/media/enhancePresets';
 import type { EnhanceFormState } from '../../../components/media/enhancePresets';
 import type { BulkEnhanceResult } from '../../../services/media';
+import { ApiError } from '../../../services/api';
 
 // ---------------------------------------------------------------------------
 // Mock media service
 // ---------------------------------------------------------------------------
 vi.mock('../../../services/media', () => ({
   bulkEnhance: vi.fn(),
+  bulkEnhanceByFilter: vi.fn(),
 }));
 
-import { bulkEnhance } from '../../../services/media';
+import { bulkEnhance, bulkEnhanceByFilter } from '../../../services/media';
 
 const mockBulkEnhance = vi.mocked(bulkEnhance);
+const mockBulkEnhanceByFilter = vi.mocked(bulkEnhanceByFilter);
 
 // ---------------------------------------------------------------------------
 // Fixtures / helpers
@@ -50,6 +63,32 @@ function makeTarget(overrides: Partial<BatchEnhanceSelectionTarget> = {}): Batch
     nonPhotoCount: 0,
     ...overrides,
   };
+}
+
+function makeFilterTarget(
+  overrides: Partial<BatchEnhanceFilterTarget> = {},
+): BatchEnhanceFilterTarget {
+  return {
+    kind: 'filter',
+    circleId: 'circle-1',
+    scope: 'filter',
+    filters: { tag: 'Beach' },
+    photoCount: null,
+    ...overrides,
+  };
+}
+
+/** Builds the `ApiError` shape `readOverCapRefusal` reads (issue #424). */
+function overCapError(matchedCount: number, maxBatchSize: number): ApiError {
+  return new ApiError('Too many photos match this filter', 400, 'BAD_REQUEST', {
+    matchedCount,
+    maxBatchSize,
+  });
+}
+
+/** The server's honest empty-match 400 — never an empty batch. */
+function noMatchError(): ApiError {
+  return new ApiError('No photos match this filter', 400, 'BAD_REQUEST');
 }
 
 function makeResult(overrides: Partial<BulkEnhanceResult> = {}): BulkEnhanceResult {
@@ -90,6 +129,7 @@ describe('BatchEnhanceDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockBulkEnhance.mockResolvedValue(makeResult());
+    mockBulkEnhanceByFilter.mockResolvedValue(makeResult());
   });
 
   // -------------------------------------------------------------------------
@@ -485,6 +525,237 @@ describe('BatchEnhanceDialog', () => {
         expect.stringMatching(/Queued AI enhancement for 0/i),
         expect.anything(),
       );
+    });
+  });
+
+  // ===========================================================================
+  // Filter mode (BatchEnhanceFilterTarget, issue #424)
+  //
+  // A filter target resolves its match set SERVER-SIDE — the user never
+  // enumerated it, and in keyset mode there is no COUNT(*) to show up front.
+  // Everything below is specific to that: the copy that says so explicitly,
+  // the two server 400s rendered as normal outcomes rather than failures, and
+  // the by-filter submit path.
+  // ===========================================================================
+  describe('filter mode', () => {
+    // -------------------------------------------------------------------------
+    // Copy
+    // -------------------------------------------------------------------------
+    describe('copy', () => {
+      it('states the filter-scope title and the load-bearing "photos off screen are included" sentence verbatim', () => {
+        render(
+          <BatchEnhanceDialog {...defaultProps} target={makeFilterTarget({ photoCount: 12 })} />,
+        );
+
+        expect(
+          screen.getByText('Enhance all 12 photos matching your current filter?'),
+        ).toBeInTheDocument();
+        // Verbatim: this sentence is the entire point of the filter-mode
+        // dialog — the user must be told outright that the match set reaches
+        // beyond what they can currently see.
+        expect(
+          screen.getByText('Photos you cannot currently see on screen are included.'),
+        ).toBeInTheDocument();
+      });
+
+      it('falls back to "Enhance all photos matching your current filter?" when photoCount is unknown (keyset gallery, no COUNT(*))', () => {
+        render(
+          <BatchEnhanceDialog {...defaultProps} target={makeFilterTarget({ photoCount: null })} />,
+        );
+
+        expect(
+          screen.getByText('Enhance all photos matching your current filter?'),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /^Enhance all matching photos$/i }),
+        ).toBeInTheDocument();
+      });
+
+      it('uses the ALBUM-scope copy variant (title + submit label) when target.scope is "album"', () => {
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({ scope: 'album', photoCount: 8 })}
+          />,
+        );
+
+        expect(screen.getByText('Enhance all 8 photos in this album?')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Enhance 8 photos$/i })).toBeInTheDocument();
+      });
+
+      it('album-scope submit label falls back to "Enhance all photos in this album" when photoCount is unknown', () => {
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({ scope: 'album', photoCount: null })}
+          />,
+        );
+
+        expect(
+          screen.getByRole('button', { name: /^Enhance all photos in this album$/i }),
+        ).toBeInTheDocument();
+        // "Photos off screen" still applies — an album's own gallery may be
+        // paginated too, so the same disclosure is warranted.
+        expect(
+          screen.getByText('Photos you cannot currently see on screen are included.'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Over-cap refusal — a REFUSAL, not a failure
+    // -------------------------------------------------------------------------
+    describe('over-cap refusal', () => {
+      it('renders the server-reported matchedCount/maxBatchSize as a refusal Alert (not the generic error message) and disables submit', async () => {
+        mockBulkEnhanceByFilter.mockRejectedValueOnce(overCapError(412, 25));
+        const user = userEvent.setup();
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({ photoCount: null })}
+            maxBatchSize={25}
+          />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /^Enhance all matching photos$/i }));
+
+        expect(await screen.findByText(/too many photos for one batch/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            /412 photos match your filter; the limit is 25 per batch\. Narrow the filter/i,
+          ),
+        ).toBeInTheDocument();
+        // NEVER the generic-failure copy — this is a normal, actionable outcome.
+        expect(
+          screen.queryByText('Failed to queue AI enhancements'),
+        ).not.toBeInTheDocument();
+
+        expect(
+          screen.getByRole('button', { name: /^Enhance all matching photos$/i }),
+        ).toBeDisabled();
+      });
+
+      it('uses the album-scope refusal wording ("are in this album" / select individually)', async () => {
+        mockBulkEnhanceByFilter.mockRejectedValueOnce(overCapError(60, 25));
+        const user = userEvent.setup();
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({ scope: 'album', photoCount: null })}
+            maxBatchSize={25}
+          />,
+        );
+
+        await user.click(
+          screen.getByRole('button', { name: /^Enhance all photos in this album$/i }),
+        );
+
+        expect(
+          await screen.findByText(/60 photos are in this album; the limit is 25 per batch/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Select photos individually instead/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Zero-match — its own distinct state, not a failure either
+    // -------------------------------------------------------------------------
+    describe('zero-match', () => {
+      it('renders a distinct "Nothing to enhance" state for the empty-match 400, not the over-cap refusal or a generic failure', async () => {
+        mockBulkEnhanceByFilter.mockRejectedValueOnce(noMatchError());
+        const user = userEvent.setup();
+        render(
+          <BatchEnhanceDialog {...defaultProps} target={makeFilterTarget({ photoCount: null })} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /^Enhance all matching photos$/i }));
+
+        expect(await screen.findByText('Nothing to enhance')).toBeInTheDocument();
+        expect(
+          screen.getByText(/No photos match your current filter\. Adjust the filter and try again\./i),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/too many photos for one batch/i)).not.toBeInTheDocument();
+        expect(screen.queryByText('Failed to queue AI enhancements')).not.toBeInTheDocument();
+      });
+
+      it('uses the album-scope empty-match wording ("This album has no photos to enhance")', async () => {
+        mockBulkEnhanceByFilter.mockRejectedValueOnce(noMatchError());
+        const user = userEvent.setup();
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({ scope: 'album', photoCount: null })}
+          />,
+        );
+
+        await user.click(
+          screen.getByRole('button', { name: /^Enhance all photos in this album$/i }),
+        );
+
+        expect(
+          await screen.findByText('This album has no photos to enhance.'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Submit payload — the by-filter endpoint, with the FILTER OBJECT, never
+    // an id list.
+    // -------------------------------------------------------------------------
+    describe('submit payload', () => {
+      it('posts to bulkEnhanceByFilter with the filter object (never an id list), merging circleId from the target', async () => {
+        const user = userEvent.setup();
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({
+              circleId: 'circle-42',
+              filters: { tag: 'Beach', favorite: true },
+              photoCount: 5,
+            })}
+          />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /^Enhance 5 photos$/i }));
+
+        await waitFor(() => {
+          expect(mockBulkEnhanceByFilter).toHaveBeenCalledTimes(1);
+        });
+        expect(mockBulkEnhanceByFilter).toHaveBeenCalledWith({
+          filters: { tag: 'Beach', favorite: true, circleId: 'circle-42' },
+          params: {},
+        });
+        // The id-list endpoint is never touched by a filter-mode submit.
+        expect(mockBulkEnhance).not.toHaveBeenCalled();
+      });
+
+      it('the circle the dialog runs in always wins over anything (incorrectly) present in filters.circleId', async () => {
+        const user = userEvent.setup();
+        render(
+          <BatchEnhanceDialog
+            {...defaultProps}
+            target={makeFilterTarget({
+              circleId: 'circle-real',
+              // A stray circleId inside `filters` (should never happen, but
+              // the target's own circleId must still win if it does).
+              filters: { tag: 'Beach', circleId: 'circle-stale' } as any,
+              photoCount: 3,
+            })}
+          />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /^Enhance 3 photos$/i }));
+
+        await waitFor(() => {
+          expect(mockBulkEnhanceByFilter).toHaveBeenCalledWith(
+            expect.objectContaining({
+              filters: expect.objectContaining({ circleId: 'circle-real' }),
+            }),
+          );
+        });
+      });
     });
   });
 });

--- a/apps/web/src/__tests__/components/media/BulkActionToolbar.test.tsx
+++ b/apps/web/src/__tests__/components/media/BulkActionToolbar.test.tsx
@@ -753,4 +753,116 @@ describe('BulkActionToolbar', () => {
       expect(button).toHaveAttribute('aria-label', 'AI Enhance 3 photos');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // "Enhance all matching" — the filter-driven batch entry point (issue #424).
+  //
+  // Lives in the overflow "More actions" menu, deliberately NOT counted from
+  // the selection (`selectedItems`): it acts on the server-resolved filter
+  // match set. Its presence is controlled entirely by whether
+  // `onOpenFilterEnhance` was supplied at all — MediaGallery passes it ONLY
+  // when a filter is genuinely active, which is what hides the menu item with
+  // no view having to opt out explicitly. Gated the same three ways as the
+  // single/batch AI Enhance action: feature flag, `onOpenFilterEnhance`
+  // presence, and non-viewer role.
+  // -------------------------------------------------------------------------
+  describe('"Enhance all matching" action (onOpenFilterEnhance, issue #424)', () => {
+    it('appears in the overflow menu when a filter is active, the feature is on, and the caller is not a viewer', async () => {
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          enhanceEnabled
+          onOpenFilterEnhance={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /more actions/i }));
+
+      expect(screen.getByText('Enhance all matching')).toBeInTheDocument();
+      expect(
+        screen.getByText('Every photo in this filter, not just the selection'),
+      ).toBeInTheDocument();
+    });
+
+    it('is ABSENT when no onOpenFilterEnhance callback is supplied (no active filter) — even with the feature on', async () => {
+      const user = userEvent.setup();
+      render(<BulkActionToolbar {...defaultProps} enhanceEnabled />);
+
+      await user.click(screen.getByRole('button', { name: /more actions/i }));
+
+      expect(screen.queryByText('Enhance all matching')).not.toBeInTheDocument();
+    });
+
+    it('is ABSENT when the feature flag is off, even with an active filter', async () => {
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          enhanceEnabled={false}
+          onOpenFilterEnhance={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /more actions/i }));
+
+      expect(screen.queryByText('Enhance all matching')).not.toBeInTheDocument();
+    });
+
+    it('is ABSENT for viewer role, even with the feature on and an active filter', async () => {
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          activeCircleRole="viewer"
+          enhanceEnabled
+          onOpenFilterEnhance={vi.fn()}
+        />,
+      );
+
+      // Viewers get no "More actions" button at all (see the viewer-role
+      // describe block above) — the entry point is unreachable full stop.
+      expect(screen.queryByRole('button', { name: /more actions/i })).not.toBeInTheDocument();
+    });
+
+    it('calls onOpenFilterEnhance and closes the menu when clicked', async () => {
+      const onOpenFilterEnhance = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          enhanceEnabled
+          onOpenFilterEnhance={onOpenFilterEnhance}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /more actions/i }));
+      await user.click(screen.getByText('Enhance all matching'));
+
+      expect(onOpenFilterEnhance).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.queryByText('Enhance all matching')).not.toBeInTheDocument();
+      });
+    });
+
+    it('is independent of the selection-scoped AI Enhance action — both can be gated on simultaneously without colliding', async () => {
+      const photoItem = makeMediaItem({ id: 'item-1', type: 'photo' });
+      const user = userEvent.setup();
+      render(
+        <BulkActionToolbar
+          {...defaultProps}
+          selected={new Set(['item-1'])}
+          singleSelectedItem={photoItem}
+          enhanceEnabled
+          onOpenEnhance={vi.fn()}
+          onOpenFilterEnhance={vi.fn()}
+        />,
+      );
+
+      // The single-photo AI Enhance icon button still renders on the bar itself...
+      expect(screen.getByRole('button', { name: /ai enhance/i })).toBeInTheDocument();
+      // ...and "Enhance all matching" is reachable in the overflow menu too.
+      await user.click(screen.getByRole('button', { name: /more actions/i }));
+      expect(screen.getByText('Enhance all matching')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/__tests__/services/bulkEnhanceByFilter.test.ts
+++ b/apps/web/src/__tests__/services/bulkEnhanceByFilter.test.ts
@@ -1,0 +1,241 @@
+/**
+ * services/media — bulkEnhanceByFilter (issue #424, epic #420 phase 4).
+ *
+ * `serializeEnhanceFilters` exists to fix a specific, money-losing failure
+ * mode: the API's `bulkEnhanceByFilterSchema` spreads the shared
+ * `mediaFilterFields`, whose boolean-ish fields (`favorite`, `missingGeo`,
+ * `missingCapturedAt`, `missingCamera`, `noFaces`) are
+ * `z.string().transform(v => v === 'true' ? true : v === 'false' ? false :
+ * undefined)` — written for a QUERY STRING. A real JSON `true` sent in a POST
+ * body transforms to `undefined` server-side and the filter is silently
+ * DROPPED — which on THIS endpoint WIDENS the match set, enhancing photos the
+ * caller never asked about and never saw. That is the load-bearing behavior
+ * under test here, via MSW intercepting the real HTTP call and inspecting the
+ * JSON body actually sent (mirroring mediaExtended.test.ts's approach) —
+ * `serializeEnhanceFilters` itself is not exported, so it is exercised only
+ * through the public `bulkEnhanceByFilter` service call, exactly as a caller
+ * would.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server';
+import { bulkEnhanceByFilter } from '../../services/media';
+import type { BulkEnhanceByFilterFilters } from '../../services/media';
+import { ApiError } from '../../services/api';
+
+const ROUTE = '*/api/media/bulk/enhance/by-filter';
+
+const mockResult = {
+  batchId: 'batch-1',
+  requested: 5,
+  queued: 5,
+  skipped: { notPhoto: 0, tooLarge: 0, alreadyLive: 0 },
+};
+
+/** Wires the by-filter route to capture and echo back the JSON body sent. */
+function captureBody(): { body: () => Record<string, unknown> | undefined } {
+  let captured: Record<string, unknown> | undefined;
+  server.use(
+    http.post(ROUTE, async ({ request }) => {
+      captured = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json(mockResult);
+    }),
+  );
+  return { body: () => captured };
+}
+
+describe('bulkEnhanceByFilter — request body serialization', () => {
+  // -------------------------------------------------------------------------
+  // THE money-losing failure mode this module exists to prevent.
+  // -------------------------------------------------------------------------
+  describe('boolean filters survive serialization as the strings "true"/"false"', () => {
+    it('serializes every boolean-ish field as the STRING "true", never the raw JSON boolean', async () => {
+      const capture = captureBody();
+
+      const filters: BulkEnhanceByFilterFilters = {
+        circleId: 'circle-1',
+        favorite: true,
+        missingGeo: true,
+        missingCapturedAt: true,
+        missingCamera: true,
+        noFaces: true,
+      };
+
+      await bulkEnhanceByFilter({ filters });
+
+      const body = capture.body();
+      expect(body).toBeDefined();
+      expect(body!.favorite).toBe('true');
+      expect(body!.missingGeo).toBe('true');
+      expect(body!.missingCapturedAt).toBe('true');
+      expect(body!.missingCamera).toBe('true');
+      expect(body!.noFaces).toBe('true');
+      // The exact failure under test: if this were the raw boolean `true`,
+      // the API's z.string().transform(...) would silently turn it into
+      // `undefined` and drop the filter, widening the match set.
+      expect(typeof body!.favorite).toBe('string');
+      expect(body!.favorite).not.toBe(true);
+    });
+
+    it('serializes false booleans as the STRING "false" — never omitted, never the raw boolean', async () => {
+      const capture = captureBody();
+
+      const filters: BulkEnhanceByFilterFilters = {
+        circleId: 'circle-1',
+        favorite: false,
+        noFaces: false,
+      };
+
+      await bulkEnhanceByFilter({ filters });
+
+      const body = capture.body();
+      expect(body!.favorite).toBe('false');
+      expect(body!.noFaces).toBe('false');
+      expect(typeof body!.favorite).toBe('string');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // excludeArchived is dropped, not forwarded — the server pins
+  // `archivedAt: null` unconditionally on this endpoint.
+  // -------------------------------------------------------------------------
+  describe('excludeArchived', () => {
+    it('is never sent — sending it would suggest a choice the caller does not have on this endpoint', async () => {
+      const capture = captureBody();
+
+      await bulkEnhanceByFilter({
+        filters: { circleId: 'circle-1', excludeArchived: true } as BulkEnhanceByFilterFilters,
+      });
+
+      const body = capture.body();
+      expect(body).toBeDefined();
+      expect(body).not.toHaveProperty('excludeArchived');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // undefined/null filter values are omitted entirely, not sent as null.
+  // -------------------------------------------------------------------------
+  describe('undefined/null filter values', () => {
+    it('omits keys whose value is undefined or null rather than sending them', async () => {
+      const capture = captureBody();
+
+      await bulkEnhanceByFilter({
+        filters: {
+          circleId: 'circle-1',
+          tag: undefined,
+          country: undefined,
+        } as BulkEnhanceByFilterFilters,
+      });
+
+      const body = capture.body();
+      expect(body).toBeDefined();
+      expect(body).not.toHaveProperty('tag');
+      expect(body).not.toHaveProperty('country');
+      expect(body!.circleId).toBe('circle-1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-boolean values pass through untouched.
+  // -------------------------------------------------------------------------
+  describe('non-boolean values', () => {
+    it('leaves string/array/enum filter values as-is', async () => {
+      const capture = captureBody();
+
+      await bulkEnhanceByFilter({
+        filters: {
+          circleId: 'circle-1',
+          tag: 'Beach',
+          personIds: ['p1', 'p2'],
+          peopleMatch: 'all',
+        } as BulkEnhanceByFilterFilters,
+      });
+
+      const body = capture.body();
+      expect(body!.tag).toBe('Beach');
+      expect(body!.personIds).toEqual(['p1', 'p2']);
+      expect(body!.peopleMatch).toBe('all');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // params passthrough
+  // -------------------------------------------------------------------------
+  describe('params', () => {
+    it('is omitted from the body entirely when not supplied', async () => {
+      const capture = captureBody();
+
+      await bulkEnhanceByFilter({ filters: { circleId: 'circle-1' } });
+
+      const body = capture.body();
+      expect(body).toBeDefined();
+      expect(body).not.toHaveProperty('params');
+    });
+
+    it('is included verbatim when supplied', async () => {
+      const capture = captureBody();
+
+      await bulkEnhanceByFilter({
+        filters: { circleId: 'circle-1' },
+        params: { strength: 'strong' },
+      });
+
+      const body = capture.body();
+      expect(body!.params).toEqual({ strength: 'strong' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Response / error propagation
+  // -------------------------------------------------------------------------
+  describe('response handling', () => {
+    it('returns the parsed BulkEnhanceResult on success', async () => {
+      server.use(http.post(ROUTE, () => HttpResponse.json(mockResult)));
+
+      const result = await bulkEnhanceByFilter({ filters: { circleId: 'circle-1' } });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('surfaces details.matchedCount/maxBatchSize on the thrown ApiError for an over-cap 400', async () => {
+      server.use(
+        http.post(ROUTE, () =>
+          HttpResponse.json(
+            {
+              message: '412 photos match this filter; the limit is 25 per batch.',
+              code: 'BAD_REQUEST',
+              details: { matchedCount: 412, maxBatchSize: 25 },
+            },
+            { status: 400 },
+          ),
+        ),
+      );
+
+      await expect(bulkEnhanceByFilter({ filters: { circleId: 'circle-1' } })).rejects.toMatchObject({
+        status: 400,
+        details: { matchedCount: 412, maxBatchSize: 25 },
+      });
+    });
+
+    it('the rejected error is an ApiError instance carrying the server message for the empty-match 400', async () => {
+      server.use(
+        http.post(ROUTE, () =>
+          HttpResponse.json(
+            { message: 'No photos match this filter', code: 'BAD_REQUEST' },
+            { status: 400 },
+          ),
+        ),
+      );
+
+      try {
+        await bulkEnhanceByFilter({ filters: { circleId: 'circle-1' } });
+        throw new Error('expected bulkEnhanceByFilter to reject');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).message).toBe('No photos match this filter');
+        expect((err as ApiError).status).toBe(400);
+      }
+    });
+  });
+});

--- a/apps/web/src/components/media/BatchEnhanceDialog.tsx
+++ b/apps/web/src/components/media/BatchEnhanceDialog.tsx
@@ -35,18 +35,21 @@ import {
   resolvePreset,
 } from './enhancePresets';
 import type { AdjustmentsState, PresetKey } from './enhancePresets';
-import { bulkEnhance } from '../../services/media';
-import type { BulkEnhanceResult } from '../../services/media';
+import { bulkEnhance, bulkEnhanceByFilter } from '../../services/media';
+import type { BulkEnhanceByFilterFilters, BulkEnhanceResult } from '../../services/media';
 import type { EnhanceQuality, EnhanceStrength } from '../../services/enhance';
+import { ApiError } from '../../services/api';
 
 // ---------------------------------------------------------------------------
 // Target
 //
-// What a batch acts on. Today there is exactly one kind — an explicit client
-// selection — but the dialog reads `photoCount` and delegates submission to
-// `submitTarget`, so issue #424's "enhance everything matching this filter"
-// mode can be added as a second member whose count comes from the server
-// (a resolved `matchedCount`) without reworking any of the UI below.
+// What a batch acts on. Two kinds, and the difference that matters is not how
+// they submit but what the user KNOWS: a selection is a set they enumerated
+// themselves, a filter is a set the SERVER resolves and may include photos they
+// have never seen. Every count string below runs through `targetPhotoCount`,
+// which is deliberately `number | null` — a keyset-paginated gallery has no
+// COUNT(*) to offer, and the honest answer there is "unknown until the server
+// says", not a plausible-looking number taken from the loaded pages.
 // ---------------------------------------------------------------------------
 
 export interface BatchEnhanceSelectionTarget {
@@ -61,12 +64,56 @@ export interface BatchEnhanceSelectionTarget {
   nonPhotoCount: number;
 }
 
-export type BatchEnhanceTarget = BatchEnhanceSelectionTarget;
+/**
+ * Which surface asked, purely so the copy reads naturally ("matching your
+ * current filter" vs "in this album") and the over-cap advice is actionable —
+ * "narrow the filter" is useless to someone standing in an album.
+ */
+export type BatchEnhanceFilterScope = 'filter' | 'album';
 
-/** How many photos this target will enhance, as far as the client can tell. */
-function targetPhotoCount(target: BatchEnhanceTarget): number {
-  return target.photoIds.length;
+export interface BatchEnhanceFilterTarget {
+  kind: 'filter';
+  circleId: string;
+  scope: BatchEnhanceFilterScope;
+  /**
+   * The filter itself — the same object `GET /api/media` takes. `circleId` is
+   * applied from the target on submit, so the two can never disagree.
+   */
+  filters: Omit<BulkEnhanceByFilterFilters, 'circleId'>;
+  /**
+   * Photos the client can already prove match, when the surface genuinely knows
+   * (an album's loaded item list, an offset-mode `meta.totalItems`). `null` in
+   * keyset mode — the server's over-cap 400 carries the real `matchedCount`.
+   */
+  photoCount: number | null;
 }
+
+export type BatchEnhanceTarget = BatchEnhanceSelectionTarget | BatchEnhanceFilterTarget;
+
+/**
+ * How many photos this target will enhance, as far as the client can tell.
+ * `null` means "only the server knows" — never conflate it with 0.
+ */
+function targetPhotoCount(target: BatchEnhanceTarget): number | null {
+  return target.kind === 'selection' ? target.photoIds.length : target.photoCount;
+}
+
+/** Scope-dependent copy. Kept together so the two scopes cannot drift apart. */
+const FILTER_SCOPE_COPY: Record<
+  BatchEnhanceFilterScope,
+  { titleScope: string; capScope: string; narrowHint: string }
+> = {
+  filter: {
+    titleScope: 'matching your current filter',
+    capScope: 'match your filter',
+    narrowHint: 'Narrow the filter, or ask an admin to raise the limit.',
+  },
+  album: {
+    titleScope: 'in this album',
+    capScope: 'are in this album',
+    narrowHint: 'Select photos individually instead, or ask an admin to raise the limit.',
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Props
@@ -128,6 +175,43 @@ const SKIP_REASON_LABELS: { key: keyof BulkEnhanceResult['skipped']; label: stri
 ];
 
 // ---------------------------------------------------------------------------
+// The two NORMAL 400s of POST /media/bulk/enhance/by-filter
+//
+// Neither is a failure. An over-cap match is a REFUSAL — the server never
+// truncates, so nothing was queued and the user is being told the real total so
+// they can act on it. An empty match is an empty match, not an empty batch.
+// Rendering either as "Request failed" would be a lie about what happened.
+// ---------------------------------------------------------------------------
+
+interface OverCapRefusal {
+  matchedCount: number;
+  maxBatchSize: number;
+}
+
+/**
+ * Read the refusal out of an `ApiError`. `details` is the ONLY place these
+ * numbers can travel: the API's `HttpExceptionFilter` rebuilds every error body
+ * from a fixed key allowlist, so a top-level field would never reach us.
+ */
+function readOverCapRefusal(err: unknown): OverCapRefusal | null {
+  if (!(err instanceof ApiError)) return null;
+  const details = err.details;
+  if (!details || typeof details !== 'object') return null;
+  const { matchedCount, maxBatchSize } = details as Record<string, unknown>;
+  if (typeof matchedCount !== 'number' || typeof maxBatchSize !== 'number') return null;
+  return { matchedCount, maxBatchSize };
+}
+
+/** The server's empty-match 400, told apart from a genuine failure. */
+function isNoMatchError(err: unknown): boolean {
+  return (
+    err instanceof ApiError &&
+    err.status === 400 &&
+    /no photos match this filter/i.test(err.message)
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -152,7 +236,8 @@ export function BatchEnhanceDialog({
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   const photoCount = targetPhotoCount(target);
-  const overCap = photoCount > maxBatchSize;
+  const isFilter = target.kind === 'filter';
+  const scopeCopy = target.kind === 'filter' ? FILTER_SCOPE_COPY[target.scope] : null;
 
   // Params state — same vocabulary as the single-item drawer (./enhancePresets)
   const [presetKey, setPresetKey] = useState<PresetKey>('auto');
@@ -168,15 +253,31 @@ export function BatchEnhanceDialog({
   const [error, setError] = useState<string | null>(null);
   /** Set once the batch is queued; the dialog then shows the skip breakdown. */
   const [result, setResult] = useState<BulkEnhanceResult | null>(null);
+  /** Server-reported over-cap refusal (filter mode only). */
+  const [refusal, setRefusal] = useState<OverCapRefusal | null>(null);
+  /** Server-reported empty match (filter mode only). */
+  const [noMatches, setNoMatches] = useState(false);
 
   // A reopened dialog is a fresh decision — never a stale result or error.
   useEffect(() => {
     if (open) {
       setError(null);
       setResult(null);
+      setRefusal(null);
+      setNoMatches(false);
       setSubmitting(false);
     }
   }, [open]);
+
+  // The over-cap gate has two independent sources: a count the client already
+  // knows (courtesy — the server would refuse anyway) and the count the server
+  // reported when it refused. The server's always wins, since it is the only
+  // one derived from the real match set.
+  const effectiveCap = refusal?.maxBatchSize ?? maxBatchSize;
+  const knownMatchCount = refusal?.matchedCount ?? photoCount;
+  const overCap = knownMatchCount !== null && knownMatchCount > effectiveCap;
+  /** Nothing to submit: a known-empty target, or the server said so. */
+  const emptyTarget = noMatches || knownMatchCount === 0;
 
   const formState = useMemo(
     () => ({ presetKey, adjustments, strength, preserveFaces, instructions, quality }),
@@ -193,16 +294,28 @@ export function BatchEnhanceDialog({
     if (key === 'custom') setCustomize(true);
   };
 
-  const submitTarget = async (): Promise<BulkEnhanceResult> =>
-    bulkEnhance({
+  const submitTarget = async (): Promise<BulkEnhanceResult> => {
+    const params = buildEnhanceParams(formState);
+    if (target.kind === 'filter') {
+      // circleId comes from the target, never from `filters`, so the circle the
+      // dialog was opened for and the circle the batch runs in cannot diverge.
+      return bulkEnhanceByFilter({
+        filters: { ...target.filters, circleId: target.circleId } as BulkEnhanceByFilterFilters,
+        params,
+      });
+    }
+    return bulkEnhance({
       circleId: target.circleId,
       ids: target.photoIds,
-      params: buildEnhanceParams(formState),
+      params,
     });
+  };
 
   const handleSubmit = async () => {
     setSubmitting(true);
     setError(null);
+    setRefusal(null);
+    setNoMatches(false);
     try {
       const res = await submitTarget();
       const message = buildResultMessage(res);
@@ -215,10 +328,18 @@ export function BatchEnhanceDialog({
         onClose();
       }
     } catch (err) {
-      // Render the SERVER's message (cap exceeded, feature disabled, no model
-      // configured) inline and leave the dialog open — the selection is still
-      // intact, so the user can act on what they were told.
-      setError(err instanceof Error ? err.message : 'Failed to queue AI enhancements');
+      // Two of the server's 400s are normal outcomes, not failures, and each
+      // gets its own presentation. Everything else renders the SERVER's message
+      // (feature disabled, no model configured) inline; the dialog stays open
+      // either way, so the user can act on what they were told.
+      const capRefusal = readOverCapRefusal(err);
+      if (capRefusal) {
+        setRefusal(capRefusal);
+      } else if (isNoMatchError(err)) {
+        setNoMatches(true);
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to queue AI enhancements');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -230,6 +351,30 @@ export function BatchEnhanceDialog({
   };
 
   const showResult = result !== null;
+
+  // -------------------------------------------------------------------------
+  // Copy
+  //
+  // Filter mode says "all", names the scope, and — the line this whole dialog
+  // exists for — states outright that photos off screen are included. The user
+  // never enumerated this set, so nothing about its size may be left implied.
+  // -------------------------------------------------------------------------
+
+  const titleText = showResult
+    ? 'AI enhancements queued'
+    : scopeCopy
+      ? photoCount !== null
+        ? `Enhance all ${plural(photoCount, 'photo', 'photos')} ${scopeCopy.titleScope}?`
+        : `Enhance all photos ${scopeCopy.titleScope}?`
+      : `Enhance ${plural(photoCount ?? 0, 'photo', 'photos')} with AI`;
+
+  const submitLabel = scopeCopy
+    ? photoCount !== null
+      ? `Enhance ${plural(photoCount, 'photo', 'photos')}`
+      : target.kind === 'filter' && target.scope === 'album'
+        ? 'Enhance all photos in this album'
+        : 'Enhance all matching photos'
+    : `Enhance ${plural(photoCount ?? 0, 'photo', 'photos')}`;
 
   return (
     <Dialog
@@ -243,9 +388,7 @@ export function BatchEnhanceDialog({
       <DialogTitle id="batch-enhance-title" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <AutoFixHighIcon color="primary" fontSize="small" />
         <Box component="span" sx={{ minWidth: 0 }}>
-          {showResult
-            ? 'AI enhancements queued'
-            : `Enhance ${plural(photoCount, 'photo', 'photos')} with AI`}
+          {titleText}
         </Box>
       </DialogTitle>
 
@@ -284,18 +427,37 @@ export function BatchEnhanceDialog({
           <Stack spacing={2}>
             {error && <Alert severity="error">{error}</Alert>}
 
-            {target.nonPhotoCount > 0 && (
+            {target.kind === 'selection' && target.nonPhotoCount > 0 && (
               <Alert severity="info">
                 {plural(target.nonPhotoCount, 'video', 'videos')} in your selection
                 will be skipped. AI Enhance works on photos only.
               </Alert>
             )}
 
-            {overCap && (
+            {noMatches && (
+              <Alert severity="info">
+                <AlertTitle>Nothing to enhance</AlertTitle>
+                {scopeCopy?.capScope === 'are in this album'
+                  ? 'This album has no photos to enhance.'
+                  : 'No photos match your current filter. Adjust the filter and try again.'}
+              </Alert>
+            )}
+
+            {overCap && scopeCopy && knownMatchCount !== null && (
+              // A REFUSAL, not a failure: the server never truncates to the cap,
+              // so nothing was queued and the real total is the actionable fact.
               <Alert severity="warning">
                 <AlertTitle>Too many photos for one batch</AlertTitle>
-                You selected {plural(photoCount, 'photo', 'photos')}; the limit is{' '}
-                {maxBatchSize} per batch. Deselect {photoCount - maxBatchSize}, or ask
+                {plural(knownMatchCount, 'photo', 'photos')} {scopeCopy.capScope}; the
+                limit is {effectiveCap} per batch. {scopeCopy.narrowHint}
+              </Alert>
+            )}
+
+            {overCap && !scopeCopy && knownMatchCount !== null && (
+              <Alert severity="warning">
+                <AlertTitle>Too many photos for one batch</AlertTitle>
+                You selected {plural(knownMatchCount, 'photo', 'photos')}; the limit is{' '}
+                {effectiveCap} per batch. Deselect {knownMatchCount - effectiveCap}, or ask
                 an admin to raise the limit.
               </Alert>
             )}
@@ -427,9 +589,24 @@ export function BatchEnhanceDialog({
 
             {/* Cost confirmation — the count is named, not implied. */}
             <Alert severity="info" icon={<AutoFixHighIcon fontSize="inherit" />}>
-              This will start {plural(photoCount, 'AI enhancement', 'AI enhancements')}.
-              Each one uses AI credits and cannot be undone once started. You&apos;ll
-              review and approve each result before anything changes.
+              {isFilter ? (
+                <>
+                  {photoCount !== null
+                    ? `This starts ${plural(photoCount, 'AI enhancement', 'AI enhancements')}.`
+                    : 'This starts one AI enhancement per matching photo.'}{' '}
+                  Each uses AI credits and cannot be undone once started.{' '}
+                  {/* The sentence this dialog exists for. A filtered batch reaches
+                      photos the user has never laid eyes on; saying so is the only
+                      thing that makes the confirmation informed. */}
+                  <strong>Photos you cannot currently see on screen are included.</strong>
+                </>
+              ) : (
+                <>
+                  This will start {plural(photoCount ?? 0, 'AI enhancement', 'AI enhancements')}.
+                  Each one uses AI credits and cannot be undone once started. You&apos;ll
+                  review and approve each result before anything changes.
+                </>
+              )}
             </Alert>
           </Stack>
         )}
@@ -448,13 +625,13 @@ export function BatchEnhanceDialog({
             <Button
               variant="contained"
               onClick={() => void handleSubmit()}
-              disabled={submitting || overCap || photoCount === 0}
+              disabled={submitting || overCap || emptyTarget}
               startIcon={
                 submitting ? <CircularProgress size={16} /> : <AutoFixHighIcon />
               }
               sx={{ minHeight: 44 }}
             >
-              Enhance {plural(photoCount, 'photo', 'photos')}
+              {submitLabel}
             </Button>
           </>
         )}

--- a/apps/web/src/components/media/BulkActionToolbar.tsx
+++ b/apps/web/src/components/media/BulkActionToolbar.tsx
@@ -125,6 +125,15 @@ interface BulkActionToolbarProps {
   onOpenEnhance?: () => void;
   /** Open the batch enhance dialog for a multi-photo selection. */
   onOpenBatchEnhance?: () => void;
+  /**
+   * Open the batch enhance dialog for EVERY photo matching the view's active
+   * filter, not just the selected ones (issue #424).
+   *
+   * Supplied only when a filter is actually active — the host owns that
+   * decision, since only it knows what its query params mean. Absent (the
+   * default) simply hides the menu item, so no caller has to opt out.
+   */
+  onOpenFilterEnhance?: () => void;
 }
 
 export function BulkActionToolbar({
@@ -148,6 +157,7 @@ export function BulkActionToolbar({
   maxBatchSize,
   onOpenEnhance,
   onOpenBatchEnhance,
+  onOpenFilterEnhance,
 }: BulkActionToolbarProps) {
   const [moreAnchor, setMoreAnchor] = useState<null | HTMLElement>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -172,6 +182,14 @@ export function BulkActionToolbar({
   const openEnhance = isBatchEnhance ? onOpenBatchEnhance : onOpenEnhance;
   const canEnhance =
     Boolean(enhanceEnabled) && enhancePhotoCount > 0 && !isViewer && Boolean(openEnhance);
+
+  /**
+   * "Enhance all matching" — deliberately NOT counted from `selectedItems`.
+   * It acts on the server-resolved match set, which is exactly why the dialog
+   * behind it spells out that off-screen photos are included.
+   */
+  const canFilterEnhance =
+    Boolean(enhanceEnabled) && !isViewer && Boolean(onOpenFilterEnhance);
 
   const enhanceLabel = `AI Enhance ${enhancePhotoCount} photo${enhancePhotoCount !== 1 ? 's' : ''}`;
   const enhanceTooltip =
@@ -398,6 +416,25 @@ export function BulkActionToolbar({
           <ListItemIcon><AutoAwesomeIcon fontSize="small" /></ListItemIcon>
           <ListItemText>Re-run AI tagging</ListItemText>
         </MenuItem>
+        {canFilterEnhance && [
+          <Divider key="filter-enhance-divider" />,
+          <MenuItem
+            key="filter-enhance"
+            onClick={() => {
+              setMoreAnchor(null);
+              onOpenFilterEnhance?.();
+            }}
+            // MenuItem defaults to `white-space: nowrap`; the secondary line is
+            // a sentence, so without this it runs off the popover on a phone.
+            sx={{ whiteSpace: 'normal', maxWidth: 320 }}
+          >
+            <ListItemIcon><AutoFixHighIcon fontSize="small" /></ListItemIcon>
+            <ListItemText
+              primary="Enhance all matching"
+              secondary="Every photo in this filter, not just the selection"
+            />
+          </MenuItem>,
+        ]}
         <Divider />
         <MenuItem onClick={() => { setMoreAnchor(null); void handleFavorite(false); }}>
           <ListItemIcon><StarBorderIcon fontSize="small" /></ListItemIcon>

--- a/apps/web/src/components/media/MediaGallery.tsx
+++ b/apps/web/src/components/media/MediaGallery.tsx
@@ -82,6 +82,7 @@ import { MediaSelectionCheckbox } from './MediaSelectionCheckbox';
 import { MediaLightbox } from './MediaLightbox';
 import { MediaEnhancementDrawer } from './MediaEnhancementDrawer';
 import { BatchEnhanceDialog } from './BatchEnhanceDialog';
+import type { BatchEnhanceTarget } from './BatchEnhanceDialog';
 import { BulkActionToolbar } from './BulkActionToolbar';
 import type { BulkEffect, BulkSuccessOptions } from './BulkActionToolbar';
 import { useFeatureFlags } from '../../hooks/useFeatureFlags';
@@ -736,7 +737,16 @@ export function MediaGallery({
   const enhanceEnabled = Boolean(pictureEnhancement?.enabled);
   const [enhanceOpen, setEnhanceOpen] = useState(false);
 
-  const [batchEnhanceOpen, setBatchEnhanceOpen] = useState(false);
+  /**
+   * Which batch-enhance target the dialog is open for (issue #424), or null
+   * when closed. A single piece of state rather than two booleans, so the two
+   * modes can never both be open — they answer the same question differently
+   * ("these photos" vs "every photo matching this filter") and showing both at
+   * once would be ambiguous about what a click actually enqueues.
+   */
+  const [batchEnhanceKind, setBatchEnhanceKind] = useState<'selection' | 'filter' | null>(
+    null,
+  );
 
   const singleSelectedItem = useMemo<MediaItem | null>(() => {
     if (selected.size !== 1) return null;
@@ -763,6 +773,50 @@ export function MediaGallery({
 
   /** The item the single-photo enhance drawer acts on, if exactly one. */
   const enhanceTargetItem = selectedPhotos.length === 1 ? selectedPhotos[0] : null;
+
+  /**
+   * "Enhance all matching" target (issue #424) — null when the view has no
+   * active filter, which is also how the menu item stays hidden.
+   *
+   * `photoCount` is deliberately null: the gallery is keyset-paginated, so
+   * there is no COUNT(*) to report and the loaded pages are NOT the match set.
+   * The server's over-cap 400 supplies the real `matchedCount` instead — a
+   * plausible-looking number from the loaded pages would be worse than none.
+   */
+  const filterEnhanceTarget = useMemo<BatchEnhanceTarget | null>(() => {
+    // Trash and Archive render their own toolbars and are out of scope for
+    // enhancement entirely; controlled mode has no filter to speak of.
+    if (mode !== 'home' || !queryParams) return null;
+
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      page: _p, pageSize: _ps, cursor: _c, sortBy: _sb, sortOrder: _so,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      circleId: _cid,
+      ...rest
+    } = queryParams;
+
+    const filters = Object.fromEntries(
+      Object.entries(rest).filter(([key, value]) => {
+        if (value === undefined || value === null || value === '') return false;
+        if (Array.isArray(value) && value.length === 0) return false;
+        // In album mode the albumId is the view, not a filter the user applied
+        // — AlbumPage carries its own, better-worded entry point for that set.
+        if (albumId && key === 'albumId') return false;
+        return true;
+      }),
+    );
+
+    if (Object.keys(filters).length === 0) return null;
+
+    return {
+      kind: 'filter',
+      circleId,
+      scope: 'filter',
+      filters,
+      photoCount: null,
+    };
+  }, [mode, queryParams, albumId, circleId]);
 
   // -------------------------------------------------------------------------
   // Bulk success handler
@@ -1063,7 +1117,12 @@ export function MediaGallery({
           enhanceEnabled={enhanceEnabled}
           maxBatchSize={pictureEnhancement?.maxBatchSize}
           onOpenEnhance={() => setEnhanceOpen(true)}
-          onOpenBatchEnhance={() => setBatchEnhanceOpen(true)}
+          onOpenBatchEnhance={() => setBatchEnhanceKind('selection')}
+          // Passed only when a filter is genuinely active — its absence is what
+          // hides the menu item, so no view has to opt out of it explicitly.
+          onOpenFilterEnhance={
+            filterEnhanceTarget ? () => setBatchEnhanceKind('filter') : undefined
+          }
         />
       )}
 
@@ -1326,16 +1385,20 @@ export function MediaGallery({
         />
       )}
 
-      {/* AI enhancement dialog (multi-photo batch) */}
+      {/* AI enhancement dialog (multi-photo batch — selection or filter) */}
       <BatchEnhanceDialog
-        open={batchEnhanceOpen}
-        onClose={() => setBatchEnhanceOpen(false)}
-        target={{
-          kind: 'selection',
-          circleId,
-          photoIds: selectedPhotos.map((it) => it.id),
-          nonPhotoCount: selectedItems.length - selectedPhotos.length,
-        }}
+        open={batchEnhanceKind !== null}
+        onClose={() => setBatchEnhanceKind(null)}
+        target={
+          batchEnhanceKind === 'filter' && filterEnhanceTarget
+            ? filterEnhanceTarget
+            : {
+                kind: 'selection',
+                circleId,
+                photoIds: selectedPhotos.map((it) => it.id),
+                nonPhotoCount: selectedItems.length - selectedPhotos.length,
+              }
+        }
         maxBatchSize={pictureEnhancement?.maxBatchSize ?? 25}
         modelLabel={pictureEnhancement?.model ?? undefined}
         // Queueing changes nothing about the items yet, so this is the ordinary
@@ -1343,7 +1406,7 @@ export function MediaGallery({
         // toast is then re-set with the batch id so it carries a link to the
         // progress page — without it a queued batch vanishes from view.
         onSuccess={(msg, batchId) => {
-          setBatchEnhanceOpen(false);
+          setBatchEnhanceKind(null);
           handleBulkSuccess(msg);
           setSnackbar({ message: msg, severity: 'success', batchId });
         }}

--- a/apps/web/src/components/media/__tests__/MediaGalleryFilterEnhanceExclusion.test.tsx
+++ b/apps/web/src/components/media/__tests__/MediaGalleryFilterEnhanceExclusion.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * MediaGallery — "Enhance all matching" is unreachable from Archive/Trash
+ * (issue #424, epic #420 phase 4).
+ *
+ * `filterEnhanceTarget` (the target that drives the "Enhance all matching"
+ * batch-enhance entry point) is derived only in `mode === 'home'`; Archive and
+ * Trash swap in entirely SEPARATE toolbar components (`ArchiveBulkToolbar` /
+ * `TrashBulkToolbar`) that carry the filter-enhance affordance nowhere at all.
+ * Rather than asserting the internal derivation directly (a white-box check
+ * that could pass even if a future edit wired the callback into the wrong
+ * toolbar), this renders the REAL toolbars with an item selected and proves,
+ * black-box, that "Enhance all matching" never appears anywhere in the tree
+ * while confirming the mode-appropriate toolbar genuinely mounted.
+ *
+ * Mocking strategy mirrors MediaGalleryOriginBadge.test.tsx: heavy sibling
+ * components (lightbox, detail drawer, bulk dialogs) are stubbed, but the
+ * bulk TOOLBARS themselves are left real — the whole point of this file is to
+ * exercise their actual rendered content once something is selected.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../__tests__/utils/test-utils';
+import { MediaGallery } from '../MediaGallery';
+import { listMedia } from '../../../services/media';
+import type { MediaItem } from '../../../types/media';
+import type { PictureEnhancementPolicy } from '../../../services/features';
+
+const mockListMedia = vi.mocked(listMedia);
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared before any imports of the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock('../MediaLightbox', () => ({ MediaLightbox: vi.fn(() => null) }));
+vi.mock('../MediaDetailDrawer', () => ({ MediaDetailDrawer: vi.fn(() => null) }));
+vi.mock('../BulkLocationDialog', () => ({ BulkLocationDialog: vi.fn(() => null) }));
+vi.mock('../BulkTagsDialog', () => ({ BulkTagsDialog: vi.fn(() => null) }));
+vi.mock('../../album/AddToAlbumDialog', () => ({ AddToAlbumDialog: vi.fn(() => null) }));
+
+// The "control group" test uses FEED mode (queryParams) to give
+// filterEnhanceTarget a genuine active filter to work with; the infinite-
+// scroll sentinel is neutered so it never fires an unexpected page-2 load.
+vi.mock('../../../hooks/useIntersectionObserver', () => ({
+  useIntersectionObserver: vi.fn(),
+}));
+
+vi.mock('../../../contexts/MediaPreviewContext', () => ({
+  useMediaPreview: vi.fn(() => ({
+    addPreview: vi.fn(),
+    getPreview: vi.fn(() => undefined),
+    removePreview: vi.fn(),
+    version: 0,
+  })),
+}));
+
+// The feature is deliberately ON here — if "Enhance all matching" could ever
+// leak into Archive/Trash, this is the config that would reveal it; leaving
+// it off would make the absence trivially true for the wrong reason.
+const enabledPictureEnhancement: PictureEnhancementPolicy = {
+  enabled: true,
+  allowReplace: true,
+  blockReplaceOnDownscale: false,
+  model: null,
+  maxBatchSize: 25,
+};
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(() => ({
+    features: {},
+    pictureEnhancement: enabledPictureEnhancement,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../services/media', () => ({
+  patchMedia: vi.fn().mockResolvedValue({}),
+  removeAlbumItem: vi.fn().mockResolvedValue(undefined),
+  listMedia: vi.fn(),
+  getThumbnails: vi.fn().mockResolvedValue([]),
+  bulkArchive: vi.fn(),
+  bulkUnarchive: vi.fn(),
+  bulkDelete: vi.fn(),
+  bulkUpdateMedia: vi.fn(),
+  bulkTags: vi.fn(),
+  bulkRerunTags: vi.fn(),
+  bulkRerunFaces: vi.fn(),
+  bulkRerunThumbnails: vi.fn(),
+  bulkEnhance: vi.fn(),
+  bulkEnhanceByFilter: vi.fn(),
+  restoreFromTrash: vi.fn(),
+  deleteForever: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeItem(id: string, overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    id,
+    storageObjectId: `storage-${id}`,
+    addedById: 'user-001',
+    circleId: 'circle-1',
+    type: 'photo',
+    capturedAt: '2024-06-15T10:00:00.000Z',
+    capturedAtOffset: null,
+    importedAt: null,
+    source: 'web',
+    contentHash: null,
+    width: 1920,
+    height: 1080,
+    durationMs: null,
+    orientation: null,
+    takenLat: null,
+    takenLng: null,
+    takenAltitude: null,
+    cameraMake: null,
+    cameraModel: null,
+    originalFilename: `file-${id}.jpg`,
+    description: null,
+    favorite: false,
+    geoCountry: null,
+    geoCountryCode: null,
+    geoAdmin1: null,
+    geoAdmin2: null,
+    geoLocality: null,
+    geoPlaceName: null,
+    geoSource: null,
+    geocodedAt: null,
+    coordSource: null,
+    createdAt: '2024-06-15T10:00:00.000Z',
+    updatedAt: '2024-06-15T10:00:00.000Z',
+    deletedAt: null,
+    archivedAt: null,
+    metadata: null,
+    thumbnailUrl: `https://cdn.example.com/${id}.jpg`,
+    downloadUrl: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MediaGallery — "Enhance all matching" is unreachable from Archive/Trash', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('archive mode: "Enhance all matching" never appears, even with an item selected and the feature on', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('a1')];
+
+    render(
+      <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" mode="archive" items={items} />,
+    );
+
+    // Select the item so the mode-appropriate toolbar actually mounts.
+    const checkbox = screen.getByRole('button', { name: /select item/i });
+    await user.click(checkbox);
+
+    // Confirms ArchiveBulkToolbar (not BulkActionToolbar) is the live toolbar
+    // — checked BEFORE opening the menu below, since MUI marks the rest of
+    // the page aria-hidden while a Menu popover is open.
+    expect(screen.getByRole('button', { name: /unarchive selected/i })).toBeInTheDocument();
+    expect(screen.queryByText(/enhance all matching/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ai enhance/i)).not.toBeInTheDocument();
+
+    // ArchiveBulkToolbar's own "More actions" overflow menu has no enhance
+    // item at all, so the absence above is not merely "the menu was never
+    // opened" — it genuinely isn't anywhere in this toolbar.
+    const moreButton = screen.getByRole('button', { name: /more actions/i });
+    await user.click(moreButton);
+
+    expect(await screen.findByRole('menuitem', { name: /move to trash/i })).toBeInTheDocument();
+    expect(screen.queryByText(/enhance all matching/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ai enhance/i)).not.toBeInTheDocument();
+  });
+
+  it('trash mode: "Enhance all matching" never appears, even with an item selected and the feature on', async () => {
+    const user = userEvent.setup();
+    const items = [makeItem('t1', { deletedAt: '2024-06-16T00:00:00.000Z' })];
+
+    render(
+      <MediaGallery circleId="circle-1" activeCircleRole="circle_admin" mode="trash" items={items} />,
+    );
+
+    const checkbox = screen.getByRole('button', { name: /select item/i });
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/enhance all matching/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ai enhance/i)).not.toBeInTheDocument();
+  });
+
+  it('home mode (same feature config, same selection) DOES expose "Enhance all matching" when a filter is active — the control group proving the exclusion above is mode-specific, not a broken feature everywhere', async () => {
+    const user = userEvent.setup();
+    mockListMedia.mockResolvedValueOnce({
+      items: [makeItem('h1')],
+      meta: { pageSize: 50, nextCursor: null, hasMore: false },
+    });
+
+    render(
+      <MediaGallery
+        circleId="circle-1"
+        activeCircleRole="circle_admin"
+        mode="home"
+        // FEED mode with a genuinely active filter — this is what makes
+        // `filterEnhanceTarget` non-null and the menu item reachable.
+        queryParams={{ circleId: 'circle-1', tag: 'Beach' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByAltText('file-h1.jpg')).toBeInTheDocument();
+    });
+
+    const checkbox = screen.getByRole('button', { name: /select item/i });
+    await user.click(checkbox);
+
+    const moreButton = await screen.findByRole('button', { name: /more actions/i });
+    await user.click(moreButton);
+
+    expect(screen.getByText('Enhance all matching')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Albums/AlbumPage.tsx
+++ b/apps/web/src/pages/Albums/AlbumPage.tsx
@@ -5,7 +5,8 @@
  * - Back link to /albums
  * - Album title + optional description (loaded via getAlbum)
  * - Icon toolbar: Map, Slideshow, People, Share
- * - Kebab menu (non-viewers): Select album cover / Rename / Delete album
+ * - Kebab menu (non-viewers): Enhance all photos in this album / Select album
+ *   cover / Rename / Delete album
  * - Rename (PATCH) and Delete (DELETE → navigate /albums) dialogs
  * - MediaGallery in FEED + album mode for the album's media items
  * - A dedicated fullscreen slideshow (MediaLightbox with autoPlay)
@@ -26,6 +27,7 @@ import {
   TextField,
   Menu,
   MenuItem,
+  Snackbar,
   Stack,
   Tooltip,
 } from '@mui/material';
@@ -36,11 +38,14 @@ import MapIcon from '@mui/icons-material/Map';
 import SlideshowIcon from '@mui/icons-material/Slideshow';
 import PeopleIcon from '@mui/icons-material/People';
 import ImageIcon from '@mui/icons-material/Image';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useCircle } from '../../hooks/useCircle';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 import { getAlbum, updateAlbum, deleteAlbum } from '../../services/media';
 import type { MediaItem } from '../../types/media';
 import { MediaGallery } from '../../components/media/MediaGallery';
+import { BatchEnhanceDialog } from '../../components/media/BatchEnhanceDialog';
 import { MediaLightbox } from '../../components/media/MediaLightbox';
 import { ShareDialog } from '../../components/share/ShareDialog';
 import { AlbumMapDialog } from '../../components/album/AlbumMapDialog';
@@ -84,6 +89,17 @@ export default function AlbumPage() {
   const [mapOpen, setMapOpen] = useState(false);
   const [peopleOpen, setPeopleOpen] = useState(false);
   const [coverOpen, setCoverOpen] = useState(false);
+
+  // Batch AI enhance for the whole album (issue #424)
+  const [enhanceAllOpen, setEnhanceAllOpen] = useState(false);
+  const [snackbar, setSnackbar] = useState<{ message: string; batchId: string } | null>(
+    null,
+  );
+
+  // `useFeatureFlags` (GET /api/features), never `useSystemSettings` — that one
+  // is Admin-gated and 403s for exactly the collaborators this affordance is for.
+  const { pictureEnhancement } = useFeatureFlags();
+  const enhanceEnabled = Boolean(pictureEnhancement?.enabled);
 
   // Slideshow lightbox — null = closed. Self-contained; does not fight the
   // MediaGallery's own lightbox.
@@ -192,6 +208,11 @@ export default function AlbumPage() {
   }
 
   const isEmpty = albumItems.length === 0;
+
+  // Photos only, matching what the server counts: `startBatchByFilter` pins
+  // `type: photo` (plus non-deleted, non-archived), so counting every member
+  // would promise a batch bigger than the one that actually runs.
+  const albumPhotoCount = albumItems.filter((item) => item.type === 'photo').length;
 
   // No minHeight/pb on this Box — the Layout shell owns viewport height and
   // the BottomNav clearance (issue #237); duplicating either stacks dead
@@ -304,6 +325,18 @@ export default function AlbumPage() {
                   open={Boolean(menuAnchor)}
                   onClose={() => setMenuAnchor(null)}
                 >
+                  {enhanceEnabled && (
+                    <MenuItem
+                      disabled={albumPhotoCount === 0}
+                      onClick={() => {
+                        setMenuAnchor(null);
+                        setEnhanceAllOpen(true);
+                      }}
+                    >
+                      <AutoFixHighIcon fontSize="small" sx={{ mr: 1 }} />
+                      Enhance all photos in this album
+                    </MenuItem>
+                  )}
                   <MenuItem
                     disabled={isEmpty}
                     onClick={() => {
@@ -403,12 +436,63 @@ export default function AlbumPage() {
         onSave={handleSaveCover}
       />
 
+      {/* Batch AI enhance — every photo in the album, not a selection (#424).
+          The count is exact: getAlbum returns the album's whole item list and
+          already excludes deleted/archived, the same rows the server counts. */}
+      <BatchEnhanceDialog
+        open={enhanceAllOpen}
+        onClose={() => setEnhanceAllOpen(false)}
+        target={{
+          kind: 'filter',
+          circleId: activeCircle.id,
+          scope: 'album',
+          filters: { albumId },
+          photoCount: albumPhotoCount,
+        }}
+        maxBatchSize={pictureEnhancement?.maxBatchSize ?? 25}
+        modelLabel={pictureEnhancement?.model ?? undefined}
+        onSuccess={(message, batchId) => {
+          setEnhanceAllOpen(false);
+          setSnackbar({ message, batchId });
+        }}
+      />
+
       {/* Share dialog */}
       <ShareDialog
         open={shareDialogOpen}
         onClose={() => setShareDialogOpen(false)}
         target={{ type: 'album', id: albumId }}
       />
+
+      {/* Queued-batch toast. Actionable, and long enough to actually act on —
+          without the link a queued batch has no visible home to go back to. */}
+      <Snackbar
+        open={snackbar !== null}
+        autoHideDuration={10000}
+        onClose={() => setSnackbar(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbar(null)}
+          severity="success"
+          sx={{ width: '100%' }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => {
+                const id = snackbar?.batchId;
+                setSnackbar(null);
+                if (id) navigate(`/enhancement-batches/${id}`);
+              }}
+            >
+              View progress
+            </Button>
+          }
+        >
+          {snackbar?.message}
+        </Alert>
+      </Snackbar>
 
       {/* Rename dialog */}
       <Dialog open={renameOpen} onClose={() => setRenameOpen(false)} maxWidth="xs" fullWidth>

--- a/apps/web/src/pages/Albums/__tests__/AlbumPage.test.tsx
+++ b/apps/web/src/pages/Albums/__tests__/AlbumPage.test.tsx
@@ -43,6 +43,26 @@ vi.mock('../../../hooks/useCircle', () => ({
   useCircle: vi.fn(),
 }));
 
+// Default matches the MSW `/api/features` fixture's shape (pictureEnhancement
+// disabled) so every pre-existing test in this file is unaffected; tests that
+// specifically cover the "Enhance all photos in this album" entry point
+// (issue #424) override it with `mockUseFeatureFlags.mockReturnValue(...)`.
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: vi.fn(() => ({
+    features: {},
+    pictureEnhancement: {
+      enabled: false,
+      allowReplace: true,
+      blockReplaceOnDownscale: false,
+      model: null,
+      maxBatchSize: 25,
+    },
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
 vi.mock('../../../services/media', () => ({
   getAlbum: vi.fn(),
   updateAlbum: vi.fn(),
@@ -61,13 +81,76 @@ vi.mock('../../../components/media/MediaGallery', () => ({
 import AlbumPage from '../AlbumPage';
 import { useParams } from 'react-router-dom';
 import { useCircle } from '../../../hooks/useCircle';
+import { useFeatureFlags } from '../../../hooks/useFeatureFlags';
 import { getAlbum, updateAlbum, deleteAlbum } from '../../../services/media';
+import type { MediaItem } from '../../../types/media';
 
 const mockUseParams = vi.mocked(useParams);
 const mockUseCircle = vi.mocked(useCircle);
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
 const mockGetAlbum = vi.mocked(getAlbum);
 const mockUpdateAlbum = vi.mocked(updateAlbum);
 const mockDeleteAlbum = vi.mocked(deleteAlbum);
+
+/** Enables pictureEnhancement in useFeatureFlags for one test. */
+function enableEnhance() {
+  mockUseFeatureFlags.mockReturnValue({
+    features: {},
+    pictureEnhancement: {
+      enabled: true,
+      allowReplace: true,
+      blockReplaceOnDownscale: false,
+      model: 'gpt-image-1',
+      maxBatchSize: 25,
+    },
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  });
+}
+
+function makeAlbumPhoto(id: string): MediaItem {
+  return {
+    id,
+    storageObjectId: `storage-${id}`,
+    addedById: 'user-1',
+    circleId: 'circle-1',
+    type: 'photo',
+    capturedAt: null,
+    capturedAtOffset: null,
+    importedAt: null,
+    source: 'web',
+    contentHash: null,
+    width: null,
+    height: null,
+    durationMs: null,
+    orientation: null,
+    takenLat: null,
+    takenLng: null,
+    takenAltitude: null,
+    cameraMake: null,
+    cameraModel: null,
+    originalFilename: `${id}.jpg`,
+    description: null,
+    favorite: false,
+    geoCountry: null,
+    geoCountryCode: null,
+    geoAdmin1: null,
+    geoAdmin2: null,
+    geoLocality: null,
+    geoPlaceName: null,
+    geoSource: null,
+    geocodedAt: null,
+    coordSource: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    deletedAt: null,
+    archivedAt: null,
+    metadata: null,
+    thumbnailUrl: null,
+    downloadUrl: null,
+  } as MediaItem;
+}
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -382,6 +465,108 @@ describe('AlbumPage', () => {
 
       expect(screen.getByRole('alert')).toBeInTheDocument();
       expect(screen.getByRole('alert')).toHaveTextContent(/album not found/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. "Enhance all photos in this album" — the album-scope batch-enhance
+  // entry point (issue #424, epic #420 phase 4). Gated on the
+  // `pictureEnhancement` feature flag (GET /api/features, via
+  // `useFeatureFlags` — never the Admin-only `useSystemSettings`, since this
+  // affordance is for ordinary collaborators) and, like every item in the
+  // album actions menu, on `canManage` (non-viewer).
+  // -------------------------------------------------------------------------
+  describe('"Enhance all photos in this album" entry point', () => {
+    // `mockUseFeatureFlags.mockReturnValue(...)` persists across tests (only
+    // `.mock.calls` are cleared by the outer `vi.clearAllMocks()`, not the
+    // configured return value) — reset explicitly so "feature off" tests are
+    // never accidentally inheriting a prior test's "feature on" override.
+    beforeEach(() => {
+      mockUseFeatureFlags.mockReturnValue({
+        features: {},
+        pictureEnhancement: {
+          enabled: false,
+          allowReplace: true,
+          blockReplaceOnDownscale: false,
+          model: null,
+          maxBatchSize: 25,
+        },
+        isLoading: false,
+        error: null,
+        refresh: vi.fn(),
+      });
+    });
+
+    it('appears in the album actions menu when the feature is enabled and the caller can manage the album', async () => {
+      enableEnhance();
+      setupDefaults();
+      mockGetAlbum.mockResolvedValue({
+        ...defaultAlbumDetail,
+        items: [makeAlbumPhoto('p1'), makeAlbumPhoto('p2')],
+      } as any);
+      const user = userEvent.setup();
+      render(<AlbumPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /summer 2024/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /album actions/i }));
+
+      expect(screen.getByText('Enhance all photos in this album')).toBeInTheDocument();
+    });
+
+    it('is ABSENT when the pictureEnhancement feature flag is off', async () => {
+      // Default mock (feature disabled) applies — enableEnhance() not called.
+      setupDefaults();
+      const user = userEvent.setup();
+      render(<AlbumPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /summer 2024/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /album actions/i }));
+
+      expect(screen.queryByText('Enhance all photos in this album')).not.toBeInTheDocument();
+      // The rest of the menu is unaffected — this is a targeted omission, not
+      // a broken menu.
+      expect(screen.getByText(/^rename$/i)).toBeInTheDocument();
+    });
+
+    it('is ABSENT for viewer role, even with the feature enabled (the whole album actions menu is unreachable)', async () => {
+      enableEnhance();
+      setupDefaults({ role: 'viewer' });
+      render(<AlbumPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /summer 2024/i })).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('button', { name: /album actions/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Enhance all photos in this album')).not.toBeInTheDocument();
+    });
+
+    it('opens the BatchEnhanceDialog with an album-scope filter target when clicked', async () => {
+      enableEnhance();
+      setupDefaults();
+      mockGetAlbum.mockResolvedValue({
+        ...defaultAlbumDetail,
+        items: [makeAlbumPhoto('p1'), makeAlbumPhoto('p2')],
+      } as any);
+      const user = userEvent.setup();
+      render(<AlbumPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /summer 2024/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /album actions/i }));
+      await user.click(screen.getByText('Enhance all photos in this album'));
+
+      // Album-scope copy: "in this album", never the generic filter wording.
+      expect(
+        await screen.findByText('Enhance all 2 photos in this album?'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/services/media.ts
+++ b/apps/web/src/services/media.ts
@@ -458,6 +458,82 @@ export async function bulkEnhance(dto: BulkEnhanceDto): Promise<BulkEnhanceResul
   return api.post<BulkEnhanceResult>('/media/bulk/enhance', dto);
 }
 
+/**
+ * The filter half of a bulk enhance (issue #424). Exactly the filter vocabulary
+ * `GET /api/media` accepts, minus everything that only describes a PAGE of
+ * results — the server resolves the whole match set, so pagination and ordering
+ * are meaningless (and `sortBy`/`sortOrder` would imply a "first N", which this
+ * endpoint deliberately never does: it refuses an over-cap match rather than
+ * truncating it).
+ */
+export type BulkEnhanceByFilterFilters = Omit<
+  MediaQueryParams,
+  'page' | 'pageSize' | 'cursor' | 'sortBy' | 'sortOrder'
+> & { circleId: string };
+
+export interface BulkEnhanceByFilterDto {
+  filters: BulkEnhanceByFilterFilters;
+  /** One params object applies to EVERY match — a batch is a single intent. */
+  params?: EnhanceParams;
+}
+
+/**
+ * Keys the endpoint's DTO does not model, stripped before sending.
+ *
+ * `excludeArchived` is dropped rather than forwarded because the server pins
+ * `archivedAt: null` unconditionally — archived photos are never in the match
+ * set — so sending it would suggest a choice the caller does not have.
+ */
+const BULK_ENHANCE_FILTER_DROP = new Set(['excludeArchived']);
+
+/**
+ * Serialize a filter object for the JSON body.
+ *
+ * `bulkEnhanceByFilterSchema` spreads the API's shared `mediaFilterFields`,
+ * which is written for a QUERY STRING: its boolean-ish fields (`favorite`,
+ * `missingGeo`, `noFaces`, …) are `z.string().transform(...)`, so a real JSON
+ * `true` transforms to `undefined` and the filter is silently DROPPED. Dropping
+ * a filter WIDENS the match set, which on this endpoint means enhancing photos
+ * the user never asked about — so booleans are stringified here rather than
+ * left to chance. Undefined/null entries are omitted entirely.
+ */
+function serializeEnhanceFilters(
+  filters: BulkEnhanceByFilterFilters,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === undefined || value === null) continue;
+    if (BULK_ENHANCE_FILTER_DROP.has(key)) continue;
+    body[key] = typeof value === 'boolean' ? String(value) : value;
+  }
+  return body;
+}
+
+/**
+ * Queue one AI enhancement per photo MATCHING A FILTER, rather than per
+ * explicitly selected id (epic #420, issue #424).
+ *
+ * The server resolves the match set, so the client never enumerates it. Two
+ * failure shapes are normal rather than exceptional and callers are expected to
+ * render both distinctly:
+ *
+ *   400 with `details: { matchedCount, maxBatchSize }` — a REFUSAL. The match
+ *       exceeds the batch cap and nothing was queued; `matchedCount` is the
+ *       only place a keyset-paginated caller can learn the real total.
+ *   400 "No photos match this filter" — an empty match, never an empty batch.
+ *
+ * Both arrive as `ApiError`, which already carries `details` through from the
+ * response body, so no extra plumbing is needed to read `matchedCount`.
+ */
+export async function bulkEnhanceByFilter(
+  dto: BulkEnhanceByFilterDto,
+): Promise<BulkEnhanceResult> {
+  return api.post<BulkEnhanceResult>('/media/bulk/enhance/by-filter', {
+    ...serializeEnhanceFilters(dto.filters),
+    ...(dto.params ? { params: dto.params } : {}),
+  });
+}
+
 export async function bulkUnarchive(dto: BulkArchiveDto): Promise<{ unarchived: number }> {
   return api.patch<{ unarchived: number }>('/media/bulk/unarchive', dto);
 }


### PR DESCRIPTION
## Summary

Phase 4 of epic #420: `POST /api/media/bulk/enhance/by-filter`, plus a filter mode on the existing dialog. Selection is bounded by what is on screen; this lets a user enhance "all 60 photos in the Christmas 1994 album" without scrolling and shift-selecting a screenful at a time.

**This is the phase that can cost the most money from a single click** — the only path where one click enqueues a batch the user never enumerated. Every guard below exists for that reason.

**The endpoint never truncates.** A filter matching 412 photos with a cap of 25 is refused with both numbers, not silently reduced to "the first 25" chosen by an ordering the user cannot see. That is the central design decision of the phase.

Stacked on #430 → #429 → #427. **Review those first**; the diff here is Phase 4 only.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue) — the `AND`-collision fix below

## Related Issues

Fixes #424
Relates to #420, depends on #421, #422, #423
Surfaces #431 (pre-existing, filed separately)

## Changes Made

**Three traps in resolving the match, each load-bearing:**

1. **`buildMediaWhere` never filters `deletedAt`** — its `excludeArchived` flag only touches `archivedAt`. Without an explicit `deletedAt: null`, this would spend real money rendering photos sitting in the Trash. Both predicates are pinned explicitly rather than relying on the flag.
2. **Photo-only is in the SQL, not a post-filter** — so the count the user is shown is the count that will actually run. Counting videos and then skipping them would make the cap check lie.
3. **Count first, refuse loudly, never truncate** — with `details.matchedCount` / `details.maxBatchSize` in the error body. `details`, not top-level: `HttpExceptionFilter` rebuilds every body from a fixed key allowlist and silently drops top-level custom fields, while `getResponse()` in a unit test still shows them present. There is a test asserting the **serialized** body through the real filter.

The resolved ids delegate to the same `createBatchFrom` internals Phase 1 extracted, with `source: 'filter'` and the filter snapshot stored for provenance. `alreadyLive` items are still skipped rather than superseded.

**Web** — no second dialog. Phase 2 built `BatchEnhanceDialog` around a `target` discriminated union precisely so this phase adds a `kind: 'filter'` member. Entry points are "Enhance all matching" in the gallery overflow (only with an active filter) and "Enhance all photos in this album" on `AlbumPage`, both gated on `useFeatureFlags()` and the collaborator role. The confirmation copy is stronger than Phase 2's, because the user did not enumerate these photos:

> This starts 23 AI enhancements. Each uses AI credits and cannot be undone once started. **Photos you cannot currently see on screen are included.**

Over-cap renders as a *refusal* using the server's `details.matchedCount` ("Narrow the filter, or ask an admin to raise the limit"), and zero-match as its own "nothing to enhance" state — neither reads as a failure.

## Testing

- [x] Unit tests pass (`npm test`) — API **336 suites / 8024 tests**, web **256 files / 5097 tests**; +35 API, +33 web, 0 regressions
- [x] Type checks pass (`npm run typecheck`) — both apps
- [ ] E2E tests pass (if applicable) — n/a
- [ ] Manual testing completed — **not performed**; no running app, database or OpenAI credential in this environment

The trashed-item exclusion has its own dedicated test — it is the highest-consequence regression in the epic. Also covered: archived and video exclusion asserted independently, people-filter composition, the never-truncate refusal (no batch created, no job enqueued), the error envelope through the real `HttpExceptionFilter`, the route-collision guard, and filter parity (every `mediaFilterFields` key reaches `buildMediaWhere` — a field added to the DTO but forgotten in the passthrough is the realistic failure).

### Test Instructions

1. Filter the gallery to a handful of photos → "Enhance all matching" in the overflow → confirm the dialog names the count and includes the off-screen sentence.
2. Filter to more than `maxBatchSize` → confirm a refusal naming the real total, and that **nothing is enqueued**.
3. Filter to zero photos → distinct "nothing to enhance" message.
4. Put a photo in the Trash that otherwise matches the filter → confirm it is **not** enhanced.
5. Confirm a video matching the filter is excluded from the count itself, not skipped afterwards.
6. Album detail → "Enhance all photos in this album".

## Additional Notes

**Two fixes beyond the issue's brief, both found during implementation:**

1. **Authorization now runs *before* the count.** `startBatch` orders feature → model → cap → auth, but its cap is a pure count of client-supplied ids and touches no data. This one's cap requires `count()` over the circle, so returning `matchedCount` to a non-member would leak how many photos a circle holds under a given filter. There is a test asserting `prisma.mediaItem.count` is never reached on the 403 path.

2. **`wherePeople('all')` was clobbering every other filter.** `buildMediaWhere` returns `{ AND: [...] }`, and so does `wherePeople(ids, 'all')` — so the object spread let the people `AND` silently overwrite the filter `AND`, dropping conditions and **widening** the match set. On this endpoint that means paying to enhance photos the filter never described. Fixed here by merging the arrays instead of spreading, with a comment naming the collision.

   The same collision exists at two **pre-existing** call sites (`MediaService.listMedia`, `addAlbumItemsByFilter`) which still spread. Fixing the shared builder would change gallery and album behaviour app-wide, so it is out of scope here and filed as **#431**. The resulting asymmetry is deliberate and safe in this direction: this endpoint resolves the *narrower, correct* set and refuses rather than truncates, so it can never overcharge — but note the gallery may show more photos than this endpoint reports as matching for that specific filter combination, until #431 lands.

**The service stringifies booleans deliberately.** `mediaFilterFields`' boolean-ish fields are `z.string().transform(...)` (query-string oriented, inherited from the `AddAlbumItemsByFilterDto` precedent), so a real JSON `true` transforms to `undefined` and the filter is **silently dropped** — which on this endpoint widens the match set. `serializeEnhanceFilters` converts them to `"true"`/`"false"` rather than leaving that to chance, and there is an explicit test. Note the pre-existing `addAlbumItemsByFilter` client path sends raw booleans and has the same latent drop; left alone as out of scope.

**`photoCount` is `number | null`, not a fallback.** In keyset mode there is no `COUNT(*)` and the loaded pages are not the match set, so the dialog says "all photos matching your current filter" and lets the server's 400 supply the real total, rather than showing a plausible-looking wrong number. The album path *does* have an exact count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXs8GNhptV9NvqDTyX3E9A)_