### PR TITLE
feat(api,web): workflow video routing, `rerun_ai_tagging`, and two correctness fixes

### DIFF
--- a/apps/api/src/workflows/actions/workflow-action.executor.spec.ts
+++ b/apps/api/src/workflows/actions/workflow-action.executor.spec.ts
@@ -14,7 +14,7 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MediaTagSource, MediaType } from '@prisma/client';
+import { JobReason, MediaTagSource, MediaTagStatusType, MediaType } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { WorkflowActionExecutor } from './workflow-action.executor';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -692,7 +692,8 @@ describe('WorkflowActionExecutor', () => {
   // ---------------------------------------------------------------------------
 
   describe('rerun_enrichment', () => {
-    it('enqueues auto_tagging for kind "tagging" at priority 100', async () => {
+    it('enqueues auto_tagging for kind "tagging" on a PHOTO at priority 100', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
       const outcome = await executor.execute(
         action('rerun_enrichment', { kinds: ['tagging'] }),
         { id: ITEM_ID },
@@ -701,6 +702,83 @@ describe('WorkflowActionExecutor', () => {
       expect(outcome).toEqual({ status: 'applied' });
       expect(enrichmentJobs.enqueue).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'auto_tagging', mediaItemId: ITEM_ID, circleId: CIRCLE_ID, priority: 100 }),
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Epic #452's headline use case: "for videos captured between A and B,
+    // re-run AI tagging". It was already expressible — mediaType and capturedAt
+    // are registered condition fields and rerun_enrichment is a shipped action
+    // — but enrichmentJobTypeForKind returned 'auto_tagging' unconditionally
+    // for `tagging`, so every matched video produced a failed job.
+    // -------------------------------------------------------------------------
+
+    it('routes "tagging" to video_auto_tagging for a VIDEO', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.video } as any);
+
+      await executor.execute(action('rerun_enrichment', { kinds: ['tagging'] }), { id: ITEM_ID }, ctx);
+
+      expect(enrichmentJobs.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'video_auto_tagging' }),
+      );
+      expect(
+        (enrichmentJobs.enqueue as jest.Mock).mock.calls.map((c) => c[0].type),
+      ).not.toContain('auto_tagging');
+    });
+
+    it('skips (not_found) when kinds includes "tagging" but the item no longer exists', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue(null);
+
+      const outcome = await executor.execute(
+        action('rerun_enrichment', { kinds: ['tagging'] }),
+        { id: ITEM_ID },
+        ctx,
+      );
+
+      expect(outcome).toEqual({ status: 'skipped', reason: 'not_found' });
+    });
+
+    it('marks MediaTagStatus pending, so the badge reflects the queued rerun and the dependency snapshot is not stale', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.video } as any);
+
+      await executor.execute(action('rerun_enrichment', { kinds: ['tagging'] }), { id: ITEM_ID }, ctx);
+
+      expect(prisma.mediaTagStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { mediaItemId: ITEM_ID },
+          update: { status: MediaTagStatusType.pending },
+        }),
+      );
+    });
+
+    it('does NOT touch MediaTagStatus for a non-tagging kind', async () => {
+      await executor.execute(action('rerun_enrichment', { kinds: ['metadata'] }), { id: ITEM_ID }, ctx);
+
+      expect(prisma.mediaTagStatus.upsert).not.toHaveBeenCalled();
+    });
+
+    it('still applies when the tag-status write fails — a cosmetic miss must not fail the run item', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
+      prisma.mediaTagStatus.upsert.mockRejectedValue(new Error('db down') as any);
+
+      const outcome = await executor.execute(
+        action('rerun_enrichment', { kinds: ['tagging'] }),
+        { id: ITEM_ID },
+        ctx,
+      );
+
+      expect(outcome).toEqual({ status: 'applied' });
+      expect(enrichmentJobs.enqueue).toHaveBeenCalled();
+    });
+
+    it('uses reason "rerun", the loop-protection contract that stops an on_media_enriched workflow re-triggering itself', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
+
+      await executor.execute(action('rerun_enrichment', { kinds: ['tagging'] }), { id: ITEM_ID }, ctx);
+
+      // workflow-trigger.listener.ts only reacts to JobReason.upload.
+      expect(enrichmentJobs.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: JobReason.rerun }),
       );
     });
 
@@ -731,6 +809,7 @@ describe('WorkflowActionExecutor', () => {
     });
 
     it('enqueues one job per kind for multiple kinds', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
       await executor.execute(
         action('rerun_enrichment', { kinds: ['tagging', 'metadata', 'thumbnail', 'duplicates'] }),
         { id: ITEM_ID },
@@ -740,6 +819,53 @@ describe('WorkflowActionExecutor', () => {
       const types = (enrichmentJobs.enqueue as jest.Mock).mock.calls.map((c) => c[0].type);
       expect(types.sort()).toEqual(
         ['auto_tagging', 'duplicate_detection', 'metadata_extraction', 'thumbnail_regen'].sort(),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // rerun_ai_tagging — the epic #452 shortcut. A PRESET over the same executor
+  // path, so video routing and the tag-status upsert cannot drift between it
+  // and "Re-run enrichment -> tick Tagging".
+  // ---------------------------------------------------------------------------
+
+  describe('rerun_ai_tagging', () => {
+    it('enqueues video_auto_tagging for a video, with no params supplied', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.video } as any);
+
+      const outcome = await executor.execute(action('rerun_ai_tagging', {}), { id: ITEM_ID }, ctx);
+
+      expect(outcome).toEqual({ status: 'applied' });
+      expect(enrichmentJobs.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'video_auto_tagging', priority: 100, reason: JobReason.rerun }),
+      );
+    });
+
+    it('enqueues auto_tagging for a photo', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
+
+      await executor.execute(action('rerun_ai_tagging', {}), { id: ITEM_ID }, ctx);
+
+      expect(enrichmentJobs.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'auto_tagging' }),
+      );
+    });
+
+    it('enqueues exactly ONE job — it is tagging only, not a full re-enrichment', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
+
+      await executor.execute(action('rerun_ai_tagging', {}), { id: ITEM_ID }, ctx);
+
+      expect(enrichmentJobs.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks MediaTagStatus pending, exactly like the long form', async () => {
+      prisma.mediaItem.findUnique.mockResolvedValue({ type: MediaType.photo } as any);
+
+      await executor.execute(action('rerun_ai_tagging', {}), { id: ITEM_ID }, ctx);
+
+      expect(prisma.mediaTagStatus.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ update: { status: MediaTagStatusType.pending } }),
       );
     });
   });

--- a/apps/api/src/workflows/actions/workflow-action.executor.ts
+++ b/apps/api/src/workflows/actions/workflow-action.executor.ts
@@ -4,7 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { CircleRole, JobReason, MediaTagSource, MediaType } from '@prisma/client';
+import { CircleRole, JobReason, MediaTagSource, MediaTagStatusType, MediaType } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { MediaService } from '../../media/media.service';
 import { MediaEnrichmentService } from '../../media/enrichment/media-enrichment.service';
@@ -116,6 +116,15 @@ export class WorkflowActionExecutor {
           return await this.moveToCircle(action, item, ctx);
         case 'rerun_enrichment':
           return await this.rerunEnrichment(action, item, ctx);
+        case 'rerun_ai_tagging':
+          // A PRESET, not a second implementation: the one-click form of
+          // "Re-run enrichment → tick Tagging". Same executor path, so video
+          // routing and the tag-status upsert cannot drift between the two.
+          return await this.rerunEnrichment(
+            { ...action, params: { kinds: ['tagging'] } },
+            item,
+            ctx,
+          );
         case 'resolve_burst_group':
           return await this.resolveBurstGroup(action, item, ctx);
         case 'dismiss_burst_group':
@@ -447,8 +456,10 @@ export class WorkflowActionExecutor {
   ): Promise<ActionOutcome> {
     const kinds = action.params['kinds'] as Array<'tagging' | 'faces' | 'metadata' | 'thumbnail' | 'duplicates'>;
 
-    // faces routes on media type (photo → face_detection, video → video_face_detection).
-    const needsType = kinds.includes('faces');
+    // BOTH `faces` and `tagging` route on media type (photo → face_detection /
+    // auto_tagging, video → video_face_detection / video_auto_tagging), so
+    // either kind requires the item's type.
+    const needsType = kinds.includes('faces') || kinds.includes('tagging');
     let type: MediaType | undefined;
     if (needsType) {
       const row = await this.prisma.mediaItem.findUnique({
@@ -463,6 +474,11 @@ export class WorkflowActionExecutor {
       const jobType = this.enrichmentJobTypeForKind(kind, type);
       // Enqueue at priority 100 (bulk/background) via the shared enqueue helper
       // — NOT the priority-0 rerun helpers, which are for interactive reruns.
+      //
+      // `reason: JobReason.rerun` is the LOOP-PROTECTION contract:
+      // workflow-trigger.listener.ts only reacts to JobReason.upload, so a
+      // rerun re-enqueue can never re-trigger the on_media_enriched workflow
+      // that caused it. An enrichment-enqueuing action must never use `upload`.
       await this.enrichmentJobs.enqueue({
         type: jobType,
         mediaItemId: item.id,
@@ -470,8 +486,44 @@ export class WorkflowActionExecutor {
         reason: JobReason.rerun,
         priority: 100,
       });
+
+      // A tagging re-run must also flip MediaTagStatus to `pending`, which
+      // MediaEnrichmentService.enqueueTagRerun already does and this path did
+      // not. Two things were broken by the omission: the UI's tag-status badge
+      // never reflected that a workflow queued anything, and — worse —
+      // buildDependencyState in workflow-trigger.listener.ts reads a stale
+      // `processed`, letting an on_media_enriched workflow fire against tags
+      // that are actively mid-rebuild.
+      if (kind === 'tagging') {
+        await this.markTagStatusPending(item.id, ctx.circleId);
+      }
     }
     return { status: 'applied' };
+  }
+
+  /**
+   * Best-effort `MediaTagStatus → pending`. A status-write failure must not
+   * fail the action — the enrichment job is already queued and will settle the
+   * status itself, so throwing here would turn a cosmetic miss into a failed
+   * run item.
+   */
+  private async markTagStatusPending(mediaItemId: string, circleId: string): Promise<void> {
+    try {
+      await this.prisma.mediaTagStatus.upsert({
+        where: { mediaItemId },
+        create: {
+          mediaItemId,
+          circleId,
+          status: MediaTagStatusType.pending,
+          tagCount: 0,
+        },
+        update: { status: MediaTagStatusType.pending },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `rerun_enrichment: failed to mark MediaTagStatus pending for ${mediaItemId} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private enrichmentJobTypeForKind(
@@ -480,7 +532,10 @@ export class WorkflowActionExecutor {
   ): string {
     switch (kind) {
       case 'tagging':
-        return 'auto_tagging';
+        // Epic #452: without this branch a video-scoped tagging workflow
+        // enqueued `auto_tagging` for every matched video, and every one of
+        // those jobs failed.
+        return type === MediaType.video ? 'video_auto_tagging' : 'auto_tagging';
       case 'faces':
         return type === MediaType.video ? 'video_face_detection' : 'face_detection';
       case 'metadata':

--- a/apps/api/src/workflows/definition/workflow-definition.validator.spec.ts
+++ b/apps/api/src/workflows/definition/workflow-definition.validator.spec.ts
@@ -6,6 +6,7 @@
  */
 import { BadRequestException } from '@nestjs/common';
 import { WorkflowDefinitionValidator } from './workflow-definition.validator';
+import { registeredActions } from '../registry/subject-registry';
 
 describe('WorkflowDefinitionValidator', () => {
   let validator: WorkflowDefinitionValidator;
@@ -169,42 +170,153 @@ describe('WorkflowDefinitionValidator', () => {
       ).toThrow(/Unknown action "launch_rocket"/);
     });
 
+    /**
+     * Valid params for each action that requires them. Actions absent from
+     * this map take none.
+     *
+     * Enumerated by hand rather than derived, so adding an action with a
+     * required param forces a deliberate entry here instead of silently
+     * passing with `{}` — which is exactly what happened before issue #459
+     * wired `paramsSchema` into the validator.
+     */
+    const VALID_PARAMS: Record<string, Record<string, unknown>> = {
+      add_to_album: { createAlbumNamed: 'Trip' },
+      remove_from_album: { albumId: '11111111-1111-4111-8111-111111111111' },
+      add_tags: { names: ['beach'] },
+      remove_tags: { names: ['beach'] },
+      set_favorite: { value: true },
+      set_captured_at: { mode: 'set', value: '2026-01-01T00:00:00.000Z' },
+      move_to_circle: { targetCircleId: '22222222-2222-4222-8222-222222222222' },
+      assign_person: { personId: '33333333-3333-4333-8333-333333333333' },
+      remove_person: { personId: '33333333-3333-4333-8333-333333333333' },
+      set_location: { lat: 9.93, lng: -84.08 },
+      resolve_burst_group: { action: 'archive' },
+      resolve_duplicate_group: { action: 'archive' },
+      rerun_enrichment: { kinds: ['tagging'] },
+    };
+
     it('accepts every action type actually registered for media_item', () => {
-      const actionTypes = [
-        'move_to_trash',
-        'hard_delete',
-        'archive',
-        'unarchive',
-        'add_to_album',
-        'remove_from_album',
-        'add_tags',
-        'remove_tags',
-        'set_favorite',
-        'set_captured_at',
-        'move_to_circle',
-        'assign_person',
-        'remove_person',
-        'set_location',
-        'clear_location',
-        'resolve_burst_group',
-        'dismiss_burst_group',
-        'resolve_duplicate_group',
-        'dismiss_duplicate_group',
-        'accept_location_suggestion',
-        'reject_location_suggestion',
-        'rerun_enrichment',
-      ];
+      // Driven off the REGISTRY rather than a hand-listed array, so a newly
+      // registered action is covered automatically instead of being forgotten.
+      const actionTypes = registeredActions('media_item').map((a) => a.type);
+      expect(actionTypes.length).toBeGreaterThan(0);
+
       for (const type of actionTypes) {
+        const params = VALID_PARAMS[type];
         expect(() =>
           validator.validate({
             version: 1,
             subject: 'media_item',
             match: 'all',
             conditions: [],
-            actions: [{ type }],
+            actions: [{ type, ...(params ?? {}) }],
           }),
         ).not.toThrow();
       }
+    });
+
+    // -------------------------------------------------------------------------
+    // Action params validation (epic #452, issue #459)
+    //
+    // `WorkflowActionDescriptor.paramsSchema` was declared on all 22 actions
+    // and never invoked anywhere, so params were structurally unvalidated at
+    // create and run time and the executor blind-cast them. A malformed value
+    // reached the executor and failed at runtime, per item, inside a batch job.
+    // -------------------------------------------------------------------------
+
+    it('rejects an action whose required params are missing, at SAVE time rather than per item at run time', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'add_tags' }],
+        }),
+      ).toThrow(/Invalid params for action "add_tags"/);
+    });
+
+    it('rejects a malformed rerun_enrichment kinds array — the exact value the executor used to blind-cast', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'rerun_enrichment', kinds: [] }],
+        }),
+      ).toThrow(/Invalid params for action "rerun_enrichment"/);
+
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'rerun_enrichment', kinds: ['not_a_kind'] }],
+        }),
+      ).toThrow(/Invalid params for action "rerun_enrichment"/);
+    });
+
+    it('rejects unknown keys on a no-param action', () => {
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'archive', surprise: true }],
+        }),
+      ).toThrow(/Invalid params for action "archive"/);
+    });
+
+    it('NORMALIZES params by applying the schema defaults the executor then reads', () => {
+      const def = validator.validate({
+        version: 1,
+        subject: 'media_item',
+        match: 'all',
+        conditions: [],
+        actions: [{ type: 'remove_tags', names: ['beach'] }],
+      });
+
+      // `sources` defaults to AI + system so a cleanup workflow never strips a
+      // user's manually-applied tags. Params are FLAT siblings of `type` —
+      // WorkflowExecuteBatchHandler rebuilds the executor's bag by
+      // destructuring `const { type, ...params } = a`.
+      expect(def.actions[0]).toEqual({
+        type: 'remove_tags',
+        names: ['beach'],
+        sources: ['ai', 'system'],
+      });
+    });
+
+    it('round-trips a no-param action byte-identically', () => {
+      const def = validator.validate({
+        version: 1,
+        subject: 'media_item',
+        match: 'all',
+        conditions: [],
+        actions: [{ type: 'archive' }],
+      });
+
+      // The normalized definition is persisted and snapshotted into
+      // definition_snapshot, so it must not sprout keys the caller never sent.
+      expect(def.actions[0]).toEqual({ type: 'archive' });
+    });
+
+    it('registers rerun_ai_tagging, the epic #452 shortcut, taking no params', () => {
+      const types = registeredActions('media_item').map((a) => a.type);
+      expect(types).toContain('rerun_ai_tagging');
+
+      expect(() =>
+        validator.validate({
+          version: 1,
+          subject: 'media_item',
+          match: 'all',
+          conditions: [],
+          actions: [{ type: 'rerun_ai_tagging' }],
+        }),
+      ).not.toThrow();
     });
   });
 

--- a/apps/api/src/workflows/definition/workflow-definition.validator.ts
+++ b/apps/api/src/workflows/definition/workflow-definition.validator.ts
@@ -9,6 +9,7 @@ import {
   WorkflowOperator,
 } from '../registry/field-descriptor.interface';
 import {
+  getActionDescriptor,
   getField,
   getSubjectRegistry,
   isRegisteredAction,
@@ -20,9 +21,10 @@ import {
  * Validates a workflow definition document against the per-Subject registry.
  *
  * Layered on top of the structural Zod schema: it rejects a `subject` not in the
- * registry, any `field`/`op`/action `type` not registered for that Subject, and
- * operator/value-type mismatches — so an unknown or cross-Subject combination
- * can never be persisted.
+ * registry, any `field`/`op`/action `type` not registered for that Subject,
+ * operator/value-type mismatches, and action `params` that fail the action's
+ * own declared schema — so an unknown or cross-Subject combination, or a
+ * malformed action parameter, can never be persisted.
  *
  * Stateless and pure (no I/O) — trivially unit-testable.
  */
@@ -61,7 +63,7 @@ export class WorkflowDefinitionValidator {
       }
     }
 
-    // 4. Actions: each type must be registered for the Subject (params: Phase 2).
+    // 4. Actions: each type must be registered for the Subject.
     for (const action of def.actions) {
       if (!isRegisteredAction(def.subject, action.type)) {
         const registry = getSubjectRegistry(def.subject);
@@ -71,6 +73,51 @@ export class WorkflowDefinitionValidator {
         );
       }
     }
+
+    // 5. Action PARAMS: validate each action's params against its declared
+    //    schema (epic #452, issue #459).
+    //
+    //    `WorkflowActionDescriptor.paramsSchema` was declared on all 22 actions
+    //    and never invoked anywhere. The definition schema's `actionSchema` is
+    //    `z.object({ type }).passthrough()`, so params were structurally
+    //    UNVALIDATED at create and run time and the executor blind-cast
+    //    `action.params['kinds']`. A malformed or missing `kinds` array reached
+    //    the executor and failed at runtime, per item, inside a batch job —
+    //    instead of being rejected with a clean 400 when the workflow was saved.
+    //
+    //    Wiring it here hardens all 22 existing actions retroactively, and
+    //    NORMALIZES params in the process (schemas carry `.default()`s, e.g.
+    //    remove_tags' `sources`), so the executor reads defaulted values rather
+    //    than undefined.
+    //
+    //    SHAPE NOTE, and it is easy to get wrong: an action is stored FLAT —
+    //    `{ type, ...params }`, each param a TOP-LEVEL SIBLING of `type`, never
+    //    nested under a `params` key. `actionSchema` is
+    //    `z.object({ type }).passthrough()` precisely to allow that, and
+    //    WorkflowExecuteBatchHandler rebuilds the executor's params bag with
+    //    `const { type, ...params } = a`. So the values to validate are the
+    //    siblings, and the normalized values are written back as siblings too.
+    def.actions = def.actions.map((action) => {
+      const descriptor = getActionDescriptor(def.subject, action.type);
+      // A registered action with no schema cannot happen today (step 4 already
+      // proved it is registered, and every descriptor declares one), but
+      // treating it as "nothing to check" is the safe reading rather than
+      // throwing on a registry the user cannot fix.
+      if (!descriptor?.paramsSchema) return action;
+
+      const { type, ...params } = action as Record<string, unknown>;
+      const result = descriptor.paramsSchema.safeParse(params);
+      if (!result.success) {
+        const issues = result.error.issues
+          .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+          .join('; ');
+        throw new BadRequestException(
+          `Invalid params for action "${action.type}": ${issues}`,
+        );
+      }
+
+      return { type, ...(result.data as Record<string, unknown>) } as typeof action;
+    });
 
     return def;
   }

--- a/apps/api/src/workflows/registry/media-item-fields.ts
+++ b/apps/api/src/workflows/registry/media-item-fields.ts
@@ -825,6 +825,19 @@ export const MEDIA_ITEM_ACTIONS: WorkflowActionDescriptor[] = [
     reversible: true,
     highImpact: false,
   },
+  {
+    // Shortcut for the epic #452 headline case ("for videos captured between
+    // A and B, re-run AI tagging"). Purely discoverability — it dispatches
+    // through the same rerun_enrichment executor path with kinds:['tagging'],
+    // so it is a preset rather than a second implementation. Takes no params.
+    type: 'rerun_ai_tagging',
+    label: 'Re-run AI tagging',
+    paramsSchema: emptyParamsSchema,
+    permission: BASE_ACTION_PERMISSION,
+    triggerCompatibility: 'all',
+    reversible: true,
+    highImpact: false,
+  },
 
   // ----------------------------- Review-queue -----------------------------
   {

--- a/apps/web/src/__tests__/utils/workflowSentence.test.ts
+++ b/apps/web/src/__tests__/utils/workflowSentence.test.ts
@@ -74,6 +74,7 @@ const SUBJECT: SubjectRegistryEntry = {
     { type: 'add_to_album', label: 'Add to album' },
     { type: 'add_tags', label: 'Add tags' },
     { type: 'resolve_duplicate_group', label: 'Resolve duplicate group' },
+    { type: 'rerun_ai_tagging', label: 'Re-run AI tagging' },
   ],
 };
 
@@ -255,6 +256,35 @@ describe('definitionToSentence', () => {
     };
     const sentence = definitionToSentence(def, SUBJECT, 'manual');
     expect(sentence).toContain('not missing camera');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Epic #452's headline use case: "for videos captured between A and B,
+  // re-run AI tagging."
+  // ---------------------------------------------------------------------------
+
+  it('renders the "Re-tag videos from a date range" template as plain English', () => {
+    const template = WORKFLOW_TEMPLATES.find((t) => t.id === 'retag-videos-in-range')!;
+
+    const sentence = definitionToSentence(template.definition, SUBJECT, template.suggestedTrigger);
+
+    expect(sentence.toLowerCase()).toContain('re-run ai tagging');
+    expect(sentence.toLowerCase()).toContain('capture date');
+  });
+
+  it('phrases rerun_ai_tagging without leaking a params list', () => {
+    const def: WorkflowDefinition = {
+      ...BASE_DEF,
+      conditions: [],
+      actions: [{ type: 'rerun_ai_tagging' }],
+    };
+
+    const sentence = definitionToSentence(def, SUBJECT, 'manual');
+
+    // It is a preset, so there is no kinds list to show — unlike
+    // rerun_enrichment, which renders "(tagging, faces)".
+    expect(sentence).toContain('re-run AI tagging');
+    expect(sentence).not.toContain('(');
   });
 
   it('falls back to a prettified label for an unknown action type', () => {

--- a/apps/web/src/constants/workflowActionMeta.ts
+++ b/apps/web/src/constants/workflowActionMeta.ts
@@ -53,6 +53,9 @@ export const ACTION_PARAM_KIND: Record<string, ActionParamKind> = {
   clear_location: 'none',
   move_to_circle: 'circle',
   rerun_enrichment: 'rerunKinds',
+  // The one-click form of "Re-run enrichment -> tick Tagging" (epic #452).
+  // Takes no params — the kinds list is fixed server-side.
+  rerun_ai_tagging: 'none',
   resolve_burst_group: 'resolveAction',
   dismiss_burst_group: 'none',
   resolve_duplicate_group: 'resolveAction',

--- a/apps/web/src/constants/workflowTemplates.ts
+++ b/apps/web/src/constants/workflowTemplates.ts
@@ -75,6 +75,33 @@ export const WORKFLOW_TEMPLATES: WorkflowTemplate[] = [
     },
   },
   {
+    // Epic #452's headline use case, made discoverable: "for videos captured
+    // between date A and date B, re-run AI tagging".
+    id: 'retag-videos-in-range',
+    name: 'Re-tag videos from a date range',
+    title: 'Re-tag videos from a date range',
+    description:
+      'Give a batch of videos AI tags and a written description, so they turn up in search.',
+    plainLanguage:
+      'If a video was captured within a date range, re-run AI tagging on it.',
+    icon: Movie,
+    suggestedTrigger: 'manual',
+    definition: {
+      version: 1,
+      subject: 'media_item',
+      match: 'all',
+      conditions: [
+        { field: 'mediaType', op: 'equals', value: 'video' },
+        {
+          field: 'capturedAt',
+          op: 'between',
+          value: ['2026-01-01T00:00:00.000Z', '2026-12-31T23:59:59.999Z'],
+        },
+      ],
+      actions: [{ type: 'rerun_ai_tagging' }],
+    },
+  },
+  {
     id: 'trip-album',
     name: 'Album from a trip',
     title: 'Album from a trip',

--- a/apps/web/src/utils/workflowSentence.ts
+++ b/apps/web/src/utils/workflowSentence.ts
@@ -190,6 +190,8 @@ function actionPhrase(
       return Array.isArray(a.kinds) && a.kinds.length
         ? `re-run enrichment (${(a.kinds as unknown[]).join(', ')})`
         : 're-run enrichment';
+    case 'rerun_ai_tagging':
+      return 're-run AI tagging';
     case 'resolve_burst_group':
       return a.action === 'archive'
         ? 'keep the best shot and archive the rest of its burst'


### PR DESCRIPTION
## Summary

This is the issue that delivers epic #452's headline use case: *"for videos captured between date A and date B, re-run AI tagging."*

That workflow was **already expressible** — `rerun_enrichment` is a shipped action, and `mediaType` (enum) and `capturedAt` (date-range) are registered condition fields. It just didn't work: `enrichmentJobTypeForKind` returned `'auto_tagging'` unconditionally for `case 'tagging'`, while its `faces` sibling *on the very next line* already branched on `MediaType.video`. So a video-scoped tagging workflow enqueued `auto_tagging` for every matched video, and every one of those jobs failed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #459

## Changes Made

**1. Video routing.** `enrichmentJobTypeForKind('tagging', type)` now returns `video_auto_tagging` for a video, and `needsType` widens from `kinds.includes('faces')` to also cover `'tagging'`.

**2. `rerun_ai_tagging` shortcut** — a registry entry so the common case is one click rather than "Re-run enrichment → tick Tagging". It dispatches through the **same** `rerunEnrichment` executor path with `kinds: ['tagging']`, so it is a preset, not a second implementation: video routing and the status upsert cannot drift between the two. `BASE_ACTION_PERMISSION`, `triggerCompatibility: 'all'`, reversible, not high-impact — so `isGatedAction` stays false and it remains approval-bypass eligible, exactly like today's `rerun_enrichment`.

**3. `MediaTagStatus → pending` on a workflow tagging re-run.** `rerunEnrichment` enqueued raw and never did this, unlike `MediaEnrichmentService.enqueueTagRerun`. Two consequences: the UI's tag-status badge never reflected that a workflow queued anything, and — more seriously — `buildDependencyState` in `workflow-trigger.listener.ts` computes the `tags` dependency as settled when the status is `processed`, so a workflow-triggered re-run left that stale `processed` in place and an `on_media_enriched` workflow could fire against tags actively mid-rebuild. Best-effort: a status-write failure must not turn a cosmetic miss into a failed run item.

**4. `paramsSchema` wired into `WorkflowDefinitionValidator` as a fifth step.** It was declared on all 22 actions and **never invoked anywhere**; `actionSchema` is `z.object({ type }).passthrough()`, so action params were structurally unvalidated at create and run time and the executor blind-cast `action.params['kinds']`. A malformed or missing `kinds` array reached the executor and failed at runtime, per item, inside a batch job — instead of a clean 400 at save time. This hardens all 22 actions retroactively and **normalizes** params, so schema `.default()`s (e.g. `remove_tags`' `sources`) are what the executor reads rather than `undefined`.

> **Shape note, and it is easy to get wrong:** an action is stored **flat** — `{ type, ...params }`, each param a top-level sibling of `type`, never nested under a `params` key. `WorkflowExecuteBatchHandler` rebuilds the executor's bag with `const { type, ...params } = a`. I initially validated a nested `params` key, which typechecked and passed the executor specs but would have rejected every real workflow the web builder creates; the validator now reads and writes siblings, and the pre-existing service spec — left on its original flat fixture — is what proves it.

**5. `reason: JobReason.rerun` preserved**, with the loop-protection contract now stated in a comment: `workflow-trigger.listener.ts` only reacts to `JobReason.upload`, so a rerun re-enqueue cannot re-trigger the `on_media_enriched` workflow that caused it.

**6. Frontend mirrors** (`GET /api/workflows/subjects` projects the registry down, so these are hand-maintained in lockstep): `ACTION_PARAM_KIND` (`'none'` — the shortcut takes no params), `actionPhrase()` in `workflowSentence.ts`, and a **`retag-videos-in-range` template** making the headline case discoverable. `ActionParamEditor` needs no case, since `'none'` is already handled.

## Testing

- [x] Unit tests pass — `apps/api` **8163 pass**, `apps/web` **5072 pass**, 0 fail
- [x] Type checks pass (`apps/api`, `apps/web`)

Acceptance evidence is asserted directly: `rerun_enrichment` with `kinds: ['tagging']` on a video enqueues `video_auto_tagging` and **zero** `auto_tagging` jobs, and the matched item's tag status reads `pending`. Also covered: the `not_found` skip now that `tagging` needs the type; the tag-status write failing without failing the action; `reason: rerun` as the loop-protection contract; `rerun_ai_tagging` enqueueing exactly one job and routing by type; params rejected at save time for a missing required value, an empty/invalid `kinds`, and an unknown key on a no-param action; defaults being applied; and a no-param action round-tripping byte-identically (it is snapshotted into `definition_snapshot`).

The validator's "every registered action" test now iterates the **registry** rather than a hand-listed array, so a newly registered action is covered automatically instead of being forgotten.

Wiring `paramsSchema` in immediately caught a real defect in an existing spec fixture: it created `add_tags` with no `names`, which would have failed at runtime, per item, inside a batch job. That is the class of bug this hook exists to prevent.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

`docs/specs/workflows.md` §6.1's per-action table is updated in #461 alongside the rest of the epic's documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_