### PR TITLE
refactor(api): compose the by-filter enhance where via the shared andWhere helper

### DIFF
--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -359,8 +359,9 @@ export class MediaEnhancementService {
    *      filter is set, and `wherePeople` emits one in 'all' mode; `{...a, ...b}`
    *      would let the people clause silently CLOBBER the entire rest of the
    *      filter, quietly widening the match set — the issue #431 defect that
-   *      `andWhere` exists to make unrepresentable. (The `addAlbumItemsByFilter`
-   *      precedent still spreads them; that is tracked separately in #473.)
+   *      `andWhere` exists to make unrepresentable. `listMedia` and
+   *      `addAlbumItemsByFilter` compose through the same helper (#472), so
+   *      there is now exactly one spelling of this rule.
    *
    * A `type: 'video'` filter is not overridden into `photo`; it AND-composes to
    * an empty match set and gets the honest zero-match 400 below.

--- a/apps/api/src/enhancement/media-enhancement.service.ts
+++ b/apps/api/src/enhancement/media-enhancement.service.ts
@@ -33,7 +33,7 @@ import { RequestUser } from '../auth/interfaces/authenticated-user.interface';
 import { EnhanceParams } from './dto/enhance-params.dto';
 import { BulkEnhance } from './dto/bulk-enhance.dto';
 import { BulkEnhanceByFilter } from './dto/bulk-enhance-by-filter.dto';
-import { buildMediaWhere, wherePeople } from '../search/media-where.builder';
+import { andWhere, buildMediaWhere, wherePeople } from '../search/media-where.builder';
 import { ListEnhancementBatchesQuery } from './dto/list-enhancement-batches-query.dto';
 import {
   ListEnhancementsQuery,
@@ -354,13 +354,13 @@ export class MediaEnhancementService {
    *      that actually runs — counting videos and then skipping them downstream
    *      would make the cap check lie.
    *
-   *   3. The two fragments are AND-NESTED, never spread-merged. `buildMediaWhere`
-   *      emits a top-level `AND` whenever any filter is set, and `wherePeople`
-   *      emits one in 'all' mode; `{...a, ...b}` would let the people clause
-   *      silently CLOBBER the entire rest of the filter, quietly widening the
-   *      match set. (The `addAlbumItemsByFilter` precedent spreads them — safe
-   *      there only by luck, and not a pattern worth copying into a path that
-   *      spends money.)
+   *   3. The fragments are AND-NESTED via the shared `andWhere` helper, never
+   *      spread-merged. `buildMediaWhere` emits a top-level `AND` whenever any
+   *      filter is set, and `wherePeople` emits one in 'all' mode; `{...a, ...b}`
+   *      would let the people clause silently CLOBBER the entire rest of the
+   *      filter, quietly widening the match set — the issue #431 defect that
+   *      `andWhere` exists to make unrepresentable. (The `addAlbumItemsByFilter`
+   *      precedent still spreads them; that is tracked separately in #473.)
    *
    * A `type: 'video'` filter is not overridden into `photo`; it AND-composes to
    * an empty match set and gets the honest zero-match 400 below.
@@ -425,16 +425,22 @@ export class MediaEnhancementService {
         ? wherePeople(effectivePersonIds, dto.peopleMatch ?? 'any')
         : {};
 
-    const where: Prisma.MediaItemWhereInput = {
-      circleId: dto.circleId,
-      // RULE 1 — never spend money on trashed or archived photos.
-      deletedAt: null,
-      archivedAt: null,
-      // RULE 2 — photo-only in the SQL so the shown count is the run count.
-      type: MediaType.photo,
-      // RULE 3 — nest, never spread.
-      AND: [filterWhere, peopleWhere].filter((f) => Object.keys(f).length > 0),
-    };
+    // RULE 3 — compose through the SHARED `andWhere` helper, never a spread.
+    // It pushes each fragment into the `AND` array, which is what stops a
+    // people clause (its own top-level `AND` in 'all' mode) from clobbering
+    // the rest of the filter — the issue #431 defect.
+    const where = andWhere(
+      {
+        circleId: dto.circleId,
+        // RULE 1 — never spend money on trashed or archived photos.
+        deletedAt: null,
+        archivedAt: null,
+        // RULE 2 — photo-only in the SQL so the shown count is the run count.
+        type: MediaType.photo,
+      },
+      filterWhere,
+      peopleWhere,
+    );
 
     const matchedCount = await this.prisma.mediaItem.count({ where });
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to #475. `startBatchByFilter` hand-rolled the same AND-composition rule that #472 landed as `andWhere()` in `media-where.builder.ts` — the two PRs were in flight at the same time, so the epic shipped with a second, divergent spelling of one rule. This collapses them onto the shared helper.

**Behaviour is unchanged.** This is a readability/consolidation change, not a fix — the existing composition was already correct.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Relates to #431
Follows up #475

## Changes Made

- `startBatchByFilter` now composes its filter and people fragments through `andWhere(base, filterWhere, peopleWhere)` instead of an inline `AND: [...].filter(...)`.
- **Rules 1 and 2 stay asserted on the base object**, with their comments: `buildMediaWhere`'s `excludeArchived` does not cover `deletedAt`, so the explicit trash/archive guard stays (this path spends money); and `type: photo` must be in the SQL so the count shown to the user is the count that actually runs.
- A second commit corrects the method's docstring, which claimed `addAlbumItemsByFilter` "still spreads them; tracked separately in #473". Both halves were wrong — **#472 converted that method and `listMedia` to `andWhere`** when it fixed #431, and #473 is the unrelated JSON-boolean-vs-`z.string()` DTO bug on the same endpoint. Left standing, it would have sent the next reader chasing a defect that no longer exists.

## Testing

- [x] Unit tests pass (`npm test`) — enhancement **8 suites / 323 tests**, exactly the pre-refactor baseline; `media-where` + `search` **5 suites / 226 tests**
- [x] Type checks pass (`npm run typecheck`) — clean
- [ ] E2E tests pass (if applicable) — n/a
- [ ] Manual testing completed — n/a for a no-op refactor

**The `AND: []` shape nuance was checked, and it cannot bite here.** `andWhere` omits the `AND` key entirely when *every* fragment is empty, whereas the old code always emitted one. But `buildMediaWhere` ends with `{ circleId, deletedAt: null }` before optionally appending its own `AND`, so `filterWhere` is never empty on this path — the two shapes are identical in every reachable case, not merely semantically equivalent. Several existing tests dereference `capturedWhere.AND as any[]` unguarded and all still pass. **No test expectation was updated or weakened.**

**The regression guard already existed, so nothing was added.** `media-enhancement.service.spec.ts:953` — *"AND-composes the buildMediaWhere fragment rather than spreading it, so a people clause cannot clobber it"* — passes `tag: 'birthday'` with `personIds: ['p1','p2'], peopleMatch: 'all'`, the exact shape that triggers #431 (since `wherePeople(…, 'all')` returns its own top-level `AND`), and asserts both survive. A spread-merge fails it. It passes unchanged after the refactor, so the guard survived the consolidation.

## Additional Notes

One pre-existing oddity left alone to keep the diff honest: the base object passes `circleId` while `filterWhere`, nested under `AND`, carries its own `circleId` for the same circle. Prisma emits both and they agree, so it is harmless — noting it only so a future reader knows the duplication is inert rather than a sign one of the two is dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtKHrngk2vQNo1PmU5PLtt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtKHrngk2vQNo1PmU5PLtt)_