### PR TITLE
feat(api,cli): node compute for `video_auto_tagging` (worker-fleet eligibility)

### DIFF
--- a/apps/api/src/nodes/dto/job-credentials.dto.ts
+++ b/apps/api/src/nodes/dto/job-credentials.dto.ts
@@ -29,6 +29,45 @@ export interface AutoTaggingJobCredentials {
   mimeTypeHint: string;
 }
 
+/**
+ * Transient credentials for a node-computed `video_auto_tagging` job
+ * (epic #452, issue #460).
+ *
+ * Differs from `AutoTaggingJobCredentials` in two ways, both because a video
+ * prompt depends on values only the node knows:
+ *
+ *   - `prompt` is ABSENT. The user prompt embeds the sampled frame timestamps,
+ *     which the node produces. It hands over `labelNames` and `peopleNames`
+ *     instead (both need DB access a node does not have) and the node composes
+ *     the prompt with the same shared `buildVideoPrompt`.
+ *   - `transcription` carries a SECOND, independent provider credential. It is
+ *     absent when transcription is off, unconfigured, or unresolvable — in
+ *     which case the node tags visual-only, matching the in-process path's
+ *     degradation exactly.
+ *
+ * Both `apiKey` fields are plaintext, scoped to a single job, and MUST NEVER
+ * be persisted to disk/config/logs by the CLI.
+ */
+export interface VideoAutoTaggingJobCredentials {
+  type: 'video_auto_tagging';
+  provider: string;
+  model: string;
+  apiKey: string;
+  baseUrl?: string;
+  /** Fixed system prompt — shared verbatim with the in-process path. */
+  system: string;
+  /** Enabled TagLabel vocabulary; the node cannot read it itself. */
+  labelNames: string[];
+  /** Assigned people on this item, for the prompt's name clause. */
+  peopleNames: string[];
+  transcription?: {
+    provider: string;
+    model: string;
+    apiKey: string;
+    baseUrl?: string;
+  };
+}
+
 export interface GeocodeJobCredentials {
   type: 'geocode';
   /**
@@ -45,4 +84,7 @@ export interface GeocodeJobCredentials {
   lng: number;
 }
 
-export type JobCredentialsResult = AutoTaggingJobCredentials | GeocodeJobCredentials;
+export type JobCredentialsResult =
+  | AutoTaggingJobCredentials
+  | VideoAutoTaggingJobCredentials
+  | GeocodeJobCredentials;

--- a/apps/api/src/nodes/nodes.service.credentials.spec.ts
+++ b/apps/api/src/nodes/nodes.service.credentials.spec.ts
@@ -50,6 +50,7 @@ import { StorageProviderResolver } from '../storage/providers/storage-provider.r
 import { AiSettingsService } from '../ai/ai-settings.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { AutoTaggingService } from '../tagging/auto-tagging.service';
+import { VideoAutoTaggingService } from '../tagging/video-auto-tagging.service';
 import { encryptSecret } from '../common/crypto/secret-cipher';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 
@@ -93,6 +94,7 @@ describe('NodesService.getJobCredentials', () => {
   let mockAiSettingsService: { resolveCredentials: jest.Mock };
   let mockSystemSettings: { getSettings: jest.Mock };
   let mockAutoTaggingService: { buildPrompt: jest.Mock };
+  let mockVideoAutoTaggingService: { buildVideoPrompt: jest.Mock };
   let originalKey: string | undefined;
   let originalGeoProviderEnv: string | undefined;
 
@@ -122,6 +124,11 @@ describe('NodesService.getJobCredentials', () => {
     mockAutoTaggingService = {
       buildPrompt: jest.fn().mockReturnValue({ system: 'SYSTEM_PROMPT', prompt: 'USER_PROMPT' }),
     };
+    mockVideoAutoTaggingService = {
+      buildVideoPrompt: jest
+        .fn()
+        .mockReturnValue({ system: 'VIDEO_SYSTEM_PROMPT', prompt: 'VIDEO_USER_PROMPT' }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -136,6 +143,7 @@ describe('NodesService.getJobCredentials', () => {
         { provide: AiSettingsService, useValue: mockAiSettingsService },
         { provide: SystemSettingsService, useValue: mockSystemSettings },
         { provide: AutoTaggingService, useValue: mockAutoTaggingService },
+        { provide: VideoAutoTaggingService, useValue: mockVideoAutoTaggingService },
       ],
     }).compile();
 
@@ -310,6 +318,152 @@ describe('NodesService.getJobCredentials', () => {
   // =========================================================================
   // geocode
   // =========================================================================
+
+  // =========================================================================
+  // video_auto_tagging (epic #452, issue #460)
+  // =========================================================================
+
+  describe('video_auto_tagging', () => {
+    const videoSettings = (overrides: Record<string, unknown> = {}) => ({
+      key: 'global',
+      value: {
+        ai: {
+          features: {
+            tagging: { provider: 'anthropic', model: 'claude-3-5-sonnet' },
+            ...((overrides['aiFeatures'] as object) ?? {}),
+          },
+        },
+        autoTagging: {
+          video: {
+            enabled: true,
+            transcription: { enabled: overrides['transcriptionEnabled'] === true, leadSeconds: 30 },
+          },
+        },
+      },
+    });
+
+    beforeEach(() => {
+      (mockPrisma.enrichmentJob.findUnique as jest.Mock).mockResolvedValue(
+        makeHeldJob({ type: 'video_auto_tagging', mediaItemId: 'media-1' }),
+      );
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(videoSettings());
+      (mockPrisma.tagLabel.findMany as jest.Mock).mockResolvedValue([
+        { name: 'Beach' },
+        { name: 'Birthday' },
+      ]);
+      (mockPrisma.face.findMany as jest.Mock).mockResolvedValue([{ person: { name: 'Alice' } }]);
+    });
+
+    it('hands over the VOCABULARY and PEOPLE rather than a finished prompt', async () => {
+      const result = (await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)) as any;
+
+      // The user prompt embeds frame timestamps only the node knows, so the
+      // node composes it with the shared builder from these inputs — neither
+      // of which it could read itself.
+      expect(result.type).toBe('video_auto_tagging');
+      expect(result.labelNames).toEqual(['Beach', 'Birthday']);
+      expect(result.peopleNames).toEqual(['Alice']);
+      expect(result.prompt).toBeUndefined();
+      expect(result.system).toBe('VIDEO_SYSTEM_PROMPT');
+    });
+
+    it('returns the decrypted tagging key and resolved provider/model', async () => {
+      const result = (await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)) as any;
+
+      expect(result.provider).toBe('anthropic');
+      expect(result.model).toBe('claude-3-5-sonnet');
+      expect(result.apiKey).toBe('anthropic-test-key');
+    });
+
+    it('calls recordModel so the server-side persist half knows what produced the result', async () => {
+      await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID);
+
+      expect(mockEnrichmentJobService.recordModel).toHaveBeenCalledWith(
+        JOB_ID,
+        'anthropic',
+        'claude-3-5-sonnet',
+      );
+    });
+
+    it('omits transcription credentials entirely when transcription is off', async () => {
+      const result = (await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)) as any;
+
+      expect(result.transcription).toBeUndefined();
+    });
+
+    it('includes a SECOND, independent transcription credential when configured', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(
+        videoSettings({
+          transcriptionEnabled: true,
+          aiFeatures: {
+            transcription: { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+          },
+        }),
+      );
+      mockAiSettingsService.resolveCredentials
+        .mockResolvedValueOnce({ apiKey: 'anthropic-test-key' })
+        .mockResolvedValueOnce({ apiKey: 'openai-audio-key' });
+
+      const result = (await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)) as any;
+
+      expect(result.transcription).toEqual({
+        provider: 'openai',
+        model: 'gpt-4o-mini-transcribe',
+        apiKey: 'openai-audio-key',
+      });
+    });
+
+    it('degrades to visual-only when transcription is on but unconfigured', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(
+        videoSettings({ transcriptionEnabled: true }),
+      );
+
+      const result = (await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)) as any;
+
+      // Not an error: the node tags visual-only, matching the in-process path.
+      expect(result.transcription).toBeUndefined();
+      expect(result.apiKey).toBe('anthropic-test-key');
+    });
+
+    it('degrades to visual-only when the transcription credential cannot be resolved', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue(
+        videoSettings({
+          transcriptionEnabled: true,
+          aiFeatures: {
+            transcription: { provider: 'openai', model: 'gpt-4o-mini-transcribe' },
+          },
+        }),
+      );
+      mockAiSettingsService.resolveCredentials
+        .mockResolvedValueOnce({ apiKey: 'anthropic-test-key' })
+        .mockRejectedValueOnce(new Error('no openai credential'));
+
+      const result = (await service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)) as any;
+
+      expect(result.transcription).toBeUndefined();
+    });
+
+    it('400s when no tagging provider/model is configured', async () => {
+      (mockPrisma.systemSettings.findUnique as jest.Mock).mockResolvedValue({
+        key: 'global',
+        value: { ai: { features: { tagging: { provider: null, model: null } } } },
+      });
+
+      await expect(service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('400s for a job with no mediaItemId', async () => {
+      (mockPrisma.enrichmentJob.findUnique as jest.Mock).mockResolvedValue(
+        makeHeldJob({ type: 'video_auto_tagging', mediaItemId: null }),
+      );
+
+      await expect(service.getJobCredentials(USER_ID, NODE_ID, JOB_ID)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
 
   describe('geocode', () => {
     const GPS_LAT = 9.9325427;

--- a/apps/api/src/nodes/nodes.service.spec.ts
+++ b/apps/api/src/nodes/nodes.service.spec.ts
@@ -59,6 +59,7 @@ import { StorageProviderResolver } from '../storage/providers/storage-provider.r
 import { AiSettingsService } from '../ai/ai-settings.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { AutoTaggingService } from '../tagging/auto-tagging.service';
+import { VideoAutoTaggingService } from '../tagging/video-auto-tagging.service';
 import { createMockPrismaService, MockPrismaService } from '../../test/mocks/prisma.mock';
 
 // ---------------------------------------------------------------------------
@@ -150,6 +151,10 @@ describe('NodesService — result/failure ingestion', () => {
         { provide: AiSettingsService, useValue: { resolveCredentials: jest.fn() } },
         { provide: SystemSettingsService, useValue: mockSystemSettings },
         { provide: AutoTaggingService, useValue: { buildPrompt: jest.fn() } },
+        {
+          provide: VideoAutoTaggingService,
+          useValue: { buildVideoPrompt: jest.fn().mockReturnValue({ system: 's', prompt: 'p' }) },
+        },
       ],
     }).compile();
 
@@ -551,6 +556,59 @@ describe('NodesService — result/failure ingestion', () => {
         mode: 'sweep',
         sampleIntervalSeconds: 7,
         maxFramesPerVideo: 42,
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // video_auto_tagging params (epic #452, issue #460)
+    //
+    // Same rationale as video_face_detection above — the job carries no
+    // payload, the in-process worker reads autoTagging.video.* fresh at
+    // process time, and a node has no DB access. durationMs likewise: frame
+    // sampling is computed from it and the node only receives a URL.
+    // -----------------------------------------------------------------------
+
+    it('merges fresh autoTagging.video.* settings AND durationMs for video_auto_tagging jobs', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({
+        autoTagging: {
+          video: {
+            maxFrames: 8,
+            sampleIntervalSeconds: 3,
+            transcription: { enabled: true, leadSeconds: 45 },
+          },
+        },
+      });
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({ durationMs: 90_000 });
+      mockClaimService.claim.mockResolvedValue([
+        claimedJob({ type: 'video_auto_tagging', mediaItemId: 'media-1', payload: null }),
+      ]);
+
+      const { jobs } = await service.claim(USER_ID, NODE_ID, 1, ['video_auto_tagging']);
+
+      expect(jobs[0].params).toEqual({
+        durationMs: 90_000,
+        maxFrames: 8,
+        sampleIntervalSeconds: 3,
+        transcriptionEnabled: true,
+        leadSeconds: 45,
+      });
+    });
+
+    it('falls back to the documented video-tagging defaults when the namespace is absent', async () => {
+      mockSystemSettings.getSettings.mockResolvedValue({});
+      (mockPrisma.mediaItem.findUnique as jest.Mock).mockResolvedValue({ durationMs: null });
+      mockClaimService.claim.mockResolvedValue([
+        claimedJob({ type: 'video_auto_tagging', mediaItemId: 'media-1', payload: null }),
+      ]);
+
+      const { jobs } = await service.claim(USER_ID, NODE_ID, 1, ['video_auto_tagging']);
+
+      expect(jobs[0].params).toEqual({
+        durationMs: null,
+        maxFrames: 6,
+        sampleIntervalSeconds: 5,
+        transcriptionEnabled: false,
+        leadSeconds: 30,
       });
     });
 

--- a/apps/api/src/nodes/nodes.service.ts
+++ b/apps/api/src/nodes/nodes.service.ts
@@ -39,8 +39,12 @@ import {
 import { AiSettingsService } from '../ai/ai-settings.service';
 import { SystemSettingsService } from '../settings/system-settings/system-settings.service';
 import { AutoTaggingService } from '../tagging/auto-tagging.service';
+import { VideoAutoTaggingService } from '../tagging/video-auto-tagging.service';
 import { decryptSecret } from '../common/crypto/secret-cipher';
-import type { JobCredentialsResult } from './dto/job-credentials.dto';
+import type {
+  JobCredentialsResult,
+  VideoAutoTaggingJobCredentials,
+} from './dto/job-credentials.dto';
 
 // ---------------------------------------------------------------------------
 // Input shapes
@@ -115,6 +119,7 @@ export class NodesService {
     private readonly aiSettingsService: AiSettingsService,
     private readonly systemSettings: SystemSettingsService,
     private readonly autoTaggingService: AutoTaggingService,
+    private readonly videoAutoTaggingService: VideoAutoTaggingService,
   ) {}
 
   // -------------------------------------------------------------------------
@@ -407,6 +412,44 @@ export class NodesService {
       return { ...basePayload, actions };
     }
 
+    // video_auto_tagging (epic #452, issue #460) — same rationale as
+    // video_face_detection below: the job carries no payload, the in-process
+    // worker reads `autoTagging.video.*` fresh from system settings at process
+    // time, and a node has no DB access, so the effective values are merged in
+    // here. `durationMs` also has to come from the DB, since frame sampling is
+    // computed from it and the node only receives a URL.
+    if (job.type === 'video_auto_tagging') {
+      const settings = await this.systemSettings.getSettings();
+      const video = (settings as { autoTagging?: { video?: Record<string, unknown> } }).autoTagging
+        ?.video;
+      const transcription = video?.['transcription'] as
+        | { enabled?: boolean; leadSeconds?: number }
+        | undefined;
+
+      let durationMs: number | null = null;
+      if (job.mediaItemId) {
+        const item = await this.prisma.mediaItem.findUnique({
+          where: { id: job.mediaItemId },
+          select: { durationMs: true },
+        });
+        durationMs = item?.durationMs ?? null;
+      }
+
+      const basePayload =
+        job.payload && typeof job.payload === 'object' && !Array.isArray(job.payload)
+          ? (job.payload as Record<string, unknown>)
+          : {};
+
+      return {
+        ...basePayload,
+        durationMs,
+        maxFrames: (video?.['maxFrames'] as number | undefined) ?? 6,
+        sampleIntervalSeconds: (video?.['sampleIntervalSeconds'] as number | undefined) ?? 5,
+        transcriptionEnabled: transcription?.enabled === true,
+        leadSeconds: transcription?.leadSeconds ?? 30,
+      };
+    }
+
     if (job.type !== 'video_face_detection') {
       return job.payload ?? null;
     }
@@ -654,6 +697,9 @@ export class NodesService {
     if (job.type === 'auto_tagging') {
       return this.getAutoTaggingCredentials(job);
     }
+    if (job.type === 'video_auto_tagging') {
+      return this.getVideoAutoTaggingCredentials(job);
+    }
     if (job.type === 'geocode') {
       return this.getGeocodeCredentials(job);
     }
@@ -723,6 +769,108 @@ export class NodesService {
       system,
       prompt,
       mimeTypeHint: 'image/jpeg',
+    };
+  }
+
+  /**
+   * Transient credentials for a node-computed `video_auto_tagging` job
+   * (epic #452, issue #460).
+   *
+   * Mirrors `getAutoTaggingCredentials` above — same provider/model
+   * resolution, same `recordModel` so the persist half knows what produced the
+   * result, same never-persisted plaintext key — and adds two video-specific
+   * things:
+   *
+   *   1. The prompt is built via the SHARED `buildVideoPrompt`, so a node
+   *      sends the exact prompt the server would have. Frame timestamps are
+   *      NOT known here (the node samples them), so the prompt is composed on
+   *      the node from these pieces instead of being handed over whole. What
+   *      IS handed over is the vocabulary and people names, which need DB
+   *      access a node does not have.
+   *   2. Transcription credentials, when enabled and configured — a SECOND,
+   *      independent provider. Absent means the node tags visual-only, which
+   *      is the same degradation the in-process path performs.
+   */
+  private async getVideoAutoTaggingCredentials(job: EnrichmentJob): Promise<JobCredentialsResult> {
+    if (!job.mediaItemId) {
+      throw new BadRequestException(`video_auto_tagging job ${job.id} has no mediaItemId`);
+    }
+
+    const row = await this.prisma.systemSettings.findUnique({ where: { key: 'global' } });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const settingsValue = (row?.value as any) ?? {};
+    const taggingConfig = settingsValue?.ai?.features?.tagging as
+      | { provider?: string; model?: string }
+      | undefined;
+    const provider = taggingConfig?.provider;
+    const model = taggingConfig?.model;
+    if (!provider || !model) {
+      throw new BadRequestException('AI tagging provider or model not configured in system settings');
+    }
+
+    await this.enrichmentJobService.recordModel(job.id, provider, model);
+
+    const creds = await this.aiSettingsService.resolveCredentials(provider);
+
+    const tagLabels = await this.prisma.tagLabel.findMany({
+      where: { enabled: true },
+      select: { name: true },
+      orderBy: { name: 'asc' },
+    });
+    const labelNames = tagLabels.map((t) => t.name);
+
+    const faces = await this.prisma.face.findMany({
+      where: {
+        mediaItemId: job.mediaItemId,
+        personId: { not: null },
+        person: { deletedAt: null, mergedIntoId: null },
+      },
+      select: { person: { select: { name: true } } },
+    });
+    const peopleNames = [
+      ...new Set(faces.map((f) => f.person?.name).filter((n): n is string => !!n)),
+    ];
+
+    // The system prompt is fixed; the user prompt depends on frame timestamps
+    // only the node knows, so hand over its inputs and let the node compose it
+    // with the same shared builder.
+    const { system } = this.videoAutoTaggingService.buildVideoPrompt(labelNames, peopleNames, [], null);
+
+    // --- Transcription: a separate, optional provider. ---
+    let transcription: VideoAutoTaggingJobCredentials['transcription'];
+    const transcriptionEnabled =
+      settingsValue?.autoTagging?.video?.transcription?.enabled === true;
+    if (transcriptionEnabled) {
+      const cfg = settingsValue?.ai?.features?.transcription as
+        | { provider?: string; model?: string }
+        | undefined;
+      if (cfg?.provider && cfg?.model) {
+        try {
+          const transcriptionCreds = await this.aiSettingsService.resolveCredentials(cfg.provider);
+          transcription = {
+            provider: cfg.provider,
+            model: cfg.model,
+            apiKey: transcriptionCreds.apiKey,
+            ...(transcriptionCreds.baseUrl ? { baseUrl: transcriptionCreds.baseUrl } : {}),
+          };
+        } catch {
+          // Best-effort, exactly like the in-process path: an unresolvable
+          // transcription credential degrades the video to visual-only rather
+          // than failing the job.
+        }
+      }
+    }
+
+    return {
+      type: 'video_auto_tagging',
+      provider,
+      model,
+      apiKey: creds.apiKey,
+      ...(creds.baseUrl ? { baseUrl: creds.baseUrl } : {}),
+      system,
+      labelNames,
+      peopleNames,
+      ...(transcription ? { transcription } : {}),
     };
   }
 

--- a/apps/api/src/tagging/video-auto-tagging.service.spec.ts
+++ b/apps/api/src/tagging/video-auto-tagging.service.spec.ts
@@ -40,10 +40,10 @@ import {
   MediaTagStatusType,
   MediaType,
 } from '@prisma/client';
-import {
-  VideoAutoTaggingService,
-  buildVideoTaggingPrompt,
-} from './video-auto-tagging.service';
+import { VideoAutoTaggingService } from './video-auto-tagging.service';
+// The prompt builder now lives in the shared parity package (issue #460), so
+// a distributed worker node composes the SAME prompt the server would.
+import { buildVideoTaggingPrompt } from '@memoriahub/enrichment-compute/ai';
 import { AutoTaggingService } from './auto-tagging.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AiSettingsService } from '../ai/ai-settings.service';

--- a/apps/api/src/tagging/video-auto-tagging.service.ts
+++ b/apps/api/src/tagging/video-auto-tagging.service.ts
@@ -51,6 +51,13 @@ import {
   extractAudioLead,
   extractFrames,
 } from '@memoriahub/enrichment-compute/video';
+// Prompt construction lives in the shared parity package so the server and a
+// distributed worker node send BYTE-IDENTICAL vision requests (issue #460).
+import {
+  VIDEO_AUTO_TAGGING_SYSTEM_PROMPT,
+  VIDEO_TAGGING_MAX_TOKENS,
+  buildVideoTaggingPrompt,
+} from '@memoriahub/enrichment-compute/ai';
 import { PrismaService } from '../prisma/prisma.service';
 import { VideoInputResolver } from '../media/enrichment/video-input.service';
 import { AiSettingsService } from '../ai/ai-settings.service';
@@ -64,33 +71,6 @@ import { prepareImageForProcessing } from '../storage/processing/image-orientati
 import { EnrichmentJobService } from '../enrichment/enrichment-job.service';
 import { RateLimitError, parseRetryAfterMs, classifyRateLimit } from '../enrichment/rate-limit.error';
 import { AutoTaggingService } from './auto-tagging.service';
-
-/**
- * System prompt for the video pass. Same output CONTRACT as the photo prompt
- * — a `{"tags": [...], "description": "..."}` JSON envelope — which is what
- * lets the entire parse/persist half be reused verbatim. What differs is the
- * framing: the model must understand it is looking at ordered stills from ONE
- * video, not a set of unrelated photos.
- *
- * Module-level so `buildVideoPrompt` can hand a distributed worker node the
- * EXACT prompt the server would have sent (issue #460), with no second
- * prompt-string construction to drift.
- */
-const VIDEO_AUTO_TAGGING_SYSTEM_PROMPT =
-  'You are a video analysis assistant. You will be shown several still frames sampled in order from a SINGLE video, ' +
-  'and optionally a transcript of its opening seconds. Your job is to analyze the video as a whole and return a JSON object ' +
-  'with two keys: "tags" and "description". ' +
-  '"tags" must be a JSON array of strings — each string must exactly match one of the labels in the provided allowed list; return an empty array if none apply. ' +
-  '"description" must be a brief 1-3 sentence description of the video as a whole, not of any single frame. ' +
-  'Respond with ONLY a JSON object with those two keys — no explanation, no code fences, no extra text.';
-
-/**
- * Output budget for the video vision call. Higher than the photo path's
- * provider defaults because a whole-video description plus a tag list does not
- * reliably fit in Anthropic's 1024, and a truncated response fails the JSON
- * parse (issue #453 added the per-request override for exactly this).
- */
-const VIDEO_TAGGING_MAX_TOKENS = 2048;
 
 /** Long-edge cap per frame — same env var and default as the photo path. */
 const TAG_MAX_DIM = (): number => parseInt(process.env['TAG_MAX_IMAGE_DIM'] ?? '1568', 10);
@@ -687,62 +667,4 @@ export class VideoAutoTaggingService {
       },
     });
   }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Render a millisecond offset as `m:ss`, for the frame-timestamp list. */
-function formatTimestamp(ms: number): string {
-  const totalSeconds = Math.max(0, Math.round(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
-
-/**
- * Build the video user prompt.
- *
- * EXTENDS the photo prompt's contract rather than replacing it: the same
- * `{"tags": [...], "description": "..."}` envelope, the same newline-joined
- * `Allowed labels:` vocabulary, and the same named-people clause. What it adds
- * is the ordered-frames framing, the timestamp of each frame, and — when
- * present — a delimited transcript block. Because the OUTPUT contract is
- * unchanged, the whole parse/persist half is reused verbatim.
- *
- * Exported for direct testing.
- */
-export function buildVideoTaggingPrompt(
-  labelNames: string[],
-  peopleNames: string[],
-  sampledTimestampsMs: number[],
-  transcript: string | null,
-): string {
-  const frameList = sampledTimestampsMs.map((ms, i) => `${i + 1}. ${formatTimestamp(ms)}`).join('\n');
-
-  let prompt = `Analyze this video and return a JSON object with two keys: "tags" and "description".
-
-You are shown ${sampledTimestampsMs.length} still frame(s) sampled in order from a single video, at these points in its runtime:
-${frameList}
-
-Treat them as one video, not as unrelated photos. Describe what the video as a whole is about.
-
-"tags": an array of applicable labels from the following allowed list. Only choose labels that clearly apply. Return an empty array if none apply.
-"description": a brief 1-3 sentence description of the video.
-
-Allowed labels:
-${labelNames.join('\n')}
-
-Example response: {"tags": ["label1", "label2"], "description": "A child blows out candles on a birthday cake while family members sing. The video was taken indoors at a decorated dining table."}`;
-
-  if (transcript) {
-    prompt += `\n\nTranscript of the video's opening seconds (may be incomplete or misheard — treat it as a hint, not as fact):\n"""\n${transcript}\n"""`;
-  }
-
-  if (peopleNames.length > 0) {
-    prompt += `\n\nThe following named people appear in this video: ${peopleNames.join(', ')}. Mention them by name in the description where appropriate.`;
-  }
-
-  return prompt;
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoriahub/cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CLI importer for MemoriaHub — import and sync photo/video folders",
   "type": "module",
   "bin": {

--- a/apps/cli/src/node/capabilities.ts
+++ b/apps/cli/src/node/capabilities.ts
@@ -148,6 +148,7 @@ export const NODE_JOB_TYPES = [
   'social_media_detection',
   'thumbnail_regen',
   'auto_tagging',
+  'video_auto_tagging',
   'geocode',
   'workflow_execute_batch',
 ] as const;
@@ -173,6 +174,9 @@ export const JOB_TYPE_REQUIREMENTS: Record<NodeJobType, string[]> = {
   social_media_detection: ['ffprobe'], // tesseract optional → Tier-1-only mode
   thumbnail_regen: ['sharp', 'ffmpeg'],
   auto_tagging: ['sharp'],
+  // Frame extraction (and optional audio extraction) means ffmpeg/ffprobe are
+  // hard requirements — a node without them must never claim this type.
+  video_auto_tagging: ['sharp', 'ffmpeg', 'ffprobe'],
   geocode: [],
   // Pure-JS declaration pass — no native libs, no model files, no ffmpeg.
   workflow_execute_batch: [],
@@ -439,6 +443,10 @@ export class ComputeDispatcher {
       ),
       thumbnail_regen: lazy(() => import('./compute/thumbnail.js'), 'thumbnail_regen'),
       auto_tagging: lazy(() => import('./compute/auto-tagging.js'), 'auto_tagging'),
+      video_auto_tagging: lazy(
+        () => import('./compute/video-auto-tagging.js'),
+        'video_auto_tagging',
+      ),
       geocode: lazy(() => import('./compute/geocode.js'), 'geocode'),
       workflow_execute_batch: lazy(
         () => import('./compute/workflow-execute-batch.js'),

--- a/apps/cli/src/node/compute/video-auto-tagging.ts
+++ b/apps/cli/src/node/compute/video-auto-tagging.ts
@@ -1,0 +1,255 @@
+/**
+ * node/compute/video-auto-tagging.ts — Video AI auto-tagging compute
+ * (epic #452, issue #460).
+ *
+ * Structurally a merge of the two existing precedents: `compute/video-face-detection.ts`
+ * (frame extraction + per-frame `prepareImageForProcessing`) and
+ * `compute/auto-tagging.ts` (transient per-job credentials, direct provider
+ * call, raw text returned unparsed).
+ *
+ * MANDATED DESIGN, same as `compute/auto-tagging.ts`: the "AI-proxy" pattern
+ * documented (stale) in docs/specs/distributed-nodes.md was explicitly
+ * rejected. Re-introducing it here would be worse still — it would mean
+ * uploading N frames per video just to call an API this node can call
+ * directly. Instead the node fetches TRANSIENT, per-job credentials, holds the
+ * plaintext key in a local variable for the duration of one compute call, and
+ * never persists it to disk, config, or logs.
+ *
+ * URL INPUT (issue #456): `video_auto_tagging` is in the engine's
+ * `URL_INPUT_TYPES`, so `input` here is the PRESIGNED URL, not a local path.
+ * ffmpeg range-seeks it, fetching only the bytes around each seek point rather
+ * than pulling a multi-gigabyte file to disk. The functions below accept
+ * either form, so a future engine change back to a local path needs no edit
+ * here.
+ *
+ * PARITY. Frame timestamps (`computeSeekTimestamps`), image preparation
+ * (`prepareImageForProcessing` at `TAG_MAX_IMAGE_DIM`), the prompt
+ * (`buildVideoTaggingPrompt`), and the vision request body all come from the
+ * shared `@memoriahub/enrichment-compute` package — the same code the server
+ * runs. That is what makes a node's result indistinguishable from the
+ * server's, which is the acceptance bar for this issue.
+ *
+ * PARSING STAYS SERVER-SIDE. A node has no access to the `tag_labels` table
+ * and so cannot validate that returned tags are in-vocabulary. This module
+ * returns raw text plus frame/transcript provenance, matching
+ * `videoAutoTaggingResultSchema`.
+ *
+ * RATE LIMITS: `callAnthropicVision`/`callOpenAiVision` already classify a
+ * 429/529 into the shared `ProviderRateLimitError` and throw it directly, so
+ * it propagates unchanged to node-engine.ts's catch, which forwards
+ * `{ rateLimited: true, retryAfterMs }` and lets the job back off instead of
+ * burning attempts.
+ */
+
+import { prepareImageForProcessing } from '@memoriahub/enrichment-compute/image';
+import {
+  VIDEO_AUTO_TAGGING_SYSTEM_PROMPT,
+  VIDEO_TAGGING_MAX_TOKENS,
+  buildVideoTaggingPrompt,
+  callAnthropicVision,
+  callOpenAiVision,
+} from '@memoriahub/enrichment-compute/ai';
+import { extractAudioLead, extractFrames } from '@memoriahub/enrichment-compute/video';
+import { CapabilityUnavailableError, type ComputeFn } from '../capabilities.js';
+import { ApiClient } from '../../api.js';
+import { loadConfig } from '../../config.js';
+
+/** Mirrors VideoAutoTaggingService's TAG_MAX_DIM default. */
+const TAG_MAX_DIM = parseInt(process.env['TAG_MAX_IMAGE_DIM'] ?? '1568', 10);
+
+/**
+ * Hard cap on the combined base64 payload across all frames in the single
+ * call. Identical to the server's `MAX_TOTAL_IMAGE_BYTES` — frames are dropped
+ * from the END (keeping the earliest, which anchor the narrative) rather than
+ * failing the video.
+ */
+const MAX_TOTAL_IMAGE_BYTES = 18_000_000;
+
+interface VideoAutoTaggingComputeResult {
+  rawText: string;
+  frameCount: number;
+  sampledTimestampsMs: number[];
+  transcript?: { text: string; language?: string; leadSeconds: number } | null;
+}
+
+function numberParam(params: Record<string, unknown>, key: string, fallback: number): number {
+  const v = params[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+const computeVideoAutoTagging: ComputeFn = async (
+  input,
+  params,
+  ctx,
+): Promise<VideoAutoTaggingComputeResult> => {
+  if (!ctx) {
+    throw new Error(
+      'job context not provided — video_auto_tagging compute requires { nodeId, jobId } to fetch transient credentials',
+    );
+  }
+
+  const config = loadConfig();
+  if (!config) {
+    throw new Error('not logged in — no CLI config found (run `memoriahub login`)');
+  }
+  const client = new ApiClient({ serverUrl: config.serverUrl, pat: config.pat });
+
+  // --- 1. Transient credentials + the vocabulary/people the prompt needs ---
+  const creds = (await client.getJobCredentials(ctx.nodeId, ctx.jobId)) as unknown as {
+    type: string;
+    provider: string;
+    model: string;
+    apiKey: string;
+    baseUrl?: string;
+    system: string;
+    labelNames: string[];
+    peopleNames: string[];
+    transcription?: { provider: string; model: string; apiKey: string; baseUrl?: string };
+  };
+
+  if (creds.type !== 'video_auto_tagging') {
+    throw new Error(`unexpected credentials type "${creds.type}" for video_auto_tagging job`);
+  }
+  if (creds.provider !== 'anthropic' && creds.provider !== 'openai') {
+    // Decline rather than fail: the job stays server-only, exactly as
+    // compute/auto-tagging.ts does for an unsupported tagging provider.
+    throw new CapabilityUnavailableError(
+      `video_auto_tagging via provider "${creds.provider}" not yet supported on nodes`,
+      'video_auto_tagging',
+    );
+  }
+
+  const p = (params ?? {}) as Record<string, unknown>;
+  const durationMsRaw = p['durationMs'];
+  const durationMs = typeof durationMsRaw === 'number' ? durationMsRaw : null;
+  const maxFrames = numberParam(p, 'maxFrames', 6);
+  const sampleIntervalSeconds = numberParam(p, 'sampleIntervalSeconds', 5);
+  const transcriptionEnabled = p['transcriptionEnabled'] === true;
+  const leadSeconds = numberParam(p, 'leadSeconds', 30);
+
+  // --- 2. Frames — bounded by maxFrames and spread across the WHOLE runtime,
+  // so a 3-hour video and a 30-second clip cost the same. ---
+  const frames = await extractFrames(input, {
+    durationMs,
+    sampleIntervalSeconds,
+    maxFrames,
+  });
+  if (frames.length === 0) {
+    throw new Error('video_auto_tagging: no frames could be extracted from the video');
+  }
+
+  // --- 3. Prepare each frame exactly as the server does. ---
+  const images: Array<{ base64: string; mimeType: string }> = [];
+  const sampledTimestampsMs: number[] = [];
+  let totalBytes = 0;
+
+  for (const frame of frames) {
+    const prepared = await prepareImageForProcessing(frame.buffer, { maxDim: TAG_MAX_DIM });
+    // A frame sharp cannot decode is skipped, not fatal — the rest still
+    // describe the video.
+    if (prepared.width === 0) continue;
+
+    const base64 = prepared.buffer.toString('base64');
+    if (totalBytes + base64.length > MAX_TOTAL_IMAGE_BYTES) break;
+    totalBytes += base64.length;
+    images.push({ base64, mimeType: 'image/jpeg' });
+    sampledTimestampsMs.push(frame.timestampMs);
+  }
+
+  if (images.length === 0) {
+    throw new Error('video_auto_tagging: no video frames could be prepared for analysis');
+  }
+
+  // --- 4. Transcription — BEST-EFFORT, exactly like the server. Absent
+  // credentials, no audio track, or an ffmpeg failure all degrade the video to
+  // visual-only rather than failing the job. A rate limit is the one thing
+  // that propagates, so the queue defers instead of silently producing a worse
+  // description. ---
+  let transcript: { text: string; language?: string; leadSeconds: number } | null = null;
+  if (transcriptionEnabled && creds.transcription) {
+    try {
+      const audio = await extractAudioLead(input, { leadSeconds });
+      const text = await transcribeViaOpenAi(creds.transcription, audio.buffer, audio.mimeType);
+      if (text) transcript = { text, leadSeconds };
+    } catch (err) {
+      if (isRateLimit(err)) throw err;
+      // Swallowed: visual-only is a valid outcome.
+    }
+  }
+
+  // --- 5. ONE multi-image vision call. apiKey stays in this local variable
+  // only — never module-level state, never logged. ---
+  const rawText = await (creds.provider === 'anthropic' ? callAnthropicVision : callOpenAiVision)(
+    { apiKey: creds.apiKey, baseUrl: creds.baseUrl },
+    {
+      model: creds.model,
+      // Prefer the server's system prompt when it sent one, so a server ahead
+      // of this CLI still governs; the shared constant is the fallback.
+      system: creds.system || VIDEO_AUTO_TAGGING_SYSTEM_PROMPT,
+      prompt: buildVideoTaggingPrompt(
+        creds.labelNames,
+        creds.peopleNames,
+        sampledTimestampsMs,
+        transcript?.text ?? null,
+      ),
+      images,
+      maxTokens: VIDEO_TAGGING_MAX_TOKENS,
+    },
+  );
+
+  return {
+    rawText,
+    frameCount: images.length,
+    sampledTimestampsMs,
+    transcript,
+  };
+};
+
+/**
+ * Minimal OpenAI transcription call.
+ *
+ * Deliberately a direct `fetch` rather than pulling the OpenAI SDK into the
+ * CLI's dependency graph for one multipart POST: the SDK is already an
+ * optional/heavy dependency here, and this endpoint's contract is a stable
+ * multipart form. Errors carry the HTTP status so `isRateLimit` below can
+ * classify a 429.
+ */
+async function transcribeViaOpenAi(
+  cfg: { provider: string; model: string; apiKey: string; baseUrl?: string },
+  audio: Buffer,
+  mimeType: string,
+): Promise<string> {
+  // Anthropic has no audio capability; anything but OpenAI degrades to
+  // visual-only rather than erroring, matching the server.
+  if (cfg.provider !== 'openai') return '';
+
+  const base = (cfg.baseUrl ?? 'https://api.openai.com/v1').replace(/\/+$/, '');
+  const form = new FormData();
+  form.append('model', cfg.model);
+  form.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), 'audio.m4a');
+
+  const response = await fetch(`${base}/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${cfg.apiKey}` },
+    body: form,
+  });
+
+  if (!response.ok) {
+    const err = new Error(`OpenAI transcription failed: HTTP ${response.status}`) as Error & {
+      status?: number;
+    };
+    err.status = response.status;
+    throw err;
+  }
+
+  const body = (await response.json()) as { text?: unknown };
+  return typeof body.text === 'string' ? body.text.trim() : '';
+}
+
+/** True for a provider throttle the queue should DEFER on rather than swallow. */
+function isRateLimit(err: unknown): boolean {
+  const status = (err as { status?: unknown } | null)?.status;
+  return status === 429 || status === 529;
+}
+
+export default computeVideoAutoTagging;

--- a/apps/cli/test/node/capabilities.spec.ts
+++ b/apps/cli/test/node/capabilities.spec.ts
@@ -50,9 +50,18 @@ describe('NODE_JOB_TYPES', () => {
       'social_media_detection',
       'thumbnail_regen',
       'auto_tagging',
+      'video_auto_tagging',
       'geocode',
       'workflow_execute_batch',
     ]);
+  });
+
+  it('requires ffmpeg AND ffprobe for video_auto_tagging — a node without them must never claim it', () => {
+    // Frame extraction (and optional audio extraction) shell out to ffmpeg;
+    // requirements are per TYPE for exactly this reason, which is also why
+    // video tagging is a separate job type from auto_tagging (['sharp']).
+    expect(JOB_TYPE_REQUIREMENTS.video_auto_tagging).toEqual(['sharp', 'ffmpeg', 'ffprobe']);
+    expect(JOB_TYPE_REQUIREMENTS.auto_tagging).toEqual(['sharp']);
   });
 });
 

--- a/apps/cli/test/node/compute/video-auto-tagging.spec.ts
+++ b/apps/cli/test/node/compute/video-auto-tagging.spec.ts
@@ -1,0 +1,387 @@
+/**
+ * test/node/compute/video-auto-tagging.spec.ts
+ *
+ * Unit tests for node/compute/video-auto-tagging.ts (epic #452, issue #460).
+ *
+ * PARITY is the acceptance bar for this issue: a node's compute must be
+ * indistinguishable from the server's. These tests assert the properties that
+ * make that true — the frame budget and prompt come from the SHARED package,
+ * the vision request carries every frame in ONE multi-image call, and the
+ * result is raw text (parsing stays server-side, since a node has no access to
+ * the tag_labels vocabulary).
+ *
+ * They also pin the two degradation rules the server has: transcription is
+ * best-effort (any failure ⇒ visual-only), except a rate limit, which
+ * propagates so the queue defers.
+ *
+ * Mocked via jest.unstable_mockModule, mirroring auto-tagging.spec.ts.
+ */
+
+import { jest } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Mocks — registered BEFORE importing the module under test.
+// ---------------------------------------------------------------------------
+
+const mockLoadConfig = jest.fn();
+jest.unstable_mockModule('../../../src/config.js', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+const mockGetJobCredentials = jest.fn();
+const MockApiClient = jest.fn().mockImplementation(() => ({
+  getJobCredentials: mockGetJobCredentials,
+}));
+jest.unstable_mockModule('../../../src/api.js', () => ({
+  ApiClient: MockApiClient,
+}));
+
+const mockPrepareImageForProcessing = jest.fn();
+jest.unstable_mockModule('@memoriahub/enrichment-compute/image', () => ({
+  prepareImageForProcessing: mockPrepareImageForProcessing,
+}));
+
+const mockCallAnthropicVision = jest.fn();
+const mockCallOpenAiVision = jest.fn();
+const mockBuildVideoTaggingPrompt = jest.fn();
+jest.unstable_mockModule('@memoriahub/enrichment-compute/ai', () => ({
+  callAnthropicVision: mockCallAnthropicVision,
+  callOpenAiVision: mockCallOpenAiVision,
+  buildVideoTaggingPrompt: mockBuildVideoTaggingPrompt,
+  VIDEO_AUTO_TAGGING_SYSTEM_PROMPT: 'SHARED_SYSTEM_PROMPT',
+  VIDEO_TAGGING_MAX_TOKENS: 2048,
+}));
+
+const mockExtractFrames = jest.fn();
+const mockExtractAudioLead = jest.fn();
+jest.unstable_mockModule('@memoriahub/enrichment-compute/video', () => ({
+  extractFrames: mockExtractFrames,
+  extractAudioLead: mockExtractAudioLead,
+}));
+
+const { CapabilityUnavailableError } = await import('../../../src/node/capabilities.js');
+const { default: computeVideoAutoTagging } = await import(
+  '../../../src/node/compute/video-auto-tagging.js'
+);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ctx = { nodeId: 'node-1', jobId: 'job-1' };
+const INPUT_URL = 'https://storage.example.com/signed/video.mp4';
+
+function baseCreds(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'video_auto_tagging',
+    provider: 'anthropic',
+    model: 'claude-3-5-sonnet-20241022',
+    apiKey: 'sk-test-key',
+    system: 'SERVER_SYSTEM_PROMPT',
+    labelNames: ['Beach', 'Birthday'],
+    peopleNames: ['Alice'],
+    ...overrides,
+  };
+}
+
+function baseParams(overrides: Record<string, unknown> = {}) {
+  return {
+    durationMs: 30_000,
+    maxFrames: 6,
+    sampleIntervalSeconds: 5,
+    transcriptionEnabled: false,
+    leadSeconds: 30,
+    ...overrides,
+  };
+}
+
+function makeFrames(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    timestampMs: (i + 1) * 2500,
+    buffer: Buffer.from(`frame-${i}`),
+  }));
+}
+
+beforeEach(() => {
+  mockLoadConfig.mockReset();
+  MockApiClient.mockClear();
+  mockGetJobCredentials.mockReset();
+  mockPrepareImageForProcessing.mockReset();
+  mockCallAnthropicVision.mockReset();
+  mockCallOpenAiVision.mockReset();
+  mockBuildVideoTaggingPrompt.mockReset();
+  mockExtractFrames.mockReset();
+  mockExtractAudioLead.mockReset();
+
+  mockLoadConfig.mockReturnValue({ serverUrl: 'https://api.example.com', pat: 'pat-test-token' });
+  mockGetJobCredentials.mockResolvedValue(baseCreds());
+  mockExtractFrames.mockResolvedValue(makeFrames(6));
+  mockPrepareImageForProcessing.mockResolvedValue({
+    buffer: Buffer.from('prepared'),
+    width: 800,
+    height: 600,
+  });
+  mockBuildVideoTaggingPrompt.mockReturnValue('VIDEO_USER_PROMPT');
+  mockCallAnthropicVision.mockResolvedValue('{"tags":["Beach"],"description":"d"}');
+  mockCallOpenAiVision.mockResolvedValue('{"tags":["Beach"],"description":"d"}');
+  mockExtractAudioLead.mockResolvedValue({
+    buffer: Buffer.from('audio'),
+    mimeType: 'audio/mp4',
+    leadSeconds: 30,
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('computeVideoAutoTagging — URL input (issue #456)', () => {
+  it('hands the presigned URL straight to the frame extractor, downloading nothing', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx);
+
+    // video_auto_tagging is in the engine's URL_INPUT_TYPES, so `input` is a
+    // URL, not a temp path — ffmpeg range-seeks it.
+    expect(mockExtractFrames.mock.calls[0][0]).toBe(INPUT_URL);
+  });
+});
+
+describe('computeVideoAutoTagging — parity with the server', () => {
+  it('makes exactly ONE multi-image vision call carrying every prepared frame', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx);
+
+    expect(mockCallAnthropicVision).toHaveBeenCalledTimes(1);
+    const [, req] = mockCallAnthropicVision.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect((req.images as unknown[]).length).toBe(6);
+    // The single-image field must not also be set.
+    expect(req.imageBase64).toBeUndefined();
+    expect(req.maxTokens).toBe(2048);
+  });
+
+  it('forwards the server-resolved frame budget, unchanged, for any video length', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams({ maxFrames: 4, durationMs: 3 * 3600_000 }), ctx);
+
+    expect(mockExtractFrames.mock.calls[0][1]).toMatchObject({
+      durationMs: 3 * 3600_000,
+      maxFrames: 4,
+      sampleIntervalSeconds: 5,
+    });
+  });
+
+  it('builds the prompt with the SHARED builder, from the server-supplied vocabulary and people', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx);
+
+    // A node cannot read tag_labels, so these must come from the credentials
+    // response — and the prompt must be composed by the same function the
+    // server uses, or the two executors drift.
+    expect(mockBuildVideoTaggingPrompt).toHaveBeenCalledWith(
+      ['Beach', 'Birthday'],
+      ['Alice'],
+      [2500, 5000, 7500, 10000, 12500, 15000],
+      null,
+    );
+  });
+
+  it('prefers the server-sent system prompt over the local constant', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx);
+
+    const [, req] = mockCallAnthropicVision.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(req.system).toBe('SERVER_SYSTEM_PROMPT');
+  });
+
+  it('falls back to the shared constant when the server sends no system prompt', async () => {
+    mockGetJobCredentials.mockResolvedValue(baseCreds({ system: '' }));
+
+    await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx);
+
+    const [, req] = mockCallAnthropicVision.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(req.system).toBe('SHARED_SYSTEM_PROMPT');
+  });
+
+  it('returns RAW text plus frame provenance — parsing stays server-side', async () => {
+    const result = (await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx)) as {
+      rawText: string;
+      frameCount: number;
+      sampledTimestampsMs: number[];
+    };
+
+    expect(result.rawText).toBe('{"tags":["Beach"],"description":"d"}');
+    expect(result.frameCount).toBe(6);
+    expect(result.sampledTimestampsMs).toEqual([2500, 5000, 7500, 10000, 12500, 15000]);
+  });
+
+  it('skips a frame sharp cannot decode rather than failing the whole video', async () => {
+    mockPrepareImageForProcessing
+      .mockResolvedValueOnce({ buffer: Buffer.from('ok'), width: 800, height: 600 })
+      .mockResolvedValueOnce({ buffer: Buffer.alloc(0), width: 0, height: 0 })
+      .mockResolvedValue({ buffer: Buffer.from('ok'), width: 800, height: 600 });
+
+    const result = (await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx)) as {
+      frameCount: number;
+    };
+
+    expect(result.frameCount).toBe(5);
+    expect(mockCallAnthropicVision).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when no frame could be extracted at all', async () => {
+    mockExtractFrames.mockResolvedValue([]);
+
+    await expect(computeVideoAutoTagging(INPUT_URL, baseParams(), ctx)).rejects.toThrow(
+      /no frames could be extracted/,
+    );
+    expect(mockCallAnthropicVision).not.toHaveBeenCalled();
+  });
+});
+
+describe('computeVideoAutoTagging — provider dispatch', () => {
+  it('routes openai to callOpenAiVision, never callAnthropicVision', async () => {
+    mockGetJobCredentials.mockResolvedValue(baseCreds({ provider: 'openai', model: 'gpt-5.4' }));
+
+    await computeVideoAutoTagging(INPUT_URL, baseParams(), ctx);
+
+    expect(mockCallOpenAiVision).toHaveBeenCalledTimes(1);
+    expect(mockCallAnthropicVision).not.toHaveBeenCalled();
+  });
+
+  it('DECLINES an unsupported provider so the job stays server-only, rather than failing it', async () => {
+    mockGetJobCredentials.mockResolvedValue(baseCreds({ provider: 'moonshot' }));
+
+    await expect(computeVideoAutoTagging(INPUT_URL, baseParams(), ctx)).rejects.toBeInstanceOf(
+      CapabilityUnavailableError,
+    );
+    expect(mockCallAnthropicVision).not.toHaveBeenCalled();
+    expect(mockCallOpenAiVision).not.toHaveBeenCalled();
+  });
+
+  it('rejects a credentials payload for the wrong job type', async () => {
+    mockGetJobCredentials.mockResolvedValue(baseCreds({ type: 'auto_tagging' }));
+
+    await expect(computeVideoAutoTagging(INPUT_URL, baseParams(), ctx)).rejects.toThrow(
+      /unexpected credentials type/,
+    );
+  });
+
+  it('requires job context to fetch transient credentials', async () => {
+    await expect(computeVideoAutoTagging(INPUT_URL, baseParams(), undefined)).rejects.toThrow(
+      /job context not provided/,
+    );
+  });
+});
+
+describe('computeVideoAutoTagging — transcription is best-effort', () => {
+  const withTranscription = (overrides: Record<string, unknown> = {}) =>
+    baseCreds({
+      transcription: {
+        provider: 'openai',
+        model: 'gpt-4o-mini-transcribe',
+        apiKey: 'sk-audio',
+        ...overrides,
+      },
+    });
+
+  it('never extracts audio when transcription is off', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams({ transcriptionEnabled: false }), ctx);
+
+    expect(mockExtractAudioLead).not.toHaveBeenCalled();
+  });
+
+  it('never extracts audio when the server sent no transcription credential', async () => {
+    await computeVideoAutoTagging(INPUT_URL, baseParams({ transcriptionEnabled: true }), ctx);
+
+    expect(mockExtractAudioLead).not.toHaveBeenCalled();
+    expect(mockCallAnthropicVision).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades to visual-only when audio extraction fails (e.g. no audio track)', async () => {
+    mockGetJobCredentials.mockResolvedValue(withTranscription());
+    mockExtractAudioLead.mockRejectedValue(new Error('ffmpeg produced an empty output file'));
+
+    const result = (await computeVideoAutoTagging(
+      INPUT_URL,
+      baseParams({ transcriptionEnabled: true }),
+      ctx,
+    )) as { transcript: unknown };
+
+    // The tagging call still happens — transcription is an enrichment, not a
+    // precondition.
+    expect(mockCallAnthropicVision).toHaveBeenCalledTimes(1);
+    expect(result.transcript).toBeNull();
+  });
+
+  it('RETHROWS a rate-limited transcription so the queue defers instead of silently degrading', async () => {
+    mockGetJobCredentials.mockResolvedValue(withTranscription());
+    mockExtractAudioLead.mockRejectedValue(Object.assign(new Error('slow down'), { status: 429 }));
+
+    await expect(
+      computeVideoAutoTagging(INPUT_URL, baseParams({ transcriptionEnabled: true }), ctx),
+    ).rejects.toThrow(/slow down/);
+    expect(mockCallAnthropicVision).not.toHaveBeenCalled();
+  });
+
+  it('bounds the audio to the server-resolved leadSeconds, not the video duration', async () => {
+    mockGetJobCredentials.mockResolvedValue(withTranscription());
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ text: 'happy birthday' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    try {
+      await computeVideoAutoTagging(
+        INPUT_URL,
+        baseParams({ transcriptionEnabled: true, leadSeconds: 45, durationMs: 3 * 3600_000 }),
+        ctx,
+      );
+
+      expect(mockExtractAudioLead.mock.calls[0][1]).toMatchObject({ leadSeconds: 45 });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('feeds a successful transcript into the prompt and returns it with its leadSeconds', async () => {
+    mockGetJobCredentials.mockResolvedValue(withTranscription());
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ text: 'happy birthday' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    try {
+      const result = (await computeVideoAutoTagging(
+        INPUT_URL,
+        baseParams({ transcriptionEnabled: true, leadSeconds: 45 }),
+        ctx,
+      )) as { transcript: { text: string; leadSeconds: number } | null };
+
+      expect(result.transcript).toEqual({ text: 'happy birthday', leadSeconds: 45 });
+      expect(mockBuildVideoTaggingPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'happy birthday',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('degrades to visual-only on a transcription HTTP error that is not a rate limit', async () => {
+    mockGetJobCredentials.mockResolvedValue(withTranscription());
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('bad request', { status: 400 })) as typeof fetch;
+
+    try {
+      const result = (await computeVideoAutoTagging(
+        INPUT_URL,
+        baseParams({ transcriptionEnabled: true }),
+        ctx,
+      )) as { transcript: unknown };
+
+      expect(result.transcript).toBeNull();
+      expect(mockCallAnthropicVision).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
     },
     "apps/cli": {
       "name": "@memoriahub/cli",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@memoriahub/enrichment-compute": "0.1.0",
         "better-sqlite3": "^12.10.0",

--- a/packages/enrichment-compute/src/ai/index.ts
+++ b/packages/enrichment-compute/src/ai/index.ts
@@ -271,3 +271,85 @@ export function classifyOpenAiRateLimit(err: unknown): ProviderRateLimitError | 
     retryAfterMs,
   );
 }
+
+
+// ---------------------------------------------------------------------------
+// Video auto-tagging prompt (epic #452, issues #455/#460)
+// ---------------------------------------------------------------------------
+
+/**
+ * System prompt for the video tagging pass.
+ *
+ * Lives HERE, in the shared parity package, for the same reason the ffmpeg
+ * argv builders do: the server's in-process path and a distributed worker node
+ * must send BYTE-IDENTICAL vision requests, and a prompt string duplicated in
+ * two places is exactly the kind of thing that drifts silently.
+ *
+ * Same output CONTRACT as the photo prompt — a `{"tags": [...],
+ * "description": "..."}` JSON envelope — which is what lets the entire
+ * parse/persist half be reused verbatim. What differs is the framing: the
+ * model must understand it is looking at ordered stills from ONE video, not a
+ * set of unrelated photos.
+ */
+export const VIDEO_AUTO_TAGGING_SYSTEM_PROMPT =
+  'You are a video analysis assistant. You will be shown several still frames sampled in order from a SINGLE video, ' +
+  'and optionally a transcript of its opening seconds. Your job is to analyze the video as a whole and return a JSON object ' +
+  'with two keys: "tags" and "description". ' +
+  '"tags" must be a JSON array of strings — each string must exactly match one of the labels in the provided allowed list; return an empty array if none apply. ' +
+  '"description" must be a brief 1-3 sentence description of the video as a whole, not of any single frame. ' +
+  'Respond with ONLY a JSON object with those two keys — no explanation, no code fences, no extra text.';
+
+/** Render a millisecond offset as `m:ss`, for the frame-timestamp list. */
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/**
+ * Build the video tagging user prompt.
+ *
+ * EXTENDS the photo prompt's contract rather than replacing it: the same
+ * `{"tags": [...], "description": "..."}` envelope, the same newline-joined
+ * `Allowed labels:` vocabulary, and the same named-people clause. What it adds
+ * is the ordered-frames framing, the timestamp of each frame, and — when
+ * present — a delimited transcript block. Because the OUTPUT contract is
+ * unchanged, the whole parse/persist half is reused verbatim.
+ */
+export function buildVideoTaggingPrompt(
+  labelNames: string[],
+  peopleNames: string[],
+  sampledTimestampsMs: number[],
+  transcript: string | null,
+): string {
+  const frameList = sampledTimestampsMs.map((ms, i) => `${i + 1}. ${formatTimestamp(ms)}`).join('\n');
+
+  let prompt = `Analyze this video and return a JSON object with two keys: "tags" and "description".
+
+You are shown ${sampledTimestampsMs.length} still frame(s) sampled in order from a single video, at these points in its runtime:
+${frameList}
+
+Treat them as one video, not as unrelated photos. Describe what the video as a whole is about.
+
+"tags": an array of applicable labels from the following allowed list. Only choose labels that clearly apply. Return an empty array if none apply.
+"description": a brief 1-3 sentence description of the video.
+
+Allowed labels:
+${labelNames.join('\n')}
+
+Example response: {"tags": ["label1", "label2"], "description": "A child blows out candles on a birthday cake while family members sing. The video was taken indoors at a decorated dining table."}`;
+
+  if (transcript) {
+    prompt += `\n\nTranscript of the video's opening seconds (may be incomplete or misheard — treat it as a hint, not as fact):\n"""\n${transcript}\n"""`;
+  }
+
+  if (peopleNames.length > 0) {
+    prompt += `\n\nThe following named people appear in this video: ${peopleNames.join(', ')}. Mention them by name in the description where appropriate.`;
+  }
+
+  return prompt;
+}
+
+/** Output budget for the video vision call — see VIDEO_TAGGING_MAX_TOKENS use. */
+export const VIDEO_TAGGING_MAX_TOKENS = 2048;


### PR DESCRIPTION
## Summary

Video auto-tagging is the most compute-heavy per-item job the system has — frame extraction, per-frame image preparation, and optionally audio extraction. Server-only, all of it lands on the API container under `ENRICHMENT_WORKER_MODE=system` (exactly the posture distributed nodes exist to avoid), and the feature is unavailable entirely under `ENRICHMENT_WORKER_MODE=off`.

The job is genuinely node-eligible: ffmpeg is already a node requirement for `video_face_detection`, and the transient per-job credential mechanism already exists for `auto_tagging`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #452
Fixes #460

## Changes Made

**Parity is the acceptance bar, so the prompt moved rather than being copied.** `buildVideoTaggingPrompt` and `VIDEO_AUTO_TAGGING_SYSTEM_PROMPT` now live in `packages/enrichment-compute/src/ai`, and the API service imports them. Duplicating a prompt string into the CLI is precisely the thing that drifts silently — one implementation, two executors, same as the ffmpeg argv builders.

**`apps/cli/src/node/compute/video-auto-tagging.ts`** — structurally a merge of `compute/video-face-detection.ts` (probe → `extractFrames` → per-frame `prepareImageForProcessing`) and `compute/auto-tagging.ts` (transient credentials → direct provider call → raw text). Declines with `CapabilityUnavailableError` for any provider other than anthropic/openai, leaving the job server-only rather than failing it.

**Registration:** `NODE_JOB_TYPES` gains the type; `JOB_TYPE_REQUIREMENTS.video_auto_tagging = ['sharp','ffmpeg','ffprobe']` so a node without ffmpeg **never claims it** — the per-type requirements map is exactly why this is a separate job type from `auto_tagging` (`['sharp']`); `ComputeDispatcher.routes` gains the lazy import.

**Server contract:** `resolveJobParams` merges `autoTagging.video.*` plus `durationMs` into the claim params — same rationale as `video_face_detection` (no payload, settings read fresh at process time, no DB access on the node), with `durationMs` added because frame sampling is computed from it and the node only receives a URL.

`getJobCredentials` gains a `video_auto_tagging` branch that hands over the **vocabulary and people rather than a finished prompt**: the user prompt embeds frame timestamps only the node knows, while `tag_labels` needs DB access the node lacks — so the node composes the prompt with the shared builder from those inputs. Transcription rides along as a **second, independent** credential; absent, unconfigured, or unresolvable all degrade the video to visual-only, matching the in-process path exactly rather than failing the job.

**Parsing stays server-side** — a node cannot validate tags against a vocabulary it cannot read — so the result is raw text plus frame/transcript provenance, matching `videoAutoTaggingResultSchema`.

`URL_INPUT_TYPES` (landed in #456) already means the node receives the presigned URL rather than a pre-downloaded temp file, so this compute never pulls gigabytes to disk.

`VIDEO_JOB_TYPES` (20-min timeout) and the Doctor node-capability mapping were already handled in #455/#457. **CLI version bumped** 1.3.0 → 1.3.1 with the lockfile synced, per the repo's mandatory rule.

**Worker image:** verified rather than assumed — `apps/cli/Dockerfile` already installs ffmpeg for `video_face_detection`, so no image change is needed.

## Testing

- [x] Unit tests pass — `apps/api` **8194 pass**; `apps/cli` node suites **324 pass**; `packages/enrichment-compute` 125 pass / 3 skipped
- [x] Type checks pass (`apps/api`, `apps/cli`, `packages/enrichment-compute`)

32 new tests. The parity properties are asserted directly: the URL goes straight to the extractor, the server-resolved frame budget is forwarded unchanged, the prompt is built by the **shared** function from the server-supplied vocabulary/people, and exactly **one** multi-image call is made. Degradation is pinned too: a frame sharp cannot decode is skipped rather than failing the video; an unsupported provider *declines* rather than failing; and transcription degrades to visual-only for a missing credential, an unconfigured model, an ffmpeg failure, or a non-429 HTTP error — while a **rate limit propagates** so the queue defers instead of silently producing a worse description.

Server-side: the credentials response omitting `prompt`, `recordModel` being called, and all four transcription branches.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Documentation lands in #461, the last issue of the epic.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ugRE1nWgcaoEhzG8WQp1y)_