### PR TITLE
feat(api): `video_auto_tagging` enrichment job type — compute &amp; persist

### DIFF
--- a/apps/api/src/enrichment/enrichment-job.worker.ts
+++ b/apps/api/src/enrichment/enrichment-job.worker.ts
@@ -149,7 +149,13 @@ const VIDEO_JOB_TIMEOUT_MS = getEnvInt('ENRICHMENT_VIDEO_JOB_TIMEOUT_MS', 1_200_
 const LEASE_MS = getEnvInt('ENRICHMENT_LEASE_MS', 1_800_000); // 30 min
 
 /** Job types governed by the video timeout override. */
-const VIDEO_JOB_TYPES = new Set(['video_face_detection', 'social_media_detection']);
+const VIDEO_JOB_TYPES = new Set([
+  'video_face_detection',
+  'social_media_detection',
+  // Frame extraction + N prepared images + one multi-image AI call on a
+  // multi-GB download legitimately exceeds the 10-minute global default.
+  'video_auto_tagging',
+]);
 
 /** Resolve the effective execution timeout (ms) for a job type. */
 function timeoutMsForType(type: string): number {

--- a/apps/api/src/enrichment/job-type-labels.ts
+++ b/apps/api/src/enrichment/job-type-labels.ts
@@ -16,6 +16,7 @@ export const JOB_TYPE_LABELS: Record<string, string> = {
   face_detection: 'Face detection',
   video_face_detection: 'Video face detection',
   auto_tagging: 'Auto-tagging',
+  video_auto_tagging: 'Video auto-tagging',
   geocode: 'Geocoding',
   duplicate_detection: 'Duplicate detection',
   duplicate_detection_batch: 'Duplicate detection (batch)',

--- a/apps/api/src/enrichment/provider-throttle.service.ts
+++ b/apps/api/src/enrichment/provider-throttle.service.ts
@@ -8,7 +8,8 @@
 // from any job immediately backs off all sibling jobs of the same kind.
 //
 // Provider key mapping (coarse, by job type):
-//   auto_tagging   → 'tagging'   (single AI tagging provider configured at a time)
+//   auto_tagging       → 'tagging'   (single AI tagging provider configured at a time)
+//   video_auto_tagging → 'tagging'   (same provider quota as the photo path)
 //   geocode        → 'geocode'   (single reverse-geocode provider at a time)
 //   face_detection → 'face'      (compreface — the only face provider)
 //   all others     → null        (not throttled: storage, insights, trash, etc.)
@@ -73,6 +74,9 @@ export class ProviderThrottleService {
   static resolveKey(jobType: string): string | null {
     switch (jobType) {
       case 'auto_tagging':
+      // Video tagging calls the SAME configured tagging provider, so it must
+      // share the photo path's cooldown gate rather than getting its own.
+      case 'video_auto_tagging':
         return 'tagging';
       case 'geocode':
         return 'geocode';

--- a/apps/api/src/tagging/tagging.module.ts
+++ b/apps/api/src/tagging/tagging.module.ts
@@ -8,6 +8,8 @@ import { SettingsModule } from '../settings/settings.module';
 import { MediaTouchModule } from '../media/media-touch.module';
 import { AutoTaggingHandler } from './auto-tagging.handler';
 import { AutoTaggingService } from './auto-tagging.service';
+import { VideoAutoTaggingHandler } from './video-auto-tagging.handler';
+import { VideoAutoTaggingService } from './video-auto-tagging.service';
 import { TaggingController } from './tagging.controller';
 import { TagLabelsController } from './tag-labels.controller';
 import { TagLabelsService } from './tag-labels.service';
@@ -17,7 +19,14 @@ import { AdminTaggingController } from './admin-tagging.controller';
 @Module({
   imports: [EnrichmentModule, AiModule, StorageProvidersModule, PrismaModule, CirclesModule, SettingsModule, MediaTouchModule],
   controllers: [TaggingController, TagLabelsController, AdminTaggingController],
-  providers: [AutoTaggingHandler, AutoTaggingService, TagLabelsService, TaggingBackfillService],
-  exports: [AutoTaggingService],
+  providers: [
+    AutoTaggingHandler,
+    AutoTaggingService,
+    VideoAutoTaggingHandler,
+    VideoAutoTaggingService,
+    TagLabelsService,
+    TaggingBackfillService,
+  ],
+  exports: [AutoTaggingService, VideoAutoTaggingService],
 })
 export class TaggingModule {}

--- a/apps/api/src/tagging/video-auto-tagging.handler.spec.ts
+++ b/apps/api/src/tagging/video-auto-tagging.handler.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for VideoAutoTaggingHandler (epic #452, issue #455).
+ *
+ * Covers the registration surface and the node-result path. The persist half
+ * is deliberately delegated to AutoTaggingService, so what these tests protect
+ * is that the delegation actually happens (and in the right order) rather than
+ * a second copy of parsing/vocabulary validation growing here.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { EnrichmentJob, JobReason, JobStatus } from '@prisma/client';
+import { videoAutoTaggingResultSchema } from '@memoriahub/enrichment-compute/dto';
+import { VideoAutoTaggingHandler } from './video-auto-tagging.handler';
+import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
+import { AutoTaggingService } from './auto-tagging.service';
+import { VideoAutoTaggingService } from './video-auto-tagging.service';
+
+function makeJob(overrides: Partial<EnrichmentJob> = {}): EnrichmentJob {
+  return {
+    id: 'job-1',
+    type: 'video_auto_tagging',
+    mediaItemId: 'media-1',
+    circleId: 'circle-1',
+    status: JobStatus.running,
+    reason: JobReason.upload,
+    priority: 20,
+    providerKey: 'openai',
+    modelVersion: 'gpt-4o',
+    payload: null,
+    attempts: 1,
+    lastError: null,
+    startedAt: new Date(),
+    finishedAt: null,
+    scheduledFor: null,
+    rateLimitedAt: null,
+    rateLimitHits: 0,
+    claimedByNodeId: null,
+    leaseExpiresAt: null,
+    executor: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('VideoAutoTaggingHandler', () => {
+  let handler: VideoAutoTaggingHandler;
+  let registry: { register: jest.Mock };
+  let videoService: { processMediaItem: jest.Mock; persistNodeTranscript: jest.Mock };
+  let autoTaggingService: { persistAutoTagging: jest.Mock };
+
+  beforeEach(async () => {
+    registry = { register: jest.fn() };
+    videoService = {
+      processMediaItem: jest.fn().mockResolvedValue(undefined),
+      persistNodeTranscript: jest.fn().mockResolvedValue(undefined),
+    };
+    autoTaggingService = { persistAutoTagging: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VideoAutoTaggingHandler,
+        { provide: EnrichmentHandlerRegistry, useValue: registry },
+        { provide: VideoAutoTaggingService, useValue: videoService },
+        { provide: AutoTaggingService, useValue: autoTaggingService },
+      ],
+    }).compile();
+
+    handler = module.get(VideoAutoTaggingHandler);
+  });
+
+  it('registers itself under a job type DISTINCT from auto_tagging', () => {
+    handler.onModuleInit();
+
+    // The distinct type is what gives video jobs the 20-minute timeout bucket
+    // and the ffmpeg node requirement without imposing either on photos.
+    expect(handler.type).toBe('video_auto_tagging');
+    expect(handler.type).not.toBe('auto_tagging');
+    expect(registry.register).toHaveBeenCalledWith(handler);
+  });
+
+  it('exposes the shared node result schema', () => {
+    expect(handler.nodeResultSchema).toBe(videoAutoTaggingResultSchema);
+  });
+
+  it('delegates process() to VideoAutoTaggingService', async () => {
+    const job = makeJob();
+    await handler.process(job);
+
+    expect(videoService.processMediaItem).toHaveBeenCalledWith(job);
+  });
+
+  it('persists a node result through the SAME persist half the photo path uses', async () => {
+    const job = makeJob();
+
+    await handler.persistNodeResult(job, {
+      rawText: '{"tags":["Beach"],"description":"d"}',
+      frameCount: 6,
+      sampledTimestampsMs: [2500, 7500],
+    });
+
+    expect(autoTaggingService.persistAutoTagging).toHaveBeenCalledWith(job, {
+      rawText: '{"tags":["Beach"],"description":"d"}',
+    });
+  });
+
+  it('persists a node-submitted transcript BEFORE the tags, so the embedding includes it', async () => {
+    const order: string[] = [];
+    videoService.persistNodeTranscript.mockImplementation(async () => {
+      order.push('transcript');
+    });
+    autoTaggingService.persistAutoTagging.mockImplementation(async () => {
+      order.push('tags');
+    });
+
+    await handler.persistNodeResult(makeJob(), {
+      rawText: '{}',
+      frameCount: 2,
+      sampledTimestampsMs: [0, 1000],
+      transcript: { text: 'happy birthday', leadSeconds: 30 },
+    });
+
+    expect(order).toEqual(['transcript', 'tags']);
+  });
+
+  it('rejects a payload that fails nodeResultSchema before touching the database', async () => {
+    await expect(
+      handler.persistNodeResult(makeJob(), { rawText: 123, frameCount: 'six' }),
+    ).rejects.toThrow();
+
+    expect(autoTaggingService.persistAutoTagging).not.toHaveBeenCalled();
+  });
+
+  it('accepts a visual-only result (no transcript key at all)', async () => {
+    await expect(
+      handler.persistNodeResult(makeJob(), {
+        rawText: '{}',
+        frameCount: 3,
+        sampledTimestampsMs: [0, 1000, 2000],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/tagging/video-auto-tagging.handler.ts
+++ b/apps/api/src/tagging/video-auto-tagging.handler.ts
@@ -1,0 +1,64 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { EnrichmentJob } from '@prisma/client';
+import { videoAutoTaggingResultSchema } from '@memoriahub/enrichment-compute/dto';
+import { EnrichmentHandler } from '../enrichment/enrichment-handler.interface';
+import { EnrichmentHandlerRegistry } from '../enrichment/enrichment-handler.registry';
+import { AutoTaggingService } from './auto-tagging.service';
+import { VideoAutoTaggingService } from './video-auto-tagging.service';
+
+/**
+ * `video_auto_tagging` — AI tags + description for videos (epic #452, #455).
+ *
+ * A SEPARATE job type from `auto_tagging`, not a branch inside it. That is
+ * required rather than stylistic, for three concrete reasons:
+ *
+ *   1. The 20-minute ENRICHMENT_VIDEO_JOB_TIMEOUT_MS budget is applied by job
+ *      TYPE (VIDEO_JOB_TYPES in enrichment-job.worker.ts). Branching inside
+ *      `auto_tagging` would hand every photo-tagging job a 20-minute budget.
+ *   2. Node capability requirements are per type — ['sharp'] for photos vs.
+ *      ['sharp','ffmpeg','ffprobe'] here. A node without ffmpeg must not
+ *      advertise the video type.
+ *   3. /admin/settings/jobs filtering, job-type-labels, and per-type queue
+ *      insights all key on type.
+ *
+ * Everything DOWNSTREAM is shared: the tag_labels vocabulary,
+ * media_tag_status, media_items.description, the MediaTagSource.ai write
+ * semantics, and the media_item_embedding upsert.
+ */
+@Injectable()
+export class VideoAutoTaggingHandler implements EnrichmentHandler, OnModuleInit {
+  readonly type = 'video_auto_tagging';
+
+  /**
+   * Node-eligibility (distributed workers, issue #460): the payload a node
+   * submits via POST /api/nodes/:id/jobs/:jobId/result.
+   */
+  readonly nodeResultSchema = videoAutoTaggingResultSchema;
+
+  constructor(
+    private readonly registry: EnrichmentHandlerRegistry,
+    private readonly videoAutoTaggingService: VideoAutoTaggingService,
+    private readonly autoTaggingService: AutoTaggingService,
+  ) {}
+
+  onModuleInit(): void {
+    this.registry.register(this);
+  }
+
+  async process(job: EnrichmentJob): Promise<void> {
+    await this.videoAutoTaggingService.processMediaItem(job);
+  }
+
+  /**
+   * Persist a node-computed result.
+   *
+   * Parsing stays SERVER-side (it needs the DB-loaded TagLabel vocabulary), so
+   * this delegates to the very same persist half the photo path uses — one
+   * implementation of vocabulary validation for both job types.
+   */
+  async persistNodeResult(job: EnrichmentJob, result: unknown): Promise<void> {
+    const parsed = videoAutoTaggingResultSchema.parse(result);
+    await this.videoAutoTaggingService.persistNodeTranscript(job, parsed);
+    await this.autoTaggingService.persistAutoTagging(job, { rawText: parsed.rawText });
+  }
+}

--- a/apps/api/src/tagging/video-auto-tagging.service.spec.ts
+++ b/apps/api/src/tagging/video-auto-tagging.service.spec.ts
@@ -1,0 +1,602 @@
+/**
+ * Unit tests for VideoAutoTaggingService (epic #452, issue #455).
+ *
+ * The two things worth protecting here are the RESOURCE CEILING (three costs,
+ * each bounded, none scaling with video duration) and the GATE LADDER (nothing
+ * downstream of a closed gate may make an AI call). Everything else — parsing,
+ * vocabulary validation, tag reconciliation — is deliberately NOT retested:
+ * this service delegates persistence to AutoTaggingService.persistAutoTagging,
+ * the same implementation the photo path uses, and duplicating its coverage
+ * here would let the two drift while both suites stayed green.
+ */
+
+// sharp is a native module; stub it as the photo spec does.
+jest.mock('sharp', () => {
+  const mockPipeline = {
+    rotate: jest.fn().mockReturnThis(),
+    resize: jest.fn().mockReturnThis(),
+    jpeg: jest.fn().mockReturnThis(),
+    toBuffer: jest.fn().mockResolvedValue({
+      data: Buffer.from('processed-frame'),
+      info: { width: 800, height: 600 },
+    }),
+  };
+  return jest.fn().mockReturnValue(mockPipeline);
+});
+
+// The shared compute package shells out to ffmpeg — stub the two entry points
+// this service uses so no binary is required.
+jest.mock('@memoriahub/enrichment-compute/video', () => ({
+  extractFrames: jest.fn(),
+  extractAudioLead: jest.fn(),
+}));
+
+// Downloading is orthogonal to what these tests assert.
+jest.mock('../storage/processing/processors/stream-utils', () => ({
+  streamToTempFile: jest.fn().mockResolvedValue(undefined),
+  assertDiskSpaceForDownload: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { Readable } from 'stream';
+import {
+  EnrichmentJob,
+  JobReason,
+  JobStatus,
+  MediaTagStatusType,
+  MediaType,
+} from '@prisma/client';
+import {
+  VideoAutoTaggingService,
+  buildVideoTaggingPrompt,
+} from './video-auto-tagging.service';
+import { AutoTaggingService } from './auto-tagging.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AiSettingsService } from '../ai/ai-settings.service';
+import { AiProviderRegistry } from '../ai/providers/ai-provider.registry';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { RateLimitError } from '../enrichment/rate-limit.error';
+import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
+import { extractFrames, extractAudioLead } from '@memoriahub/enrichment-compute/video';
+
+const mockExtractFrames = extractFrames as jest.Mock;
+const mockExtractAudioLead = extractAudioLead as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJob(overrides: Partial<EnrichmentJob> = {}): EnrichmentJob {
+  return {
+    id: 'job-1',
+    type: 'video_auto_tagging',
+    mediaItemId: 'media-1',
+    circleId: 'circle-1',
+    status: JobStatus.running,
+    reason: JobReason.upload,
+    priority: 20,
+    providerKey: null,
+    modelVersion: null,
+    payload: null,
+    attempts: 0,
+    lastError: null,
+    startedAt: null,
+    finishedAt: null,
+    scheduledFor: null,
+    rateLimitedAt: null,
+    rateLimitHits: 0,
+    claimedByNodeId: null,
+    leaseExpiresAt: null,
+    executor: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeMediaItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'media-1',
+    circleId: 'circle-1',
+    type: MediaType.video,
+    deletedAt: null,
+    durationMs: 30_000,
+    socialMediaSource: null,
+    storageObject: {
+      storageKey: 'videos/clip.mp4',
+      storageProvider: 's3',
+      bucket: 'test-bucket',
+      name: 'clip.mp4',
+      size: BigInt(5_000_000),
+    },
+    ...overrides,
+  };
+}
+
+/** System settings with every gate open by default. */
+function makeSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    key: 'global',
+    value: {
+      features: { autoTagging: true },
+      autoTagging: {
+        video: {
+          enabled: true,
+          maxFrames: 6,
+          sampleIntervalSeconds: 5,
+          transcription: { enabled: false, leadSeconds: 30 },
+        },
+      },
+      ai: { features: { tagging: { provider: 'openai', model: 'gpt-4o' } } },
+      ...overrides,
+    },
+  };
+}
+
+function makeFrames(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    timestampMs: (i + 1) * 2500,
+    buffer: Buffer.from(`frame-${i}`),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+
+describe('VideoAutoTaggingService', () => {
+  let service: VideoAutoTaggingService;
+  let mockPrisma: MockPrismaService;
+  let mockAiSettings: {
+    resolveCredentials: jest.Mock;
+    resolveTranscriptionConfig: jest.Mock;
+  };
+  let mockRegistry: { get: jest.Mock };
+  let mockProvider: { analyzeImage: jest.Mock; transcribeAudio?: jest.Mock };
+  let mockResolver: { getProviderFor: jest.Mock };
+  let mockEnrichmentJobService: { recordModel: jest.Mock };
+  let mockAutoTaggingService: { persistAutoTagging: jest.Mock };
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+
+    mockPrisma = createMockPrismaService();
+    mockProvider = {
+      analyzeImage: jest.fn().mockResolvedValue(
+        JSON.stringify({ tags: ['Beach'], description: 'Kids playing at the shore.' }),
+      ),
+      transcribeAudio: jest.fn().mockResolvedValue({ text: 'happy birthday', language: 'en' }),
+    };
+    mockRegistry = { get: jest.fn().mockReturnValue(mockProvider) };
+    mockAiSettings = {
+      resolveCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-key' }),
+      resolveTranscriptionConfig: jest.fn().mockResolvedValue(null),
+    };
+    mockResolver = {
+      getProviderFor: jest.fn().mockResolvedValue({
+        download: jest.fn().mockResolvedValue(Readable.from([Buffer.from('video')])),
+      }),
+    };
+    mockEnrichmentJobService = { recordModel: jest.fn().mockResolvedValue(undefined) };
+    mockAutoTaggingService = { persistAutoTagging: jest.fn().mockResolvedValue(undefined) };
+
+    (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(makeSettings());
+    (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(makeMediaItem());
+    (mockPrisma.tagLabel.findMany as jest.Mock).mockResolvedValue([
+      { name: 'Beach' },
+      { name: 'Birthday' },
+    ]);
+    (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([]);
+    (mockPrisma.mediaTagStatus.upsert as jest.Mock).mockResolvedValue({});
+    (mockPrisma.mediaTranscript.upsert as jest.Mock).mockResolvedValue({});
+
+    mockExtractFrames.mockResolvedValue(makeFrames(6));
+    mockExtractAudioLead.mockResolvedValue({
+      buffer: Buffer.from('audio'),
+      mimeType: 'audio/mp4',
+      leadSeconds: 30,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VideoAutoTaggingService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AiSettingsService, useValue: mockAiSettings },
+        { provide: AiProviderRegistry, useValue: mockRegistry },
+        { provide: StorageProviderResolver, useValue: mockResolver },
+        { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
+        { provide: AutoTaggingService, useValue: mockAutoTaggingService },
+      ],
+    }).compile();
+
+    service = module.get(VideoAutoTaggingService);
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  // =========================================================================
+  // Gate ladder — nothing downstream of a closed gate may cost money
+  // =========================================================================
+
+  describe('gate ladder', () => {
+    it('makes NO AI call when features.autoTagging is off', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue({
+        key: 'global',
+        value: { features: { autoTagging: false } },
+      });
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+      expect(mockPrisma.mediaTagStatus.upsert).not.toHaveBeenCalled();
+    });
+
+    it('makes NO AI call when AUTO_TAG_ENABLED=false — video tagging has no kill-switch of its own', async () => {
+      process.env['AUTO_TAG_ENABLED'] = 'false';
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+    });
+
+    it('makes NO AI call when autoTagging.video.enabled is off — the DEFAULT, so an upgrade costs nothing', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(
+        makeSettings({
+          autoTagging: { video: { enabled: false } },
+        }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+      expect(mockPrisma.mediaItem.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('skips a flagged social-media re-share without an AI call, and without failing the item', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ socialMediaSource: 'tiktok' }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+      // A skip, not a failure — the item is correctly classified.
+      expect(mockPrisma.mediaTagStatus.upsert).not.toHaveBeenCalled();
+    });
+
+    it('fails a PHOTO routed here by mistake rather than tagging it as a video', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ type: MediaType.photo }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+      const call = (mockPrisma.mediaTagStatus.upsert as jest.Mock).mock.calls[0][0];
+      expect(call.create.status).toBe(MediaTagStatusType.failed);
+      expect(call.create.lastError).toMatch(/not video/);
+    });
+
+    it('skips without downloading when the object exceeds VIDEO_ENRICHMENT_MAX_BYTES', async () => {
+      process.env['VIDEO_ENRICHMENT_MAX_BYTES'] = '1000';
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockResolver.getProviderFor).not.toHaveBeenCalled();
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+    });
+
+    it('fails cleanly when no tagging provider/model is configured', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(
+        makeSettings({ ai: { features: { tagging: { provider: null, model: null } } } }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+      const lastCall = (mockPrisma.mediaTagStatus.upsert as jest.Mock).mock.calls.at(-1)![0];
+      expect(lastCall.update.status).toBe(MediaTagStatusType.failed);
+    });
+
+    it('marks processed with zero tags — never calls the model — when the vocabulary is empty', async () => {
+      (mockPrisma.tagLabel.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+      const lastCall = (mockPrisma.mediaTagStatus.upsert as jest.Mock).mock.calls.at(-1)![0];
+      expect(lastCall.update.status).toBe(MediaTagStatusType.processed);
+      expect(lastCall.update.tagCount).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // The resource ceiling
+  // =========================================================================
+
+  describe('resource ceiling', () => {
+    it('makes exactly ONE AI call carrying every frame, never one call per frame', async () => {
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).toHaveBeenCalledTimes(1);
+      const req = mockProvider.analyzeImage.mock.calls[0][1];
+      expect(req.images).toHaveLength(6);
+      // The single-image field must not also be set, or a provider could send
+      // a seventh, unrelated image.
+      expect(req.imageBase64).toBeUndefined();
+    });
+
+    it('passes maxFrames through to the extractor unchanged, for both a short clip and a 3-hour video', async () => {
+      await service.processMediaItem(makeJob());
+      expect(mockExtractFrames.mock.calls[0][1]).toMatchObject({
+        durationMs: 30_000,
+        maxFrames: 6,
+        sampleIntervalSeconds: 5,
+      });
+
+      mockExtractFrames.mockClear();
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ durationMs: 3 * 60 * 60 * 1000 }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      // Same frame budget for a 3-hour video — the cost is duration-independent,
+      // which is exactly why there is no maxDurationSeconds skip gate.
+      expect(mockExtractFrames.mock.calls[0][1]).toMatchObject({ maxFrames: 6 });
+    });
+
+    it('raises the per-request output budget so a whole-video description is not truncated', async () => {
+      await service.processMediaItem(makeJob());
+
+      const req = mockProvider.analyzeImage.mock.calls[0][1];
+      expect(req.maxTokens).toBeGreaterThan(1024);
+    });
+
+    it('does NOT skip a 3-hour video — degrade, never skip on duration', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ durationMs: 3 * 60 * 60 * 1000 }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).toHaveBeenCalledTimes(1);
+      expect(mockAutoTaggingService.persistAutoTagging).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops trailing frames rather than failing when the combined image budget is exceeded', async () => {
+      const huge = Buffer.alloc(8_000_000, 1);
+      (jest.requireMock('sharp') as jest.Mock).mockReturnValue({
+        rotate: jest.fn().mockReturnThis(),
+        resize: jest.fn().mockReturnThis(),
+        jpeg: jest.fn().mockReturnThis(),
+        toBuffer: jest.fn().mockResolvedValue({ data: huge, info: { width: 800, height: 600 } }),
+      });
+
+      await service.processMediaItem(makeJob());
+
+      const req = mockProvider.analyzeImage.mock.calls[0][1];
+      expect(req.images.length).toBeGreaterThan(0);
+      expect(req.images.length).toBeLessThan(6);
+    });
+  });
+
+  // =========================================================================
+  // Persist delegation — one implementation of vocabulary validation
+  // =========================================================================
+
+  describe('persistence', () => {
+    it('delegates the persist half to AutoTaggingService, passing the raw text through unparsed', async () => {
+      mockProvider.analyzeImage.mockResolvedValue('{"tags":["Beach"],"description":"d"}');
+
+      const job = makeJob();
+      await service.processMediaItem(job);
+
+      expect(mockAutoTaggingService.persistAutoTagging).toHaveBeenCalledWith(job, {
+        rawText: '{"tags":["Beach"],"description":"d"}',
+      });
+    });
+
+    it('records the provider/model on the job row AND the in-memory object before persisting', async () => {
+      const job = makeJob();
+      await service.processMediaItem(job);
+
+      expect(mockEnrichmentJobService.recordModel).toHaveBeenCalledWith('job-1', 'openai', 'gpt-4o');
+      // persistAutoTagging reads these off the same reference without re-fetching.
+      expect(job.providerKey).toBe('openai');
+      expect(job.modelVersion).toBe('gpt-4o');
+    });
+
+    it('marks the item failed and rethrows when the vision call errors, so the queue retries', async () => {
+      mockProvider.analyzeImage.mockRejectedValue(new Error('provider exploded'));
+
+      await expect(service.processMediaItem(makeJob())).rejects.toThrow('provider exploded');
+
+      const lastCall = (mockPrisma.mediaTagStatus.upsert as jest.Mock).mock.calls.at(-1)![0];
+      expect(lastCall.update.status).toBe(MediaTagStatusType.failed);
+    });
+
+    it('converts a provider 429 into RateLimitError so the job is DEFERRED, not counted as a failure', async () => {
+      mockProvider.analyzeImage.mockRejectedValue(
+        Object.assign(new Error('slow down'), { status: 429, headers: { 'retry-after': '30' } }),
+      );
+
+      await expect(service.processMediaItem(makeJob())).rejects.toBeInstanceOf(RateLimitError);
+    });
+
+    it('converts a provider 529 (Anthropic "Overloaded") the same way', async () => {
+      mockProvider.analyzeImage.mockRejectedValue(
+        Object.assign(new Error('overloaded'), { status: 529 }),
+      );
+
+      await expect(service.processMediaItem(makeJob())).rejects.toBeInstanceOf(RateLimitError);
+    });
+  });
+
+  // =========================================================================
+  // Transcription — best-effort by contract
+  // =========================================================================
+
+  describe('transcription', () => {
+    const withTranscription = () =>
+      makeSettings({
+        autoTagging: {
+          video: {
+            enabled: true,
+            maxFrames: 6,
+            sampleIntervalSeconds: 5,
+            transcription: { enabled: true, leadSeconds: 45 },
+          },
+        },
+      });
+
+    beforeEach(() => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(withTranscription());
+      mockAiSettings.resolveTranscriptionConfig.mockResolvedValue({
+        provider: 'openai',
+        model: 'gpt-4o-mini-transcribe',
+      });
+    });
+
+    it('never extracts audio at all when transcription is off', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(makeSettings());
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockExtractAudioLead).not.toHaveBeenCalled();
+    });
+
+    it('bounds the audio to the configured leadSeconds, not the video duration', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ durationMs: 3 * 60 * 60 * 1000 }),
+      );
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockExtractAudioLead.mock.calls[0][1]).toMatchObject({ leadSeconds: 45 });
+    });
+
+    it('feeds the transcript into the prompt and persists it with the leadSeconds actually paid for', async () => {
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage.mock.calls[0][1].prompt).toContain('happy birthday');
+
+      const upsert = (mockPrisma.mediaTranscript.upsert as jest.Mock).mock.calls[0][0];
+      expect(upsert.where).toEqual({ mediaItemId: 'media-1' });
+      expect(upsert.create).toMatchObject({
+        text: 'happy birthday',
+        language: 'en',
+        leadSeconds: 45,
+        provider: 'openai',
+        model: 'gpt-4o-mini-transcribe',
+      });
+    });
+
+    it('persists the transcript BEFORE persisting tags, so this run’s embedding already includes it', async () => {
+      const order: string[] = [];
+      (mockPrisma.mediaTranscript.upsert as jest.Mock).mockImplementation(async () => {
+        order.push('transcript');
+        return {};
+      });
+      mockAutoTaggingService.persistAutoTagging.mockImplementation(async () => {
+        order.push('tags');
+      });
+
+      await service.processMediaItem(makeJob());
+
+      expect(order).toEqual(['transcript', 'tags']);
+    });
+
+    it('degrades to visual-only when the provider has no audio capability', async () => {
+      mockRegistry.get.mockReturnValue({ analyzeImage: mockProvider.analyzeImage });
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockProvider.analyzeImage).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.mediaTranscript.upsert).not.toHaveBeenCalled();
+    });
+
+    it('degrades to visual-only when no transcription model is configured', async () => {
+      mockAiSettings.resolveTranscriptionConfig.mockResolvedValue(null);
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockExtractAudioLead).not.toHaveBeenCalled();
+      expect(mockProvider.analyzeImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('degrades to visual-only when the video has no audio track (ffmpeg fails)', async () => {
+      mockExtractAudioLead.mockRejectedValue(new Error('ffmpeg produced an empty output file'));
+
+      await service.processMediaItem(makeJob());
+
+      // The tagging job still succeeds — transcription is an enrichment, not a
+      // precondition.
+      expect(mockProvider.analyzeImage).toHaveBeenCalledTimes(1);
+      expect(mockAutoTaggingService.persistAutoTagging).toHaveBeenCalledTimes(1);
+    });
+
+    it('RETHROWS a rate-limited transcription rather than silently producing a worse description', async () => {
+      mockProvider.transcribeAudio!.mockRejectedValue(
+        Object.assign(new Error('slow down'), { status: 429 }),
+      );
+
+      await expect(service.processMediaItem(makeJob())).rejects.toBeInstanceOf(RateLimitError);
+      // The visual call must not have happened either — the job is deferred whole.
+      expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
+    });
+
+    it('still tags when the transcript row cannot be written', async () => {
+      (mockPrisma.mediaTranscript.upsert as jest.Mock).mockRejectedValue(new Error('db down'));
+
+      await service.processMediaItem(makeJob());
+
+      expect(mockAutoTaggingService.persistAutoTagging).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // =========================================================================
+  // Prompt contract
+  // =========================================================================
+
+  describe('buildVideoTaggingPrompt', () => {
+    it('keeps the photo path’s output envelope so the parse/persist half is reusable verbatim', () => {
+      const prompt = buildVideoTaggingPrompt(['Beach', 'Birthday'], [], [0, 5000], null);
+
+      expect(prompt).toContain('"tags"');
+      expect(prompt).toContain('"description"');
+      expect(prompt).toContain('Allowed labels:\nBeach\nBirthday');
+    });
+
+    it('frames the images as ordered stills from ONE video, with their timestamps', () => {
+      const prompt = buildVideoTaggingPrompt(['Beach'], [], [2500, 65_000], null);
+
+      expect(prompt).toMatch(/2 still frame\(s\) sampled in order from a single video/);
+      expect(prompt).toContain('1. 0:03');
+      expect(prompt).toContain('2. 1:05');
+      expect(prompt).toMatch(/not as unrelated photos/);
+    });
+
+    it('delimits the transcript and flags it as a hint rather than fact', () => {
+      const prompt = buildVideoTaggingPrompt(['Beach'], [], [0], 'happy birthday to you');
+
+      expect(prompt).toContain('happy birthday to you');
+      expect(prompt).toMatch(/treat it as a hint, not as fact/i);
+    });
+
+    it('omits the transcript block entirely when there is none', () => {
+      const prompt = buildVideoTaggingPrompt(['Beach'], [], [0], null);
+
+      expect(prompt).not.toMatch(/Transcript/i);
+    });
+
+    it('names assigned people, matching the photo prompt’s clause', () => {
+      const prompt = buildVideoTaggingPrompt(['Beach'], ['Alice', 'Bob'], [0], null);
+
+      expect(prompt).toContain('Alice, Bob');
+      expect(prompt).toMatch(/Mention them by name/);
+    });
+  });
+});

--- a/apps/api/src/tagging/video-auto-tagging.service.ts
+++ b/apps/api/src/tagging/video-auto-tagging.service.ts
@@ -1,0 +1,747 @@
+// =============================================================================
+// VideoAutoTaggingService
+// =============================================================================
+//
+// AI tags, a written description, and a semantic embedding for VIDEOS, at
+// parity with what photos already get (epic #452, issue #455).
+//
+// COMPUTE/PERSIST SPLIT, mirroring AutoTaggingService and
+// VideoFaceDetectionService:
+//
+//   - processMediaItem: the in-process orchestration — gates, provider/creds
+//     resolution, video download, and everything else that needs server-held
+//     DB or storage credentials.
+//
+//   - computeVideoAutoTagging: the half a distributed worker node runs
+//     locally with a transiently-fetched API key (issue #460) — extract
+//     frames, prepare each one, optionally transcribe the audio lead, and make
+//     ONE multi-image vision call. Returns raw, unparsed text.
+//
+//   - PERSIST is deliberately NOT reimplemented here. It delegates to
+//     AutoTaggingService.persistAutoTagging, which already reloads the
+//     MediaItem, the enabled TagLabel vocabulary, and the assigned people
+//     names itself (it had to, for the node-result path). Vocabulary
+//     validation therefore has exactly ONE implementation: a second copy that
+//     drifted would let video tagging emit tags outside the admin's
+//     vocabulary — precisely the failure that validation exists to prevent.
+//
+// THE RESOURCE CEILING is the load-bearing design constraint. Three costs,
+// each independently bounded, NONE scaling with video duration:
+//
+//   - Frames: `autoTagging.video.maxFrames`. computeSeekTimestamps uses
+//     interval = max(sampleIntervalSeconds, durationSec / maxFrames), so six
+//     frames come out of a 30-second clip AND a 3-hour recital. Spreading the
+//     same six frames across the full runtime costs identically to taking them
+//     from the opening seconds, and describes the video far better.
+//   - Transcription: `transcription.leadSeconds` of audio, via ffmpeg `-t`.
+//   - One vision call per video, never one per frame.
+//
+// Consequently there is deliberately NO duration skip gate. The longest videos
+// in a family library — a whole recital, a wedding — are often the most
+// significant, and are exactly the ones a `maxDurationSeconds` cap would
+// silently leave undescribed. Since cost is already duration-independent,
+// skipping them buys nothing. Degrade, never skip on duration.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { EnrichmentJob, MediaTagStatusType, MediaType } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { tmpdir } from 'os';
+import { join, extname } from 'path';
+import { promises as fs } from 'fs';
+import type { VideoAutoTaggingResult } from '@memoriahub/enrichment-compute/dto';
+import {
+  extractAudioLead,
+  extractFrames,
+} from '@memoriahub/enrichment-compute/video';
+import { PrismaService } from '../prisma/prisma.service';
+import { AiSettingsService } from '../ai/ai-settings.service';
+import { AiProviderRegistry } from '../ai/providers/ai-provider.registry';
+import type {
+  AiProvider,
+  AiProviderCredentials,
+  AnalyzeImageInputImage,
+} from '../ai/providers/ai-provider.interface';
+import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+import {
+  streamToTempFile,
+  assertDiskSpaceForDownload,
+} from '../storage/processing/processors/stream-utils';
+import { prepareImageForProcessing } from '../storage/processing/image-orientation.util';
+import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { RateLimitError, parseRetryAfterMs, classifyRateLimit } from '../enrichment/rate-limit.error';
+import { AutoTaggingService } from './auto-tagging.service';
+
+/**
+ * System prompt for the video pass. Same output CONTRACT as the photo prompt
+ * — a `{"tags": [...], "description": "..."}` JSON envelope — which is what
+ * lets the entire parse/persist half be reused verbatim. What differs is the
+ * framing: the model must understand it is looking at ordered stills from ONE
+ * video, not a set of unrelated photos.
+ *
+ * Module-level so `buildVideoPrompt` can hand a distributed worker node the
+ * EXACT prompt the server would have sent (issue #460), with no second
+ * prompt-string construction to drift.
+ */
+const VIDEO_AUTO_TAGGING_SYSTEM_PROMPT =
+  'You are a video analysis assistant. You will be shown several still frames sampled in order from a SINGLE video, ' +
+  'and optionally a transcript of its opening seconds. Your job is to analyze the video as a whole and return a JSON object ' +
+  'with two keys: "tags" and "description". ' +
+  '"tags" must be a JSON array of strings — each string must exactly match one of the labels in the provided allowed list; return an empty array if none apply. ' +
+  '"description" must be a brief 1-3 sentence description of the video as a whole, not of any single frame. ' +
+  'Respond with ONLY a JSON object with those two keys — no explanation, no code fences, no extra text.';
+
+/**
+ * Output budget for the video vision call. Higher than the photo path's
+ * provider defaults because a whole-video description plus a tag list does not
+ * reliably fit in Anthropic's 1024, and a truncated response fails the JSON
+ * parse (issue #453 added the per-request override for exactly this).
+ */
+const VIDEO_TAGGING_MAX_TOKENS = 2048;
+
+/** Long-edge cap per frame — same env var and default as the photo path. */
+const TAG_MAX_DIM = (): number => parseInt(process.env['TAG_MAX_IMAGE_DIM'] ?? '1568', 10);
+
+/**
+ * Hard cap on the base64 payload across ALL frames in the single call.
+ * Anthropic enforces ~5 MB per image and a request-wide budget; frames are
+ * dropped from the END (keeping the earliest, which anchor the narrative)
+ * rather than failing the job.
+ */
+const MAX_TOTAL_IMAGE_BYTES = 18_000_000;
+
+/**
+ * Optional hard cap (bytes) on videos processed by video enrichment; 0
+ * disables. Shared with video face detection and social-media detection so an
+ * operator sets one knob for all video work.
+ */
+const VIDEO_ENRICHMENT_MAX_BYTES = (): number =>
+  parseInt(process.env['VIDEO_ENRICHMENT_MAX_BYTES'] ?? '0', 10);
+
+/** Effective `autoTagging.video.*` values, after defaults. */
+export interface VideoTaggingParams {
+  maxFrames: number;
+  sampleIntervalSeconds: number;
+  transcriptionEnabled: boolean;
+  leadSeconds: number;
+}
+
+@Injectable()
+export class VideoAutoTaggingService {
+  private readonly logger = new Logger(VideoAutoTaggingService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly aiSettingsService: AiSettingsService,
+    private readonly aiProviderRegistry: AiProviderRegistry,
+    private readonly resolver: StorageProviderResolver,
+    private readonly enrichmentJobService: EnrichmentJobService,
+    private readonly autoTaggingService: AutoTaggingService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // processMediaItem — in-process orchestration
+  // ---------------------------------------------------------------------------
+
+  async processMediaItem(job: EnrichmentJob): Promise<void> {
+    if (!job.mediaItemId) {
+      throw new Error('video_auto_tagging job missing mediaItemId');
+    }
+
+    // --- Gates, cheapest first (mirrors SocialMediaDetectionHandler). Each
+    // gate that fires must leave NO status row change beyond what it states,
+    // and must never make an AI call. ---
+    const settingsRow = await this.prisma.systemSettings.findUnique({ where: { key: 'global' } });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const settingsValue = (settingsRow?.value as any) ?? {};
+
+    if (settingsValue?.features?.autoTagging !== true) {
+      this.logger.log(
+        `VideoAutoTagJob ${job.id}: features.autoTagging is off; skipping without an AI call`,
+      );
+      return;
+    }
+    // Video tagging has no kill-switch of its own — it rides on
+    // AUTO_TAG_ENABLED, exactly as video face detection rides on
+    // FACE_AUTO_DETECT.
+    if (process.env['AUTO_TAG_ENABLED'] === 'false') {
+      this.logger.log(`VideoAutoTagJob ${job.id}: AUTO_TAG_ENABLED=false; skipping`);
+      return;
+    }
+    const videoSettings = settingsValue?.autoTagging?.video ?? {};
+    if (videoSettings?.enabled !== true) {
+      this.logger.log(
+        `VideoAutoTagJob ${job.id}: autoTagging.video.enabled is off; skipping without an AI call`,
+      );
+      return;
+    }
+
+    const params: VideoTaggingParams = {
+      maxFrames: videoSettings?.maxFrames ?? 6,
+      sampleIntervalSeconds: videoSettings?.sampleIntervalSeconds ?? 5,
+      transcriptionEnabled: videoSettings?.transcription?.enabled === true,
+      leadSeconds: videoSettings?.transcription?.leadSeconds ?? 30,
+    };
+
+    const mediaItem = await this.prisma.mediaItem.findUnique({
+      where: { id: job.mediaItemId },
+      select: {
+        id: true,
+        circleId: true,
+        type: true,
+        deletedAt: true,
+        durationMs: true,
+        socialMediaSource: true,
+        storageObject: {
+          select: { storageKey: true, storageProvider: true, bucket: true, name: true, size: true },
+        },
+      },
+    });
+
+    if (
+      !mediaItem ||
+      mediaItem.deletedAt ||
+      mediaItem.type !== MediaType.video ||
+      !mediaItem.storageObject
+    ) {
+      const reason = !mediaItem
+        ? `MediaItem ${job.mediaItemId} not found`
+        : mediaItem.deletedAt
+          ? `MediaItem ${job.mediaItemId} is soft-deleted`
+          : !mediaItem.storageObject
+            ? `MediaItem ${job.mediaItemId} has no storageObject`
+            : `MediaItem ${job.mediaItemId} is type ${mediaItem.type}, not video`;
+      this.logger.warn(`VideoAutoTagJob ${job.id}: ${reason}; skipping`);
+      const circleId = mediaItem?.circleId ?? (job.circleId as string);
+      await this.markFailed(job.mediaItemId, circleId, null, 'unknown', reason);
+      return;
+    }
+
+    // Never burn an AI call on a TikTok/Instagram re-share. This is a skip,
+    // not a failure — the item is correctly classified, there is just nothing
+    // worth describing.
+    if (mediaItem.socialMediaSource) {
+      this.logger.log(
+        `VideoAutoTagJob ${job.id}: skipping — flagged social media (${mediaItem.socialMediaSource})`,
+      );
+      return;
+    }
+
+    await this.prisma.mediaTagStatus.upsert({
+      where: { mediaItemId: job.mediaItemId },
+      create: {
+        mediaItemId: job.mediaItemId,
+        circleId: mediaItem.circleId,
+        status: MediaTagStatusType.processing,
+        tagCount: 0,
+      },
+      update: { status: MediaTagStatusType.processing, lastError: null },
+    });
+
+    // --- Provider/model + credentials ---
+    const taggingConfig = settingsValue?.ai?.features?.tagging as
+      | { provider?: string; model?: string }
+      | undefined;
+    const provider = taggingConfig?.provider;
+    const model = taggingConfig?.model;
+
+    if (!provider || !model) {
+      const errMsg = 'AI tagging provider or model not configured in system settings';
+      this.logger.error(`VideoAutoTagJob ${job.id}: ${errMsg}`);
+      await this.markFailed(job.mediaItemId, mediaItem.circleId, null, 'unknown', errMsg);
+      return;
+    }
+
+    await this.enrichmentJobService.recordModel(job.id, provider, model);
+    // recordModel writes the DB row only; keep the in-memory job object in
+    // sync since persistAutoTagging reads providerKey/modelVersion off this
+    // same reference without a re-fetch (identical to the photo path).
+    job.providerKey = provider;
+    job.modelVersion = model;
+
+    let creds: AiProviderCredentials;
+    try {
+      creds = await this.aiSettingsService.resolveCredentials(provider);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`VideoAutoTagJob ${job.id}: failed to resolve credentials: ${errMsg}`);
+      await this.markFailed(job.mediaItemId, mediaItem.circleId, provider, model, errMsg);
+      return;
+    }
+
+    const aiProvider = this.aiProviderRegistry.get(provider);
+
+    const tagLabels = await this.prisma.tagLabel.findMany({
+      where: { enabled: true },
+      select: { name: true },
+      orderBy: { name: 'asc' },
+    });
+
+    if (tagLabels.length === 0) {
+      this.logger.warn(`VideoAutoTagJob ${job.id}: no enabled TagLabels found; skipping tagging`);
+      await this.prisma.mediaTagStatus.upsert({
+        where: { mediaItemId: job.mediaItemId },
+        create: {
+          mediaItemId: job.mediaItemId,
+          circleId: mediaItem.circleId,
+          status: MediaTagStatusType.processed,
+          tagCount: 0,
+          providerKey: provider,
+          modelVersion: model,
+          processedAt: new Date(),
+        },
+        update: {
+          status: MediaTagStatusType.processed,
+          tagCount: 0,
+          providerKey: provider,
+          modelVersion: model,
+          processedAt: new Date(),
+          lastError: null,
+        },
+      });
+      return;
+    }
+
+    // Optional hard size cap — checked BEFORE the download, so an over-cap
+    // video costs nothing.
+    const maxBytes = VIDEO_ENRICHMENT_MAX_BYTES();
+    if (maxBytes > 0 && mediaItem.storageObject.size > BigInt(maxBytes)) {
+      const reason =
+        `object size ${mediaItem.storageObject.size} bytes exceeds VIDEO_ENRICHMENT_MAX_BYTES=${maxBytes}`;
+      this.logger.warn(`VideoAutoTagJob ${job.id}: skipping — ${reason}`);
+      await this.markFailed(job.mediaItemId, mediaItem.circleId, provider, model, reason);
+      return;
+    }
+
+    try {
+      const peopleNames = await this.loadPeopleNames(job.mediaItemId);
+      const labelNames = tagLabels.map((t) => t.name);
+
+      const fileExt = extname(mediaItem.storageObject.name || '') || '.mp4';
+      const tmpVideoPath = join(tmpdir(), `memoriaHub-vtag-dl-${randomUUID()}${fileExt}`);
+
+      const objectProvider = await this.resolver.getProviderFor(
+        mediaItem.storageObject.storageProvider,
+        mediaItem.storageObject.bucket,
+      );
+
+      // Pre-flight: fail fast through the normal retry/backoff path when the
+      // temp filesystem cannot hold the download plus headroom.
+      await assertDiskSpaceForDownload(mediaItem.storageObject.size, tmpdir());
+
+      let computed: VideoAutoTaggingResult;
+      try {
+        // Download INSIDE the try so a partial file is still unlinked below.
+        const videoStream = await objectProvider.download(mediaItem.storageObject.storageKey);
+        await streamToTempFile(videoStream, tmpVideoPath);
+
+        computed = await this.computeVideoAutoTagging(tmpVideoPath, {
+          durationMs: mediaItem.durationMs,
+          fileExtension: fileExt,
+          params,
+          labelNames,
+          peopleNames,
+          model,
+          creds,
+          aiProvider,
+          providerKey: provider,
+          jobId: job.id,
+        });
+      } finally {
+        await fs.unlink(tmpVideoPath).catch(() => {});
+      }
+
+      // The transcript is persisted BEFORE the shared persist runs, so
+      // embedAndStore's transcript lookup (issue #454) picks it up on this
+      // very pass rather than only on the next re-run.
+      await this.persistTranscript(mediaItem.id, mediaItem.circleId, computed);
+
+      this.logger.log(
+        `VideoAutoTagJob ${job.id}: analyzed ${computed.frameCount} frame(s) at ` +
+          `[${computed.sampledTimestampsMs.join(', ')}]ms` +
+          `${computed.transcript ? ' with a transcript' : ' (visual-only)'}`,
+      );
+
+      // PERSIST half — the SAME implementation the photo path uses, so
+      // vocabulary validation cannot drift between the two.
+      await this.autoTaggingService.persistAutoTagging(job, { rawText: computed.rawText });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      await this.markFailed(job.mediaItemId, mediaItem.circleId, provider, model, errMsg);
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // computeVideoAutoTagging — COMPUTE half
+  //
+  // Everything here is pure compute against a local video file plus a
+  // provider API key: exactly what a distributed worker node runs locally
+  // (issue #460). No DB access, no storage credentials.
+  // ---------------------------------------------------------------------------
+
+  async computeVideoAutoTagging(
+    videoPath: string,
+    ctx: {
+      durationMs: number | null;
+      fileExtension?: string;
+      params: VideoTaggingParams;
+      labelNames: string[];
+      peopleNames: string[];
+      model: string;
+      creds: AiProviderCredentials;
+      aiProvider: AiProvider;
+      providerKey: string;
+      jobId: string;
+    },
+  ): Promise<VideoAutoTaggingResult> {
+    // --- 1. Frames. Bounded by maxFrames and spread across the WHOLE
+    // duration; see the resource-ceiling note in this file's header. ---
+    const frames = await extractFrames(videoPath, {
+      durationMs: ctx.durationMs,
+      sampleIntervalSeconds: ctx.params.sampleIntervalSeconds,
+      maxFrames: ctx.params.maxFrames,
+      ...(ctx.fileExtension ? { fileExtension: ctx.fileExtension } : {}),
+    });
+
+    if (frames.length === 0) {
+      throw new Error('No frames could be extracted from the video');
+    }
+
+    // --- 2. Prepare each frame, exactly as the photo path prepares its one
+    // image (EXIF/orientation parity, same TAG_MAX_IMAGE_DIM budget). ---
+    const maxDim = TAG_MAX_DIM();
+    const images: AnalyzeImageInputImage[] = [];
+    const sampledTimestampsMs: number[] = [];
+    let totalBytes = 0;
+
+    for (const frame of frames) {
+      const prepared = await prepareImageForProcessing(frame.buffer, { maxDim });
+      // A frame sharp could not decode is skipped rather than failing the
+      // whole video — the remaining frames still describe it.
+      const buffer = prepared.width > 0 ? prepared.buffer : null;
+      if (!buffer) {
+        this.logger.warn(
+          `VideoAutoTagJob ${ctx.jobId}: frame at ${frame.timestampMs}ms failed preprocessing; skipping it`,
+        );
+        continue;
+      }
+
+      const base64 = buffer.toString('base64');
+      if (totalBytes + base64.length > MAX_TOTAL_IMAGE_BYTES) {
+        this.logger.warn(
+          `VideoAutoTagJob ${ctx.jobId}: image budget reached after ${images.length} frame(s); ` +
+            'dropping the remaining frames',
+        );
+        break;
+      }
+      totalBytes += base64.length;
+      images.push({ base64, mimeType: 'image/jpeg' });
+      sampledTimestampsMs.push(frame.timestampMs);
+    }
+
+    if (images.length === 0) {
+      throw new Error('No video frames could be prepared for analysis');
+    }
+
+    // --- 3. Transcription — strictly BEST-EFFORT. ---
+    const transcript = await this.transcribeLead(videoPath, ctx.params, ctx.jobId);
+
+    // --- 4. ONE multi-image vision call. ---
+    const { system, prompt } = this.buildVideoPrompt(
+      ctx.labelNames,
+      ctx.peopleNames,
+      sampledTimestampsMs,
+      transcript?.text ?? null,
+    );
+
+    let rawText: string;
+    try {
+      rawText = await ctx.aiProvider.analyzeImage(ctx.creds, {
+        model: ctx.model,
+        system,
+        prompt,
+        images,
+        maxTokens: VIDEO_TAGGING_MAX_TOKENS,
+      });
+    } catch (providerErr) {
+      throw this.asRateLimitIfThrottled(providerErr, ctx.providerKey);
+    }
+
+    return {
+      rawText,
+      frameCount: images.length,
+      sampledTimestampsMs,
+      transcript: transcript
+        ? {
+            text: transcript.text,
+            ...(transcript.language ? { language: transcript.language } : {}),
+            leadSeconds: ctx.params.leadSeconds,
+          }
+        : null,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildVideoPrompt — shared prompt construction.
+  //
+  // Used by BOTH the in-process compute path above and the node
+  // transient-credentials endpoint (NodesService.getJobCredentials, issue
+  // #460), so a worker node receives the EXACT prompt the server would have
+  // sent. Mirrors AutoTaggingService.buildPrompt's role for photos.
+  // ---------------------------------------------------------------------------
+
+  buildVideoPrompt(
+    labelNames: string[],
+    peopleNames: string[],
+    sampledTimestampsMs: number[],
+    transcript: string | null,
+  ): { system: string; prompt: string } {
+    return {
+      system: VIDEO_AUTO_TAGGING_SYSTEM_PROMPT,
+      prompt: buildVideoTaggingPrompt(labelNames, peopleNames, sampledTimestampsMs, transcript),
+    };
+  }
+
+  /**
+   * Persist a NODE-computed result's transcript before the shared persist runs
+   * (issue #460). Called only from VideoAutoTaggingHandler.persistNodeResult;
+   * the in-process path persists its transcript inline in processMediaItem.
+   *
+   * Resolves the item's circleId itself, since a node-result call has no
+   * preloaded context — the same self-contained posture persistAutoTagging
+   * already takes.
+   */
+  async persistNodeTranscript(job: EnrichmentJob, result: VideoAutoTaggingResult): Promise<void> {
+    if (!result.transcript || !job.mediaItemId) return;
+
+    const mediaItem = await this.prisma.mediaItem.findUnique({
+      where: { id: job.mediaItemId },
+      select: { id: true, circleId: true },
+    });
+    if (!mediaItem) return;
+
+    await this.persistTranscript(mediaItem.id, mediaItem.circleId, result);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Transcribe the opening seconds of the video's audio.
+   *
+   * BEST-EFFORT by contract: a video with no audio track, a provider with no
+   * `transcribeAudio` capability, an unconfigured model, or an ffmpeg failure
+   * all resolve to `null` and the video is tagged visual-only. The ONE
+   * exception is a rate-limit error, which is rethrown so the queue's
+   * deferral path handles it — matching how `embedAndStore` already treats
+   * RateLimitError, and avoiding a silent quality drop on a throttled account.
+   */
+  private async transcribeLead(
+    videoPath: string,
+    params: VideoTaggingParams,
+    jobId: string,
+  ): Promise<{ text: string; language?: string } | null> {
+    if (!params.transcriptionEnabled) return null;
+
+    try {
+      const config = await this.aiSettingsService.resolveTranscriptionConfig();
+      if (!config) {
+        this.logger.warn(
+          `VideoAutoTagJob ${jobId}: transcription is enabled but ai.features.transcription is unset; tagging visual-only`,
+        );
+        return null;
+      }
+
+      const provider = this.aiProviderRegistry.get(config.provider);
+      if (typeof provider.transcribeAudio !== 'function') {
+        this.logger.warn(
+          `VideoAutoTagJob ${jobId}: provider ${config.provider} has no audio capability; tagging visual-only`,
+        );
+        return null;
+      }
+
+      const creds = await this.aiSettingsService.resolveCredentials(config.provider);
+      const audio = await extractAudioLead(videoPath, { leadSeconds: params.leadSeconds });
+      const result = await provider.transcribeAudio(creds, {
+        model: config.model,
+        audio: audio.buffer,
+        mimeType: audio.mimeType,
+      });
+
+      const text = result.text?.trim() ?? '';
+      if (!text) return null;
+      return { text, ...(result.language ? { language: result.language } : {}) };
+    } catch (err) {
+      // A throttled transcription provider is the queue's problem, not a
+      // reason to silently produce a worse description.
+      const rateLimited = err instanceof RateLimitError ? err : classifyRateLimit(err);
+      if (rateLimited) throw rateLimited;
+
+      this.logger.warn(
+        `VideoAutoTagJob ${jobId}: transcription failed — ${err instanceof Error ? err.message : String(err)}; tagging visual-only`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Upsert the transcript row (issue #454). Best-effort: a failure here costs
+   * the stored transcript and its contribution to the embedding, never the
+   * tags and description that were already paid for.
+   */
+  private async persistTranscript(
+    mediaItemId: string,
+    circleId: string,
+    computed: VideoAutoTaggingResult,
+  ): Promise<void> {
+    if (!computed.transcript) return;
+
+    const config = await this.aiSettingsService.resolveTranscriptionConfig().catch(() => null);
+    const data = {
+      text: computed.transcript.text,
+      language: computed.transcript.language ?? null,
+      provider: config?.provider ?? null,
+      model: config?.model ?? null,
+      leadSeconds: computed.transcript.leadSeconds,
+    };
+
+    try {
+      await this.prisma.mediaTranscript.upsert({
+        where: { mediaItemId },
+        create: { mediaItemId, circleId, ...data },
+        update: data,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `VideoAutoTagging: failed to persist transcript for MediaItem ${mediaItemId} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Distinct names of people assigned to faces on this item. */
+  private async loadPeopleNames(mediaItemId: string): Promise<string[]> {
+    const faces = await this.prisma.face.findMany({
+      where: {
+        mediaItemId,
+        personId: { not: null },
+        person: { deletedAt: null, mergedIntoId: null },
+      },
+      select: { person: { select: { name: true } } },
+    });
+    return [...new Set(faces.map((f) => f.person?.name).filter((n): n is string => !!n))];
+  }
+
+  /**
+   * Convert a provider 429/529 into the queue's RateLimitError so the job is
+   * DEFERRED rather than counted as a normal failed attempt. Byte-for-byte
+   * the same classification the photo path applies.
+   */
+  private asRateLimitIfThrottled(providerErr: unknown, providerKey: string): unknown {
+    const e = providerErr as Record<string, unknown> | null;
+    const httpStatus = typeof e?.['status'] === 'number' ? e['status'] : undefined;
+    // 529 = Anthropic "Overloaded" — transient, treated the same as 429.
+    if (httpStatus !== 429 && httpStatus !== 529) return providerErr;
+
+    const headers = e?.['headers'] as Record<string, unknown> | undefined;
+    const responseHeaders = (e?.['response'] as Record<string, unknown> | undefined)?.['headers'] as
+      | Record<string, unknown>
+      | undefined;
+    const retryHeader =
+      typeof headers?.['retry-after'] === 'string'
+        ? (headers['retry-after'] as string)
+        : typeof responseHeaders?.['retry-after'] === 'string'
+          ? (responseHeaders['retry-after'] as string)
+          : undefined;
+
+    return new RateLimitError(
+      typeof e?.['message'] === 'string' ? e['message'] : 'AI provider rate limit exceeded (429)',
+      parseRetryAfterMs(retryHeader) ?? undefined,
+      providerKey,
+    );
+  }
+
+  private async markFailed(
+    mediaItemId: string,
+    circleId: string,
+    providerKey: string | null,
+    modelVersion: string,
+    error: string,
+  ): Promise<void> {
+    await this.prisma.mediaTagStatus.upsert({
+      where: { mediaItemId },
+      create: {
+        mediaItemId,
+        circleId,
+        status: MediaTagStatusType.failed,
+        tagCount: 0,
+        lastError: error,
+        ...(providerKey ? { providerKey, modelVersion } : {}),
+      },
+      update: {
+        status: MediaTagStatusType.failed,
+        lastError: error,
+        ...(providerKey ? { providerKey, modelVersion } : {}),
+      },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Render a millisecond offset as `m:ss`, for the frame-timestamp list. */
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/**
+ * Build the video user prompt.
+ *
+ * EXTENDS the photo prompt's contract rather than replacing it: the same
+ * `{"tags": [...], "description": "..."}` envelope, the same newline-joined
+ * `Allowed labels:` vocabulary, and the same named-people clause. What it adds
+ * is the ordered-frames framing, the timestamp of each frame, and — when
+ * present — a delimited transcript block. Because the OUTPUT contract is
+ * unchanged, the whole parse/persist half is reused verbatim.
+ *
+ * Exported for direct testing.
+ */
+export function buildVideoTaggingPrompt(
+  labelNames: string[],
+  peopleNames: string[],
+  sampledTimestampsMs: number[],
+  transcript: string | null,
+): string {
+  const frameList = sampledTimestampsMs.map((ms, i) => `${i + 1}. ${formatTimestamp(ms)}`).join('\n');
+
+  let prompt = `Analyze this video and return a JSON object with two keys: "tags" and "description".
+
+You are shown ${sampledTimestampsMs.length} still frame(s) sampled in order from a single video, at these points in its runtime:
+${frameList}
+
+Treat them as one video, not as unrelated photos. Describe what the video as a whole is about.
+
+"tags": an array of applicable labels from the following allowed list. Only choose labels that clearly apply. Return an empty array if none apply.
+"description": a brief 1-3 sentence description of the video.
+
+Allowed labels:
+${labelNames.join('\n')}
+
+Example response: {"tags": ["label1", "label2"], "description": "A child blows out candles on a birthday cake while family members sing. The video was taken indoors at a decorated dining table."}`;
+
+  if (transcript) {
+    prompt += `\n\nTranscript of the video's opening seconds (may be incomplete or misheard — treat it as a hint, not as fact):\n"""\n${transcript}\n"""`;
+  }
+
+  if (peopleNames.length > 0) {
+    prompt += `\n\nThe following named people appear in this video: ${peopleNames.join(', ')}. Mention them by name in the description where appropriate.`;
+  }
+
+  return prompt;
+}

--- a/packages/enrichment-compute/src/dto/index.ts
+++ b/packages/enrichment-compute/src/dto/index.ts
@@ -188,6 +188,45 @@ export const autoTaggingResultSchema = z.object({
 export type AutoTaggingResult = z.infer<typeof autoTaggingResultSchema>;
 
 // ---------------------------------------------------------------------------
+// video_auto_tagging (epic #452, issue #455)
+// ---------------------------------------------------------------------------
+
+/**
+ * The RAW, unparsed vision-model response text for a video, plus the frame /
+ * transcript provenance the server persists and logs.
+ *
+ * Parsing stays server-side for the same reason as `autoTaggingResultSchema`
+ * above: validating returned tags against the enabled TagLabel vocabulary
+ * needs a DB-loaded label set that a node does not have. The node returns
+ * text; the server decides what counts as a tag.
+ *
+ * `sampledTimestampsMs` is carried so a node-computed result records WHICH
+ * moments the description was written from — the same audit value the
+ * in-process path logs.
+ */
+export const videoAutoTaggingResultSchema = z.object({
+  rawText: z.string(),
+  frameCount: z.number().int().nonnegative(),
+  sampledTimestampsMs: z.array(z.number()),
+  /**
+   * Present only when transcription ran and produced speech. Absent or null
+   * means the video was tagged visual-only — which is the normal outcome when
+   * transcription is off, unconfigured, or the provider has no audio
+   * capability.
+   */
+  transcript: z
+    .object({
+      text: z.string(),
+      language: z.string().optional(),
+      /** Seconds of audio actually transcribed — see `media_transcripts`. */
+      leadSeconds: z.number().int().positive(),
+    })
+    .nullable()
+    .optional(),
+});
+export type VideoAutoTaggingResult = z.infer<typeof videoAutoTaggingResultSchema>;
+
+// ---------------------------------------------------------------------------
 // geocode
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The core of epic #452. Videos now get AI tags, a written description, and a semantic embedding at parity with photos. `AutoTaggingService.processMediaItem` previously hard-failed any video with *"is type video, not photo"* — so videos carried no description, no AI tags, and no `media_item_embedding` row, making them **invisible to semantic search**.

Builds on #453 (multi-image vision), #454 (transcription), and #457 (settings), all merged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #455

## Changes Made

**A separate job type, not a branch inside `auto_tagging`** — required rather than stylistic, for three concrete reasons documented on the handler: the 20-minute `ENRICHMENT_VIDEO_JOB_TIMEOUT_MS` budget is applied by job **type** (branching would hand every photo-tagging job a 20-minute budget); node capability requirements are per type (`['sharp']` vs. ffmpeg/ffprobe); and `/admin/settings/jobs` filtering, `job-type-labels`, and per-type queue insights all key on type.

**The resource ceiling** is the load-bearing design constraint. Three costs, each independently bounded, **none scaling with video duration**: `maxFrames` images (`computeSeekTimestamps` spreads exactly that many across the *whole* runtime, so six frames come out of a 30-second clip **and** a 3-hour recital), `leadSeconds` of audio, and **one** vision call per video rather than one per frame. Consequently there is deliberately **no duration skip gate** — the longest videos in a family library are often the most significant, and since cost is already duration-independent, skipping them buys nothing. *Degrade, never skip on duration.*

**The persist half is not reimplemented.** It delegates to `AutoTaggingService.persistAutoTagging`, which already reloads the MediaItem, the enabled `TagLabel` vocabulary, and the people names itself (it had to, for the node-result path). Vocabulary validation therefore has exactly **one** implementation — a drifted second copy would let video tagging emit tags outside the admin's vocabulary, which is precisely the failure that validation exists to prevent.

**Gates, cheapest first** (mirroring `social-media-detection.handler.ts`): `features.autoTagging` → `AUTO_TAG_ENABLED` → `autoTagging.video.enabled` → non-video/deleted/missing-object → `socialMediaSource` non-null → size cap. Every one of them returns before any download or AI call.

**The prompt extends the photo contract rather than replacing it** — same `{"tags", "description"}` envelope, same newline-joined vocabulary, same named-people clause. It adds only the ordered-frames framing ("treat them as one video, not as unrelated photos"), each frame's timestamp, and a delimited transcript block flagged as a hint rather than fact. Because the *output* contract is unchanged, the whole parse/persist half is reused verbatim. `buildVideoPrompt` is public so #460 can hand a node the exact same prompt.

**Transcription is best-effort by contract**: no audio track, no `transcribeAudio` capability, no configured model, or an ffmpeg failure all degrade to visual-only. The one exception is a rate-limit error, which is rethrown so the queue's deferral path handles it — matching how `embedAndStore` already treats `RateLimitError`, and avoiding a silent quality drop on a throttled account. The transcript row is written *before* the shared persist runs, so this run's embedding already includes it.

Registered in all four required places: `EnrichmentHandlerRegistry` (via `onModuleInit`), `job-type-labels.ts`, `VIDEO_JOB_TYPES`, and `ProviderThrottleService.resolveKey` → `'tagging'` (the same provider quota as the photo path, so the two share one cooldown gate).

## Testing

- [x] Unit tests pass — `apps/api` **8116 pass**; `packages/enrichment-compute` 115 pass / 3 skipped
- [x] Type checks pass

**Photo auto-tagging is byte-identical**: `git diff origin/main -- auto-tagging.service.ts auto-tagging.service.spec.ts` is empty, and the existing 62-test photo suite passes untouched — which is the actual evidence for success criterion 7, not an assertion I wrote.

38 new tests. The gate ladder is covered branch-by-branch with an explicit `analyzeImage` non-call assertion on each, since a leaked gate costs money rather than failing loudly. The resource ceiling has its own block: one call carrying all frames (never one per frame), the same `maxFrames` reaching the extractor for a 30-second clip and a 3-hour video, a 3-hour video not being skipped, and trailing frames being dropped rather than the job failing when the image budget is hit. Transcription covers all four degrade paths, the rate-limit rethrow, and the transcript-before-tags ordering.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Nothing enqueues this type yet — that is #458 (routing) and #459 (workflows). Node compute is #460, docs are #461.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_