### PR TITLE
feat(api,db): audio transcription capability + `media_transcripts` table

### DIFF
--- a/apps/api/prisma/migrations/20260812000000_add_media_transcripts/migration.sql
+++ b/apps/api/prisma/migrations/20260812000000_add_media_transcripts/migration.sql
@@ -1,0 +1,39 @@
+-- Video auto-tagging: speech transcribed from the OPENING SECONDS of a video
+-- (epic #452, issue #454). Never the whole track — `lead_seconds` records how
+-- much audio was actually transcribed, which makes a later re-run with a
+-- larger budget detectable rather than silently mixed with older, shorter rows.
+--
+-- Deliberately its own table rather than a column on `media_tag_status`: that
+-- is a status table wiped on every tagging reset, and losing the transcript
+-- with a status reset would re-pay the transcription bill.
+
+-- CreateTable
+CREATE TABLE "media_transcripts" (
+    "id" UUID NOT NULL,
+    "media_item_id" UUID NOT NULL,
+    "circle_id" UUID NOT NULL,
+    "text" TEXT NOT NULL,
+    "language" TEXT,
+    "provider" TEXT,
+    "model" TEXT,
+    "lead_seconds" INTEGER NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "media_transcripts_pkey" PRIMARY KEY ("id")
+);
+
+-- One transcript per media item: a re-run upserts rather than duplicating.
+-- CreateIndex
+CREATE UNIQUE INDEX "media_transcripts_media_item_id_key" ON "media_transcripts"("media_item_id");
+
+-- CreateIndex
+CREATE INDEX "media_transcripts_circle_id_idx" ON "media_transcripts"("circle_id");
+
+-- Both FKs cascade: a transcript is speech recognized from one video in one
+-- circle and must not outlive either.
+-- AddForeignKey
+ALTER TABLE "media_transcripts" ADD CONSTRAINT "media_transcripts_media_item_id_fkey" FOREIGN KEY ("media_item_id") REFERENCES "media_items"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "media_transcripts" ADD CONSTRAINT "media_transcripts_circle_id_fkey" FOREIGN KEY ("circle_id") REFERENCES "circles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -412,6 +412,8 @@ model Circle {
   enrichmentJobs        EnrichmentJob[]
   // Auto-Tagging relations
   mediaTagStatuses      MediaTagStatus[]
+  // Video Auto-Tagging relations (epic #452, issue #454)
+  mediaTranscripts      MediaTranscript[]
   // Metadata Re-run relations
   mediaMetadataStatuses MediaMetadataStatus[]
   // Geocode Status relations
@@ -594,6 +596,8 @@ model MediaItem {
   profileForPeople       Person[]             @relation("PersonProfileMedia")
   // Auto-Tagging relations
   tagStatus              MediaTagStatus?
+  // Video Auto-Tagging relations (epic #452, issue #454)
+  transcript             MediaTranscript?
   // Metadata Re-run relations
   metadataStatus         MediaMetadataStatus?
   // Geocode Status relations
@@ -1070,6 +1074,43 @@ model MediaTagStatus {
   @@index([circleId])
   @@index([status])
   @@map("media_tag_status")
+}
+
+/// Speech transcribed from the OPENING SECONDS of a video (epic #452, issue
+/// #454) — never the whole track. `leadSeconds` records how much audio was
+/// actually transcribed, which is what makes a later re-run with a larger
+/// budget detectable rather than silently mixed in with older, shorter rows.
+///
+/// One row per media item (`@unique media_item_id`), upserted so a re-run
+/// replaces rather than duplicates. Both FKs cascade: a transcript is speech
+/// recognized from a specific video in a specific circle, and must not outlive
+/// either. It is stored rather than discarded so a re-run does not re-pay
+/// transcription, and so there is a record of WHY the AI described a video the
+/// way it did.
+///
+/// Deliberately a separate table rather than a column on `media_tag_status`:
+/// that is a status table, wiped on every tagging reset, and losing the
+/// transcript with a status reset would re-pay the transcription bill.
+model MediaTranscript {
+  id          String   @id @default(uuid()) @db.Uuid
+  mediaItemId String   @unique @map("media_item_id") @db.Uuid
+  circleId    String   @map("circle_id") @db.Uuid
+  text        String
+  /// Detected or declared language (ISO-639-1), when the provider reports one.
+  language    String?
+  provider    String?
+  model       String?
+  /// Seconds of audio actually transcribed, from the start of the video.
+  leadSeconds Int      @map("lead_seconds")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  // Relations
+  mediaItem MediaItem @relation(fields: [mediaItemId], references: [id], onDelete: Cascade)
+  circle    Circle    @relation(fields: [circleId], references: [id], onDelete: Cascade)
+
+  @@index([circleId])
+  @@map("media_transcripts")
 }
 
 // =============================================================================

--- a/apps/api/src/ai/ai-settings.controller.ts
+++ b/apps/api/src/ai/ai-settings.controller.ts
@@ -27,6 +27,7 @@ import {
   SetEmbeddingFeatureDto,
   SetEnhanceFeatureDto,
   SetMemoriesFeatureDto,
+  SetTranscriptionFeatureDto,
   TestEmbeddingDto,
 } from './dto/ai-credentials.dto';
 
@@ -105,13 +106,15 @@ export class AiSettingsController {
     description:
       'When capability=embedding, returns embedding model IDs instead of chat model IDs. ' +
       'When capability=image, returns image-edit (enhancement) model IDs. ' +
+      'When capability=transcription, returns speech-to-text model IDs. ' +
       'Providers that do not support the requested capability return an empty array.',
   })
   @ApiQuery({ name: 'provider', required: true, description: 'Provider key' })
   @ApiQuery({
     name: 'capability',
     required: false,
-    description: 'Model capability filter: "chat" (default) | "embedding" | "image"',
+    description:
+      'Model capability filter: "chat" (default) | "embedding" | "image" | "transcription"',
   })
   @ApiResponse({ status: 200, description: 'List of model IDs' })
   async listModels(
@@ -123,6 +126,9 @@ export class AiSettingsController {
     }
     if (capability === 'image') {
       return this.aiSettingsService.listImageModels(provider);
+    }
+    if (capability === 'transcription') {
+      return this.aiSettingsService.listTranscriptionModels(provider);
     }
     return this.aiSettingsService.listModels(provider);
   }
@@ -201,5 +207,30 @@ export class AiSettingsController {
     @CurrentUser('id') userId: string,
   ) {
     return this.aiSettingsService.setMemoriesFeature(dto, userId);
+  }
+
+  @Put('features/transcription')
+  @Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.AI_SETTINGS_WRITE] })
+  @ApiOperation({
+    summary:
+      'Set active provider and model for video audio transcription (Admin)',
+    description:
+      'Speech-to-text provider/model used by video auto-tagging to transcribe the ' +
+      'opening seconds of a video (epic #452). List candidates with ' +
+      'GET /api/ai/models?capability=transcription — OpenAI-only in v1. Passing a ' +
+      'null provider or model clears the selection, in which case video tagging ' +
+      'runs visual-only. Returns 400 when the selected provider has no configured, ' +
+      'enabled credential.',
+  })
+  @ApiResponse({ status: 200, description: 'Transcription feature config updated' })
+  @ApiResponse({
+    status: 400,
+    description: 'Provider is not configured or is disabled',
+  })
+  async setTranscriptionFeature(
+    @Body() dto: SetTranscriptionFeatureDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.aiSettingsService.setTranscriptionFeature(dto, userId);
   }
 }

--- a/apps/api/src/ai/ai-settings.service.spec.ts
+++ b/apps/api/src/ai/ai-settings.service.spec.ts
@@ -12,6 +12,7 @@ import { AiProviderRegistry } from './providers/ai-provider.registry';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 import { encryptSecret } from '../common/crypto/secret-cipher';
+import { patchSystemSettingsSchema } from '../settings/dto/update-system-settings.dto';
 
 const VALID_KEY = 'MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=';
 
@@ -419,6 +420,141 @@ describe('AiSettingsService', () => {
         expect.objectContaining({ ai: { features: { memories: null } } }),
         'user-1',
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // setTranscriptionFeature / resolveTranscriptionConfig (epic #452, issue #454)
+  // ---------------------------------------------------------------------------
+  describe('setTranscriptionFeature', () => {
+    it('persists the provider/model pair when the credential exists and is enabled', async () => {
+      mockPrisma.aiProviderCredential.findUnique.mockResolvedValue({
+        enabled: true,
+      } as any);
+      mockSystemSettings.patchSettings.mockResolvedValue(undefined);
+
+      const result = await service.setTranscriptionFeature(
+        { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+        'user-1',
+      );
+
+      expect(mockSystemSettings.patchSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ai: {
+            features: {
+              transcription: { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+            },
+          },
+        }),
+        'user-1',
+      );
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o-mini-transcribe' });
+    });
+
+    it('rejects a provider with no configured credential (400) — a bad selection would otherwise only surface inside an unattended job', async () => {
+      mockPrisma.aiProviderCredential.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.setTranscriptionFeature(
+          { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockSystemSettings.patchSettings).not.toHaveBeenCalled();
+    });
+
+    it('rejects a provider whose credential is DISABLED (400)', async () => {
+      mockPrisma.aiProviderCredential.findUnique.mockResolvedValue({
+        enabled: false,
+      } as any);
+
+      await expect(
+        service.setTranscriptionFeature(
+          { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockSystemSettings.patchSettings).not.toHaveBeenCalled();
+    });
+
+    it('clears the selection to null when either field is null — no credential check', async () => {
+      mockSystemSettings.patchSettings.mockResolvedValue(undefined);
+
+      const result = await service.setTranscriptionFeature(
+        { provider: 'openai', model: null },
+        'user-1',
+      );
+
+      expect(result).toBeNull();
+      expect(mockPrisma.aiProviderCredential.findUnique).not.toHaveBeenCalled();
+      expect(mockSystemSettings.patchSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ ai: { features: { transcription: null } } }),
+        'user-1',
+      );
+    });
+  });
+
+  describe('resolveTranscriptionConfig', () => {
+    it('returns {provider, model} when configured', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({
+        ai: {
+          features: {
+            transcription: { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+          },
+        },
+      });
+
+      await expect(service.resolveTranscriptionConfig()).resolves.toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini-transcribe',
+      });
+    });
+
+    it('returns null when unset, so video tagging runs visual-only rather than failing', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({
+        ai: { features: { transcription: null } },
+      });
+
+      await expect(service.resolveTranscriptionConfig()).resolves.toBeNull();
+    });
+
+    it('returns null for a half-filled pair — not a usable selection', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({
+        ai: { features: { transcription: { provider: 'openai', model: null } } },
+      });
+
+      await expect(service.resolveTranscriptionConfig()).resolves.toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The wire DTO is a hand-maintained THIRD copy of every settings namespace
+  // and strips unknown keys, so a namespace present only in the two zod
+  // schemas validates in unit tests while every real PATCH silently no-ops.
+  // See CLAUDE.md's "three hand-maintained copies" pitfall.
+  // ---------------------------------------------------------------------------
+  describe('ai.features.transcription is registered in the PATCH wire DTO', () => {
+    it('survives patchSystemSettingsSchema parsing rather than being stripped', () => {
+      const parsed = patchSystemSettingsSchema.parse({
+        ai: {
+          features: {
+            transcription: { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+          },
+        },
+      });
+
+      expect(parsed.ai?.features?.transcription).toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini-transcribe',
+      });
+    });
+
+    it('accepts an explicit null (clearing the selection)', () => {
+      const parsed = patchSystemSettingsSchema.parse({
+        ai: { features: { transcription: null } },
+      });
+
+      expect(parsed.ai?.features?.transcription).toBeNull();
     });
   });
 

--- a/apps/api/src/ai/ai-settings.service.ts
+++ b/apps/api/src/ai/ai-settings.service.ts
@@ -16,6 +16,7 @@ import {
   SetEmbeddingFeatureDto,
   SetEnhanceFeatureDto,
   SetMemoriesFeatureDto,
+  SetTranscriptionFeatureDto,
   TestEmbeddingDto,
 } from './dto/ai-credentials.dto';
 
@@ -175,6 +176,19 @@ export class AiSettingsService {
       return [];
     }
     return (provider as any).listEmbeddingModels() as string[];
+  }
+
+  /**
+   * List speech-to-text models for a provider (epic #452, issue #454).
+   * Returns an empty array for providers with no audio capability.
+   */
+  async listTranscriptionModels(providerKey: string): Promise<string[]> {
+    // Validate the provider key — registry.get throws for unknown providers.
+    const provider = this.registry.get(providerKey);
+    if (typeof (provider as any).listTranscriptionModels !== 'function') {
+      return [];
+    }
+    return (provider as any).listTranscriptionModels() as string[];
   }
 
   /**
@@ -363,6 +377,51 @@ export class AiSettingsService {
       userId,
     );
     return value;
+  }
+
+  /**
+   * Update the video-transcription feature config (epic #452, issue #454).
+   *
+   * Same nullable-object shape and up-front credential validation as
+   * `setMemoriesFeature` above, for the same reason: a bad selection here
+   * would otherwise only ever surface inside an unattended
+   * `video_auto_tagging` job, where the admin never sees the error.
+   */
+  async setTranscriptionFeature(dto: SetTranscriptionFeatureDto, userId: string) {
+    const value =
+      dto.provider && dto.model
+        ? { provider: dto.provider, model: dto.model }
+        : null;
+
+    if (value) {
+      await this.assertProviderUsable(value.provider);
+    }
+
+    await this.systemSettings.patchSettings(
+      {
+        ai: {
+          features: {
+            transcription: value,
+          },
+        },
+      } as any,
+      userId,
+    );
+    return value;
+  }
+
+  /**
+   * Resolve the active transcription provider + model from system settings.
+   * Returns null when unset — callers run visual-only rather than failing
+   * (epic #452, issue #454).
+   */
+  async resolveTranscriptionConfig(): Promise<{ provider: string; model: string } | null> {
+    const sysSettings = await this.systemSettings.getSettings();
+    const transcription = (sysSettings.ai?.features as any)?.transcription;
+    if (!transcription?.provider || !transcription?.model) {
+      return null;
+    }
+    return { provider: transcription.provider, model: transcription.model };
   }
 
   /**

--- a/apps/api/src/ai/dto/ai-credentials.dto.ts
+++ b/apps/api/src/ai/dto/ai-credentials.dto.ts
@@ -47,6 +47,15 @@ export const setMemoriesFeatureSchema = z.object({
 });
 export class SetMemoriesFeatureDto extends createZodDto(setMemoriesFeatureSchema) {}
 
+// Speech-to-text for video auto-tagging (epic #452, issue #454). Same
+// nullable pair shape as `enhance`/`memories` — a half-filled provider/model
+// pair is not a usable selection.
+export const setTranscriptionFeatureSchema = z.object({
+  provider: z.string().min(1).nullable(),
+  model: z.string().min(1).nullable(),
+});
+export class SetTranscriptionFeatureDto extends createZodDto(setTranscriptionFeatureSchema) {}
+
 // Both fields optional — an empty body tests the configured ai.features.embedding.
 // .default({}) so a bodyless POST parses as {} — see issue #289 (app.module.ts).
 export const testEmbeddingSchema = z.object({

--- a/apps/api/src/ai/providers/ai-provider.interface.ts
+++ b/apps/api/src/ai/providers/ai-provider.interface.ts
@@ -110,6 +110,22 @@ export interface EnhanceImageResult {
   mimeType: string;
 }
 
+export interface TranscribeAudioRequest {
+  model: string;
+  /** Encoded audio bytes. Bounded by the caller — see `extractAudioLead`. */
+  audio: Buffer;
+  /** MIME type of `audio`, e.g. 'audio/mp4'. */
+  mimeType: string;
+  /** Optional ISO-639-1 hint; omit to let the model detect the language. */
+  language?: string;
+}
+
+export interface TranscribeAudioResult {
+  text: string;
+  /** Detected or declared language, when the provider reports one. */
+  language?: string;
+}
+
 export interface AiProvider {
   /** Unique key identifying this provider, e.g. 'openai' | 'anthropic' */
   readonly key: string;
@@ -131,4 +147,18 @@ export interface AiProvider {
    * capability implement it (OpenAI only in v1). Returns the enhanced bytes.
    */
   enhanceImage?(creds: AiProviderCredentials, req: EnhanceImageRequest): Promise<EnhanceImageResult>;
+  /**
+   * Speech-to-text. Optional — only providers with an audio capability
+   * implement it (OpenAI only in v1); Anthropic has none, so the method is
+   * simply ABSENT there rather than throwing, exactly like `embedText?` and
+   * `enhanceImage?`.
+   *
+   * Callers check `typeof provider.transcribeAudio === 'function'` and
+   * proceed without a transcript when it is missing — video auto-tagging
+   * degrades to visual-only rather than failing.
+   */
+  transcribeAudio?(
+    creds: AiProviderCredentials,
+    req: TranscribeAudioRequest,
+  ): Promise<TranscribeAudioResult>;
 }

--- a/apps/api/src/ai/providers/openai.provider.ts
+++ b/apps/api/src/ai/providers/openai.provider.ts
@@ -9,6 +9,8 @@ import type {
   ChatStreamEvent,
   EnhanceImageRequest,
   EnhanceImageResult,
+  TranscribeAudioRequest,
+  TranscribeAudioResult,
 } from './ai-provider.interface';
 
 // =============================================================================
@@ -45,6 +47,16 @@ const OPENAI_EMBEDDING_MODELS = ['text-embedding-3-small', 'text-embedding-3-lar
 // the chat-model isEligibleOpenAiModel regex (which excludes the 'image'
 // keyword), so image models need their own curated source.
 const OPENAI_IMAGE_MODELS = ['gpt-image-1'] as const;
+
+// Curated speech-to-text models (issue #454). Like the image models above,
+// these are filtered OUT of `client.models.list()` by isEligibleOpenAiModel's
+// modality regex ('audio', 'whisper', 'transcribe'), so they need their own
+// curated source.
+const OPENAI_TRANSCRIPTION_MODELS = [
+  'gpt-4o-mini-transcribe',
+  'gpt-4o-transcribe',
+  'whisper-1',
+] as const;
 
 /**
  * Returns true for OpenAI chat/LLM model ids that have a GPT major.minor
@@ -234,6 +246,10 @@ export class OpenAiProvider implements AiProvider {
     return [...OPENAI_IMAGE_MODELS];
   }
 
+  listTranscriptionModels(): string[] {
+    return [...OPENAI_TRANSCRIPTION_MODELS];
+  }
+
   async testModel(
     creds: AiProviderCredentials,
     model: string,
@@ -370,7 +386,74 @@ export class OpenAiProvider implements AiProvider {
       );
     }
   }
+
+  /**
+   * Speech-to-text (issue #454). OpenAI-only — see `AiProvider.transcribeAudio?`
+   * for why Anthropic simply omits the method rather than throwing.
+   *
+   * The caller owns bounding the audio (see `extractAudioLead`'s `leadSeconds`),
+   * so this method never has to reason about duration or the ~25 MB request cap.
+   *
+   * Errors are rethrown through `rethrowWithProviderStatus` so a genuine 429
+   * carries its HTTP status and Retry-After into `classifyRateLimit` and routes
+   * through the queue's deferral path instead of burning a retry attempt.
+   */
+  async transcribeAudio(
+    creds: AiProviderCredentials,
+    req: TranscribeAudioRequest,
+  ): Promise<TranscribeAudioResult> {
+    try {
+      const client = new OpenAI({
+        apiKey: creds.apiKey,
+        ...(creds.baseUrl && { baseURL: creds.baseUrl }),
+      });
+
+      // Extension is derived from the MIME so OpenAI infers the container.
+      const ext = AUDIO_EXT_BY_MIME[req.mimeType] ?? 'm4a';
+      const file = await toFile(req.audio, `audio.${ext}`, { type: req.mimeType });
+
+      const resp = await client.audio.transcriptions.create({
+        model: req.model,
+        file,
+        ...(req.language && { language: req.language }),
+      } as any);
+
+      // `language` is present on the verbose response shapes but absent from
+      // the SDK's narrowest `Transcription` type, so read both fields off an
+      // index-signature view rather than asserting a shape the SDK disowns.
+      const body = resp as unknown as Record<string, unknown>;
+      const text = typeof body['text'] === 'string' ? body['text'] : '';
+      const language = typeof body['language'] === 'string' ? body['language'] : undefined;
+
+      return { text: text.trim(), ...(language && { language }) };
+    } catch (err: unknown) {
+      const e = err as { status?: number; code?: string; message?: string };
+      if (e?.status === 401) {
+        throw rethrowWithProviderStatus(err, 'Invalid API key');
+      }
+      if (e?.status === 404 || e?.code === 'model_not_found') {
+        throw rethrowWithProviderStatus(err, `Model not found: ${req.model}`);
+      }
+      throw rethrowWithProviderStatus(
+        err,
+        e?.message ?? 'Unknown error calling OpenAI audio transcription',
+      );
+    }
+  }
 }
+
+/** Container extension OpenAI infers the audio format from, keyed by MIME. */
+const AUDIO_EXT_BY_MIME: Record<string, string> = {
+  'audio/mp4': 'm4a',
+  'audio/m4a': 'm4a',
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/webm': 'webm',
+  'audio/ogg': 'ogg',
+  'audio/flac': 'flac',
+};
 
 /**
  * Re-shape a provider SDK error into a plain `Error` with `message`, while

--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -507,6 +507,14 @@ export const systemSettingsSchema = z.object({
         provider: z.string(),
         model: z.string(),
       }).nullable().default(null),
+      // Speech-to-text for video auto-tagging (epic #452, issue #454).
+      // Same nullable-object shape as `enhance`/`memories`: a half-filled
+      // provider/model pair is not a valid selection. OpenAI-only in v1 —
+      // with this unset, video tagging runs visual-only rather than failing.
+      transcription: z.object({
+        provider: z.string(),
+        model: z.string(),
+      }).nullable().default(null),
     }),
   }),
   face: z.object({
@@ -862,6 +870,10 @@ export const systemSettingsPatchSchema = z.object({
         model: z.string(),
       }).nullable().optional(),
       memories: z.object({
+        provider: z.string(),
+        model: z.string(),
+      }).nullable().optional(),
+      transcription: z.object({
         provider: z.string(),
         model: z.string(),
       }).nullable().optional(),

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -212,6 +212,15 @@ export interface SystemSettingsValue {
         provider: string;
         model: string;
       } | null;
+      /**
+       * Active speech-to-text provider+model for video auto-tagging (epic
+       * #452, issue #454); null when unset, in which case video tagging runs
+       * visual-only. OpenAI-only in v1 — Anthropic has no audio capability.
+       */
+      transcription?: {
+        provider: string;
+        model: string;
+      } | null;
     };
   };
   face?: {
@@ -684,6 +693,7 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
       embedding: { provider: null, model: null },
       enhance: null,
       memories: null,
+      transcription: null,
     },
   },
   face: {

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -79,6 +79,13 @@ export const patchSystemSettingsSchema = z.object({
             })
             .nullable()
             .optional(),
+          transcription: z
+            .object({
+              provider: z.string(),
+              model: z.string(),
+            })
+            .nullable()
+            .optional(),
         })
         .optional(),
     })

--- a/apps/api/src/settings/system-settings/system-settings.service.spec.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.spec.ts
@@ -129,7 +129,7 @@ describe('SystemSettingsService', () => {
       const expectedParsed = {
         ...newSettings,
         ai: {
-          features: { ...newSettings.ai.features, enhance: null, memories: null },
+          features: { ...newSettings.ai.features, enhance: null, memories: null, transcription: null },
         },
         face: DEFAULT_SYSTEM_SETTINGS.face,
         storage: DEFAULT_SYSTEM_SETTINGS.storage,
@@ -239,7 +239,7 @@ describe('SystemSettingsService', () => {
       const expectedValidated = {
         ...newSettings,
         ai: {
-          features: { ...newSettings.ai.features, enhance: null, memories: null },
+          features: { ...newSettings.ai.features, enhance: null, memories: null, transcription: null },
         },
         face: DEFAULT_SYSTEM_SETTINGS.face,
         storage: DEFAULT_SYSTEM_SETTINGS.storage,

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -319,6 +319,11 @@ export class SystemSettingsService {
             (dto as any).ai?.features?.memories !== undefined
               ? (dto as any).ai?.features?.memories
               : ((current.ai?.features as any)?.memories ?? null),
+          // Nullable object, same contract as `enhance` above (epic #452).
+          transcription:
+            (dto as any).ai?.features?.transcription !== undefined
+              ? (dto as any).ai?.features?.transcription
+              : ((current.ai?.features as any)?.transcription ?? null),
         },
       },
       face: {

--- a/apps/api/src/tagging/auto-tagging.service.spec.ts
+++ b/apps/api/src/tagging/auto-tagging.service.spec.ts
@@ -980,6 +980,88 @@ describe('AutoTaggingService', () => {
       expect(mockPrisma.$executeRaw).toHaveBeenCalled();
     });
 
+    it('folds a video transcript into the embedded text alongside description/tags/people (#454)', async () => {
+      mockAiSettingsService.resolveEmbeddingConfig.mockResolvedValue({
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+      });
+      mockAiSettingsService.resolveCredentials
+        .mockResolvedValueOnce({ apiKey: 'tagging-key' })
+        .mockResolvedValueOnce({ apiKey: 'embedding-key' });
+      mockRegistry.get
+        .mockReturnValueOnce(mockProvider)
+        .mockReturnValueOnce(mockAiProviderForEmbedding);
+      mockAiProviderForEmbedding.embedText.mockResolvedValue([0.1, 0.2, 0.3]);
+      (mockPrisma.mediaTranscript.findUnique as jest.Mock).mockResolvedValue({
+        text: 'happy birthday to you',
+      });
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([
+        { person: { name: 'Alice' } },
+      ]);
+      mockProvider.analyzeImage.mockResolvedValue(
+        JSON.stringify({ tags: ['Beach'], description: 'Sand.' }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      // This is the ENTIRE "make speech searchable" change — the transcript
+      // rides the existing embedding text, so semanticQuery matches spoken
+      // content with no new search field, index, or endpoint.
+      const embeddedText = mockAiProviderForEmbedding.embedText.mock.calls[0][2] as string;
+      expect(embeddedText).toContain('happy birthday to you');
+      expect(embeddedText).toContain('Sand.');
+      expect(embeddedText).toContain('Beach');
+      expect(embeddedText).toContain('Alice');
+    });
+
+    it('embeds without a transcript when the item has none (the photo path)', async () => {
+      mockAiSettingsService.resolveEmbeddingConfig.mockResolvedValue({
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+      });
+      mockAiSettingsService.resolveCredentials
+        .mockResolvedValueOnce({ apiKey: 'tagging-key' })
+        .mockResolvedValueOnce({ apiKey: 'embedding-key' });
+      mockRegistry.get
+        .mockReturnValueOnce(mockProvider)
+        .mockReturnValueOnce(mockAiProviderForEmbedding);
+      mockAiProviderForEmbedding.embedText.mockResolvedValue([0.1, 0.2, 0.3]);
+      (mockPrisma.mediaTranscript.findUnique as jest.Mock).mockResolvedValue(null);
+      mockProvider.analyzeImage.mockResolvedValue(
+        JSON.stringify({ tags: ['Beach'], description: 'Sand.' }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockAiProviderForEmbedding.embedText.mock.calls[0][2]).toBe('Sand.. Beach');
+    });
+
+    it('still embeds when the transcript lookup itself fails — degrade, never skip', async () => {
+      mockAiSettingsService.resolveEmbeddingConfig.mockResolvedValue({
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+      });
+      mockAiSettingsService.resolveCredentials
+        .mockResolvedValueOnce({ apiKey: 'tagging-key' })
+        .mockResolvedValueOnce({ apiKey: 'embedding-key' });
+      mockRegistry.get
+        .mockReturnValueOnce(mockProvider)
+        .mockReturnValueOnce(mockAiProviderForEmbedding);
+      mockAiProviderForEmbedding.embedText.mockResolvedValue([0.1, 0.2, 0.3]);
+      (mockPrisma.mediaTranscript.findUnique as jest.Mock).mockRejectedValue(
+        new Error('transcripts table unreachable'),
+      );
+      mockProvider.analyzeImage.mockResolvedValue(
+        JSON.stringify({ tags: ['Beach'], description: 'Sand.' }),
+      );
+
+      await expect(service.processMediaItem(makeJob())).resolves.toBeUndefined();
+
+      // A failed transcript read must cost the transcript, not the embedding.
+      expect(mockAiProviderForEmbedding.embedText).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.$executeRaw).toHaveBeenCalled();
+    });
+
     it('swallows embedText errors — tagging job still succeeds', async () => {
       mockAiSettingsService.resolveEmbeddingConfig.mockResolvedValue({
         provider: 'openai',

--- a/apps/api/src/tagging/auto-tagging.service.ts
+++ b/apps/api/src/tagging/auto-tagging.service.ts
@@ -516,8 +516,20 @@ export class AutoTaggingService {
     peopleNames: string[],
   ): Promise<void> {
     try {
+      // A video's transcript (epic #452, issue #454) joins the same embedding
+      // text as description/tags/people. That is the ENTIRE "make speech
+      // searchable" change — no new search field, index, or endpoint —
+      // `semanticQuery` starts matching spoken content for free. Photos never
+      // have a transcript row, so this read is a miss on the photo path.
+      //
+      // Isolated try/catch rather than relying on the outer one: a failed
+      // transcript read must degrade to "no transcript", not to "no
+      // embedding at all", which is what falling through to the outer catch
+      // would silently do.
+      const transcriptText = await this.readTranscriptText(mediaItemId);
+
       // Build text from all available signals
-      const text = [description, ...tagNames, ...peopleNames]
+      const text = [description, ...tagNames, ...peopleNames, transcriptText]
         .filter(Boolean)
         .join('. ');
       if (!text) {
@@ -579,6 +591,28 @@ export class AutoTaggingService {
         `AutoTagging embedAndStore: embedding failed for MediaItem ${mediaItemId} — ${err instanceof Error ? err.message : String(err)}`,
       );
       // Swallow the error — embedding failure must not fail the tagging job
+    }
+  }
+
+  /**
+   * Read a media item's transcript text, if one exists (epic #452, issue #454).
+   *
+   * Never throws: a transcript is an enrichment of the embedding text, not a
+   * precondition for it, so any failure resolves to `null` and the embedding
+   * proceeds from description/tags/people alone.
+   */
+  private async readTranscriptText(mediaItemId: string): Promise<string | null> {
+    try {
+      const row = await this.prisma.mediaTranscript.findUnique({
+        where: { mediaItemId },
+        select: { text: true },
+      });
+      return row?.text ?? null;
+    } catch (err) {
+      this.logger.warn(
+        `AutoTagging embedAndStore: transcript lookup failed for MediaItem ${mediaItemId} — ${err instanceof Error ? err.message : String(err)}; embedding without it`,
+      );
+      return null;
     }
   }
 

--- a/packages/enrichment-compute/src/ffmpeg/index.ts
+++ b/packages/enrichment-compute/src/ffmpeg/index.ts
@@ -141,6 +141,43 @@ export function buildFrameExtractionArgs(spec: FrameExtractionArgsSpec): string[
   return args;
 }
 
+export interface AudioLeadArgsSpec {
+  /** Source media path handed to `-i`. */
+  input: string;
+  /** Destination path (ffmpeg's positional output argument). */
+  output: string;
+  /** Seconds of audio to keep, from the start (`-t`). */
+  durationSecs: number;
+}
+
+/**
+ * Build the argv for a bounded, transcription-ready audio extraction.
+ *
+ * `-t <n>` after `-i` bounds the OUTPUT duration to the first n seconds, so
+ * the cost is fixed regardless of how long the source video is. `-vn` drops
+ * video; `-ac 1 -ar 16000` produce mono 16 kHz, which is what transcription
+ * models want anyway and keeps the payload far under any request size cap.
+ *
+ * Like {@link buildFrameExtractionArgs}, argument ORDER is the parity surface
+ * — server and worker node must invoke ffmpeg identically. See
+ * test/ffmpeg.test.mjs for the regression guard.
+ */
+export function buildAudioLeadArgs(spec: AudioLeadArgsSpec): string[] {
+  return [
+    '-i',
+    spec.input,
+    '-y',
+    '-vn',
+    '-t',
+    String(spec.durationSecs),
+    '-ac',
+    '1',
+    '-ar',
+    '16000',
+    spec.output,
+  ];
+}
+
 /** Build the argv fluent-ffmpeg's `ffprobe()` used: default (INI-ish) output. */
 export function buildFfprobeArgs(input: string): string[] {
   return ['-show_streams', '-show_format', input];

--- a/packages/enrichment-compute/src/video/index.ts
+++ b/packages/enrichment-compute/src/video/index.ts
@@ -29,7 +29,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
-import { buildFrameExtractionArgs, runFfmpeg } from '../ffmpeg/index.js';
+import { buildAudioLeadArgs, buildFrameExtractionArgs, runFfmpeg } from '../ffmpeg/index.js';
 import { computeLog } from '../logging.js';
 
 export interface ExtractedFrame {
@@ -168,6 +168,82 @@ export async function extractFramesAt(
     for (const p of tmpFramePaths) {
       await fs.unlink(p).catch(() => {});
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extractAudioLead — bounded audio extraction for transcription
+// ---------------------------------------------------------------------------
+
+export interface AudioLeadOpts {
+  /**
+   * Seconds of audio to extract, from the START of the video (ffmpeg `-t`).
+   *
+   * This is the entire cost bound for transcription: a 3-hour video and a
+   * 30-second clip both yield at most `leadSeconds` of billable audio.
+   * Transcribing the whole track was rejected outright — ~180 billable
+   * minutes for a 3-hour video, and well past the transcription API's ~25 MB
+   * request cap. See docs/specs/video-auto-tagging.md.
+   */
+  leadSeconds: number;
+  /**
+   * ffmpeg timeout in ms before SIGKILL. Defaults to `FFMPEG_TIMEOUT_MS`
+   * (read at call time — this package has no NestJS DI/config), falling back
+   * to 60000 when unset/unparsable.
+   */
+  ffmpegTimeoutMs?: number;
+}
+
+export interface ExtractedAudioLead {
+  /** Encoded audio bytes, ready to hand to a transcription API. */
+  buffer: Buffer;
+  /** MIME type of `buffer`. */
+  mimeType: string;
+  /** The `leadSeconds` actually requested — recorded for audit/re-run detection. */
+  leadSeconds: number;
+}
+
+/**
+ * Extract the first `leadSeconds` of audio from the video already on disk at
+ * `videoPath`, as mono 16 kHz AAC in an m4a container.
+ *
+ * Mono 16 kHz is what the transcription models downsample to anyway, and it
+ * keeps the payload tiny — ~30 s lands well under 1 MB, so the request is
+ * never near the provider's size cap regardless of the source video.
+ *
+ * `videoPath` must already be a seekable file on disk — like the frame
+ * extractors above, this function does NOT take ownership of it. It owns and
+ * unlinks its OWN temp output in a `finally`. The temp prefix is
+ * `memoriaHub-audio-*` so the API's TempFileJanitorTask reaps an orphan left
+ * behind by a SIGKILLed worker.
+ *
+ * Throws when ffmpeg fails or produces no audio (a video with no audio track
+ * exits non-zero, or writes an empty file). Callers treat transcription as
+ * best-effort and proceed visual-only.
+ */
+export async function extractAudioLead(
+  videoPath: string,
+  opts: AudioLeadOpts,
+): Promise<ExtractedAudioLead> {
+  const ffmpegTimeoutMs =
+    opts.ffmpegTimeoutMs ?? parseInt(process.env.FFMPEG_TIMEOUT_MS ?? '60000', 10);
+
+  const tmpOut = join(tmpdir(), `memoriaHub-audio-${randomUUID()}.m4a`);
+
+  try {
+    await runFfmpeg(buildAudioLeadArgs({ input: videoPath, output: tmpOut, durationSecs: opts.leadSeconds }), {
+      timeoutMs: ffmpegTimeoutMs,
+      timeoutMessage: `ffmpeg audio extraction timed out after ${ffmpegTimeoutMs}ms`,
+    });
+    await assertNonEmptyFile(tmpOut);
+
+    return {
+      buffer: await fs.readFile(tmpOut),
+      mimeType: 'audio/mp4',
+      leadSeconds: opts.leadSeconds,
+    };
+  } finally {
+    await fs.unlink(tmpOut).catch(() => {});
   }
 }
 

--- a/packages/enrichment-compute/test/ffmpeg.test.mjs
+++ b/packages/enrichment-compute/test/ffmpeg.test.mjs
@@ -35,6 +35,7 @@ import { Readable } from 'node:stream';
 
 const {
   buildFrameExtractionArgs,
+  buildAudioLeadArgs,
   buildFfprobeArgs,
   parseFfprobeOutput,
   extractFfmpegError,
@@ -94,6 +95,33 @@ test('argv parity: frames(1).output(out) — the HEIC transcode shape, no seek a
     '1',
     OUT,
   ]);
+});
+
+test('argv parity: audio-lead extraction bounds the OUTPUT with `-t` after `-i`, mono 16 kHz, no video', () => {
+  assert.deepEqual(buildAudioLeadArgs({ input: IN, output: '/tmp/out.m4a', durationSecs: 30 }), [
+    '-i',
+    IN,
+    '-y',
+    '-vn',
+    '-t',
+    '30',
+    '-ac',
+    '1',
+    '-ar',
+    '16000',
+    '/tmp/out.m4a',
+  ]);
+});
+
+test('audio-lead `-t` stays AFTER `-i` — an output-duration bound, not an input seek', () => {
+  const args = buildAudioLeadArgs({ input: IN, output: '/tmp/out.m4a', durationSecs: 5 });
+  assert.ok(args.indexOf('-t') > args.indexOf('-i'), '-t must follow -i to bound the output duration');
+  assert.equal(args.includes('-ss'), false, 'audio-lead extraction never seeks');
+});
+
+test('audio-lead duration seconds are stringified, not rounded', () => {
+  const args = buildAudioLeadArgs({ input: IN, output: '/tmp/out.m4a', durationSecs: 12.5 });
+  assert.equal(args[args.indexOf('-t') + 1], '12.5');
 });
 
 test('argv parity: ffprobe uses the DEFAULT output format (never -print_format json)', () => {

--- a/packages/enrichment-compute/test/video.test.mjs
+++ b/packages/enrichment-compute/test/video.test.mjs
@@ -341,3 +341,98 @@ test('settles only once: a late "error" event fired as a side effect of kill() d
     restore();
   }
 });
+
+// ---------------------------------------------------------------------------
+// extractAudioLead (epic #452, issue #454)
+//
+// The cost bound for transcription: the FIRST `leadSeconds` of audio only, so
+// a 3-hour video and a 30-second clip cost the same. These tests reuse the
+// same scripted-spawn seam as the poster-frame ladder above.
+// ---------------------------------------------------------------------------
+
+test('extractAudioLead returns the encoded bytes and echoes the leadSeconds it was given', async () => {
+  const { restore, calls } = installFakeFfmpeg([{ kind: 'success', bytes: Buffer.from('fake-audio') }]);
+
+  try {
+    const { extractAudioLead } = await import('@memoriahub/enrichment-compute/video');
+
+    const result = await extractAudioLead(fakeVideoPath(), { leadSeconds: 30 });
+
+    assert.equal(result.buffer.toString(), 'fake-audio');
+    assert.equal(result.mimeType, 'audio/mp4');
+    assert.equal(result.leadSeconds, 30, 'leadSeconds is echoed so the caller can persist what was actually paid for');
+    assert.equal(calls.length, 1, 'exactly one ffmpeg invocation');
+  } finally {
+    restore();
+  }
+});
+
+test('extractAudioLead bounds the extraction with `-t <leadSeconds>` regardless of video duration', async () => {
+  const { restore, calls } = installFakeFfmpeg([{ kind: 'success' }]);
+
+  try {
+    const { extractAudioLead } = await import('@memoriahub/enrichment-compute/video');
+    await extractAudioLead(fakeVideoPath(), { leadSeconds: 30 });
+
+    const { args } = calls[0];
+    assert.equal(args[args.indexOf('-t') + 1], '30');
+    assert.ok(args.includes('-vn'), 'video stream must be dropped');
+    assert.deepEqual(
+      [args[args.indexOf('-ac') + 1], args[args.indexOf('-ar') + 1]],
+      ['1', '16000'],
+      'mono 16 kHz keeps the payload far under the provider request cap',
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('extractAudioLead unlinks its own temp output on success', async () => {
+  const { restore, calls } = installFakeFfmpeg([{ kind: 'success' }]);
+
+  try {
+    const { extractAudioLead } = await import('@memoriahub/enrichment-compute/video');
+    await extractAudioLead(fakeVideoPath(), { leadSeconds: 10 });
+
+    await assert.rejects(
+      () => fs.stat(calls[0].outputPath),
+      /ENOENT/,
+      'the module owns its outputs and must clean them up',
+    );
+    assert.match(calls[0].outputPath, /memoriaHub-audio-/, 'temp prefix must be reapable by TempFileJanitorTask');
+  } finally {
+    restore();
+  }
+});
+
+test('extractAudioLead throws when ffmpeg produces an empty file (e.g. a video with no audio track)', async () => {
+  const { restore, calls } = installFakeFfmpeg([{ kind: 'empty' }]);
+
+  try {
+    const { extractAudioLead } = await import('@memoriahub/enrichment-compute/video');
+
+    await assert.rejects(
+      () => extractAudioLead(fakeVideoPath(), { leadSeconds: 30 }),
+      /empty output file/,
+    );
+    await assert.rejects(() => fs.stat(calls[0].outputPath), /ENOENT/, 'temp file cleaned up on failure too');
+  } finally {
+    restore();
+  }
+});
+
+test('extractAudioLead SIGKILLs a hung ffmpeg and rejects with its own timeout message', async () => {
+  const { restore, calls } = installFakeFfmpeg([{ kind: 'hang' }]);
+
+  try {
+    const { extractAudioLead } = await import('@memoriahub/enrichment-compute/video');
+
+    await assert.rejects(
+      () => extractAudioLead(fakeVideoPath(), { leadSeconds: 30, ffmpegTimeoutMs: 30 }),
+      /audio extraction timed out after 30ms/,
+    );
+    assert.deepEqual(calls[0].killSignals, ['SIGKILL'], 'ffmpeg ignores SIGTERM mid-decode');
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary

The richest signal in a family video is usually **spoken** — a name being called, "happy birthday", where they are. None of it was reachable: `AiProvider` had no audio capability at all, so video auto-tagging (#452) would be limited to what a handful of stills happen to show.

The second foundation issue of epic #452. Independent of #453 and consumed at runtime behind a feature flag by the core handler.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #454

## Changes Made

**Bounded audio extraction** — `extractAudioLead` (`packages/enrichment-compute/src/video/index.ts`) on the existing `runFfmpeg` wrapper (SIGKILL-guarded timeout, bounded stderr ring). `buildAudioLeadArgs` emits `-i … -vn -t <n> -ac 1 -ar 16000`: the **first N seconds only**, so a 3-hour video and a 30-second clip cost the same, and mono 16 kHz keeps the payload far under the provider's ~25 MB request cap. `-t` deliberately sits *after* `-i` (an output-duration bound, not an input seek) and a test pins that. Owns and unlinks its own temp file in a `finally`, prefixed `memoriaHub-audio-*` so `TempFileJanitorTask` reaps an orphan left by a SIGKILLed worker. Transcribing the **whole track** was rejected outright — ~180 billable minutes for a 3-hour video, and a hard failure against the size cap.

**New optional provider capability** — `transcribeAudio?(creds, req)` on `AiProvider`, implemented on **OpenAI only**. Anthropic has no audio capability, so the method is simply **absent** there rather than throwing — the same precedent as `embedText?` and `enhanceImage?`. Callers check `typeof provider.transcribeAudio === 'function'` and proceed visual-only. Errors go through the existing `rethrowWithProviderStatus`, so a genuine 429 keeps its HTTP status/Retry-After and routes through the queue's deferral path instead of burning a retry attempt.

**`ai.features.transcription` setting** — `{provider, model} | null`, the same nullable-object shape as `enhance`/`memories` (a half-filled pair is not a valid selection). New `PUT /api/ai/features/transcription` (`ai_settings:write`) and a `capability=transcription` branch on `GET /api/ai/models`. Following the `memories` precedent, a non-null selection is validated against the credential store up front and rejected 400 — a bad selection would otherwise only ever surface inside an unattended background job.

**New table `media_transcripts`** (migration `20260812000000_add_media_transcripts`) — `media_item_id` unique so a re-run upserts rather than duplicates; both FKs cascade; `lead_seconds` records how much audio was actually transcribed, which is what makes a later re-run with a larger budget *detectable* rather than silently mixed with older, shorter rows. Deliberately **not** a column on `media_tag_status`: that is a status table wiped on every tagging reset, and losing the transcript with a status reset would re-pay the transcription bill.

**Folded into the existing embedding** — `AutoTaggingService.embedAndStore` appends the transcript to the description + tags + people text it already joins. That is the entire "make speech searchable" change: no new endpoint, index, search field, or UI, and `semanticQuery` starts matching spoken content immediately. The lookup sits in its own `readTranscriptText` try/catch so a failed read costs the transcript, **not the whole embedding** — falling through to the outer catch would have silently skipped embedding entirely.

## Testing

- [x] Unit tests pass — `packages/enrichment-compute` 115 pass / 3 skipped; `apps/api` **8064 pass**, 0 fail
- [x] Type checks pass (`apps/api`, `packages/enrichment-compute`)

New coverage: the audio-lead argv (`-t` after `-i`, `-vn`, mono 16 kHz, no `-ss`); `extractAudioLead` echoing `leadSeconds`, cleaning its temp file on both success and failure, throwing on an empty output (a video with no audio track), and SIGKILLing a hung ffmpeg; `setTranscriptionFeature` persisting, rejecting an unconfigured/disabled provider, and clearing on a half-filled pair; `resolveTranscriptionConfig`; the transcript reaching the embedded text alongside description/tags/people, the photo path embedding without one, and a **failed** transcript read still producing an embedding.

Per CLAUDE.md's "three hand-maintained copies" pitfall, a spec asserts the namespace survives `patchSystemSettingsSchema` — the wire DTO that strips unknown keys — rather than only the two zod schemas, which is the check that actually proves a real `PATCH` won't silently no-op.

## Additional Notes

**Privacy.** This stores recognized speech from family videos as queryable text. It is off by default (the consuming feature ships disabled), cascade-deleted with the media item and the circle, and never leaves the configured AI provider. Admin UI copy calling this out lands with the settings page in #457.

Documentation for the epic lands in #461, per the epic's plan.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_