### PR TITLE
feat(api): multi-image vision requests (send N frames in one AI call)

### DIFF
--- a/apps/api/src/ai/providers/ai-provider.interface.ts
+++ b/apps/api/src/ai/providers/ai-provider.interface.ts
@@ -54,14 +54,36 @@ export type ChatStreamEvent =
   | { type: 'tool_call'; id: string; name: string; input: unknown }
   | { type: 'done'; stopReason?: string };
 
+export interface AnalyzeImageInputImage {
+  /** Raw base64-encoded image data — no `data:` URI prefix. */
+  base64: string;
+  /** MIME type, e.g. 'image/jpeg' */
+  mimeType: string;
+}
+
 export interface AnalyzeImageRequest {
   model: string;
   system?: string;
   prompt: string;
-  /** Raw base64-encoded image data — no `data:` URI prefix. */
-  imageBase64: string;
-  /** MIME type, e.g. 'image/jpeg' */
-  mimeType: string;
+  /**
+   * Single-image form. Ignored when `images` is present and non-empty.
+   * Optional only so the multi-image form can omit it — a request supplying
+   * neither form throws before any network call.
+   */
+  imageBase64?: string;
+  /** MIME type of `imageBase64`, e.g. 'image/jpeg' */
+  mimeType?: string;
+  /**
+   * Multi-image form — ORDERED; the model sees the images in array order.
+   * Lets video auto-tagging send N frames sampled across a video in ONE call
+   * (issue #453) rather than N calls. Takes precedence over `imageBase64`.
+   */
+  images?: AnalyzeImageInputImage[];
+  /**
+   * Per-request output token budget. Absent keeps each provider's existing
+   * default, so every pre-existing caller sends an unchanged request.
+   */
+  maxTokens?: number;
 }
 
 export interface EnhanceImageRequest {

--- a/apps/api/src/ai/providers/openai.provider.ts
+++ b/apps/api/src/ai/providers/openai.provider.ts
@@ -282,6 +282,8 @@ export class OpenAiProvider implements AiProvider {
         prompt: req.prompt,
         imageBase64: req.imageBase64,
         mimeType: req.mimeType,
+        images: req.images,
+        maxTokens: req.maxTokens,
       },
     );
   }

--- a/packages/enrichment-compute/src/ai/index.ts
+++ b/packages/enrichment-compute/src/ai/index.ts
@@ -50,14 +50,60 @@ export interface AnthropicVisionCredentials {
   baseUrl?: string;
 }
 
+/**
+ * Default Anthropic output budget for a vision call. Comfortable for a
+ * photo's tag list plus a one-line description; a multi-frame video summary
+ * raises it per-request via `AnthropicVisionRequest.maxTokens` rather than
+ * moving this default, so the photo path stays byte-identical.
+ */
+const ANTHROPIC_VISION_MAX_TOKENS = 1024;
+
+export interface VisionImage {
+  /** Raw base64-encoded image data — no `data:` URI prefix. */
+  base64: string;
+  /** MIME type, e.g. 'image/jpeg' */
+  mimeType: string;
+}
+
 export interface AnthropicVisionRequest {
   model: string;
   system?: string;
   prompt: string;
-  /** Raw base64-encoded image data — no `data:` URI prefix. */
-  imageBase64: string;
-  /** MIME type, e.g. 'image/jpeg' */
-  mimeType: string;
+  /**
+   * Single-image form. Ignored when `images` is present and non-empty.
+   * Optional only so the multi-image form can omit it — one of the two forms
+   * must supply at least one image or the call throws before any network I/O.
+   */
+  imageBase64?: string;
+  /** MIME type of `imageBase64`, e.g. 'image/jpeg' */
+  mimeType?: string;
+  /**
+   * Multi-image form — ORDERED; the model sees the images in array order.
+   * Used by video auto-tagging to send N frames sampled across a video in a
+   * single call (issue #453). Takes precedence over `imageBase64`/`mimeType`.
+   */
+  images?: VisionImage[];
+  /**
+   * Per-request output token budget. Absent keeps each provider's existing
+   * default, so every pre-existing caller sends a byte-identical request.
+   */
+  maxTokens?: number;
+}
+
+/**
+ * Normalizes the two request forms into one ordered image list. Throws before
+ * any network call when neither form supplies an image — a malformed request
+ * is cheaper to reject here than to have the provider reject it after a
+ * round trip (and, on a rate-limited account, after burning a retry).
+ */
+function resolveVisionImages(req: AnthropicVisionRequest): VisionImage[] {
+  if (req.images && req.images.length > 0) return req.images;
+  if (req.imageBase64 && req.mimeType) {
+    return [{ base64: req.imageBase64, mimeType: req.mimeType }];
+  }
+  throw new Error(
+    'Vision request requires at least one image: supply `imageBase64` + `mimeType`, or a non-empty `images` array',
+  );
 }
 
 /**
@@ -75,31 +121,28 @@ export async function callAnthropicVision(
     ...(creds.baseUrl && { baseURL: creds.baseUrl }),
   });
 
+  const images = resolveVisionImages(req);
+
+  // Image blocks first, then the single text block — the same ordering the
+  // single-image form has always produced, so a one-image request is
+  // byte-identical to what this function sent before multi-image support.
+  const content: Anthropic.ContentBlockParam[] = images.map((image) => ({
+    type: 'image' as const,
+    source: {
+      type: 'base64' as const,
+      media_type: image.mimeType as Anthropic.Base64ImageSource['media_type'],
+      data: image.base64,
+    },
+  }));
+  content.push({ type: 'text' as const, text: req.prompt });
+
   let response: Anthropic.Message;
   try {
     response = await client.messages.create({
       model: req.model,
-      max_tokens: 1024,
+      max_tokens: req.maxTokens ?? ANTHROPIC_VISION_MAX_TOKENS,
       ...(req.system && { system: req.system }),
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'image',
-              source: {
-                type: 'base64',
-                media_type: req.mimeType as Anthropic.Base64ImageSource['media_type'],
-                data: req.imageBase64,
-              },
-            },
-            {
-              type: 'text',
-              text: req.prompt,
-            },
-          ],
-        },
-      ],
+      messages: [{ role: 'user', content }],
     });
   } catch (err) {
     throw classifyAnthropicRateLimit(err) ?? err;
@@ -155,6 +198,8 @@ export async function callOpenAiVision(
   creds: AnthropicVisionCredentials,
   req: AnthropicVisionRequest,
 ): Promise<string> {
+  const images = resolveVisionImages(req);
+
   const client = new OpenAI({
     apiKey: creds.apiKey,
     ...(creds.baseUrl && { baseURL: creds.baseUrl }),
@@ -166,28 +211,32 @@ export async function callOpenAiVision(
     messages.push({ role: 'system', content: req.system });
   }
 
-  messages.push({
-    role: 'user',
-    content: [
-      {
-        type: 'text',
-        text: req.prompt,
+  // Text block first, then the image blocks — the same ordering the
+  // single-image form has always produced, so a one-image request is
+  // byte-identical to what this function sent before multi-image support.
+  const content: OpenAI.ChatCompletionContentPart[] = [
+    {
+      type: 'text',
+      text: req.prompt,
+    },
+  ];
+  for (const image of images) {
+    content.push({
+      type: 'image_url',
+      image_url: {
+        url: `data:${image.mimeType};base64,${image.base64}`,
       },
-      {
-        type: 'image_url',
-        image_url: {
-          url: `data:${req.mimeType};base64,${req.imageBase64}`,
-        },
-      },
-    ],
-  });
+    });
+  }
+
+  messages.push({ role: 'user', content });
 
   let response: OpenAI.ChatCompletion;
   try {
     response = await client.chat.completions.create({
       model: req.model,
       reasoning_effort: OPENAI_REASONING_EFFORT as any,
-      max_completion_tokens: ANALYZE_IMAGE_MAX_COMPLETION_TOKENS,
+      max_completion_tokens: req.maxTokens ?? ANALYZE_IMAGE_MAX_COMPLETION_TOKENS,
       messages,
     });
   } catch (err) {

--- a/packages/enrichment-compute/test/ai-openai.test.mjs
+++ b/packages/enrichment-compute/test/ai-openai.test.mjs
@@ -260,3 +260,114 @@ test('callOpenAiVision rethrows non-rate-limit errors unchanged (e.g. HTTP 400)'
     globalThis.fetch = originalFetch;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Multi-image support (issue #453)
+// ---------------------------------------------------------------------------
+
+test('callOpenAiVision emits the text block first, then one image_url block per `images` entry in array order', async () => {
+  const { callOpenAiVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const { captured, restore } = stubFetchOnce(makeOpenAiChatCompletionResponse('ok'));
+
+  try {
+    await callOpenAiVision(
+      { apiKey: 'sk-test-key' },
+      {
+        model: 'gpt-5-mini',
+        prompt: 'Summarize this video.',
+        images: [
+          { base64: 'ZnJhbWUtMA==', mimeType: 'image/jpeg' },
+          { base64: 'ZnJhbWUtMQ==', mimeType: 'image/png' },
+        ],
+      },
+    );
+
+    const [userMessage] = captured.body.messages;
+    assert.equal(userMessage.content.length, 3, 'one text block plus two image blocks');
+    assert.equal(userMessage.content[0].type, 'text');
+    assert.equal(userMessage.content[0].text, 'Summarize this video.');
+
+    assert.deepEqual(
+      userMessage.content.slice(1).map((b) => [b.type, b.image_url.url]),
+      [
+        ['image_url', 'data:image/jpeg;base64,ZnJhbWUtMA=='],
+        ['image_url', 'data:image/png;base64,ZnJhbWUtMQ=='],
+      ],
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('callOpenAiVision prefers a non-empty `images` array over the single-image fields', async () => {
+  const { callOpenAiVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const { captured, restore } = stubFetchOnce(makeOpenAiChatCompletionResponse('ok'));
+
+  try {
+    await callOpenAiVision(
+      { apiKey: 'sk-test-key' },
+      {
+        model: 'gpt-5-mini',
+        prompt: 'p',
+        imageBase64: 'c2luZ2xl',
+        mimeType: 'image/jpeg',
+        images: [{ base64: 'bXVsdGk=', mimeType: 'image/jpeg' }],
+      },
+    );
+
+    const [userMessage] = captured.body.messages;
+    assert.equal(userMessage.content.length, 2);
+    assert.equal(userMessage.content[1].image_url.url, 'data:image/jpeg;base64,bXVsdGk=');
+  } finally {
+    restore();
+  }
+});
+
+test('callOpenAiVision honors `maxTokens`, and defaults to 4096 when absent', async () => {
+  const { callOpenAiVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const overridden = stubFetchOnce(makeOpenAiChatCompletionResponse('ok'));
+  try {
+    await callOpenAiVision(
+      { apiKey: 'sk-test-key' },
+      { model: 'gpt-5-mini', prompt: 'p', imageBase64: 'ZmFrZQ==', mimeType: 'image/jpeg', maxTokens: 8192 },
+    );
+    assert.equal(overridden.captured.body.max_completion_tokens, 8192);
+  } finally {
+    overridden.restore();
+  }
+
+  const defaulted = stubFetchOnce(makeOpenAiChatCompletionResponse('ok'));
+  try {
+    await callOpenAiVision(
+      { apiKey: 'sk-test-key' },
+      { model: 'gpt-5-mini', prompt: 'p', imageBase64: 'ZmFrZQ==', mimeType: 'image/jpeg' },
+    );
+    assert.equal(defaulted.captured.body.max_completion_tokens, 4096);
+  } finally {
+    defaulted.restore();
+  }
+});
+
+test('callOpenAiVision throws before any network call when no image is supplied', async () => {
+  const { callOpenAiVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const originalFetch = globalThis.fetch;
+  let fetched = false;
+  globalThis.fetch = async () => {
+    fetched = true;
+    throw new Error('should never be called');
+  };
+
+  try {
+    await assert.rejects(
+      () => callOpenAiVision({ apiKey: 'sk-test-key' }, { model: 'm', prompt: 'p' }),
+      /at least one image/i,
+    );
+    assert.equal(fetched, false, 'no request should be sent for a request with no image');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/enrichment-compute/test/ai.test.mjs
+++ b/packages/enrichment-compute/test/ai.test.mjs
@@ -276,3 +276,154 @@ test('callAnthropicVision routes requests through creds.baseUrl when provided', 
     restore();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Multi-image support (issue #453)
+// ---------------------------------------------------------------------------
+
+test('callAnthropicVision emits one image block per `images` entry, in array order, before the text block', async () => {
+  const { callAnthropicVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const { captured, restore } = stubFetchOnce(makeAnthropicMessageResponse(['ok']));
+
+  try {
+    await callAnthropicVision(
+      { apiKey: 'sk-test-key' },
+      {
+        model: 'claude-3-5-sonnet-20241022',
+        prompt: 'Summarize this video.',
+        images: [
+          { base64: 'ZnJhbWUtMA==', mimeType: 'image/jpeg' },
+          { base64: 'ZnJhbWUtMQ==', mimeType: 'image/png' },
+          { base64: 'ZnJhbWUtMg==', mimeType: 'image/webp' },
+        ],
+      },
+    );
+
+    const [message] = captured.body.messages;
+    assert.equal(message.content.length, 4, 'three image blocks plus one text block');
+
+    // Array order is preserved and per-image mimeType is respected (frames are
+    // JPEG in practice, but the type must not be assumed).
+    assert.deepEqual(
+      message.content.slice(0, 3).map((b) => [b.type, b.source.media_type, b.source.data]),
+      [
+        ['image', 'image/jpeg', 'ZnJhbWUtMA=='],
+        ['image', 'image/png', 'ZnJhbWUtMQ=='],
+        ['image', 'image/webp', 'ZnJhbWUtMg=='],
+      ],
+    );
+
+    assert.equal(message.content[3].type, 'text');
+    assert.equal(message.content[3].text, 'Summarize this video.');
+  } finally {
+    restore();
+  }
+});
+
+test('callAnthropicVision prefers a non-empty `images` array over the single-image fields', async () => {
+  const { callAnthropicVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const { captured, restore } = stubFetchOnce(makeAnthropicMessageResponse(['ok']));
+
+  try {
+    await callAnthropicVision(
+      { apiKey: 'sk-test-key' },
+      {
+        model: 'claude-3-5-sonnet-20241022',
+        prompt: 'p',
+        imageBase64: 'c2luZ2xl',
+        mimeType: 'image/jpeg',
+        images: [{ base64: 'bXVsdGk=', mimeType: 'image/jpeg' }],
+      },
+    );
+
+    const [message] = captured.body.messages;
+    assert.equal(message.content.length, 2);
+    assert.equal(message.content[0].source.data, 'bXVsdGk=');
+  } finally {
+    restore();
+  }
+});
+
+test('callAnthropicVision falls back to the single-image fields when `images` is an empty array', async () => {
+  const { callAnthropicVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const { captured, restore } = stubFetchOnce(makeAnthropicMessageResponse(['ok']));
+
+  try {
+    await callAnthropicVision(
+      { apiKey: 'sk-test-key' },
+      {
+        model: 'claude-3-5-sonnet-20241022',
+        prompt: 'p',
+        imageBase64: 'c2luZ2xl',
+        mimeType: 'image/jpeg',
+        images: [],
+      },
+    );
+
+    const [message] = captured.body.messages;
+    assert.equal(message.content.length, 2);
+    assert.equal(message.content[0].source.data, 'c2luZ2xl');
+  } finally {
+    restore();
+  }
+});
+
+test('callAnthropicVision honors `maxTokens`, and defaults to 1024 when absent', async () => {
+  const { callAnthropicVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const overridden = stubFetchOnce(makeAnthropicMessageResponse(['ok']));
+  try {
+    await callAnthropicVision(
+      { apiKey: 'sk-test-key' },
+      {
+        model: 'claude-3-5-sonnet-20241022',
+        prompt: 'p',
+        imageBase64: 'ZmFrZQ==',
+        mimeType: 'image/jpeg',
+        maxTokens: 4096,
+      },
+    );
+    assert.equal(overridden.captured.body.max_tokens, 4096);
+  } finally {
+    overridden.restore();
+  }
+
+  const defaulted = stubFetchOnce(makeAnthropicMessageResponse(['ok']));
+  try {
+    await callAnthropicVision(
+      { apiKey: 'sk-test-key' },
+      { model: 'claude-3-5-sonnet-20241022', prompt: 'p', imageBase64: 'ZmFrZQ==', mimeType: 'image/jpeg' },
+    );
+    assert.equal(defaulted.captured.body.max_tokens, 1024);
+  } finally {
+    defaulted.restore();
+  }
+});
+
+test('callAnthropicVision throws before any network call when no image is supplied', async () => {
+  const { callAnthropicVision } = await import('@memoriahub/enrichment-compute/ai');
+
+  const originalFetch = globalThis.fetch;
+  let fetched = false;
+  globalThis.fetch = async () => {
+    fetched = true;
+    throw new Error('should never be called');
+  };
+
+  try {
+    await assert.rejects(
+      () => callAnthropicVision({ apiKey: 'sk-test-key' }, { model: 'm', prompt: 'p' }),
+      /at least one image/i,
+    );
+    await assert.rejects(
+      () => callAnthropicVision({ apiKey: 'sk-test-key' }, { model: 'm', prompt: 'p', images: [] }),
+      /at least one image/i,
+    );
+    assert.equal(fetched, false, 'no request should be sent for a request with no image');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

Every vision path could send exactly **one** image per AI call. Video auto-tagging (#452) needs the model to see several frames sampled across a video **in a single call**, so the description summarizes the whole video rather than captioning one moment — and so cost stays at one request per video rather than N.

This is the first foundation issue of epic #452 and is additive: **no existing caller changes**, and a single-image request produces a byte-identical request body to before.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #453

## Changes Made

- `packages/enrichment-compute/src/ai/index.ts` — `AnthropicVisionRequest` gains optional `images?: VisionImage[]` and `maxTokens?`, alongside the now-optional `imageBase64`/`mimeType` pair. A new `resolveVisionImages` helper normalizes the two forms into one ordered list and **throws before any network call** when neither supplies an image (cheaper than a provider round trip, and it never burns a retry on a rate-limited account).
- `callAnthropicVision` emits N `image` blocks then the text block; `callOpenAiVision` emits the text block then N `image_url` blocks — each matching the ordering the single-image form already produced, which is what keeps the photo path byte-identical.
- Anthropic's hardcoded `max_tokens: 1024` becomes `req.maxTokens ?? ANTHROPIC_VISION_MAX_TOKENS`. A multi-frame description plus a tag list will not reliably fit in 1024, and a truncated response fails `parseAnalysisResult`'s JSON parse. OpenAI's `max_completion_tokens` gets the same treatment.
- `apps/api/src/ai/providers/ai-provider.interface.ts` — mirrors `images?` / `maxTokens?` onto `AnalyzeImageRequest`; `OpenAiProvider.analyzeImage` forwards the two new fields (Anthropic's already forwards the whole request).

Rate-limit classification is untouched: `classifyAnthropicRateLimit` / `classifyOpenAiRateLimit` wrap the call, not the request shape, so multi-image requests route through the existing deferral path automatically.

## Testing

- [x] Unit tests pass (25/25 in `packages/enrichment-compute`, `test/ai.test.mjs` + `test/ai-openai.test.mjs`)
- [x] Type checks pass (`packages/enrichment-compute`, `apps/api`)

The parity contract here is load-bearing — server and worker nodes import the same functions — so the **pre-existing** single-image tests were left untouched and still pass, which is the actual proof the request body did not move. New coverage adds: image blocks emitted in array order with per-image `mimeType` respected; a non-empty `images` array taking precedence over the single-image fields; an *empty* `images` array falling back to them; `maxTokens` honored and the prior default applied when absent; and zero images throwing with no `fetch` ever issued.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Documentation for the epic lands in #461, per the epic's plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_