### PR TITLE
fix(api,web): route videos to AI tagging across every enqueue path

### DIFF
--- a/apps/api/src/media/enrichment/media-enrichment-video-tagging.service.spec.ts
+++ b/apps/api/src/media/enrichment/media-enrichment-video-tagging.service.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for MediaEnrichmentService — video AI tagging routing
+ * (epic #452, issue #458).
+ *
+ * Four paths enqueue AI tagging, and before this issue ALL of them were
+ * photo-only — one of them (bulk rerun) an outright bug that produced a failed
+ * job for an action the UI offered. This file covers the upload and per-item
+ * rerun paths on the enrichment service; the bulk path is covered in
+ * media.service's own spec and the controller path in tagging.controller.spec.
+ *
+ * The load-bearing behavior here is that video tagging rides the
+ * POST-SOCIAL-MEDIA-DETECTION fan-out rather than being enqueued directly at
+ * upload — which is what guarantees a TikTok re-share is never sent to the
+ * vision model.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { MediaType, JobReason, MediaTagStatusType } from '@prisma/client';
+import { MediaEnrichmentService } from './media-enrichment.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EnrichmentJobService } from '../../enrichment/enrichment-job.service';
+import { SystemSettingsService } from '../../settings/system-settings/system-settings.service';
+import { createMockPrismaService, MockPrismaService } from '../../../test/mocks/prisma.mock';
+
+function makeSettings(opts: {
+  autoTagging?: boolean;
+  videoTagging?: boolean;
+  faceRecognition?: boolean;
+  socialMediaDetection?: boolean;
+} = {}) {
+  return {
+    features: {
+      autoTagging: opts.autoTagging ?? true,
+      faceRecognition: opts.faceRecognition ?? false,
+      burstDetection: false,
+      socialMediaDetection: opts.socialMediaDetection ?? false,
+    },
+    autoTagging: {
+      video: {
+        enabled: opts.videoTagging ?? true,
+        maxFrames: 6,
+        sampleIntervalSeconds: 5,
+        transcription: { enabled: false, leadSeconds: 30 },
+      },
+    },
+    face: { video: { enabled: true, sampleIntervalSeconds: 5, maxFramesPerVideo: 60 } },
+  };
+}
+
+describe('MediaEnrichmentService — video AI tagging routing', () => {
+  let service: MediaEnrichmentService;
+  let mockPrisma: MockPrismaService;
+  let mockEnrichmentJobService: { enqueue: jest.Mock };
+  let mockSystemSettings: { getSettings: jest.Mock };
+
+  const videoItem = {
+    id: 'media-v1',
+    type: MediaType.video,
+    circleId: 'circle-1',
+    deletedAt: null,
+  };
+  const photoItem = {
+    id: 'media-p1',
+    type: MediaType.photo,
+    circleId: 'circle-1',
+    deletedAt: null,
+  };
+
+  const enqueuedTypes = (): string[] =>
+    mockEnrichmentJobService.enqueue.mock.calls.map((c: any[]) => c[0].type as string);
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    mockEnrichmentJobService = { enqueue: jest.fn().mockResolvedValue({ id: 'job-x' }) };
+    mockSystemSettings = { getSettings: jest.fn().mockResolvedValue(makeSettings()) };
+
+    mockPrisma.mediaTagStatus.upsert.mockResolvedValue({} as any);
+    mockPrisma.mediaFaceStatus.upsert.mockResolvedValue({} as any);
+    mockPrisma.mediaSocialStatus.upsert.mockResolvedValue({} as any);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaEnrichmentService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
+        { provide: SystemSettingsService, useValue: mockSystemSettings },
+      ],
+    }).compile();
+
+    service = module.get(MediaEnrichmentService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete process.env['AUTO_TAG_ENABLED'];
+    delete process.env['SOCIAL_MEDIA_DETECTION_ENABLED'];
+  });
+
+  // -------------------------------------------------------------------------
+  // Upload
+  // -------------------------------------------------------------------------
+
+  describe('upload', () => {
+    it('enqueues video_auto_tagging (never auto_tagging) for a video', async () => {
+      await service.enqueueUploadEnrichment(videoItem);
+
+      expect(enqueuedTypes()).toContain('video_auto_tagging');
+      expect(enqueuedTypes()).not.toContain('auto_tagging');
+    });
+
+    it('upserts the tag status to pending so the UI badge reflects the queued work', async () => {
+      await service.enqueueUploadEnrichment(videoItem);
+
+      expect(mockPrisma.mediaTagStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { mediaItemId: 'media-v1' },
+          update: { status: MediaTagStatusType.pending },
+        }),
+      );
+    });
+
+    it('WITHHOLDS video tagging behind social-media detection, so a TikTok re-share is never sent to the vision model', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ socialMediaDetection: true }),
+      );
+
+      await service.enqueueUploadEnrichment(videoItem);
+
+      // Only the classifier is queued; video_auto_tagging is fanned out later
+      // by SocialMediaDetectionHandler, and only on the CLEAN path.
+      expect(enqueuedTypes()).toEqual(['social_media_detection']);
+      expect(enqueuedTypes()).not.toContain('video_auto_tagging');
+    });
+
+    it('enqueues nothing tagging-related for a video when autoTagging.video.enabled is off (the default)', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings({ videoTagging: false }));
+
+      await service.enqueueUploadEnrichment(videoItem);
+
+      expect(enqueuedTypes()).not.toContain('video_auto_tagging');
+      expect(mockPrisma.mediaTagStatus.upsert).not.toHaveBeenCalled();
+    });
+
+    it('enqueues nothing tagging-related when the master autoTagging flag is off', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings({ autoTagging: false }));
+
+      await service.enqueueUploadEnrichment(videoItem);
+
+      expect(enqueuedTypes()).not.toContain('video_auto_tagging');
+    });
+
+    it('respects the AUTO_TAG_ENABLED kill-switch — video tagging has none of its own', async () => {
+      process.env['AUTO_TAG_ENABLED'] = 'false';
+
+      await service.enqueueUploadEnrichment(videoItem);
+
+      expect(enqueuedTypes()).not.toContain('video_auto_tagging');
+    });
+
+    it('still routes photos to auto_tagging — the photo path is unchanged', async () => {
+      await service.enqueueUploadEnrichment(photoItem);
+
+      expect(enqueuedTypes()).toContain('auto_tagging');
+      expect(enqueuedTypes()).not.toContain('video_auto_tagging');
+    });
+
+    it('enqueues nothing for a soft-deleted video', async () => {
+      await service.enqueueUploadEnrichment({ ...videoItem, deletedAt: new Date() });
+
+      expect(mockEnrichmentJobService.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Post-detection fan-out (the clean path out of social-media detection)
+  // -------------------------------------------------------------------------
+
+  describe('post-detection fan-out', () => {
+    it('releases BOTH video face detection and video AI tagging once a video is cleared', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ faceRecognition: true, videoTagging: true }),
+      );
+
+      await service.enqueueVideoPostDetectionEnrichment(videoItem, JobReason.upload);
+
+      expect(enqueuedTypes().sort()).toEqual(['video_auto_tagging', 'video_face_detection']);
+    });
+
+    it('still releases video face detection when video tagging is off — the two gates are independent', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ faceRecognition: true, videoTagging: false }),
+      );
+
+      await service.enqueueVideoPostDetectionEnrichment(videoItem, JobReason.upload);
+
+      expect(enqueuedTypes()).toEqual(['video_face_detection']);
+    });
+
+    it('still releases video tagging when face recognition is off', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(
+        makeSettings({ faceRecognition: false, videoTagging: true }),
+      );
+
+      await service.enqueueVideoPostDetectionEnrichment(videoItem, JobReason.upload);
+
+      expect(enqueuedTypes()).toEqual(['video_auto_tagging']);
+    });
+
+    it('maps the job reason to the same priority as the face path (rerun 0, upload 20, backfill 100)', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue(makeSettings({ videoTagging: true }));
+
+      for (const [reason, priority] of [
+        [JobReason.rerun, 0],
+        [JobReason.upload, 20],
+        [JobReason.backfill, 100],
+      ] as const) {
+        mockEnrichmentJobService.enqueue.mockClear();
+        await service.enqueueVideoPostDetectionEnrichment(videoItem, reason);
+        expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'video_auto_tagging', reason, priority }),
+        );
+      }
+    });
+
+    it('never enqueues for a photo handed to the video fan-out', async () => {
+      await service.enqueueVideoPostDetectionEnrichment(photoItem, JobReason.upload);
+
+      expect(mockEnrichmentJobService.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-item rerun
+  // -------------------------------------------------------------------------
+
+  describe('enqueueTagRerun', () => {
+    it('routes a video to video_auto_tagging when the caller supplies the type', async () => {
+      await service.enqueueTagRerun({
+        id: 'media-v1',
+        circleId: 'circle-1',
+        type: MediaType.video,
+      });
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'video_auto_tagging', priority: 0, reason: JobReason.rerun }),
+      );
+      // No lookup needed when the caller already knows the type.
+      expect(mockPrisma.mediaItem.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('routes a photo to auto_tagging', async () => {
+      await service.enqueueTagRerun({
+        id: 'media-p1',
+        circleId: 'circle-1',
+        type: MediaType.photo,
+      });
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'auto_tagging' }),
+      );
+    });
+
+    it('resolves the type itself when the caller omits it, so no call site can route wrongly by forgetting', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({ type: MediaType.video });
+
+      await service.enqueueTagRerun({ id: 'media-v1', circleId: 'circle-1' });
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'video_auto_tagging' }),
+      );
+    });
+
+    it('marks the tag status pending regardless of which type it routed to', async () => {
+      await service.enqueueTagRerun({
+        id: 'media-v1',
+        circleId: 'circle-1',
+        type: MediaType.video,
+      });
+
+      expect(mockPrisma.mediaTagStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ update: { status: MediaTagStatusType.pending } }),
+      );
+    });
+  });
+});

--- a/apps/api/src/media/enrichment/media-enrichment.service.ts
+++ b/apps/api/src/media/enrichment/media-enrichment.service.ts
@@ -28,7 +28,10 @@ export interface EnrichmentMediaItem {
  * Routing rules:
  *   - Soft-deleted items (deletedAt non-null) are skipped regardless of type.
  *   - Photos → auto_tagging (priority 20), face_detection (priority 10), burst_detection (priority 10).
- *   - Videos → video_face_detection (priority 20) when faceRecognition + face.video.enabled.
+ *   - Videos → video_face_detection (priority 20) when faceRecognition + face.video.enabled,
+ *     and video_auto_tagging (priority 20) when autoTagging + autoTagging.video.enabled.
+ *     Both ride the post-social-media-detection fan-out, so a TikTok re-share is
+ *     never sent to the vision model.
  *   - Other types are silently skipped.
  *   - Each feature has an environment kill-switch AND a system-settings flag.
  *   - EnrichmentJobService.enqueue is idempotent (deduplicates pending/running).
@@ -278,48 +281,101 @@ export class MediaEnrichmentService {
       // Reuse the caller's already-resolved settings when provided (upload path)
       // to avoid a redundant read; the social handler calls without them.
       const settings = resolvedSettings ?? (await this.systemSettings.getSettings());
+      const priority =
+        reason === JobReason.rerun ? 0 : reason === JobReason.backfill ? 100 : 20;
+      const enqueued: string[] = [];
+
+      // --- Video face detection ---
       const faceOn = settings.features?.['faceRecognition'] === true;
       const videoFaceOn = settings.face?.video?.enabled !== false;
       const faceKilled = (process.env['FACE_AUTO_DETECT'] ?? 'true') === 'false';
 
-      if (!faceOn || faceKilled || !videoFaceOn) {
+      if (faceOn && !faceKilled && videoFaceOn) {
+        const job = await this.enrichmentJobService.enqueue({
+          type: 'video_face_detection',
+          mediaItemId: item.id,
+          circleId: item.circleId,
+          reason,
+          priority,
+        });
+
+        await this.prisma.mediaFaceStatus.upsert({
+          where: { mediaItemId: item.id },
+          create: {
+            mediaItemId: item.id,
+            status: MediaFaceStatusType.pending,
+            faceCount: 0,
+          },
+          update: {
+            status: MediaFaceStatusType.pending,
+          },
+        });
+
+        enqueued.push(`video_face_detection(job=${job.id})`);
+      } else {
         const why = !faceOn
           ? 'feature disabled'
           : faceKilled
             ? 'FACE_AUTO_DETECT=false'
             : 'face.video.enabled=false';
         this.logger.debug(
-          `MediaItem ${item.id} (video) post-detection enrichment skipped: ${why}`,
+          `MediaItem ${item.id} (video) video_face_detection skipped: ${why}`,
         );
-        return;
       }
 
-      const priority =
-        reason === JobReason.rerun ? 0 : reason === JobReason.backfill ? 100 : 20;
+      // --- Video AI tagging (epic #452, issue #458) ---
+      //
+      // Deliberately part of the post-detection fan-out rather than enqueued
+      // directly at upload: `social_media_detection` withholds video
+      // enrichment until a video is classified, so routing through here means
+      // a TikTok/Instagram re-share is NEVER sent to the vision model —
+      // cheaper and more correct. Gated on autoTagging + AUTO_TAG_ENABLED +
+      // autoTagging.video.enabled, all read from the one settings object the
+      // caller already resolved.
+      const taggingOn = settings.features?.['autoTagging'] === true;
+      const videoTaggingOn = (settings as { autoTagging?: { video?: { enabled?: boolean } } })
+        .autoTagging?.video?.enabled === true;
+      const autoTagKilled = process.env['AUTO_TAG_ENABLED'] === 'false';
 
-      const job = await this.enrichmentJobService.enqueue({
-        type: 'video_face_detection',
-        mediaItemId: item.id,
-        circleId: item.circleId,
-        reason,
-        priority,
-      });
-
-      await this.prisma.mediaFaceStatus.upsert({
-        where: { mediaItemId: item.id },
-        create: {
+      if (taggingOn && !autoTagKilled && videoTaggingOn) {
+        const job = await this.enrichmentJobService.enqueue({
+          type: 'video_auto_tagging',
           mediaItemId: item.id,
-          status: MediaFaceStatusType.pending,
-          faceCount: 0,
-        },
-        update: {
-          status: MediaFaceStatusType.pending,
-        },
-      });
+          circleId: item.circleId,
+          reason,
+          priority,
+        });
 
-      this.logger.log(
-        `MediaItem ${item.id} (video) post-detection enrichment: enqueued video_face_detection(job=${job.id}, reason=${reason}, priority=${priority})`,
-      );
+        await this.prisma.mediaTagStatus.upsert({
+          where: { mediaItemId: item.id },
+          create: {
+            mediaItemId: item.id,
+            circleId: item.circleId,
+            status: MediaTagStatusType.pending,
+            tagCount: 0,
+          },
+          update: {
+            status: MediaTagStatusType.pending,
+          },
+        });
+
+        enqueued.push(`video_auto_tagging(job=${job.id})`);
+      } else {
+        const why = !taggingOn
+          ? 'feature disabled'
+          : autoTagKilled
+            ? 'AUTO_TAG_ENABLED=false'
+            : 'autoTagging.video.enabled=false';
+        this.logger.debug(
+          `MediaItem ${item.id} (video) video_auto_tagging skipped: ${why}`,
+        );
+      }
+
+      if (enqueued.length > 0) {
+        this.logger.log(
+          `MediaItem ${item.id} (video) post-detection enrichment: enqueued ${enqueued.join(', ')} (reason=${reason}, priority=${priority})`,
+        );
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(
@@ -341,12 +397,29 @@ export class MediaEnrichmentService {
   // ---------------------------------------------------------------------------
 
   /**
-   * Re-enqueue auto-tagging for a single item and mark its tag status pending.
-   * Mirrors TaggingController.rerunTagging.
+   * Re-enqueue AI tagging for a single item and mark its tag status pending.
+   *
+   * Routes to `video_auto_tagging` for videos and `auto_tagging` otherwise —
+   * mirroring `enqueueFaceRerun` below, which has always branched this way.
+   * Before issue #458 this enqueued `auto_tagging` unconditionally, so any
+   * caller handed a video produced a job the handler then failed.
+   *
+   * `type` is optional so a caller that already knows it avoids a lookup; when
+   * absent it is resolved here, which keeps every call site correct by default
+   * rather than correct only if it remembered to pass one.
    */
-  async enqueueTagRerun(item: { id: string; circleId: string }): Promise<void> {
+  async enqueueTagRerun(item: { id: string; circleId: string; type?: MediaType }): Promise<void> {
+    const type =
+      item.type ??
+      (
+        await this.prisma.mediaItem.findUnique({
+          where: { id: item.id },
+          select: { type: true },
+        })
+      )?.type;
+
     await this.enrichmentJobService.enqueue({
-      type: 'auto_tagging',
+      type: type === MediaType.video ? 'video_auto_tagging' : 'auto_tagging',
       mediaItemId: item.id,
       circleId: item.circleId,
       reason: JobReason.rerun,

--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -4,7 +4,7 @@ import {
   ForbiddenException,
   BadRequestException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { MediaType, Prisma } from '@prisma/client';
 import { MediaService } from './media.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
@@ -3650,7 +3650,7 @@ describe('MediaService', () => {
       const ids = [randomUUID(), randomUUID(), randomUUID()];
       const dto = makeBulkRerunDto({ ids });
       mockPrisma.mediaItem.findMany.mockResolvedValue(
-        ids.map((id) => ({ id })) as any,
+        ids.map((id) => ({ id, type: MediaType.photo })) as any,
       );
 
       const result = await service.bulkRerunTags(dto, 'user-1', ownPerms);
@@ -3659,10 +3659,41 @@ describe('MediaService', () => {
       for (const id of ids) {
         expect(mockMediaEnrichmentService.enqueueTagRerun).toHaveBeenCalledWith({
           id,
+          type: MediaType.photo,
           circleId: CIRCLE_ID,
         });
       }
       expect(result).toEqual({ queued: 3 });
+    });
+
+    // -----------------------------------------------------------------------
+    // Issue #458: this method used to enqueue `auto_tagging` for every id with
+    // NO type filter, so selecting a video in the gallery and choosing "Re-run
+    // AI tagging" — an action the UI offers — produced a failed job. Its
+    // sibling bulkRerunFaces, immediately below, always routed by type.
+    // -----------------------------------------------------------------------
+    it('passes each item\'s TYPE through, so a mixed selection routes per item', async () => {
+      const photoId = randomUUID();
+      const videoId = randomUUID();
+      const dto = makeBulkRerunDto({ ids: [photoId, videoId] });
+      mockPrisma.mediaItem.findMany.mockResolvedValue([
+        { id: photoId, type: MediaType.photo },
+        { id: videoId, type: MediaType.video },
+      ] as any);
+
+      const result = await service.bulkRerunTags(dto, 'user-1', ownPerms);
+
+      expect(mockMediaEnrichmentService.enqueueTagRerun).toHaveBeenCalledWith({
+        id: photoId,
+        type: MediaType.photo,
+        circleId: CIRCLE_ID,
+      });
+      expect(mockMediaEnrichmentService.enqueueTagRerun).toHaveBeenCalledWith({
+        id: videoId,
+        type: MediaType.video,
+        circleId: CIRCLE_ID,
+      });
+      expect(result).toEqual({ queued: 2 });
     });
   });
 

--- a/apps/api/src/media/media.service.ts
+++ b/apps/api/src/media/media.service.ts
@@ -2176,13 +2176,29 @@ export class MediaService {
     await this.assertAllInCircle(dto.ids, dto.circleId, userId, perms, 'collaborator' as CircleRole);
 
     const uniqueIds = [...new Set(dto.ids)];
+
+    // AI tagging routes on media type (photo -> auto_tagging, video ->
+    // video_auto_tagging), so fetch each item's type — exactly as
+    // bulkRerunFaces below already does. Before issue #458 this loop enqueued
+    // `auto_tagging` for every id with no type filter, so selecting a video in
+    // the gallery and choosing "Re-run AI tagging" — an action the UI offers —
+    // produced a job the handler then failed.
+    const items = await this.prisma.mediaItem.findMany({
+      where: { id: { in: uniqueIds }, circleId: dto.circleId, deletedAt: null },
+      select: { id: true, type: true },
+    });
+
     let queued = 0;
-    for (const id of uniqueIds) {
-      await this.mediaEnrichmentService.enqueueTagRerun({ id, circleId: dto.circleId });
+    for (const item of items) {
+      await this.mediaEnrichmentService.enqueueTagRerun({
+        id: item.id,
+        type: item.type,
+        circleId: dto.circleId,
+      });
       queued++;
     }
 
-    this.logger.log(`bulkRerunTags: queued ${queued} auto_tagging reruns in circle ${dto.circleId} by user ${userId}`);
+    this.logger.log(`bulkRerunTags: queued ${queued} AI tagging reruns in circle ${dto.circleId} by user ${userId}`);
     return { queued };
   }
 

--- a/apps/api/src/tagging/admin-tagging.controller.ts
+++ b/apps/api/src/tagging/admin-tagging.controller.ts
@@ -8,6 +8,7 @@ import {
   Post,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { MediaType } from '@prisma/client';
 import { createZodDto } from 'nestjs-zod';
 import { z } from 'zod';
 import { Auth } from '../auth/decorators/auth.decorator';
@@ -21,6 +22,15 @@ const adminBackfillSchema = z.object({
   from: flexibleDate.optional(),
   to: flexibleDate.optional(),
   force: z.boolean().optional().default(false),
+  /**
+   * Which media types to back-fill. Videos are OPT-IN (epic #452, issue #458):
+   * an admin used to running photo backfills would otherwise, on their first
+   * run after upgrading, dispatch an AI call for EVERY video in the library —
+   * a large, unexpected bill from a command whose behavior they thought they
+   * understood. Deliberately no `.default()`: an absent value is resolved in
+   * the service, so the default lives in exactly one place.
+   */
+  mediaTypes: z.array(z.enum(['photo', 'video'])).nonempty().optional(),
   // .prefault({}) so a bodyless POST parses exactly like {} (force: false) —
   // see issue #289 (app.module.ts) and admin-metadata.controller.ts.
 }).prefault({});
@@ -40,7 +50,13 @@ export class AdminTaggingController {
   @Post('backfill')
   @Auth({ roles: [ROLES.ADMIN], permissions: [PERMISSIONS.SYSTEM_SETTINGS_WRITE] })
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Backfill auto-tagging across ALL circles (Admin)' })
+  @ApiOperation({
+    summary: 'Backfill AI tagging across ALL circles (Admin)',
+    description:
+      'Queues AI tagging for unprocessed (or all, if forced) media across every circle. ' +
+      'Photos only by default — pass mediaTypes: ["photo","video"] to include videos, ' +
+      'which routes each video to video_auto_tagging.',
+  })
   @ApiResponse({ status: 201, description: 'Backfill jobs enqueued' })
   @ApiResponse({ status: 400, description: 'Auto-tagging is disabled globally' })
   async backfillAllCircles(@Body() dto: AdminBackfillDto) {
@@ -52,6 +68,7 @@ export class AdminTaggingController {
       from: dto.from,
       to: dto.to,
       force: dto.force,
+      ...(dto.mediaTypes ? { mediaTypes: dto.mediaTypes as MediaType[] } : {}),
     });
     return { data: result };
   }

--- a/apps/api/src/tagging/tagging-backfill.service.spec.ts
+++ b/apps/api/src/tagging/tagging-backfill.service.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for TaggingBackfillService (epic #452, issue #458).
+ *
+ * The load-bearing behavior is that videos are OPT-IN. An admin used to
+ * running photo backfills would otherwise, on their first run after
+ * upgrading, dispatch an AI call for EVERY video in the library — a large,
+ * unexpected bill from a command whose behavior they thought they understood.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobReason, MediaTagStatusType, MediaType } from '@prisma/client';
+import { TaggingBackfillService } from './tagging-backfill.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
+import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
+
+describe('TaggingBackfillService', () => {
+  let service: TaggingBackfillService;
+  let mockPrisma: MockPrismaService;
+  let mockEnrichmentJobService: { enqueue: jest.Mock };
+
+  /** The `type` filter the eligibility query was built with. */
+  const typeFilter = () =>
+    (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0].where.type;
+
+  const enqueuedTypes = (): string[] =>
+    mockEnrichmentJobService.enqueue.mock.calls.map((c: any[]) => c[0].type as string);
+
+  beforeEach(async () => {
+    mockPrisma = createMockPrismaService();
+    mockEnrichmentJobService = { enqueue: jest.fn().mockResolvedValue({ id: 'job-x' }) };
+    (mockPrisma.mediaItem.findMany as jest.Mock).mockResolvedValue([]);
+    (mockPrisma.mediaTagStatus.upsert as jest.Mock).mockResolvedValue({});
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaggingBackfillService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
+      ],
+    }).compile();
+
+    service = module.get(TaggingBackfillService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('media-type scoping', () => {
+    it('backfills PHOTOS ONLY when mediaTypes is omitted — videos are opt-in', async () => {
+      await service.backfillCircle('circle-1', {});
+
+      expect(typeFilter()).toEqual({ in: [MediaType.photo] });
+    });
+
+    it('backfills photos only when mediaTypes is an empty array', async () => {
+      await service.backfillCircle('circle-1', { mediaTypes: [] });
+
+      expect(typeFilter()).toEqual({ in: [MediaType.photo] });
+    });
+
+    it('includes videos when they are explicitly requested', async () => {
+      await service.backfillCircle('circle-1', {
+        mediaTypes: [MediaType.photo, MediaType.video],
+      });
+
+      expect(typeFilter()).toEqual({ in: [MediaType.photo, MediaType.video] });
+    });
+
+    it('can target videos alone', async () => {
+      await service.backfillCircle('circle-1', { mediaTypes: [MediaType.video] });
+
+      expect(typeFilter()).toEqual({ in: [MediaType.video] });
+    });
+  });
+
+  describe('job-type routing', () => {
+    it('routes each matched item by its own type', async () => {
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockResolvedValue([
+        { id: 'p1', circleId: 'circle-1', type: MediaType.photo },
+        { id: 'v1', circleId: 'circle-1', type: MediaType.video },
+      ]);
+
+      const enqueued = await service.backfillCircle('circle-1', {
+        mediaTypes: [MediaType.photo, MediaType.video],
+      });
+
+      expect(enqueuedTypes()).toEqual(['auto_tagging', 'video_auto_tagging']);
+      expect(enqueued).toBe(2);
+    });
+
+    it('enqueues at backfill priority 100 so it never starves upload enrichment', async () => {
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockResolvedValue([
+        { id: 'v1', circleId: 'circle-1', type: MediaType.video },
+      ]);
+
+      await service.backfillCircle('circle-1', { mediaTypes: [MediaType.video] });
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: JobReason.backfill, priority: 100 }),
+      );
+    });
+
+    it('marks each item pending regardless of which type it routed to', async () => {
+      (mockPrisma.mediaItem.findMany as jest.Mock).mockResolvedValue([
+        { id: 'v1', circleId: 'circle-1', type: MediaType.video },
+      ]);
+
+      await service.backfillCircle('circle-1', { mediaTypes: [MediaType.video] });
+
+      expect(mockPrisma.mediaTagStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ update: { status: MediaTagStatusType.pending } }),
+      );
+    });
+  });
+
+  describe('eligibility', () => {
+    it('skips already-processed items unless forced', async () => {
+      await service.backfillCircle('circle-1', {});
+
+      const where = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0].where;
+      expect(where.OR).toBeDefined();
+    });
+
+    it('re-tags everything when forced', async () => {
+      await service.backfillCircle('circle-1', { force: true });
+
+      const where = (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls[0][0].where;
+      expect(where.OR).toBeUndefined();
+    });
+  });
+
+  describe('backfillAllCircles', () => {
+    it('forwards mediaTypes to every circle', async () => {
+      (mockPrisma.circle.findMany as jest.Mock).mockResolvedValue([
+        { id: 'circle-1' },
+        { id: 'circle-2' },
+      ]);
+
+      const result = await service.backfillAllCircles({
+        mediaTypes: [MediaType.photo, MediaType.video],
+      });
+
+      expect(result.circles).toBe(2);
+      for (const call of (mockPrisma.mediaItem.findMany as jest.Mock).mock.calls) {
+        expect(call[0].where.type).toEqual({ in: [MediaType.photo, MediaType.video] });
+      }
+    });
+
+    it('still defaults to photos only across every circle', async () => {
+      (mockPrisma.circle.findMany as jest.Mock).mockResolvedValue([{ id: 'circle-1' }]);
+
+      await service.backfillAllCircles({});
+
+      expect(typeFilter()).toEqual({ in: [MediaType.photo] });
+    });
+  });
+});

--- a/apps/api/src/tagging/tagging-backfill.service.ts
+++ b/apps/api/src/tagging/tagging-backfill.service.ts
@@ -14,15 +14,24 @@ export class TaggingBackfillService {
   ) {}
 
   /**
-   * Backfill auto-tagging for all eligible photos in a single circle.
+   * Backfill AI tagging for all eligible items in a single circle.
    * No per-circle opt-in gate — the global toggle is the only gate (checked in the controller).
    * No membership check — intended for admin/internal usage.
+   *
+   * `mediaTypes` is OPT-IN for videos (defaults to photos only, epic #452,
+   * issue #458). An admin who has been running photo backfills would
+   * otherwise, on their first run after upgrading, dispatch an AI call for
+   * EVERY video in the library — a large, unexpected bill from a command
+   * whose behavior they thought they understood. Videos are included by
+   * passing `mediaTypes: ['photo','video']` explicitly.
    */
   async backfillCircle(
     circleId: string,
-    opts: { from?: string; to?: string; force?: boolean },
+    opts: { from?: string; to?: string; force?: boolean; mediaTypes?: MediaType[] },
   ): Promise<number> {
     const { force = false } = opts;
+    const mediaTypes =
+      opts.mediaTypes && opts.mediaTypes.length > 0 ? opts.mediaTypes : [MediaType.photo];
 
     const from = opts.from ? new Date(opts.from) : undefined;
     const to = opts.to ? new Date(opts.to) : undefined;
@@ -31,7 +40,7 @@ export class TaggingBackfillService {
     const mediaItems = await this.prisma.mediaItem.findMany({
       where: {
         circleId,
-        type: MediaType.photo,
+        type: { in: mediaTypes },
         deletedAt: null,
         ...dateWhere,
         ...(force
@@ -47,13 +56,14 @@ export class TaggingBackfillService {
               ],
             }),
       },
-      select: { id: true, circleId: true },
+      select: { id: true, circleId: true, type: true },
     });
 
     let enqueued = 0;
     for (const item of mediaItems) {
       await this.enrichmentJobService.enqueue({
-        type: 'auto_tagging',
+        // Route by type, the same rule every other enqueue path follows.
+        type: item.type === MediaType.video ? 'video_auto_tagging' : 'auto_tagging',
         mediaItemId: item.id,
         circleId: item.circleId,
         reason: JobReason.backfill,
@@ -77,21 +87,24 @@ export class TaggingBackfillService {
     }
 
     this.logger.log(
-      `Backfill: queued ${enqueued} auto-tagging job(s) for circle ${circleId}`,
+      `Backfill: queued ${enqueued} AI tagging job(s) for circle ${circleId} (types: ${mediaTypes.join(', ')})`,
     );
 
     return enqueued;
   }
 
   /**
-   * Backfill auto-tagging across ALL circles.
+   * Backfill AI tagging across ALL circles.
    * No per-circle opt-in gate — the global toggle is the only gate (checked in the controller).
    * Returns the total number of enqueued jobs and the number of circles processed.
+   *
+   * See `backfillCircle` for why `mediaTypes` defaults to photos only.
    */
   async backfillAllCircles(opts: {
     from?: string;
     to?: string;
     force?: boolean;
+    mediaTypes?: MediaType[];
   }): Promise<{ enqueued: number; circles: number }> {
     const allCircles = await this.prisma.circle.findMany({
       select: { id: true },

--- a/apps/api/src/tagging/tagging.controller.spec.ts
+++ b/apps/api/src/tagging/tagging.controller.spec.ts
@@ -58,11 +58,13 @@ function makeUser(overrides: Partial<RequestUser> = {}): RequestUser {
 function makeMediaItem(overrides: Partial<{
   id: string;
   circleId: string;
+  type: MediaType;
   deletedAt: Date | null;
 }> = {}) {
   return {
     id: 'media-1',
     circleId: 'circle-1',
+    type: MediaType.photo,
     deletedAt: null,
     ...overrides,
   };
@@ -126,7 +128,39 @@ describe('TaggingController', () => {
       expect(result.data.status).toBe(JobStatus.pending);
     });
 
-    it('enqueues with type auto_tagging, reason rerun, and priority 0', async () => {
+    // -----------------------------------------------------------------------
+    // Issue #458: this endpoint had NO type guard at all, so a video id
+    // enqueued an `auto_tagging` job the handler then failed.
+    // -----------------------------------------------------------------------
+    it('routes a VIDEO to video_auto_tagging', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ type: MediaType.video }),
+      );
+      (mockPrisma.mediaTagStatus.upsert as jest.Mock).mockResolvedValue({});
+
+      await controller.rerunTagging('media-1', makeUser());
+
+      expect(mockEnrichmentJobService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'video_auto_tagging', priority: 0 }),
+      );
+    });
+
+    it('marks the tag status pending for a video too, so the UI badge reflects the queued rerun', async () => {
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
+        makeMediaItem({ type: MediaType.video }),
+      );
+      (mockPrisma.mediaTagStatus.upsert as jest.Mock).mockResolvedValue({});
+
+      await controller.rerunTagging('media-1', makeUser());
+
+      expect(mockPrisma.mediaTagStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({ status: MediaTagStatusType.pending }),
+        }),
+      );
+    });
+
+    it('enqueues with type auto_tagging (photo), reason rerun, and priority 0', async () => {
       (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue(
         makeMediaItem(),
       );

--- a/apps/api/src/tagging/tagging.controller.ts
+++ b/apps/api/src/tagging/tagging.controller.ts
@@ -13,7 +13,7 @@ import {
   ApiResponse,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import { CircleRole, JobReason, MediaTagStatusType } from '@prisma/client';
+import { CircleRole, JobReason, MediaTagStatusType, MediaType } from '@prisma/client';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PERMISSIONS } from '../common/constants/roles.constants';
@@ -57,8 +57,14 @@ export class TaggingController {
       'collaborator' as CircleRole,
     );
 
+    // Route by media type (epic #452, issue #458). This endpoint previously
+    // had NO type guard at all, so a video id enqueued an `auto_tagging` job
+    // the handler then failed.
+    const jobType =
+      mediaItem.type === MediaType.video ? 'video_auto_tagging' : 'auto_tagging';
+
     const job = await this.enrichmentJobService.enqueue({
-      type: 'auto_tagging',
+      type: jobType,
       mediaItemId,
       circleId: mediaItem.circleId,
       reason: JobReason.rerun,
@@ -79,7 +85,7 @@ export class TaggingController {
     });
 
     this.logger.log(
-      `Rerun auto-tagging job ${job.id} enqueued for MediaItem ${mediaItemId} by user ${user.id}`,
+      `Rerun ${jobType} job ${job.id} enqueued for MediaItem ${mediaItemId} by user ${user.id}`,
     );
 
     return { data: { jobId: job.id, status: job.status } };
@@ -128,10 +134,10 @@ export class TaggingController {
     mediaItemId: string,
     user: RequestUser,
     requiredRole: CircleRole = 'viewer' as CircleRole,
-  ): Promise<{ id: string; circleId: string }> {
+  ): Promise<{ id: string; circleId: string; type: MediaType }> {
     const mediaItem = await this.prisma.mediaItem.findUnique({
       where: { id: mediaItemId },
-      select: { id: true, circleId: true, deletedAt: true },
+      select: { id: true, circleId: true, type: true, deletedAt: true },
     });
 
     if (!mediaItem || mediaItem.deletedAt) {
@@ -145,6 +151,6 @@ export class TaggingController {
       requiredRole,
     );
 
-    return { id: mediaItem.id, circleId: mediaItem.circleId };
+    return { id: mediaItem.id, circleId: mediaItem.circleId, type: mediaItem.type };
   }
 }

--- a/apps/web/src/pages/Admin/TaggingSettingsPage.tsx
+++ b/apps/web/src/pages/Admin/TaggingSettingsPage.tsx
@@ -33,6 +33,9 @@ function TaggingSettingsContent() {
   const [backfillFrom, setBackfillFrom] = useState('');
   const [backfillTo, setBackfillTo] = useState('');
   const [backfillForce, setBackfillForce] = useState(false);
+  // Videos are opt-in: the default backfill must not surprise an admin with an
+  // AI call for every video in the library.
+  const [backfillIncludeVideos, setBackfillIncludeVideos] = useState(false);
   const [backfillLoading, setBackfillLoading] = useState(false);
   const [backfillResult, setBackfillResult] = useState<GlobalBackfillResult | null>(null);
   const [backfillError, setBackfillError] = useState<string | null>(null);
@@ -77,6 +80,7 @@ function TaggingSettingsContent() {
       from: backfillFrom || undefined,
       to: backfillTo || undefined,
       force: backfillForce,
+      mediaTypes: backfillIncludeVideos ? ['photo', 'video'] : ['photo'],
     })
       .then((result) => setBackfillResult(result))
       .catch((err: unknown) => {
@@ -264,8 +268,8 @@ function TaggingSettingsContent() {
             Run Backfill on All Circles
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Queue AI tagging for unprocessed (or all, if forced) photos across every circle that has
-            auto-tagging enabled.
+            Queue AI tagging for unprocessed (or all, if forced) media across every circle that has
+            auto-tagging enabled. Photos only unless you opt videos in below.
           </Typography>
 
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2 }}>
@@ -297,8 +301,25 @@ function TaggingSettingsContent() {
               />
             }
             label="Force re-tag all"
-            sx={{ mb: 2, display: 'block' }}
+            sx={{ display: 'block' }}
           />
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={backfillIncludeVideos}
+                onChange={(e) => setBackfillIncludeVideos(e.target.checked)}
+                disabled={!videoEnabled}
+              />
+            }
+            label="Include videos"
+            sx={{ display: 'block' }}
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {videoEnabled
+              ? `Off by default. Each video costs one AI call with ${maxFrames} frames, so a whole-library run can be a large, one-off bill.`
+              : 'Turn on video AI tagging above to back-fill videos.'}
+          </Typography>
 
           {backfillResult && (
             <Alert severity="success" sx={{ mb: 2 }}>

--- a/apps/web/src/services/adminBackfill.ts
+++ b/apps/web/src/services/adminBackfill.ts
@@ -9,6 +9,12 @@ export async function runGlobalTaggingBackfill(body?: {
   from?: string;
   to?: string;
   force?: boolean;
+  /**
+   * Media types to back-fill. Videos are OPT-IN (epic #452): omitting this
+   * backfills photos only, so an admin's habitual backfill does not suddenly
+   * dispatch an AI call for every video in the library.
+   */
+  mediaTypes?: ('photo' | 'video')[];
 }): Promise<GlobalBackfillResult> {
   return api.post<GlobalBackfillResult>('/admin/tagging/backfill', body ?? {});
 }


### PR DESCRIPTION
## Summary

Four separate paths enqueue AI tagging, and all four were photo-only. One of them was an **outright bug that predates this epic**: `MediaService.bulkRerunTags` enqueued `auto_tagging` for every id with no type filter, so selecting a video in the gallery and choosing "Re-run AI tagging" — an action the UI offers — produced a failed job. Its sibling `bulkRerunFaces`, immediately below in the same file, has always routed by type.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #458

## Changes Made

**1. Upload** — videos join the existing **post-social-media-detection fan-out** (`enqueueVideoPostDetectionEnrichment`) rather than being enqueued directly. `social_media_detection` already withholds video enrichment until a video is classified, so routing `video_auto_tagging` through there means a TikTok/Instagram re-share is **never** sent to the vision model — both cheaper and more correct. When social detection is off, the direct call the upload path already makes covers it. The two video gates (face, tagging) are independent, so either feature can be on alone.

**2. Per-item rerun** — `TaggingController.rerunTagging` had **no type guard at all**. It now resolves the item's type (the access helper already loads the row) and routes accordingly. `MediaEnrichmentService.enqueueTagRerun` takes an optional `type` so a caller that already knows it avoids a lookup, and **resolves it itself when absent** — which keeps every call site correct by default rather than correct only if it remembered to pass one.

**3. Bulk rerun (the live bug)** — `bulkRerunTags` now fetches `{ id, type }` for the selection in one query and routes per item, exactly mirroring `bulkRerunFaces`.

**4. Admin backfill** — `POST /api/admin/tagging/backfill` gains an optional `mediaTypes?: ('photo'|'video')[]`, and each matched item routes by its own type.

### The open question in the issue

The issue asked whether backfill should include videos by default or make them opt-in, and recommended **opt-in**. That is what this implements. An admin used to running photo backfills would otherwise, on their first run after upgrading, dispatch an AI call for *every video in the library* — a large, unexpected bill from a command whose behavior they thought they understood. The default lives in exactly one place (the service; the zod field deliberately has no `.default()`), and the admin UI adds an "Include videos" toggle that names the per-video cost and is disabled until video tagging is on.

## Testing

- [x] Unit tests pass — `apps/api` **8147 pass**, `apps/web` tagging page 24 pass
- [x] Type checks pass (`apps/api`, `apps/web`)

31 new tests across four files. The acceptance evidence the issue asks for is covered directly: a **mixed photo/video selection** through `bulkRerunTags` enqueues the correct job type per item. Also covered: video tagging being *withheld* behind social-media detection (asserted as `enqueuedTypes() === ['social_media_detection']`, so a regression that enqueues it early fails loudly); the two video fan-out gates being independent; the `rerun`/`upload`/`backfill` priority mapping; `enqueueTagRerun` resolving an omitted type; and backfill defaulting to photos only in both the per-circle and all-circles entry points.

One pre-existing assertion was tightened rather than left alone: `bulkRerunTags`' spec passed `{ id }` rows, so `type` came through `undefined` and Jest's `toHaveBeenCalledWith` treated it as absent — the test would have stayed green with the routing broken. It now asserts real types.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Documentation for the epic lands in #461, per the epic's plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_