### PR TITLE
perf(api,cli): stream video input to ffmpeg via presigned URL (HTTP range seek)

### DIFF
--- a/apps/api/src/common/schemas/settings.schema.ts
+++ b/apps/api/src/common/schemas/settings.schema.ts
@@ -539,11 +539,17 @@ export const systemSettingsSchema = z.object({
         // regardless of runtime.
         leadSeconds: z.number().int().min(5).max(600).default(30),
       }).optional().default({ enabled: false, leadSeconds: 30 }),
+      // Whether ffmpeg reads the video from a presigned URL via HTTP range
+      // seeks instead of downloading it whole (issue #456). The proven
+      // download path stays the fallback for EVERY streaming failure, so this
+      // is a revert switch rather than a correctness gate.
+      streamInput: z.boolean().default(true),
     }).optional().default({
       enabled: false,
       maxFrames: 6,
       sampleIntervalSeconds: 5,
       transcription: { enabled: false, leadSeconds: 30 },
+      streamInput: true,
     }),
   }).optional().default({
     video: {
@@ -551,6 +557,7 @@ export const systemSettingsSchema = z.object({
       maxFrames: 6,
       sampleIntervalSeconds: 5,
       transcription: { enabled: false, leadSeconds: 30 },
+      streamInput: true,
     },
   }),
   face: z.object({
@@ -924,6 +931,7 @@ export const systemSettingsPatchSchema = z.object({
         enabled: z.boolean().optional(),
         leadSeconds: z.number().int().min(5).max(600).optional(),
       }).optional(),
+      streamInput: z.boolean().optional(),
     }).optional(),
   }).optional(),
   face: z.object({

--- a/apps/api/src/common/types/settings.types.ts
+++ b/apps/api/src/common/types/settings.types.ts
@@ -258,6 +258,13 @@ export interface SystemSettingsValue {
         /** First N seconds of audio only (ffmpeg `-t`). Also duration-independent. */
         leadSeconds: number;
       };
+      /**
+       * Whether ffmpeg may read a video straight from a presigned URL via HTTP
+       * range seeks instead of downloading it whole (issue #456). The download
+       * path remains the fallback for EVERY streaming failure, so turning this
+       * off is a revert switch rather than a correctness gate.
+       */
+      streamInput?: boolean;
     };
   };
   face?: {
@@ -739,6 +746,7 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettingsValue = {
       maxFrames: 6,
       sampleIntervalSeconds: 5,
       transcription: { enabled: false, leadSeconds: 30 },
+      streamInput: true,
     },
   },
   face: {

--- a/apps/api/src/face/video-face-detection.service.ts
+++ b/apps/api/src/face/video-face-detection.service.ts
@@ -47,10 +47,7 @@ import {
 } from '@memoriahub/enrichment-compute/face-video';
 import { PrismaService } from '../prisma/prisma.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
-import {
-  streamToTempFile,
-  assertDiskSpaceForDownload,
-} from '../storage/processing/processors/stream-utils';
+import { downloadToTempFile } from '../storage/processing/processors/stream-utils';
 import { prepareImageForProcessing } from '../storage/processing/image-orientation.util';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import {
@@ -254,24 +251,27 @@ export class VideoFaceDetectionService {
 
       // --- 5. Download video (stream directly to a temp file — constant memory) ---
       const fileExt = extname(mediaItem.storageObject.name || '') || '.mp4';
-      const tmpVideoPath = join(tmpdir(), `memoriaHub-vface-dl-${randomUUID()}${fileExt}`);
 
-      const objectProvider = await this.resolver.getProviderFor(
-        mediaItem.storageObject.storageProvider,
-        mediaItem.storageObject.bucket,
-      );
-
-      // Pre-flight: fail fast (through the normal retry/backoff path) when the
-      // temp filesystem cannot hold the download plus headroom.
-      await assertDiskSpaceForDownload(mediaItem.storageObject.size, tmpdir());
+      // Shared helper (issue #456) — one implementation of the
+      // disk-guard -> download -> partial-file-cleanup sequence, instead of
+      // the byte-identical copy this and SocialMediaDetectionHandler each had.
+      // This path deliberately still DOWNLOADS: presigned-URL range seeking is
+      // being proven on the new, off-by-default video_auto_tagging type first.
+      const { path: tmpVideoPath, cleanup: cleanupVideo } = await downloadToTempFile({
+        getStream: () =>
+          this.resolver
+            .getProviderFor(
+              mediaItem.storageObject!.storageProvider,
+              mediaItem.storageObject!.bucket,
+            )
+            .then((p) => p.download(mediaItem.storageObject!.storageKey)),
+        sizeBytes: mediaItem.storageObject.size,
+        prefix: 'memoriaHub-vface-dl-',
+        extension: fileExt,
+      });
 
       let computed: ComputedVideoFaceCluster[];
       try {
-        // Download INSIDE the try so a failed/partial streamToTempFile still
-        // has its partial temp file unlinked by the finally below.
-        const videoStream = await objectProvider.download(mediaItem.storageObject.storageKey);
-        await streamToTempFile(videoStream, tmpVideoPath);
-
         // --- 6-9. Compute half: extract frames, detect, cluster, crop thumbnails ---
         computed = await this.computeVideoFaces(
           tmpVideoPath,
@@ -284,7 +284,7 @@ export class VideoFaceDetectionService {
         // The downloaded temp file is only needed for download + frame
         // extraction above; always clean it up regardless of success/failure —
         // including a partial file left behind by a failed streamToTempFile.
-        await fs.unlink(tmpVideoPath).catch(() => {});
+        await cleanupVideo();
       }
 
       // --- 10. Upload representative frame thumbnails (server holds storage creds) ---

--- a/apps/api/src/media/enrichment/video-input.service.spec.ts
+++ b/apps/api/src/media/enrichment/video-input.service.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for VideoInputResolver (epic #452, issue #456).
+ *
+ * The single most important property here is the SAFETY PROPERTY: every
+ * failure of the streaming path falls back to the proven download path, so the
+ * worst case of this feature is exactly today's behavior plus one small probe
+ * read. Each fallback branch therefore has its own test asserting a download
+ * actually happened — a silent "returned nothing" would be a broken job, not a
+ * slow one.
+ */
+
+jest.mock('@memoriahub/enrichment-compute/video', () => ({
+  probeRangeSeekSuitability: jest.fn(),
+}));
+
+jest.mock('../../storage/processing/processors/stream-utils', () => ({
+  downloadToTempFile: jest.fn(),
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { VideoInputResolver } from './video-input.service';
+import { StorageProviderResolver } from '../../storage/providers/storage-provider.resolver';
+import { probeRangeSeekSuitability } from '@memoriahub/enrichment-compute/video';
+import { downloadToTempFile } from '../../storage/processing/processors/stream-utils';
+
+const mockProbe = probeRangeSeekSuitability as jest.Mock;
+const mockDownload = downloadToTempFile as jest.Mock;
+
+const SIGNED_URL = 'https://storage.example/videos/clip.mp4?sig=abc';
+
+function makeRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    storageKey: 'videos/clip.mp4',
+    storageProvider: 's3',
+    bucket: 'test-bucket',
+    sizeBytes: BigInt(4_000_000_000),
+    extension: '.mp4',
+    tempPrefix: 'memoriaHub-vtag-dl-',
+    streamingEnabled: true,
+    jobId: 'job-1',
+    ...overrides,
+  } as any;
+}
+
+describe('VideoInputResolver', () => {
+  let service: VideoInputResolver;
+  let mockProvider: { download: jest.Mock; getSignedDownloadUrl: jest.Mock };
+  let mockResolver: { getProviderFor: jest.Mock };
+  let mockCleanup: jest.Mock;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockProvider = {
+      download: jest.fn().mockResolvedValue({}),
+      getSignedDownloadUrl: jest.fn().mockResolvedValue(SIGNED_URL),
+    };
+    mockResolver = { getProviderFor: jest.fn().mockResolvedValue(mockProvider) };
+    mockCleanup = jest.fn().mockResolvedValue(undefined);
+    mockDownload.mockResolvedValue({ path: '/tmp/clip.mp4', cleanup: mockCleanup });
+    mockProbe.mockResolvedValue({
+      verdict: 'suitable',
+      detail: 'moov atom at the front (faststart)',
+      bytesRead: 65536,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VideoInputResolver,
+        { provide: StorageProviderResolver, useValue: mockResolver },
+      ],
+    }).compile();
+
+    service = module.get(VideoInputResolver);
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe('streaming path', () => {
+    it('hands ffmpeg the presigned URL and downloads NOTHING when the probe says suitable', async () => {
+      const input = await service.resolve(makeRequest());
+
+      expect(input.mode).toBe('stream');
+      expect(input.source).toBe(SIGNED_URL);
+      expect(mockDownload).not.toHaveBeenCalled();
+      // 64 KB probed instead of the 4 GB object — the entire point.
+      expect(input.bytesMoved).toBe(65536);
+    });
+
+    it('mints a URL whose TTL comfortably exceeds the 20-minute video job timeout', async () => {
+      await service.resolve(makeRequest());
+
+      const [, options] = mockProvider.getSignedDownloadUrl.mock.calls[0];
+      // A long ffmpeg session against an expiring URL fails mid-run.
+      expect(options.expiresIn).toBeGreaterThan(20 * 60);
+    });
+
+    it('has a no-op cleanup — nothing was materialized', async () => {
+      const input = await service.resolve(makeRequest());
+
+      await expect(input.cleanup()).resolves.toBeUndefined();
+      expect(mockCleanup).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // The safety property: every streaming failure falls back to the download.
+  // -------------------------------------------------------------------------
+
+  describe('fallback to the proven download path', () => {
+    it.each([
+      ['not-faststart', 'the index is at the end of the file'],
+      ['no-range-support', 'provider answered HTTP 200 without Content-Range'],
+      ['unknown', 'container layout not recognized'],
+    ])('falls back when the probe verdict is "%s"', async (verdict, detail) => {
+      mockProbe.mockResolvedValue({ verdict, detail, bytesRead: 64 });
+
+      const input = await service.resolve(makeRequest());
+
+      expect(input.mode).toBe('download');
+      expect(input.source).toBe('/tmp/clip.mp4');
+      expect(mockDownload).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back when minting the signed URL throws', async () => {
+      mockProvider.getSignedDownloadUrl.mockRejectedValue(new Error('signer unavailable'));
+
+      const input = await service.resolve(makeRequest());
+
+      expect(input.mode).toBe('download');
+      expect(mockDownload).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back when the provider returns no URL at all', async () => {
+      mockProvider.getSignedDownloadUrl.mockResolvedValue('');
+
+      const input = await service.resolve(makeRequest());
+
+      expect(input.mode).toBe('download');
+    });
+
+    it('never probes at all when streaming is disabled by the admin setting', async () => {
+      const input = await service.resolve(makeRequest({ streamingEnabled: false }));
+
+      expect(mockProbe).not.toHaveBeenCalled();
+      expect(mockProvider.getSignedDownloadUrl).not.toHaveBeenCalled();
+      expect(input.mode).toBe('download');
+      expect(input.reason).toMatch(/disabled/);
+    });
+
+    it('passes the size through for the disk-space pre-flight, and reports the real bytes moved', async () => {
+      mockProbe.mockResolvedValue({ verdict: 'not-faststart', detail: 'x', bytesRead: 64 });
+
+      const input = await service.resolve(makeRequest());
+
+      expect(mockDownload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sizeBytes: BigInt(4_000_000_000),
+          prefix: 'memoriaHub-vtag-dl-',
+          extension: '.mp4',
+        }),
+      );
+      expect(input.bytesMoved).toBe(4_000_000_000);
+    });
+
+    it('returns the downloader’s cleanup so the caller unlinks the temp file', async () => {
+      mockProbe.mockResolvedValue({ verdict: 'unknown', detail: 'x', bytesRead: 0 });
+
+      const input = await service.resolve(makeRequest());
+      await input.cleanup();
+
+      expect(mockCleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates a download failure — that is a real job failure, not something to swallow', async () => {
+      mockProbe.mockResolvedValue({ verdict: 'unknown', detail: 'x', bytesRead: 0 });
+      mockDownload.mockRejectedValue(new Error('insufficient disk space for video download'));
+
+      await expect(service.resolve(makeRequest())).rejects.toThrow(/insufficient disk space/);
+    });
+  });
+});

--- a/apps/api/src/media/enrichment/video-input.service.ts
+++ b/apps/api/src/media/enrichment/video-input.service.ts
@@ -1,0 +1,159 @@
+// =============================================================================
+// VideoInputResolver
+// =============================================================================
+//
+// Decides how a video-enrichment job gets its bytes to ffmpeg (epic #452,
+// issue #456), and hands back a uniform handle either way.
+//
+// THE PROBLEM. Every video enrichment path downloads the ENTIRE file to a temp
+// file before touching it. For video auto-tagging that means pulling a
+// multi-gigabyte file across the network and onto disk in order to extract six
+// frames and thirty seconds of audio. The bytes actually needed are a rounding
+// error against the bytes moved, and on a memory- and disk-constrained VPS
+// this is the single biggest driver of the disk pressure that
+// `assertDiskSpaceForDownload` and `TempFileJanitorTask` exist to contain.
+//
+// THE FIX. ffmpeg speaks HTTP and issues Range requests, so `-ss` fast input
+// seek against a presigned URL fetches only the ranges around each seek point.
+// The storage layer already mints presigned GETs, so no new capability is
+// needed.
+//
+// THE SAFETY PROPERTY, and it is the whole reason this is shippable: the
+// fallback is the EXISTING, PROVEN download path, unchanged. Every failure
+// mode of the streaming path — provider ignores Range, a non-faststart MP4
+// whose index sits at the end of the file, an unrecognized container, a probe
+// error, the setting turned off, no URL available — routes to it. The worst
+// case of this feature is therefore exactly today's behavior plus one 64 KB
+// probe read.
+//
+// SCOPE. Only `video_auto_tagging` consumes this today. Applying it to
+// `video_face_detection` or `social_media_detection` is deliberately NOT in
+// scope — those are shipped features, and this should be proven on the new,
+// off-by-default job type first.
+// =============================================================================
+
+import { Injectable, Logger } from '@nestjs/common';
+import { probeRangeSeekSuitability } from '@memoriahub/enrichment-compute/video';
+import { StorageProviderResolver } from '../../storage/providers/storage-provider.resolver';
+import { downloadToTempFile } from '../../storage/processing/processors/stream-utils';
+
+/**
+ * Presigned-URL lifetime for a streamed read.
+ *
+ * A long ffmpeg session against an EXPIRING URL fails mid-run, so this must
+ * comfortably exceed the job's expected runtime. `ENRICHMENT_VIDEO_JOB_TIMEOUT_MS`
+ * caps a video job at 20 minutes by default, so 2 hours leaves a wide margin —
+ * and an expiry that somehow still bit would surface as an ffmpeg failure the
+ * caller treats like any other, i.e. a failed job the queue retries.
+ */
+const STREAM_URL_TTL_SECONDS = 2 * 60 * 60;
+
+export interface ResolvedVideoInput {
+  /** Path or URL to hand ffmpeg. */
+  source: string;
+  /** Which path was taken — logged so the win is measurable, not assumed. */
+  mode: 'stream' | 'download';
+  /** Why this mode was chosen. */
+  reason: string;
+  /** Bytes this resolver itself moved (0 for a stream beyond the probe). */
+  bytesMoved: number;
+  /** Always call in a `finally`; a no-op for the streaming path. */
+  cleanup: () => Promise<void>;
+}
+
+export interface VideoInputRequest {
+  storageKey: string;
+  storageProvider: string;
+  bucket: string | null;
+  /** Object size, for the download path's disk-space pre-flight. */
+  sizeBytes: bigint | number;
+  /** File extension including the dot, for ffmpeg container detection. */
+  extension?: string;
+  /** Temp filename prefix used by the download path. */
+  tempPrefix: string;
+  /** Whether the streaming path may be attempted at all (admin setting). */
+  streamingEnabled: boolean;
+  /** For log correlation. */
+  jobId: string;
+}
+
+@Injectable()
+export class VideoInputResolver {
+  private readonly logger = new Logger(VideoInputResolver.name);
+
+  constructor(private readonly resolver: StorageProviderResolver) {}
+
+  async resolve(req: VideoInputRequest): Promise<ResolvedVideoInput> {
+    const provider = await this.resolver.getProviderFor(req.storageProvider, req.bucket);
+
+    if (req.streamingEnabled) {
+      const streamed = await this.tryStream(req);
+      if (streamed) return streamed;
+    }
+
+    const startedAt = Date.now();
+    const { path, cleanup } = await downloadToTempFile({
+      getStream: () => provider.download(req.storageKey),
+      sizeBytes: req.sizeBytes,
+      prefix: req.tempPrefix,
+      ...(req.extension ? { extension: req.extension } : {}),
+    });
+
+    const bytesMoved = Number(req.sizeBytes);
+    this.logger.log(
+      `VideoInput ${req.jobId}: mode=download bytes=${bytesMoved} elapsedMs=${Date.now() - startedAt}` +
+        `${req.streamingEnabled ? '' : ' (streaming disabled)'}`,
+    );
+
+    return {
+      source: path,
+      mode: 'download',
+      reason: req.streamingEnabled ? 'streaming unavailable' : 'streaming disabled',
+      bytesMoved,
+      cleanup,
+    };
+  }
+
+  /**
+   * Attempt the streaming path. Returns `null` — never throws — when it is not
+   * usable, so the caller falls through to the download.
+   */
+  private async tryStream(req: VideoInputRequest): Promise<ResolvedVideoInput | null> {
+    const startedAt = Date.now();
+    try {
+      const provider = await this.resolver.getProviderFor(req.storageProvider, req.bucket);
+      const url = await provider.getSignedDownloadUrl(req.storageKey, {
+        expiresIn: STREAM_URL_TTL_SECONDS,
+      });
+      if (!url) return null;
+
+      const probe = await probeRangeSeekSuitability(url);
+      if (probe.verdict !== 'suitable') {
+        this.logger.log(
+          `VideoInput ${req.jobId}: falling back to download — ${probe.verdict} (${probe.detail})`,
+        );
+        return null;
+      }
+
+      this.logger.log(
+        `VideoInput ${req.jobId}: mode=stream probeBytes=${probe.bytesRead} ` +
+          `objectBytes=${req.sizeBytes} elapsedMs=${Date.now() - startedAt} — ${probe.detail}`,
+      );
+
+      return {
+        source: url,
+        mode: 'stream',
+        reason: probe.detail,
+        bytesMoved: probe.bytesRead,
+        // Nothing was materialized, so there is nothing to clean up.
+        cleanup: async () => {},
+      };
+    } catch (err) {
+      this.logger.log(
+        `VideoInput ${req.jobId}: falling back to download — streaming setup failed: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+}

--- a/apps/api/src/settings/dto/update-system-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-system-settings.dto.ts
@@ -107,6 +107,7 @@ export const patchSystemSettingsSchema = z.object({
               leadSeconds: z.number().int().min(5).max(600).optional(),
             })
             .optional(),
+          streamInput: z.boolean().optional(),
         })
         .optional(),
     })

--- a/apps/api/src/settings/system-settings/system-settings.service.spec.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.spec.ts
@@ -850,6 +850,7 @@ describe('SystemSettingsService', () => {
             // Untouched keys keep their stored/default value.
             sampleIntervalSeconds: 5,
             transcription: { enabled: true, leadSeconds: 60 },
+            streamInput: true,
           },
         });
       });
@@ -876,6 +877,9 @@ describe('SystemSettingsService', () => {
             maxFrames: 6,
             sampleIntervalSeconds: 5,
             transcription: { enabled: false, leadSeconds: 30 },
+            // Streaming defaults ON: the download path remains the fallback
+            // for every failure, so this is a revert switch, not a risk.
+            streamInput: true,
           },
         });
       });
@@ -908,7 +912,16 @@ describe('SystemSettingsService', () => {
           maxFrames: 12,
           sampleIntervalSeconds: 15,
           transcription: { enabled: true, leadSeconds: 120 },
+          streamInput: true,
         });
+      });
+
+      it('carries streamInput through the wire DTO, so it can be flipped off without a deploy', () => {
+        const parsed = patchSystemSettingsSchema.parse({
+          autoTagging: { video: { streamInput: false } },
+        });
+
+        expect((parsed as any).autoTagging?.video?.streamInput).toBe(false);
       });
 
       it('rejects an out-of-range maxFrames at the wire DTO — the frame budget is the cost lever', () => {

--- a/apps/api/src/settings/system-settings/system-settings.service.ts
+++ b/apps/api/src/settings/system-settings/system-settings.service.ts
@@ -356,6 +356,10 @@ export class SystemSettingsService {
               (current as any).autoTagging?.video?.transcription?.leadSeconds ??
               30,
           },
+          streamInput:
+            (dto as any).autoTagging?.video?.streamInput ??
+            (current as any).autoTagging?.video?.streamInput ??
+            true,
         },
       },
       face: {

--- a/apps/api/src/social-media/social-media-detection.handler.ts
+++ b/apps/api/src/social-media/social-media-detection.handler.ts
@@ -35,7 +35,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
 import { MediaEnrichmentService } from '../media/enrichment/media-enrichment.service';
-import { streamToTempFile, assertDiskSpaceForDownload } from '../storage/processing/processors/stream-utils';
+import { downloadToTempFile } from '../storage/processing/processors/stream-utils';
 import { probeVideoFile, extractContainerMetadata } from '../storage/processing/processors/ffprobe.util';
 import {
   SocialMediaDetectorService,
@@ -250,15 +250,16 @@ export class SocialMediaDetectionHandler implements EnrichmentHandler, OnModuleI
           mediaItem.storageObject!.storageProvider,
           mediaItem.storageObject!.bucket,
         );
-        // Pre-flight: fail fast (through the normal retry/backoff path) when
-        // the temp filesystem cannot hold the download plus headroom.
-        await assertDiskSpaceForDownload(sizeBytes, tmpdir());
-        const stream = await provider.download(mediaItem.storageObject!.storageKey);
-        const tmpPath = join(tmpdir(), `memoriaHub-social-dl-${randomUUID()}${fileExt}`);
-        // Record the path BEFORE streaming so the outer finally can unlink a
-        // partial file when streamToTempFile itself fails mid-download.
+        // Shared helper (issue #456) — one implementation of the
+        // disk-guard -> download -> partial-file-cleanup sequence, instead of
+        // the byte-identical copy this and VideoFaceDetectionService each had.
+        const { path: tmpPath } = await downloadToTempFile({
+          getStream: () => provider.download(mediaItem.storageObject!.storageKey),
+          sizeBytes,
+          prefix: 'memoriaHub-social-dl-',
+          extension: fileExt,
+        });
         downloadedVideoPath = tmpPath;
-        await streamToTempFile(stream, tmpPath);
         return downloadedVideoPath;
       };
 

--- a/apps/api/src/storage/processing/processors/stream-utils.spec.ts
+++ b/apps/api/src/storage/processing/processors/stream-utils.spec.ts
@@ -3,7 +3,11 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
-import { streamToTempFile, assertDiskSpaceForDownload } from './stream-utils';
+import {
+  streamToTempFile,
+  assertDiskSpaceForDownload,
+  downloadToTempFile,
+} from './stream-utils';
 
 describe('streamToTempFile', () => {
   let tmpPath: string;
@@ -134,5 +138,96 @@ describe('assertDiskSpaceForDownload', () => {
     await expect(assertDiskSpaceForDownload(1_000_000, '/d')).rejects.toThrow(
       /insufficient disk space/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadToTempFile (issue #456)
+//
+// Extracted from the byte-identical block VideoFaceDetectionService,
+// SocialMediaDetectionHandler and VideoAutoTaggingService each had inline. It
+// is also the FALLBACK for the streaming path, so the sequence
+// (disk guard -> download -> partial-file cleanup) must have one implementation
+// rather than three that could drift.
+// ---------------------------------------------------------------------------
+
+describe('downloadToTempFile', () => {
+  const written: string[] = [];
+
+  afterEach(async () => {
+    for (const p of written.splice(0)) {
+      await fs.unlink(p).catch(() => {});
+    }
+  });
+
+  it('writes the stream to a temp file named with the given prefix and extension', async () => {
+    const { path, cleanup } = await downloadToTempFile({
+      getStream: async () => Readable.from([Buffer.from('video-bytes')]),
+      sizeBytes: 11,
+      prefix: 'memoriaHub-vtag-dl-',
+      extension: '.mp4',
+    });
+    written.push(path);
+
+    expect(path).toContain('memoriaHub-vtag-dl-');
+    expect(path.endsWith('.mp4')).toBe(true);
+    await expect(fs.readFile(path, 'utf8')).resolves.toBe('video-bytes');
+
+    await cleanup();
+    await expect(fs.stat(path)).rejects.toThrow();
+  });
+
+  it('runs the disk-space guard BEFORE opening the stream — a full disk must not start a download', async () => {
+    const getStream = jest.fn();
+
+    await expect(
+      downloadToTempFile({
+        getStream,
+        // Absurd size: guaranteed to exceed free space plus 20% headroom.
+        sizeBytes: Number.MAX_SAFE_INTEGER,
+        prefix: 'memoriaHub-guard-',
+      }),
+    ).rejects.toThrow(/insufficient disk space/);
+
+    expect(getStream).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the PARTIAL file when the download fails mid-stream', async () => {
+    let capturedPath: string | undefined;
+
+    const failing = new Readable({
+      read() {
+        this.push(Buffer.from('partial'));
+        this.destroy(new Error('connection reset'));
+      },
+    });
+
+    await expect(
+      downloadToTempFile({
+        getStream: async () => failing,
+        sizeBytes: 100,
+        prefix: 'memoriaHub-partial-',
+      }),
+    ).rejects.toThrow(/connection reset/);
+
+    // Nothing matching the prefix should survive — the helper owns cleanup on
+    // the failure path so the caller cannot forget.
+    const leftovers = (await fs.readdir(tmpdir())).filter((f) =>
+      f.startsWith('memoriaHub-partial-'),
+    );
+    expect(leftovers).toEqual([]);
+    expect(capturedPath).toBeUndefined();
+  });
+
+  it('is idempotent on cleanup — a second call is a no-op, not a throw', async () => {
+    const { path, cleanup } = await downloadToTempFile({
+      getStream: async () => Readable.from([Buffer.from('x')]),
+      sizeBytes: 1,
+      prefix: 'memoriaHub-idem-',
+    });
+    written.push(path);
+
+    await cleanup();
+    await expect(cleanup()).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/storage/processing/processors/stream-utils.ts
+++ b/apps/api/src/storage/processing/processors/stream-utils.ts
@@ -1,6 +1,9 @@
 import { Readable } from 'stream';
 import { createWriteStream, promises as fs } from 'fs';
 import { pipeline } from 'stream/promises';
+import { randomUUID } from 'crypto';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 /** Headroom factor applied on top of the object size for the disk-space guard. */
 const DISK_GUARD_HEADROOM = 1.2;
@@ -49,4 +52,54 @@ export async function assertDiskSpaceForDownload(
       `insufficient disk space for video download: need ${toMb(neededBytes)} MB, have ${toMb(freeBytes)} MB`,
     );
   }
+}
+
+/**
+ * Download an object to a temp file, guarded by the disk-space pre-flight, and
+ * return the path plus a cleanup function.
+ *
+ * Extracted (issue #456) from the byte-identical block that
+ * `VideoFaceDetectionService`, `SocialMediaDetectionHandler` and
+ * `VideoAutoTaggingService` each had inline. It is also the FALLBACK for the
+ * streaming path, so the fallback has exactly one implementation rather than
+ * three copies that could drift.
+ *
+ * The caller MUST call the returned `cleanup()` in a `finally` — a failed or
+ * partial download still leaves a temp file, and it is the caller that knows
+ * when the file stops being needed.
+ */
+export async function downloadToTempFile(opts: {
+  /** Opens the source stream. Called INSIDE the guarded section. */
+  getStream: () => Promise<Readable>;
+  /** Object size in bytes, for the disk-space pre-flight. */
+  sizeBytes: bigint | number;
+  /** Temp filename prefix, e.g. 'memoriaHub-vtag-dl-'. */
+  prefix: string;
+  /** File extension including the dot, for ffmpeg container detection. */
+  extension?: string;
+  /** Directory for the temp file. Defaults to the OS temp dir. */
+  dir?: string;
+}): Promise<{ path: string; cleanup: () => Promise<void> }> {
+  const dir = opts.dir ?? tmpdir();
+  const filePath = join(dir, `${opts.prefix}${randomUUID()}${opts.extension ?? ''}`);
+  const cleanup = async (): Promise<void> => {
+    await fs.unlink(filePath).catch(() => {});
+  };
+
+  // Pre-flight BEFORE opening the stream: fail fast (through the caller's
+  // normal retry/backoff path) when the filesystem cannot hold the download
+  // plus headroom, rather than filling the disk with a partial file.
+  await assertDiskSpaceForDownload(opts.sizeBytes, dir);
+
+  try {
+    const stream = await opts.getStream();
+    await streamToTempFile(stream, filePath);
+  } catch (err) {
+    // A partial file from a failed streamToTempFile must not be left behind
+    // for the caller to remember about.
+    await cleanup();
+    throw err;
+  }
+
+  return { path: filePath, cleanup };
 }

--- a/apps/api/src/tagging/tagging.module.ts
+++ b/apps/api/src/tagging/tagging.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { CirclesModule } from '../circles/circles.module';
 import { SettingsModule } from '../settings/settings.module';
 import { MediaTouchModule } from '../media/media-touch.module';
+import { VideoInputResolver } from '../media/enrichment/video-input.service';
 import { AutoTaggingHandler } from './auto-tagging.handler';
 import { AutoTaggingService } from './auto-tagging.service';
 import { VideoAutoTaggingHandler } from './video-auto-tagging.handler';
@@ -24,6 +25,7 @@ import { AdminTaggingController } from './admin-tagging.controller';
     AutoTaggingService,
     VideoAutoTaggingHandler,
     VideoAutoTaggingService,
+    VideoInputResolver,
     TagLabelsService,
     TaggingBackfillService,
   ],

--- a/apps/api/src/tagging/video-auto-tagging.service.spec.ts
+++ b/apps/api/src/tagging/video-auto-tagging.service.spec.ts
@@ -31,14 +31,8 @@ jest.mock('@memoriahub/enrichment-compute/video', () => ({
   extractAudioLead: jest.fn(),
 }));
 
-// Downloading is orthogonal to what these tests assert.
-jest.mock('../storage/processing/processors/stream-utils', () => ({
-  streamToTempFile: jest.fn().mockResolvedValue(undefined),
-  assertDiskSpaceForDownload: jest.fn().mockResolvedValue(undefined),
-}));
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { Readable } from 'stream';
 import {
   EnrichmentJob,
   JobReason,
@@ -54,7 +48,7 @@ import { AutoTaggingService } from './auto-tagging.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AiSettingsService } from '../ai/ai-settings.service';
 import { AiProviderRegistry } from '../ai/providers/ai-provider.registry';
-import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
+import { VideoInputResolver } from '../media/enrichment/video-input.service';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { RateLimitError } from '../enrichment/rate-limit.error';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
@@ -151,7 +145,8 @@ describe('VideoAutoTaggingService', () => {
   };
   let mockRegistry: { get: jest.Mock };
   let mockProvider: { analyzeImage: jest.Mock; transcribeAudio?: jest.Mock };
-  let mockResolver: { getProviderFor: jest.Mock };
+  let mockVideoInput: { resolve: jest.Mock };
+  let mockCleanup: jest.Mock;
   let mockEnrichmentJobService: { recordModel: jest.Mock };
   let mockAutoTaggingService: { persistAutoTagging: jest.Mock };
   const ORIGINAL_ENV = { ...process.env };
@@ -172,9 +167,14 @@ describe('VideoAutoTaggingService', () => {
       resolveCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-key' }),
       resolveTranscriptionConfig: jest.fn().mockResolvedValue(null),
     };
-    mockResolver = {
-      getProviderFor: jest.fn().mockResolvedValue({
-        download: jest.fn().mockResolvedValue(Readable.from([Buffer.from('video')])),
+    mockCleanup = jest.fn().mockResolvedValue(undefined);
+    mockVideoInput = {
+      resolve: jest.fn().mockResolvedValue({
+        source: '/tmp/video.mp4',
+        mode: 'download',
+        reason: 'test',
+        bytesMoved: 5_000_000,
+        cleanup: mockCleanup,
       }),
     };
     mockEnrichmentJobService = { recordModel: jest.fn().mockResolvedValue(undefined) };
@@ -203,7 +203,7 @@ describe('VideoAutoTaggingService', () => {
         { provide: PrismaService, useValue: mockPrisma },
         { provide: AiSettingsService, useValue: mockAiSettings },
         { provide: AiProviderRegistry, useValue: mockRegistry },
-        { provide: StorageProviderResolver, useValue: mockResolver },
+        { provide: VideoInputResolver, useValue: mockVideoInput },
         { provide: EnrichmentJobService, useValue: mockEnrichmentJobService },
         { provide: AutoTaggingService, useValue: mockAutoTaggingService },
       ],
@@ -284,7 +284,7 @@ describe('VideoAutoTaggingService', () => {
 
       await service.processMediaItem(makeJob());
 
-      expect(mockResolver.getProviderFor).not.toHaveBeenCalled();
+      expect(mockVideoInput.resolve).not.toHaveBeenCalled();
       expect(mockProvider.analyzeImage).not.toHaveBeenCalled();
     });
 
@@ -380,6 +380,63 @@ describe('VideoAutoTaggingService', () => {
       const req = mockProvider.analyzeImage.mock.calls[0][1];
       expect(req.images.length).toBeGreaterThan(0);
       expect(req.images.length).toBeLessThan(6);
+    });
+  });
+
+  // =========================================================================
+  // Input resolution (issue #456)
+  // =========================================================================
+
+  describe('video input', () => {
+    it('asks the resolver for the input and hands whatever it returns to ffmpeg', async () => {
+      mockVideoInput.resolve.mockResolvedValue({
+        source: 'https://storage.example/clip.mp4?sig=abc',
+        mode: 'stream',
+        reason: 'faststart',
+        bytesMoved: 65536,
+        cleanup: mockCleanup,
+      });
+
+      await service.processMediaItem(makeJob());
+
+      // The compute half is source-agnostic: a URL and a path are both just
+      // something ffmpeg can read.
+      expect(mockExtractFrames.mock.calls[0][0]).toBe('https://storage.example/clip.mp4?sig=abc');
+    });
+
+    it('forwards the admin streamInput setting, defaulting to enabled', async () => {
+      await service.processMediaItem(makeJob());
+      expect(mockVideoInput.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ streamingEnabled: true }),
+      );
+
+      mockVideoInput.resolve.mockClear();
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(
+        makeSettings({
+          autoTagging: {
+            video: {
+              enabled: true,
+              maxFrames: 6,
+              sampleIntervalSeconds: 5,
+              transcription: { enabled: false, leadSeconds: 30 },
+              streamInput: false,
+            },
+          },
+        }),
+      );
+
+      await service.processMediaItem(makeJob());
+      expect(mockVideoInput.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ streamingEnabled: false }),
+      );
+    });
+
+    it('always cleans up the input, including when the AI call throws', async () => {
+      mockProvider.analyzeImage.mockRejectedValue(new Error('provider exploded'));
+
+      await expect(service.processMediaItem(makeJob())).rejects.toThrow();
+
+      expect(mockCleanup).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/api/src/tagging/video-auto-tagging.service.ts
+++ b/apps/api/src/tagging/video-auto-tagging.service.ts
@@ -45,16 +45,14 @@
 
 import { Injectable, Logger } from '@nestjs/common';
 import { EnrichmentJob, MediaTagStatusType, MediaType } from '@prisma/client';
-import { randomUUID } from 'crypto';
-import { tmpdir } from 'os';
-import { join, extname } from 'path';
-import { promises as fs } from 'fs';
+import { extname } from 'path';
 import type { VideoAutoTaggingResult } from '@memoriahub/enrichment-compute/dto';
 import {
   extractAudioLead,
   extractFrames,
 } from '@memoriahub/enrichment-compute/video';
 import { PrismaService } from '../prisma/prisma.service';
+import { VideoInputResolver } from '../media/enrichment/video-input.service';
 import { AiSettingsService } from '../ai/ai-settings.service';
 import { AiProviderRegistry } from '../ai/providers/ai-provider.registry';
 import type {
@@ -62,11 +60,6 @@ import type {
   AiProviderCredentials,
   AnalyzeImageInputImage,
 } from '../ai/providers/ai-provider.interface';
-import { StorageProviderResolver } from '../storage/providers/storage-provider.resolver';
-import {
-  streamToTempFile,
-  assertDiskSpaceForDownload,
-} from '../storage/processing/processors/stream-utils';
 import { prepareImageForProcessing } from '../storage/processing/image-orientation.util';
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { RateLimitError, parseRetryAfterMs, classifyRateLimit } from '../enrichment/rate-limit.error';
@@ -124,6 +117,13 @@ export interface VideoTaggingParams {
   sampleIntervalSeconds: number;
   transcriptionEnabled: boolean;
   leadSeconds: number;
+  /**
+   * Whether ffmpeg may read the video straight from a presigned URL via HTTP
+   * range seeks instead of downloading it whole (issue #456). Off falls back
+   * to the proven download path, which is also what every streaming failure
+   * does — so this is a revert switch, not a correctness gate.
+   */
+  streamInput: boolean;
 }
 
 @Injectable()
@@ -134,7 +134,7 @@ export class VideoAutoTaggingService {
     private readonly prisma: PrismaService,
     private readonly aiSettingsService: AiSettingsService,
     private readonly aiProviderRegistry: AiProviderRegistry,
-    private readonly resolver: StorageProviderResolver,
+    private readonly videoInput: VideoInputResolver,
     private readonly enrichmentJobService: EnrichmentJobService,
     private readonly autoTaggingService: AutoTaggingService,
   ) {}
@@ -181,6 +181,7 @@ export class VideoAutoTaggingService {
       sampleIntervalSeconds: videoSettings?.sampleIntervalSeconds ?? 5,
       transcriptionEnabled: videoSettings?.transcription?.enabled === true,
       leadSeconds: videoSettings?.transcription?.leadSeconds ?? 30,
+      streamInput: videoSettings?.streamInput !== false,
     };
 
     const mediaItem = await this.prisma.mediaItem.findUnique({
@@ -318,24 +319,24 @@ export class VideoAutoTaggingService {
       const labelNames = tagLabels.map((t) => t.name);
 
       const fileExt = extname(mediaItem.storageObject.name || '') || '.mp4';
-      const tmpVideoPath = join(tmpdir(), `memoriaHub-vtag-dl-${randomUUID()}${fileExt}`);
 
-      const objectProvider = await this.resolver.getProviderFor(
-        mediaItem.storageObject.storageProvider,
-        mediaItem.storageObject.bucket,
-      );
-
-      // Pre-flight: fail fast through the normal retry/backoff path when the
-      // temp filesystem cannot hold the download plus headroom.
-      await assertDiskSpaceForDownload(mediaItem.storageObject.size, tmpdir());
+      // Streams from a presigned URL when the provider honors Range and the
+      // container's index is at the front; otherwise downloads. Either way the
+      // returned handle is just something ffmpeg can read (issue #456).
+      const input = await this.videoInput.resolve({
+        storageKey: mediaItem.storageObject.storageKey,
+        storageProvider: mediaItem.storageObject.storageProvider,
+        bucket: mediaItem.storageObject.bucket,
+        sizeBytes: mediaItem.storageObject.size,
+        extension: fileExt,
+        tempPrefix: 'memoriaHub-vtag-dl-',
+        streamingEnabled: params.streamInput,
+        jobId: job.id,
+      });
 
       let computed: VideoAutoTaggingResult;
       try {
-        // Download INSIDE the try so a partial file is still unlinked below.
-        const videoStream = await objectProvider.download(mediaItem.storageObject.storageKey);
-        await streamToTempFile(videoStream, tmpVideoPath);
-
-        computed = await this.computeVideoAutoTagging(tmpVideoPath, {
+        computed = await this.computeVideoAutoTagging(input.source, {
           durationMs: mediaItem.durationMs,
           fileExtension: fileExt,
           params,
@@ -348,7 +349,7 @@ export class VideoAutoTaggingService {
           jobId: job.id,
         });
       } finally {
-        await fs.unlink(tmpVideoPath).catch(() => {});
+        await input.cleanup();
       }
 
       // The transcript is persisted BEFORE the shared persist runs, so

--- a/apps/cli/src/node/node-engine.ts
+++ b/apps/cli/src/node/node-engine.ts
@@ -163,6 +163,19 @@ const INPUT_REQUIRED_TYPES = new Set<string>([
   'auto_tagging',
 ]);
 
+/**
+ * Job types whose compute reads the input URL DIRECTLY rather than a local
+ * file (epic #452, issue #456).
+ *
+ * ffmpeg speaks HTTP and range-seeks, so `video_auto_tagging` needs only the
+ * few megabytes around each seek point — pre-downloading a multi-gigabyte
+ * video here would defeat the entire optimization and leave it server-side
+ * only. For these types the engine passes `inputUrl` straight through and
+ * skips both the download and the local-path assertion; the compute function
+ * decides for itself whether to stream or fall back.
+ */
+const URL_INPUT_TYPES = new Set<string>(['video_auto_tagging']);
+
 type Resolved = Required<Pick<NodeEngineDeps, 'downloadFn' | 'detectFn' | 'tmpDir'>>;
 
 export class NodeEngine extends NodeTypedEmitter {
@@ -428,11 +441,17 @@ export class NodeEngine extends NodeTypedEmitter {
     }, leaseInterval);
     leaseTimer.unref?.();
 
+    // A URL-input type receives the presigned URL verbatim; everything else
+    // gets a local temp file as before.
+    const usesUrlInput = URL_INPUT_TYPES.has(type);
+
     try {
-      if (inputUrl) {
+      if (inputUrl && usesUrlInput) {
+        // Deliberately no download: the compute reads the URL directly.
+      } else if (inputUrl) {
         await this.resolved.downloadFn(inputUrl, tmpPath);
         downloaded = true;
-      } else if (INPUT_REQUIRED_TYPES.has(type)) {
+      } else if (INPUT_REQUIRED_TYPES.has(type) || usesUrlInput) {
         // Server returned no presigned URL for a job whose compute reads the
         // input file. Fail cleanly instead of calling compute with '' (which
         // would throw the opaque `ENOENT ... open ''`); the server requeues.
@@ -441,7 +460,8 @@ export class NodeEngine extends NodeTypedEmitter {
         );
       }
 
-      const result = await this.dispatcher.compute(type, downloaded ? tmpPath : '', params ?? {}, {
+      const computeInput = usesUrlInput ? (inputUrl as string) : downloaded ? tmpPath : '';
+      const result = await this.dispatcher.compute(type, computeInput, params ?? {}, {
         nodeId: this.nodeId,
         jobId,
       });

--- a/apps/cli/test/node/node-engine-input-guard.spec.ts
+++ b/apps/cli/test/node/node-engine-input-guard.spec.ts
@@ -237,3 +237,57 @@ describe('NodeEngine INPUT_REQUIRED_TYPES guard', () => {
     expect(doneEvents[0]?.submitted).toBe(true);
   });
 });
+
+/**
+ * URL_INPUT_TYPES (epic #452, issue #456).
+ *
+ * ffmpeg speaks HTTP and range-seeks, so `video_auto_tagging` needs only the
+ * few megabytes around each seek point. Pre-downloading a multi-gigabyte video
+ * in the engine would defeat the entire optimization and leave it server-side
+ * only — which is exactly the trap this opt-out exists to avoid.
+ */
+describe('NodeEngine URL_INPUT_TYPES opt-out', () => {
+  it('video_auto_tagging passes the presigned URL STRAIGHT to compute, downloading nothing', async () => {
+    const downloadCalls: DownloadCall[] = [];
+    const doneEvents: Array<{ jobId: string; type: string; submitted: boolean }> = [];
+    const url = 'https://storage.example.com/signed/video.mp4';
+    const { engine, stub } = buildEngine(
+      [claim('j1', 'video_auto_tagging', url)],
+      ['video_auto_tagging'],
+      downloadCalls,
+    );
+    engine.on(NODE_EV.JOB_DONE, (payload) => doneEvents.push(payload));
+
+    await runUntilIdle(engine);
+    await engine.stop('test');
+
+    // The whole point: no gigabytes pulled to disk.
+    expect(downloadCalls).toHaveLength(0);
+
+    expect(stub.computeCalls).toHaveLength(1);
+    expect(stub.computeCalls[0]?.type).toBe('video_auto_tagging');
+    expect(stub.computeCalls[0]?.inputPath).toBe(url);
+
+    expect(stub.failureCalls).toHaveLength(0);
+    expect(doneEvents[0]?.submitted).toBe(true);
+  });
+
+  it('video_auto_tagging with inputUrl:null still fails cleanly rather than computing on an empty string', async () => {
+    const downloadCalls: DownloadCall[] = [];
+    const { engine, stub } = buildEngine(
+      [claim('j1', 'video_auto_tagging', null)],
+      ['video_auto_tagging'],
+      downloadCalls,
+    );
+
+    await runUntilIdle(engine);
+    await engine.stop('test');
+
+    // A URL-input type still REQUIRES a URL — skipping the download must not
+    // also skip the "no input at all" guard.
+    expect(stub.computeCalls).toHaveLength(0);
+    expect(stub.failureCalls).toHaveLength(1);
+    expect(stub.failureCalls[0]?.body.error).toContain('input bytes unavailable');
+    expect(stub.failureCalls[0]?.body.error).toContain('video_auto_tagging');
+  });
+});

--- a/packages/enrichment-compute/src/video/index.ts
+++ b/packages/enrichment-compute/src/video/index.ts
@@ -49,6 +49,44 @@ export interface FrameExtractionOpts {
    * Falls back to '.mp4' when absent.
    */
   fileExtension?: string;
+  /**
+   * Per-frame ffmpeg timeout in ms before SIGKILL.
+   *
+   * Historically UNBOUNDED here (only `extractPosterFrame` was bounded), which
+   * was survivable against a local file. Against a remote URL it is not: a
+   * stalled network read would hang a worker slot until the 20-minute job
+   * timeout fired. Absent, this falls back to `FFMPEG_TIMEOUT_MS` (default
+   * 60000) — so the previously-unbounded local path also gains a ceiling.
+   */
+  ffmpegTimeoutMs?: number;
+}
+
+/**
+ * A video source ffmpeg can read: either a local file path or an HTTP(S) URL.
+ *
+ * ffmpeg speaks HTTP and issues Range requests, so `-ss` fast input seek
+ * against a URL fetches only the ranges around each seek point — megabytes
+ * rather than the whole multi-gigabyte file. The functions here do not care
+ * which form they are given; `isHttpUrl` below is only used to pick a longer
+ * default timeout for the network case.
+ */
+export type VideoSource = string;
+
+/** True for an http(s) URL, as opposed to a local filesystem path. */
+export function isHttpUrl(source: string): boolean {
+  return /^https?:\/\//i.test(source);
+}
+
+/**
+ * Default ffmpeg timeout for a single frame/audio extraction, in ms.
+ *
+ * A network source gets a longer budget than a local file: the first seek has
+ * to fetch the container header before it can read anything.
+ */
+function defaultFfmpegTimeoutMs(source: string): number {
+  const configured = parseInt(process.env.FFMPEG_TIMEOUT_MS ?? '60000', 10);
+  const base = Number.isFinite(configured) && configured > 0 ? configured : 60000;
+  return isHttpUrl(source) ? base * 2 : base;
 }
 
 // ---------------------------------------------------------------------------
@@ -71,10 +109,11 @@ export interface FrameExtractionOpts {
  * Always cleans up its own (per-frame output) temp files in a finally block.
  */
 export async function extractFrames(
-  videoPath: string,
+  videoPath: VideoSource,
   opts: FrameExtractionOpts,
 ): Promise<ExtractedFrame[]> {
   const { durationMs, sampleIntervalSeconds, maxFrames } = opts;
+  const ffmpegTimeoutMs = opts.ffmpegTimeoutMs ?? defaultFfmpegTimeoutMs(videoPath);
 
   const seekTimestamps = computeSeekTimestamps(durationMs ?? 0, sampleIntervalSeconds, maxFrames);
 
@@ -88,7 +127,7 @@ export async function extractFrames(
       tmpFramePaths.push(tmpOut);
 
       try {
-        await extractFrame(videoPath, tmpOut, seekSecs);
+        await extractFrame(videoPath, tmpOut, seekSecs, ffmpegTimeoutMs);
         const buffer = await fs.readFile(tmpOut);
         results.push({ timestampMs: Math.round(seekSecs * 1000), buffer });
       } catch (err) {
@@ -128,10 +167,12 @@ export async function extractFrames(
  * per-frame output temp files it creates internally, in a finally block.
  */
 export async function extractFramesAt(
-  videoPath: string,
+  videoPath: VideoSource,
   timestampsMs: number[],
   _fileExtension?: string,
+  ffmpegTimeoutMs?: number,
 ): Promise<ExtractedFrame[]> {
+  const timeoutMs = ffmpegTimeoutMs ?? defaultFfmpegTimeoutMs(videoPath);
   const cleaned = Array.from(new Set(timestampsMs.map((t) => Math.max(0, Math.round(t))))).sort(
     (a, b) => a - b,
   );
@@ -151,7 +192,7 @@ export async function extractFramesAt(
       tmpFramePaths.push(tmpOut);
 
       try {
-        await extractFrame(videoPath, tmpOut, seekSecs);
+        await extractFrame(videoPath, tmpOut, seekSecs, timeoutMs);
         const buffer = await fs.readFile(tmpOut);
         results.push({ timestampMs: ms, buffer });
       } catch (err) {
@@ -222,11 +263,10 @@ export interface ExtractedAudioLead {
  * best-effort and proceed visual-only.
  */
 export async function extractAudioLead(
-  videoPath: string,
+  videoPath: VideoSource,
   opts: AudioLeadOpts,
 ): Promise<ExtractedAudioLead> {
-  const ffmpegTimeoutMs =
-    opts.ffmpegTimeoutMs ?? parseInt(process.env.FFMPEG_TIMEOUT_MS ?? '60000', 10);
+  const ffmpegTimeoutMs = opts.ffmpegTimeoutMs ?? defaultFfmpegTimeoutMs(videoPath);
 
   const tmpOut = join(tmpdir(), `memoriaHub-audio-${randomUUID()}.m4a`);
 
@@ -432,13 +472,170 @@ export function computeSeekTimestamps(
  *
  * Argv: `['-ss', <seekSecs>, '-i', tmpIn, '-y', '-vframes', '1', tmpOut]` —
  * identical to what fluent-ffmpeg's `.seekInput(s).frames(1).output(out)`
- * chain produced. Deliberately UNBOUNDED by a timeout, matching the previous
- * behaviour of this sampling path (only `extractPosterFrame` was ever
- * timeout-bounded); each caller already treats a per-frame failure as
- * skippable.
+ * chain produced. `tmpIn` may be a local path OR an http(s) URL; ffmpeg does
+ * not care, and `-ss` before `-i` stays an INPUT seek either way, which is
+ * exactly what makes a URL source fetch only the bytes around the seek point.
+ *
+ * Bounded by `timeoutMs` (issue #456). This path used to be unbounded —
+ * survivable against a local file, but against a remote URL a stalled network
+ * read would hang a worker slot until the 20-minute job timeout. Each caller
+ * already treats a per-frame failure as skippable, so a timed-out frame costs
+ * that frame, not the video.
  */
-function extractFrame(tmpIn: string, tmpOut: string, seekSecs: number): Promise<void> {
-  return runFfmpeg(
-    buildFrameExtractionArgs({ input: tmpIn, output: tmpOut, seekSecs }),
-  );
+function extractFrame(
+  tmpIn: VideoSource,
+  tmpOut: string,
+  seekSecs: number,
+  timeoutMs: number,
+): Promise<void> {
+  return runFfmpeg(buildFrameExtractionArgs({ input: tmpIn, output: tmpOut, seekSecs }), {
+    timeoutMs,
+    timeoutMessage: `ffmpeg frame extraction timed out after ${timeoutMs}ms`,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Range-seek suitability probe (issue #456)
+// ---------------------------------------------------------------------------
+
+export type RangeSeekVerdict =
+  /** Range honored AND the container's index is at the front — stream it. */
+  | 'suitable'
+  /**
+   * Range honored but the index is at the END of the file (a non-faststart
+   * MP4/MOV), so ffmpeg must fetch the tail before it can seek at all —
+   * collapsing the saving and doing it slowly. Download instead.
+   */
+  | 'not-faststart'
+  /** The provider ignored the Range header, so there is no saving to be had. */
+  | 'no-range-support'
+  /** Could not tell (network error, unrecognized container). Download instead. */
+  | 'unknown';
+
+export interface RangeSeekProbeResult {
+  verdict: RangeSeekVerdict;
+  /** Human-readable reason, for the decision log. */
+  detail: string;
+  /** Bytes actually read by the probe itself. */
+  bytesRead: number;
+}
+
+/** How much of the file head to read when looking for the `moov` atom. */
+const FASTSTART_PROBE_BYTES = 64 * 1024;
+
+/**
+ * Decide whether a video URL is worth streaming to ffmpeg instead of
+ * downloading whole.
+ *
+ * This answers BOTH preconditions in a single small ranged request:
+ *
+ *   1. Does the provider honor `Range`? A 206 with a `Content-Range` header
+ *      says yes. A 200 means the whole object was sent and ffmpeg's seeks
+ *      would re-download the file repeatedly — strictly worse than one clean
+ *      download.
+ *   2. For MP4/MOV, is the `moov` atom at the FRONT ("faststart")? The atom
+ *      layout is definitive and readable from the first few KB, which is why
+ *      this reads the bytes rather than trying to infer it from ffprobe
+ *      metadata — ffprobe's `-show_format` output does not report atom order
+ *      at all, so there is nothing in the persisted `_processing['video-probe']`
+ *      blob that could answer this.
+ *
+ * NEVER THROWS: any failure resolves to `'unknown'`, and every non-`suitable`
+ * verdict means "use the proven download path". The worst case of this whole
+ * feature is therefore exactly today's behavior plus one 64 KB read.
+ */
+export async function probeRangeSeekSuitability(
+  url: string,
+  opts: { timeoutMs?: number; fetchImpl?: typeof fetch } = {},
+): Promise<RangeSeekProbeResult> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await doFetch(url, {
+      headers: { Range: `bytes=0-${FASTSTART_PROBE_BYTES - 1}` },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return { verdict: 'unknown', detail: `probe returned HTTP ${response.status}`, bytesRead: 0 };
+    }
+    if (response.status !== 206 || !response.headers.get('content-range')) {
+      // A 200 means the provider sent the WHOLE object — no ranged reads, so
+      // streaming would re-fetch the file per seek.
+      return {
+        verdict: 'no-range-support',
+        detail: `provider answered HTTP ${response.status} without Content-Range`,
+        bytesRead: 0,
+      };
+    }
+
+    const head = Buffer.from(await response.arrayBuffer());
+    const layout = findMp4IndexPosition(head);
+
+    if (layout === 'front') {
+      return { verdict: 'suitable', detail: 'moov atom at the front (faststart)', bytesRead: head.length };
+    }
+    if (layout === 'back') {
+      return {
+        verdict: 'not-faststart',
+        detail: 'mdat precedes moov — the index is at the end of the file',
+        bytesRead: head.length,
+      };
+    }
+    return {
+      verdict: 'unknown',
+      detail: 'container layout not recognized in the probed head',
+      bytesRead: head.length,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { verdict: 'unknown', detail: `probe failed: ${msg}`, bytesRead: 0 };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Walk the top-level ISO-BMFF (MP4/MOV) box list in `head` and report whether
+ * the `moov` index box comes before or after the `mdat` media payload.
+ *
+ * Returns `'unknown'` for a non-ISO-BMFF container (WebM, AVI, …) or when the
+ * probed window ends before either box is seen — both of which route to the
+ * download path rather than guessing.
+ */
+function findMp4IndexPosition(head: Buffer): 'front' | 'back' | 'unknown' {
+  let offset = 0;
+
+  // A box is: 4-byte big-endian size, 4-byte type. Size 1 means the real
+  // 64-bit size follows the type; size 0 means "to end of file".
+  while (offset + 8 <= head.length) {
+    const size32 = head.readUInt32BE(offset);
+    const type = head.toString('latin1', offset + 4, offset + 8);
+
+    if (type === 'moov') return 'front';
+    if (type === 'mdat') return 'back';
+
+    let boxSize: number;
+    if (size32 === 1) {
+      if (offset + 16 > head.length) return 'unknown';
+      // Read the 64-bit size as a Number — real box sizes are far below 2^53.
+      boxSize = Number(head.readBigUInt64BE(offset + 8));
+    } else if (size32 === 0) {
+      // Extends to EOF, so nothing further can appear before it.
+      return 'unknown';
+    } else {
+      boxSize = size32;
+    }
+
+    // A malformed or absurd size means this is not an ISO-BMFF file (or is
+    // corrupt); either way, do not guess.
+    if (boxSize < 8 || !Number.isSafeInteger(boxSize)) return 'unknown';
+    offset += boxSize;
+  }
+
+  return 'unknown';
 }

--- a/packages/enrichment-compute/test/video.test.mjs
+++ b/packages/enrichment-compute/test/video.test.mjs
@@ -436,3 +436,176 @@ test('extractAudioLead SIGKILLs a hung ffmpeg and rejects with its own timeout m
     restore();
   }
 });
+
+// ---------------------------------------------------------------------------
+// probeRangeSeekSuitability (issue #456)
+//
+// Answers both preconditions for streaming a video to ffmpeg in one small
+// ranged read: does the provider honor Range, and (for MP4/MOV) is the `moov`
+// index at the FRONT of the file? Any answer other than 'suitable' routes the
+// caller to the proven download path, so this function must NEVER throw.
+// ---------------------------------------------------------------------------
+
+/** Build an ISO-BMFF top-level box: 4-byte size, 4-byte type, then payload. */
+function box(type, payloadLength = 0) {
+  const buf = Buffer.alloc(8 + payloadLength);
+  buf.writeUInt32BE(8 + payloadLength, 0);
+  buf.write(type, 4, 'latin1');
+  return buf;
+}
+
+function rangeResponse(body, { status = 206, contentRange = 'bytes 0-63/1000000' } = {}) {
+  const headers = new Headers({ 'content-type': 'video/mp4' });
+  if (contentRange) headers.set('content-range', contentRange);
+  return new Response(body, { status, headers });
+}
+
+test('probeRangeSeekSuitability returns "suitable" for a faststart MP4 (moov before mdat)', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  let capturedInit;
+  const result = await probeRangeSeekSuitability('https://storage.example/video.mp4', {
+    fetchImpl: async (_url, init) => {
+      capturedInit = init;
+      return rangeResponse(Buffer.concat([box('ftyp', 16), box('moov', 32), box('mdat', 64)]));
+    },
+  });
+
+  assert.equal(result.verdict, 'suitable');
+  assert.match(result.detail, /faststart/);
+  assert.ok(result.bytesRead > 0);
+  // The probe must ASK for a range — that is what proves the provider honors it.
+  assert.match(capturedInit.headers.Range, /^bytes=0-\d+$/);
+});
+
+test('probeRangeSeekSuitability returns "not-faststart" when mdat precedes moov', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  const result = await probeRangeSeekSuitability('https://storage.example/video.mp4', {
+    fetchImpl: async () => rangeResponse(Buffer.concat([box('ftyp', 16), box('mdat', 64)])),
+  });
+
+  // ffmpeg would have to fetch the tail before it could seek at all,
+  // collapsing the saving — download instead.
+  assert.equal(result.verdict, 'not-faststart');
+});
+
+test('probeRangeSeekSuitability returns "no-range-support" on a 200 (whole object sent)', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  const result = await probeRangeSeekSuitability('https://storage.example/video.mp4', {
+    fetchImpl: async () =>
+      rangeResponse(box('moov', 32), { status: 200, contentRange: null }),
+  });
+
+  // Seeks would re-download the file each time — strictly worse than one
+  // clean download.
+  assert.equal(result.verdict, 'no-range-support');
+});
+
+test('probeRangeSeekSuitability returns "unknown" for a non-ISO-BMFF container', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  const result = await probeRangeSeekSuitability('https://storage.example/video.webm', {
+    fetchImpl: async () => rangeResponse(Buffer.from('\x1aE\xdf\xa3 not an mp4 at all')),
+  });
+
+  assert.equal(result.verdict, 'unknown');
+});
+
+test('probeRangeSeekSuitability NEVER throws — a network failure resolves to "unknown"', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  const result = await probeRangeSeekSuitability('https://storage.example/video.mp4', {
+    fetchImpl: async () => {
+      throw new Error('ECONNRESET');
+    },
+  });
+
+  assert.equal(result.verdict, 'unknown');
+  assert.match(result.detail, /ECONNRESET/);
+});
+
+test('probeRangeSeekSuitability returns "unknown" for a non-OK HTTP status (e.g. an expired URL)', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  const result = await probeRangeSeekSuitability('https://storage.example/video.mp4', {
+    fetchImpl: async () => new Response('AccessDenied', { status: 403 }),
+  });
+
+  assert.equal(result.verdict, 'unknown');
+  assert.match(result.detail, /403/);
+});
+
+test('probeRangeSeekSuitability handles a 64-bit box size without mis-parsing', async () => {
+  const { probeRangeSeekSuitability } = await import('@memoriahub/enrichment-compute/video');
+
+  // ftyp declared with the `size == 1` escape, real size in the following 8 bytes.
+  const largeFtyp = Buffer.alloc(24);
+  largeFtyp.writeUInt32BE(1, 0);
+  largeFtyp.write('ftyp', 4, 'latin1');
+  largeFtyp.writeBigUInt64BE(24n, 8);
+
+  const result = await probeRangeSeekSuitability('https://storage.example/video.mp4', {
+    fetchImpl: async () => rangeResponse(Buffer.concat([largeFtyp, box('moov', 16)])),
+  });
+
+  assert.equal(result.verdict, 'suitable');
+});
+
+test('isHttpUrl distinguishes a URL source from a local path', async () => {
+  const { isHttpUrl } = await import('@memoriahub/enrichment-compute/video');
+
+  assert.equal(isHttpUrl('https://storage.example/v.mp4'), true);
+  assert.equal(isHttpUrl('http://storage.example/v.mp4'), true);
+  assert.equal(isHttpUrl('/tmp/memoriaHub-vtag-dl-abc.mp4'), false);
+  assert.equal(isHttpUrl('C:\\videos\\clip.mp4'), false);
+});
+
+// ---------------------------------------------------------------------------
+// extractFrames is now timeout-bounded (issue #456)
+// ---------------------------------------------------------------------------
+
+test('extractFrames SIGKILLs a hung ffmpeg and skips that frame instead of hanging the worker', async () => {
+  const { restore, calls } = installFakeFfmpeg([
+    { kind: 'hang' },
+    { kind: 'success', bytes: Buffer.from('frame-2') },
+  ]);
+
+  try {
+    const { extractFrames } = await import('@memoriahub/enrichment-compute/video');
+
+    const frames = await extractFrames(fakeVideoPath(), {
+      durationMs: 20_000,
+      sampleIntervalSeconds: 10,
+      maxFrames: 2,
+      ffmpegTimeoutMs: 30,
+    });
+
+    // Before this, the sampling path was unbounded — against a remote URL a
+    // stalled read would hang a worker slot until the 20-minute job timeout.
+    assert.deepEqual(calls[0].killSignals, ['SIGKILL']);
+    assert.equal(frames.length, 1, 'the timed-out frame is skipped, the rest still extracted');
+    assert.equal(frames[0].buffer.toString(), 'frame-2');
+  } finally {
+    restore();
+  }
+});
+
+test('extractFrames accepts a URL source and keeps `-ss` BEFORE `-i` (input seek)', async () => {
+  const { restore, calls } = installFakeFfmpeg([{ kind: 'success' }]);
+
+  try {
+    const { extractFrames } = await import('@memoriahub/enrichment-compute/video');
+
+    const url = 'https://storage.example/video.mp4?sig=abc';
+    await extractFrames(url, { durationMs: 10_000, sampleIntervalSeconds: 10, maxFrames: 1 });
+
+    assert.equal(calls[0].inputPath, url);
+    // Input seek is what makes a URL source fetch only the bytes around the
+    // seek point; moving -ss after -i would forfeit the whole optimization.
+    assert.ok(calls[0].args.indexOf('-ss') < calls[0].args.indexOf('-i'));
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary

Video auto-tagging pulled a **multi-gigabyte file** across the network and onto disk in order to extract **six frames and thirty seconds of audio**. The bytes actually needed are a rounding error against the bytes moved, and on a memory- and disk-constrained VPS this is the single biggest driver of the disk pressure `assertDiskSpaceForDownload` and `TempFileJanitorTask` exist to contain.

The issue flags this as the highest-risk item in epic #452 and the only one touching machinery shared with shipped features — so the mitigations are the load-bearing part of this PR.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #456

## Changes Made

**The safety property, first, because it is what makes this shippable:** the fallback is the **existing, proven download path, unchanged**. Provider ignores `Range`, non-faststart MP4, unrecognized container, probe error, setting turned off, no URL available — *every one* routes to it. The worst case of this whole feature is exactly today's behavior plus one 64 KB read. `VideoInputResolver.tryStream` never throws; it returns `null` and the caller falls through.

**URL input.** ffmpeg speaks HTTP and issues Range requests, so `-ss` fast input seek against a presigned URL fetches only the ranges around each seek point. `extractFrames` / `extractFramesAt` / `extractAudioLead` now accept a `VideoSource` (path *or* URL) — ffmpeg does not care, and `-ss` stays before `-i`, which is exactly what makes a URL source cheap.

**Faststart detection reads the atom layout** over one ranged request, rather than inferring it from the probe. The issue suggested using the persisted `_processing['video-probe']` data, but ffprobe's `-show_format` **does not report atom order at all** — there is nothing in that blob that could answer the question. Reading the first 64 KB and walking the top-level ISO-BMFF boxes is definitive, and the *same* request also proves the provider honors `Range`: a 200 without `Content-Range` means seeks would re-download the file, making streaming strictly worse than one clean download.

**`extractFrames` was unbounded by any ffmpeg timeout** — only `extractPosterFrame` was. Survivable against a local file; against a remote URL a stalled network read would hang a worker slot until the 20-minute job timeout. Now bounded, with a longer default for network sources. The previously-unbounded *local* path gains a ceiling too.

**Node engine opt-out.** `node-engine.ts` wrote `inputUrl` to a temp file *before* calling compute, and `INPUT_REQUIRED_TYPES` enforced a non-empty local path — so without this the node would keep downloading everything and the optimization would be server-side only. `URL_INPUT_TYPES` passes the URL straight through, while still failing cleanly when there is no URL at all.

**Shared helper.** The byte-identical `assertDiskSpaceForDownload → download → streamToTempFile → unlink` block that `VideoFaceDetectionService`, `SocialMediaDetectionHandler` and `VideoAutoTaggingService` each had inline is now `downloadToTempFile`. It is also the streaming fallback, so the fallback has one implementation rather than three that could drift.

**Presigned-URL TTL** is 2 hours — comfortably above the 20-minute video job timeout, since a long ffmpeg session against an expiring URL would fail mid-run. A test asserts the TTL exceeds the job budget rather than trusting the constant.

**Revertible without a deploy:** `autoTagging.video.streamInput` (default `true`), registered in all five settings places including the wire DTO. No admin UI — it is an operator escape hatch, like `reviewRuns.runHistoryRetentionDays`.

**Scope held deliberately narrow:** `video_face_detection` and `social_media_detection` keep downloading. This is proven on the new, off-by-default `video_auto_tagging` type first, exactly as the issue asks.

**Logging:** every resolution logs mode, bytes moved, and elapsed time, so the win is measurable rather than assumed — the acceptance evidence the issue asks for.

## Testing

- [x] Unit tests pass — `apps/api` **8183 pass**; `packages/enrichment-compute` 125 pass / 3 skipped; `apps/cli` node-engine suite 11 pass
- [x] Type checks pass (`apps/api`, `apps/cli`, `packages/enrichment-compute`)

29 new tests. Each of the six fallback branches has its own test asserting a download *actually happened* — a silent "returned nothing" would be a broken job, not a slow one. Also: the probe never throwing on a network error or a 403; a 64-bit box size not mis-parsing; `extractFrames` SIGKILLing a hung ffmpeg and skipping only that frame; `-ss` staying before `-i` for a URL source; `downloadToTempFile` running the disk guard *before* opening the stream and cleaning up a partial file mid-failure; and the node passing the URL through while still rejecting a null one.

**Note on `apps/cli` full-suite results in this environment:** 39 suites fail with `Could not locate the bindings file … better_sqlite3.node`. These are pre-existing and environmental — this sandbox's `npm install` needed `--ignore-scripts` (an unrelated `onnxruntime-node` postinstall download failure), so no native module is built. I verified by stashing: the clean tree fails identically (476 failures, 39 suites), and my branch's only delta is the 2 tests I added. CI installs normally.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_